### PR TITLE
Add block-number data-selector to template and fix feature test that …

### DIFF
--- a/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
+++ b/apps/explorer_web/lib/explorer_web/templates/transaction/overview.html.eex
@@ -29,7 +29,7 @@
           <!-- Block Hash -->
           <dl class="row">
             <dt class="col-sm-3 text-muted"><%= gettext "Block Number" %> </dt>
-            <dd class="col-sm-9">
+            <dd class="col-sm-9" data-selector="block-number">
               <%= if block do %>
                 <%= link(
                       block,

--- a/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_transactions_test.exs
@@ -132,14 +132,14 @@ defmodule ExplorerWeb.ViewingTransactionsTest do
     end
 
     test "block confirmations via live update", %{session: session, first_shown_transaction: transaction} do
-      blocks = [insert(:block, number: transaction.block_number + 10)]
+      session
+      |> TransactionPage.visit_page(transaction)
+      |> assert_text(TransactionPage.block_confirmations(), "0")
 
-      TransactionPage.visit_page(session, transaction)
-
-      assert_text(session, TransactionPage.block_confirmations(), "0")
+      blocks = [insert(:block, number: transaction.block_number + 5)]
 
       Notifier.handle_event({:chain_event, :blocks, blocks})
-      assert_text(session, TransactionPage.block_confirmations(), "10")
+      assert_text(session, TransactionPage.block_confirmations(), "5")
     end
   end
 end


### PR DESCRIPTION
Resolves #520 

## Motivation

Block confirmations was not live updating on transaction detail page

## Changelog

### Bug Fixes
* Added missing data-selector tag used for live update
* Fixed feature test which wasn't failing (always would pass)
