### PR TITLE
contract page and read/verify contract layout and style improvements

### DIFF
--- a/apps/explorer_web/assets/css/_code.scss
+++ b/apps/explorer_web/assets/css/_code.scss
@@ -9,3 +9,7 @@
 .pre-scrollable-shorty {
   max-height: $pre-scrollable-max-height / 7;
 }
+
+.tile pre  {
+  margin-bottom: 0;
+}

--- a/apps/explorer_web/assets/css/_typography.scss
+++ b/apps/explorer_web/assets/css/_typography.scss
@@ -53,7 +53,7 @@ a {
   }
 }
 
-label {
+label, textarea.form-control {
   font-size: 13px;
 }
 

--- a/apps/explorer_web/assets/css/_typography.scss
+++ b/apps/explorer_web/assets/css/_typography.scss
@@ -16,6 +16,7 @@ h2 {
 h3 {
   font-size: 14px;
   font-weight: 600;
+  line-height: 36px;
 }
 
 h4 {

--- a/apps/explorer_web/assets/css/_typography.scss
+++ b/apps/explorer_web/assets/css/_typography.scss
@@ -19,11 +19,11 @@ h3 {
 }
 
 h4 {
-  font-size: 16px !important;
-  line-height: 24px !important;
-  font-weight: 300 !important;
-  color: $gray-600 !important;
-  margin-top: 4px !important;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 300;
+  color: $gray-600;
+  margin-top: 4px;
 
   &.underline {
     text-decoration: underline;
@@ -34,7 +34,7 @@ p {
   font-size: 13px;
 
   @media screen and (max-width: 768px) {
-    font-size: 14px !important;
+    font-size: 14px;
    }
 }
 
@@ -52,6 +52,11 @@ a {
     color: $white;
   }
 }
+
+label {
+  font-size: 13px;
+}
+
 .monospace {
   font-family: $font-family-monospace;
 }

--- a/apps/explorer_web/assets/css/app.scss
+++ b/apps/explorer_web/assets/css/app.scss
@@ -56,6 +56,7 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "tooltip";
 @import "code";
 @import "elements";
+@import "forms";
 @import "components/panels";
 @import "components/nav_tabs";
 @import "components/dot";

--- a/apps/explorer_web/assets/css/components/_button.scss
+++ b/apps/explorer_web/assets/css/components/_button.scss
@@ -6,17 +6,19 @@
   white-space:  nowrap;
   padding: 8px 10px;
   border-radius: .14589803rem;
+  cursor: pointer;
 
   &--primary {
-    background-color: lighten($primary, 20%) !important;
-    color: $black !important;
-    -webkit-transition: background-color .25s, color .25s !important;
+    background-color: lighten($primary, 20%);
+    color: $white;
+    border: 1px solid lighten($primary, 20%);
+    -webkit-transition: background-color .25s, color .25s;
     transition: background-color .25s, color .25s;
 
     &:hover,
     &:focus {
-      background-color: $gray-700 !important;
-      color: $gray-200 !important;
+      background-color: $primary;
+      border-color: $primary;
       text-decoration: none;
     }
 

--- a/apps/explorer_web/assets/css/components/_button.scss
+++ b/apps/explorer_web/assets/css/components/_button.scss
@@ -5,15 +5,15 @@
   text-decoration: none;
   white-space:  nowrap;
   padding: 8px 10px;
-  border-radius: .14589803rem;
+  border-radius: 2px;
   cursor: pointer;
+  -webkit-transition: all 0.25s;
+  transition: all 0.25s;
 
   &--primary {
     background-color: lighten($primary, 20%);
     color: $white;
     border: 1px solid lighten($primary, 20%);
-    -webkit-transition: background-color .25s, color .25s;
-    transition: background-color .25s, color .25s;
 
     &:hover,
     &:focus {
@@ -32,13 +32,12 @@
   &--secondary {
     border: 1px solid lighten($primary, 25%);
     color: lighten($primary, 25%);
-    -webkit-transition: background-color .25s;
-    transition: background-color .25s;
     font-weight: 400;
 
     &:hover,
     &:focus {
       background-color: $primary;
+      border-color: $primary;
       color: $white;
       text-decoration: none;
       outline: none !important;

--- a/apps/explorer_web/assets/css/components/_tile.scss
+++ b/apps/explorer_web/assets/css/components/_tile.scss
@@ -117,6 +117,5 @@
 .tile-muted {
   border-left: 1px solid $border-color;
   background-color: $gray-100;
-  color: $text-muted;
   box-shadow: none;
 }

--- a/apps/explorer_web/assets/css/forms.scss
+++ b/apps/explorer_web/assets/css/forms.scss
@@ -1,0 +1,3 @@
+.address-input-sm {
+  min-width: calc(42ch + (#{$input-padding-x-sm} * 2));
+}

--- a/apps/explorer_web/assets/js/app.js
+++ b/apps/explorer_web/assets/js/app.js
@@ -26,6 +26,7 @@ import './lib/tooltip'
 import './lib/smart_contract/read_function'
 import './lib/pretty_json'
 import './lib/try_api'
+import './lib/expandable_textarea'
 
 import './pages/address'
 import './pages/block'

--- a/apps/explorer_web/assets/js/app.js
+++ b/apps/explorer_web/assets/js/app.js
@@ -20,6 +20,7 @@ import 'bootstrap'
 
 import './lib/clipboard_buttons'
 import './lib/from_now'
+import './lib/loading_element'
 import './lib/market_history_chart'
 import './lib/reload_button'
 import './lib/tooltip'

--- a/apps/explorer_web/assets/js/app.js
+++ b/apps/explorer_web/assets/js/app.js
@@ -26,7 +26,6 @@ import './lib/tooltip'
 import './lib/smart_contract/read_function'
 import './lib/pretty_json'
 import './lib/try_api'
-import './lib/expandable_textarea'
 
 import './pages/address'
 import './pages/block'

--- a/apps/explorer_web/assets/js/lib/expandable_textarea.js
+++ b/apps/explorer_web/assets/js/lib/expandable_textarea.js
@@ -1,0 +1,5 @@
+import $ from 'jquery'
+
+$('[data-is-expandable]').on( 'change keyup keydown paste cut', 'textarea', function (){
+  $(this).height(0).height(this.scrollHeight);
+}).find( 'textarea' ).change();

--- a/apps/explorer_web/assets/js/lib/expandable_textarea.js
+++ b/apps/explorer_web/assets/js/lib/expandable_textarea.js
@@ -1,5 +1,0 @@
-import $ from 'jquery'
-
-$('[data-is-expandable]').on( 'change keyup keydown paste cut', 'textarea', function () {
-  $(this).height(0).height(this.scrollHeight)
-}).find( 'textarea' ).change()

--- a/apps/explorer_web/assets/js/lib/expandable_textarea.js
+++ b/apps/explorer_web/assets/js/lib/expandable_textarea.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
 
-$('[data-is-expandable]').on( 'change keyup keydown paste cut', 'textarea', function (){
-  $(this).height(0).height(this.scrollHeight);
-}).find( 'textarea' ).change();
+$('[data-is-expandable]').on( 'change keyup keydown paste cut', 'textarea', function () {
+  $(this).height(0).height(this.scrollHeight)
+}).find( 'textarea' ).change()

--- a/apps/explorer_web/assets/js/lib/loading_element.js
+++ b/apps/explorer_web/assets/js/lib/loading_element.js
@@ -1,0 +1,9 @@
+import $ from 'jquery'
+
+$('button[data-loading="animation"]').click(event => {
+  const clickedButton = $(event.target)
+
+  clickedButton.addClass("d-none")
+  $('#loading').removeClass("d-none")
+
+})

--- a/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address/overview.html.eex
@@ -43,8 +43,7 @@
                         @locale,
                         @address.contracts_creation_internal_transaction.transaction_hash
                       ),
-                      "data-test": "transaction_hash_link",
-                      class: "tile-title"
+                      "data-test": "transaction_hash_link"
                     ) %>
               </span>
             <% end %>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
@@ -85,7 +85,7 @@
         </div>
       <% end %>
 
-      <h3>Contract creation code</h3>
+      <h2 class="card-title">Contract creation code</h2>
       <div class="tile tile-muted">
         <pre class="pre-wrap">
           <code><%= @address.contract_code %></code>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
@@ -51,37 +51,41 @@
       <% end %>
 
       <%= if smart_contract_verified?(@address) do %>
-        <table class="table">
-          <tr>
-            <th>Contract name:</th>
-            <td><%= @address.smart_contract.name %></td>
-          </tr>
-          <tr>
-            <th>Optimization enabled:</th>
-            <td><%= format_optimization(@address.smart_contract.optimization) %></td>
-          </tr>
-          <tr>
-            <th>Compiler version:</th>
-            <td><%= @address.smart_contract.compiler_version %></td>
-          </tr>
-        </table>
+        <div class="mb-4">
+          <dl class="row">
+            <dt class="col-sm-4 col-md-2 text-muted">Contract name:</dt>
+            <dd class="col-sm-8 col-md-10"><%= @address.smart_contract.name %></dd>
+          </dl>
+          <dl class="row">
+            <dt class="col-sm-4 col-md-2 text-muted">Optimization enabled</dt>
+            <dd class="col-sm-8 col-md-10"><%= format_optimization(@address.smart_contract.optimization) %></dd>
+          </dl>
+          <dl class="row">
+            <dt class="col-sm-4 col-md-2 text-muted">Compiler version</dt>
+            <dd class="col-sm-8 col-md-10"><%= @address.smart_contract.compiler_version %></dd>
+          </dl>
+        </div>
+        <hr/>
+        <h3>Contract source code</h3>
+        <div class="tile tile-muted mb-4">
+          <pre>
+            <code>
+              <%= text_to_html(@address.smart_contract.contract_source_code, insert_brs: false) %>
+            </code>
+          </pre>
+        </div>
 
-        <h4>Contract source code</h4>
-        <pre class="p-2 bg-light mb-4">
-          <code>
-            <%= text_to_html(@address.smart_contract.contract_source_code, insert_brs: false) %>
-          </code>
-        </pre>
-
-        <h4>Contract ABI</h4>
-        <pre class="p-2 bg-light mb-4">
-          <code>
-            <%= format_smart_contract_abi(@address.smart_contract.abi) %>
-          </code>
-        </pre>
+        <h3>Contract ABI</h3>
+        <div class="tile tile-muted mb-4">
+          <pre>
+            <code>
+              <p><%= format_smart_contract_abi(@address.smart_contract.abi) %></p>
+            </code>
+          </pre>
+        </div>
       <% end %>
 
-      <h2 class="card-title">Contract creation code</h2>
+      <h3>Contract creation code</h3>
       <div class="tile tile-muted">
         <pre class="pre-wrap">
           <code><%= @address.contract_code %></code>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
@@ -46,7 +46,7 @@
       <%= if !smart_contract_verified?(@address) do %>
         <%= link(
               gettext("Verify and Publish"),
-              to: address_verify_contract_path(@conn, :new, @conn.assigns.locale, @conn.params["address_id"]), class: "button button--secondary button-xsmall float-right"
+              to: address_verify_contract_path(@conn, :new, @conn.assigns.locale, @conn.params["address_id"]), class: "button button--primary button--sm float-right ml-3"
             ) %>
       <% end %>
 

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
@@ -66,31 +66,60 @@
           </dl>
         </div>
         <hr/>
-        <h3>Contract source code</h3>
-        <div class="tile tile-muted mb-4">
-          <pre>
-            <code>
-              <%= text_to_html(@address.smart_contract.contract_source_code, insert_brs: false) %>
-            </code>
-          </pre>
-        </div>
+        <section>
+          <div class="d-flex justify-content-between align-items-baseline">
+            <h3>Contract source code</h3>
+            <span class="icon-links" data-clipboard-text="<%= @address.smart_contract.contract_source_code %>">
+              <button type="button" class="button button--secondary button--sm" id="button" data-toggle="tooltip" data-placement="top" title="<%= gettext("Copy Address") %>" aria-label="Copy Address">
+                Copy Contract Source Code
+              </button>
+            </span>
+          </div>
+          <div class="tile tile-muted mb-4">
+            <pre class="pre-scrollable">
+              <code>
+                <%= text_to_html(@address.smart_contract.contract_source_code, insert_brs: false) %>
+              </code>
+            </pre>
+          </div>
+        </section>
 
-        <h3>Contract ABI</h3>
-        <div class="tile tile-muted mb-4">
-          <pre>
-            <code>
-              <p><%= format_smart_contract_abi(@address.smart_contract.abi) %></p>
-            </code>
-          </pre>
-        </div>
+        <section>
+          <div class="d-flex justify-content-between align-items-baseline">
+            <h3>Contract ABI</h3>
+            <span class="icon-links" data-clipboard-text="<%= format_smart_contract_abi(@address.smart_contract.abi) %>">
+              <button type="button" class="button button--secondary button--sm" id="button">
+                Copy Contract ABI
+              </button>
+            </span>
+          </div>
+          <div class="tile tile-muted mb-4">
+            <pre class="pre-scrollable">
+              <code>
+                <p><%= format_smart_contract_abi(@address.smart_contract.abi) %></p>
+              </code>
+            </pre>
+          </div>
+        </section>
+
+
       <% end %>
+      <section>
+        <div class="d-flex justify-content-between align-items-baseline">
+          <h3>Contract creation code</h3>
+          <span class="icon-links" data-clipboard-text="<%= @address.contract_code %>">
+            <button type="button" class="button button--secondary button--sm" id="button">
+              Copy Contract Creation Code
+            </button>
+          </span>
+        </div>
+        <div class="tile tile-muted">
+          <pre class="pre-wrap pre-scrollable">
+            <code><%= @address.contract_code %></code>
+          </pre>
+        </div>
+      </section>
 
-      <h2 class="card-title">Contract creation code</h2>
-      <div class="tile tile-muted">
-        <pre class="pre-wrap">
-          <code><%= @address.contract_code %></code>
-        </pre>
-      </div>
     </div>
   </div>
 </section>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract/index.html.eex
@@ -1,4 +1,4 @@
-<section class="container-fluid">
+<section class="container">
 
   <%= render ExplorerWeb.AddressView, "overview.html", assigns %>
 
@@ -44,14 +44,10 @@
 
     <div class="card-body">
       <%= if !smart_contract_verified?(@address) do %>
-        <p>
-          <%= link(
-                to: address_verify_contract_path(@conn, :new, @conn.assigns.locale, @conn.params["address_id"])
-              ) do %>
-              <i class="fas fa-info-circle"></i>
-              <%= gettext("Verify and Publish") %>
-          <% end %>
-        </p>
+        <%= link(
+              gettext("Verify and Publish"),
+              to: address_verify_contract_path(@conn, :new, @conn.assigns.locale, @conn.params["address_id"]), class: "button button--secondary button-xsmall float-right"
+            ) %>
       <% end %>
 
       <%= if smart_contract_verified?(@address) do %>
@@ -85,10 +81,12 @@
         </pre>
       <% end %>
 
-      <h4>Contract creation code</h4>
-      <pre class="pre-wrap p-2 bg-light mb-4">
-        <code><%= @address.contract_code %></code>
-      </pre>
+      <h2 class="card-title">Contract creation code</h2>
+      <div class="tile tile-muted">
+        <pre class="pre-wrap">
+          <code><%= @address.contract_code %></code>
+        </pre>
+      </div>
     </div>
   </div>
 </section>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
@@ -48,7 +48,8 @@
           <%= error_tag f, :contract_source_code, id: "contract-source-code-help-block", class: "text-danger", "data-test": "contract-source-code-error" %>
         </div>
 
-        <%= submit "Verify and publish", class: "button button--primary button--sm mr-2" %>
+        <%= submit "Verify and publish", class: "button button--primary button--sm mr-2", "data-loading": "animation"  %>
+        <button type="button" name="button" id="loading" disabled="true" class="d-none button button--primary button--sm mr-2"><i class="fa fa-spinner fa-spin"></i> loading...</button>
         <%= reset "Reset", class: "button button--secondary button--sm mr-2" %>
         <%= link(
             "Cancel",

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
@@ -42,7 +42,7 @@
           <%= error_tag f, :optimization, id: "optimization-help-block", class: "text-danger" %>
         </div>
 
-        <div class="form-group mb-4" data-is-expandable>
+        <div class="form-group mb-4">
           <%= label f, :contract_source_code, "Enter the Solidity Contract Code below" %>
           <%= textarea f, :contract_source_code, class: "form-control monospace", rows: 3, "aria-describedby": "contract-source-code-help-block" %>
           <%= error_tag f, :contract_source_code, id: "contract-source-code-help-block", class: "text-danger", "data-test": "contract-source-code-error" %>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
@@ -50,7 +50,11 @@
         </div>
 
         <%= submit "Verify and publish", class: "button button--primary button--sm mr-2" %>
-        <%= reset "Reset", class: "button button--secondary button--sm" %>
+        <%= reset "Reset", class: "button button--secondary button--sm mr-2" %>
+        <%= link(
+            "Cancel",
+            to: address_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+            class: "button button--sm") %>
       <% end %>
     </div>
   </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
@@ -45,7 +45,7 @@
         <div class="form-group mb-4" data-is-expandable>
           <%= label f, :contract_source_code, "Enter the Solidity Contract Code below" %>
           <%= textarea f, :contract_source_code, class: "form-control monospace", rows: 3, "aria-describedby": "contract-source-code-help-block" %>
-          <%= error_tag f, :contract_source_code, id: "contract-source-code-help-block", class: "text-danger" %>
+          <%= error_tag f, :contract_source_code, id: "contract-source-code-help-block", class: "text-danger", "data-test": "contract-source-code-error" %>
         </div>
 
         <%= submit "Verify and publish", class: "button button--primary button--sm mr-2" %>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
@@ -6,24 +6,25 @@
 
       <%= form_for @changeset,
           address_verify_contract_path(@conn, :create, @conn.assigns.locale, @conn.params["address_id"]),
+          [class: "needs-validation"],
           fn f -> %>
 
         <div class="form-group">
           <%= label f, :address_hash, "Contract Address" %>
-          <%= text_input f, :address_hash, class: "form-control", disabled: true %>
-          <%= error_tag f, :address_hash %>
+          <%= text_input f, :address_hash, class: "form-control", readonly: true %>
+          <%= error_tag f, :address_hash, class: "text-danger" %>
         </div>
 
         <div class="form-group">
           <%= label f, :name, "Contract Name" %>
           <%= text_input f, :name, class: "form-control" %>
-          <%= error_tag f, :name %>
+          <%= error_tag f, :name, class: "text-danger" %>
         </div>
 
         <div class="form-group mb-4">
           <%= label f, :compiler_version, "Compiler" %>
           <%= select f, :compiler_version, @compiler_versions, class: "form-control", selected: "latest" %>
-          <%= error_tag f, :compiler_version %>
+          <%= error_tag f, :compiler_version, class: "text-danger" %>
         </div>
 
         <div class="form-group mb-4">
@@ -39,13 +40,13 @@
             <%= label :smart_contract_optimization, :true, "Yes", class: "form-check-label" %>
           </div>
 
-          <%= error_tag f, :optimization %>
+          <%= error_tag f, :optimization, class: "text-danger" %>
         </div>
 
         <div class="form-group mb-4">
           <%= label f, :contract_source_code, "Enter the Solidity Contract Code below" %>
           <%= textarea f, :contract_source_code, class: "form-control", rows: 3 %>
-          <%= error_tag f, :contract_source_code %>
+          <%= error_tag f, :contract_source_code, class: "text-danger" %>
         </div>
 
         <%= submit "Verify and publish", class: "button button--primary button--sm mr-2" %>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
@@ -43,9 +43,9 @@
           <%= error_tag f, :optimization, id: "optimization-help-block", class: "text-danger" %>
         </div>
 
-        <div class="form-group mb-4">
+        <div class="form-group mb-4" data-is-expandable>
           <%= label f, :contract_source_code, "Enter the Solidity Contract Code below" %>
-          <%= textarea f, :contract_source_code, class: "form-control", rows: 3, "aria-describedby": "contract-source-code-help-block" %>
+          <%= textarea f, :contract_source_code, class: "form-control monospace", rows: 3, "aria-describedby": "contract-source-code-help-block" %>
           <%= error_tag f, :contract_source_code, id: "contract-source-code-help-block", class: "text-danger" %>
         </div>
 

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
@@ -11,42 +11,42 @@
 
         <div class="form-group">
           <%= label f, :address_hash, "Contract Address" %>
-          <%= text_input f, :address_hash, class: "form-control", readonly: true %>
-          <%= error_tag f, :address_hash, class: "text-danger" %>
+          <%= text_input f, :address_hash, class: "form-control", "aria-describedby": "contract-address-help-block", readonly: true %>
+          <%= error_tag f, :address_hash, id: "contract-address-help-block", class: "text-danger" %>
         </div>
 
         <div class="form-group">
           <%= label f, :name, "Contract Name" %>
-          <%= text_input f, :name, class: "form-control" %>
-          <%= error_tag f, :name, class: "text-danger" %>
+          <%= text_input f, :name, class: "form-control", "aria-describedby": "contract-name-help-block" %>
+          <%= error_tag f, :name, id: "contract-name-help-block", class: "text-danger" %>
         </div>
 
         <div class="form-group mb-4">
           <%= label f, :compiler_version, "Compiler" %>
-          <%= select f, :compiler_version, @compiler_versions, class: "form-control", selected: "latest" %>
-          <%= error_tag f, :compiler_version, class: "text-danger" %>
+          <%= select f, :compiler_version, @compiler_versions, class: "form-control", selected: "latest", "aria-describedby": "compiler-help-block" %>
+          <%= error_tag f, :compiler_version, id: "compiler-help-block", class: "text-danger" %>
         </div>
 
         <div class="form-group mb-4">
           <%= label f, "Optimization" %>
 
           <div class="form-check mb-2">
-            <%= radio_button f, :optimization, false, checked: true, class: "form-check-input" %>
+            <%= radio_button f, :optimization, false, checked: true, class: "form-check-input", "aria-describedby": "optimization-help-block" %>
             <%= label :smart_contract_optimization, :false, "No", class: "form-check-label" %>
           </div>
 
           <div class="form-check">
-            <%= radio_button f, :optimization, true, class: "form-check-input" %>
+            <%= radio_button f, :optimization, true, class: "form-check-input", "aria-describedby": "optimization-help-block" %>
             <%= label :smart_contract_optimization, :true, "Yes", class: "form-check-label" %>
           </div>
 
-          <%= error_tag f, :optimization, class: "text-danger" %>
+          <%= error_tag f, :optimization, id: "optimization-help-block", class: "text-danger" %>
         </div>
 
         <div class="form-group mb-4">
           <%= label f, :contract_source_code, "Enter the Solidity Contract Code below" %>
-          <%= textarea f, :contract_source_code, class: "form-control", rows: 3 %>
-          <%= error_tag f, :contract_source_code, class: "text-danger" %>
+          <%= textarea f, :contract_source_code, class: "form-control", rows: 3, "aria-describedby": "contract-source-code-help-block" %>
+          <%= error_tag f, :contract_source_code, id: "contract-source-code-help-block", class: "text-danger" %>
         </div>
 
         <%= submit "Verify and publish", class: "button button--primary button--sm mr-2" %>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
@@ -1,19 +1,9 @@
-<section class="container-fluid">
-  <h1>Smart Contract</h1>
-
+<section class="container">
   <div class="card">
-    <div class="card-header">
-      <ul class="nav nav-tabs card-header-tabs">
-        <li class="nav-item">
-          <%= link(
-            gettext("Contract Source Code"),
-            class: "nav-link active",
-            to: '#'
-          ) %>
-        </li>
-      </ul>
-    </div>
     <div class="card-body">
+
+      <h1 class="card-title">New Smart Contract</h1>
+
       <%= form_for @changeset,
           address_verify_contract_path(@conn, :create, @conn.assigns.locale, @conn.params["address_id"]),
           fn f -> %>
@@ -30,21 +20,21 @@
           <%= error_tag f, :name %>
         </div>
 
-        <div class="form-group">
+        <div class="form-group mb-4">
           <%= label f, :compiler_version, "Compiler" %>
           <%= select f, :compiler_version, @compiler_versions, class: "form-control", selected: "latest" %>
           <%= error_tag f, :compiler_version %>
         </div>
 
-        <div class="form-group">
-          <%= label f, "Optimization", class: "d-block" %>
+        <div class="form-group mb-4">
+          <%= label f, "Optimization" %>
 
-          <div class="form-check form-check-inline">
+          <div class="form-check mb-2">
             <%= radio_button f, :optimization, false, checked: true, class: "form-check-input" %>
             <%= label :smart_contract_optimization, :false, "No", class: "form-check-label" %>
           </div>
 
-          <div class="form-check form-check-inline">
+          <div class="form-check">
             <%= radio_button f, :optimization, true, class: "form-check-input" %>
             <%= label :smart_contract_optimization, :true, "Yes", class: "form-check-label" %>
           </div>
@@ -52,14 +42,14 @@
           <%= error_tag f, :optimization %>
         </div>
 
-        <div class="form-group">
+        <div class="form-group mb-4">
           <%= label f, :contract_source_code, "Enter the Solidity Contract Code below" %>
           <%= textarea f, :contract_source_code, class: "form-control", rows: 3 %>
           <%= error_tag f, :contract_source_code %>
         </div>
 
-        <%= submit "Verify and publish", class: "button button--secondary button--sm" %>
-        <%= reset "Reset", class: "button button--tertiary button--sm" %>
+        <%= submit "Verify and publish", class: "button button--primary button--sm mr-2" %>
+        <%= reset "Reset", class: "button button--secondary button--sm" %>
       <% end %>
     </div>
   </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_contract_verification/new.html.eex
@@ -6,7 +6,6 @@
 
       <%= form_for @changeset,
           address_verify_contract_path(@conn, :create, @conn.assigns.locale, @conn.params["address_id"]),
-          [class: "needs-validation"],
           fn f -> %>
 
         <div class="form-group">

--- a/apps/explorer_web/lib/explorer_web/templates/address_read_contract/_function_response.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_read_contract/_function_response.html.eex
@@ -1,7 +1,8 @@
-<span>
-  [ <%= @function_name %> method Response ] <br />
+<div class="tile tile-muted monospace">
+  [ <%= @function_name %> method Response ]
 
   <%= for item <- @outputs do %>
-    <i class="fa fa-angle-double-right"></i> <%= item["type"] %> : <%= item["value"] %>
+    <i class="fa fa-angle-double-right"></i>
+    <span class="text-dark"> <%= item["type"] %> : <%= item["value"] %> </span>
   <% end %>
-</span>
+</div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_read_contract/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_read_contract/index.html.eex
@@ -41,14 +41,11 @@
     </div>
 
     <div class="card-body">
-      <h2>
-        <i class="fas fa-book"></i>
-        <%= gettext("Read Contract Information") %>
-      </h2>
+      <h2 class="crad-title"> <%= gettext("Read Contract Information") %> </h2>
 
       <%= for {function, counter} <- Enum.with_index(@read_only_functions, 1) do %>
-        <div class="d-flex py-2 flex-wrap border-bottom" data-function>
-          <div class="py-2 pr-2">
+        <div class="d-flex py-2 border-bottom" data-function>
+          <div class="py-2 pr-2 text-nowrap">
             <%= counter %>.
 
             <%= function["name"] %>
@@ -57,17 +54,30 @@
           </div>
 
           <%= if queryable?(function["inputs"]) do %>
-            <form class="form-inline" data-function-form data-url="<%= address_read_contract_path(@conn, :show, :en, @address, @address.hash) %>">
-              <input type="hidden" name="function_name" value='<%= function["name"] %>' />
+            <div class="">
+              <form class="form-inline" data-function-form data-url="<%= address_read_contract_path(@conn, :show, :en, @address, @address.hash) %>">
+                <input type="hidden" name="function_name" value='<%= function["name"] %>' />
 
-              <%= for input <- function["inputs"] do %>
-                <div class="form-group pr-2">
-                  <input type="text" name="function_input" class="form-control form-control-sm mb-1" placeholder='<%= input["name"] %>(<%= input["type"] %>)'  />
-                </div>
-              <% end %>
+                <%= for input <- function["inputs"] do %>
+                  <div class="form-group pr-2">
+                    <input type="text" name="function_input" class="form-control form-control-sm address-input-sm" placeholder='<%= input["name"] %>(<%= input["type"] %>)'  />
+                  </div>
+                <% end %>
 
-              <input type="submit" value='<%= gettext("Query")%>' class="button button--secondary button--xsmall py-0" />
-            </form>
+                <input type="submit" value='<%= gettext("Query")%>' class="button button--secondary button--xsmall py-0" />
+              </form>
+
+              <div class='p-2 text-muted <%= if (queryable?(function["inputs"]) == true), do: "w-100" %>'>
+                <%= if (queryable?(function["inputs"])), do: raw "&#8627;" %>
+
+                <%= for output <- function["outputs"] do %>
+                  <%= output["type"] %>
+                <% end %>
+              </div>
+
+              <div data-function-response></div>
+            </div>
+
           <% else %>
             <span class="py-2">
               <%= for output <- function["outputs"] do %>
@@ -83,15 +93,6 @@
             </span>
           <% end %>
 
-          <div class='p-2 text-muted <%= if (queryable?(function["inputs"]) == true), do: "w-100" %>'>
-            <%= if (queryable?(function["inputs"])), do: raw "&#8627;" %>
-
-            <%= for output <- function["outputs"] do %>
-              <%= output["type"] %>
-            <% end %>
-          </div>
-
-          <div data-function-response></div>
         </div>
       <% end %>
     </div>

--- a/apps/explorer_web/lib/explorer_web/templates/address_read_contract/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_read_contract/index.html.eex
@@ -60,11 +60,11 @@
 
                 <%= for input <- function["inputs"] do %>
                   <div class="form-group pr-2">
-                    <input type="text" name="function_input" class="form-control form-control-sm address-input-sm" placeholder='<%= input["name"] %>(<%= input["type"] %>)'  />
+                    <input type="text" name="function_input" class="form-control form-control-sm address-input-sm mt-2" placeholder='<%= input["name"] %>(<%= input["type"] %>)'  />
                   </div>
                 <% end %>
 
-                <input type="submit" value='<%= gettext("Query")%>' class="button button--secondary button--xsmall py-0" />
+                <input type="submit" value='<%= gettext("Query")%>' class="button button--secondary button--xsmall py-0 mt-2" />
               </form>
 
               <div class='p-2 text-muted <%= if (queryable?(function["inputs"]) == true), do: "w-100" %>'>

--- a/apps/explorer_web/lib/explorer_web/templates/address_read_contract/index.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/address_read_contract/index.html.eex
@@ -1,4 +1,4 @@
-<section class="container-fluid">
+<section class="container">
 
   <%= render ExplorerWeb.AddressView, "overview.html", assigns %>
 

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -480,7 +480,7 @@ msgstr ""
 msgid "Contract Source Code"
 msgstr ""
 
-#: lib/explorer_web/templates/address_contract/index.html.eex:52
+#: lib/explorer_web/templates/address_contract/index.html.eex:48
 msgid "Verify and Publish"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:13
-#: lib/explorer_web/templates/address/overview.html.eex:66
+#: lib/explorer_web/templates/address/overview.html.eex:65
 msgid "QR Code"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgid "OUT"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_read_contract/index.html.eex:69
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:67
 msgid "Query"
 msgstr ""
 
@@ -659,7 +659,7 @@ msgid "Read Contract"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_read_contract/index.html.eex:46
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:44
 msgid "Read Contract Information"
 msgstr ""
 
@@ -674,7 +674,7 @@ msgid "Block Height #%{height}"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address/overview.html.eex:75
+#: lib/explorer_web/templates/address/overview.html.eex:74
 msgid "Close"
 msgstr ""
 

--- a/apps/explorer_web/priv/gettext/default.pot
+++ b/apps/explorer_web/priv/gettext/default.pot
@@ -574,6 +574,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:8
+#: lib/explorer_web/templates/address_contract/index.html.eex:73
 msgid "Copy Address"
 msgstr ""
 

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -492,7 +492,7 @@ msgstr ""
 msgid "Contract Source Code"
 msgstr "Contract Source Code"
 
-#: lib/explorer_web/templates/address_contract/index.html.eex:52
+#: lib/explorer_web/templates/address_contract/index.html.eex:48
 msgid "Verify and Publish"
 msgstr ""
 
@@ -598,7 +598,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:13
-#: lib/explorer_web/templates/address/overview.html.eex:66
+#: lib/explorer_web/templates/address/overview.html.eex:65
 msgid "QR Code"
 msgstr ""
 
@@ -658,7 +658,7 @@ msgid "OUT"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_read_contract/index.html.eex:69
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:67
 msgid "Query"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid "Read Contract"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address_read_contract/index.html.eex:46
+#: lib/explorer_web/templates/address_read_contract/index.html.eex:44
 msgid "Read Contract Information"
 msgstr ""
 
@@ -686,7 +686,7 @@ msgid "Block Height #%{height}"
 msgstr ""
 
 #, elixir-format
-#: lib/explorer_web/templates/address/overview.html.eex:75
+#: lib/explorer_web/templates/address/overview.html.eex:74
 msgid "Close"
 msgstr ""
 

--- a/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/explorer_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -586,6 +586,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/explorer_web/templates/address/overview.html.eex:8
+#: lib/explorer_web/templates/address_contract/index.html.eex:73
 msgid "Copy Address"
 msgstr ""
 

--- a/apps/explorer_web/test/explorer_web/features/address_contract_verification_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/address_contract_verification_test.exs
@@ -50,7 +50,7 @@ defmodule ExplorerWeb.AddressContractVerificationTest do
     |> fill_in(text_field("Contract Name"), with: "")
     |> fill_in(text_field("Enter the Solidity Contract Code below"), with: "")
     |> click(button("Verify and publish"))
-    |> assert_has(css(".has-error", text: "there was an error validating your contract, please try again."))
+    |> assert_has(css("[data-test='contract-source-code-error']", text: "there was an error validating your contract, please try again."))
   end
 
   def solc_bin_versions() do

--- a/apps/explorer_web/test/explorer_web/features/address_contract_verification_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/address_contract_verification_test.exs
@@ -50,7 +50,12 @@ defmodule ExplorerWeb.AddressContractVerificationTest do
     |> fill_in(text_field("Contract Name"), with: "")
     |> fill_in(text_field("Enter the Solidity Contract Code below"), with: "")
     |> click(button("Verify and publish"))
-    |> assert_has(css("[data-test='contract-source-code-error']", text: "there was an error validating your contract, please try again."))
+    |> assert_has(
+      css(
+        "[data-test='contract-source-code-error']",
+        text: "there was an error validating your contract, please try again."
+      )
+    )
   end
 
   def solc_bin_versions() do


### PR DESCRIPTION
Resolves: #448 

## Motivation

Implement styling and layout improvements to the views associated to smart contracts within and address page. These changes will improve readability and maintain consistancy with other styling decisions. 

## Changelog

### Enhancements
* Add accessibility attributes to form elements for use with assistive technologies.
* Added the ability to cancel the verifiy and pubish operation and return to the unverified "Code" view of the address page.
* Improve readability of element that display code blocks.

### Testing
1. Navigate to a contract address details page.
2. Naviagte to the "Code" page of the page.
3. Review contract code and click the "Verify and Publish" button.
4. Review the verification form.
4a. Click the "Cancel" link to return to the code tab of the contract address details page.
4b. Submit an empty form to see th error messages.
4c. Input appropriate data and submit the form.
5. Review the verified code tab.
6. Navigate to the "Read Contract" tab.
7. Add the appropriate data into a function field and exicute the function to view the result.

### Screenshots
![localhost_4000_en_addresses_0x89ab7bd4530a7a7106cf03e5c017b3de57078d50_contracts](https://user-images.githubusercontent.com/1641169/43916455-9731d1cc-9bdb-11e8-96e9-fd2d678bf621.png)

![localhost_4000_en_addresses_0x89ab7bd4530a7a7106cf03e5c017b3de57078d50_contract_verifications_new](https://user-images.githubusercontent.com/1641169/43916473-a4af48fc-9bdb-11e8-9f18-a003c1d309b5.png)

![localhost_4000_en_addresses_0x39890bc400aa6489b5e6e27a44260be356aef29d_read_contract](https://user-images.githubusercontent.com/1641169/43916521-bd79eaa4-9bdb-11e8-960b-480a4bea0227.png)
