### PR TITLE
Add 'http_host' config to ExplorerWeb.Endpoint

### DIFF
--- a/apps/explorer_web/config/prod.exs
+++ b/apps/explorer_web/config/prod.exs
@@ -20,5 +20,6 @@ config :explorer_web, ExplorerWeb.Endpoint,
   http: [port: System.get_env("PORT")],
   url: [
     scheme: "http",
-    port: System.get_env("PORT")
+    port: System.get_env("PORT"),
+    host: System.get_env("HTTP_HOST")
   ]


### PR DESCRIPTION
#435

We need to configure the host so the WebSocket can accept requests from other machines in the same host. 

## Changelog

Add a `host` option at the `ExplorerWeb` `url`  prod config file.
