### PR TITLE
Add API Docs link to navbar

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -17,7 +17,12 @@
           <%= link to: transaction_path(@conn, :index, Gettext.get_locale), class: "nav-link topnav-nav-link" do %>
             <%= gettext("Transactions") %>
           <% end %>
-        </li>  
+        </li>
+        <li class="nav-item">
+          <%= link to: api_docs_path(@conn, :index, Gettext.get_locale), class: "nav-link topnav-nav-link" do %>
+            <%= gettext("API") %>
+          <% end %>
+        </li>
       </ul>
       <%= form_for @conn, chain_path(@conn, :search, Gettext.get_locale), [class: "form-inline my-2 my-lg-0", method: :get, enforce_utf8: false], fn f -> %>
         <div class="input-group">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Internal Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:27
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:32
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
@@ -521,17 +521,17 @@ msgid "Contract Creation"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:34
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:39
 msgid "Mainnet"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:38
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:43
 msgid "POA Core"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:37
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:42
 msgid "POA Sokol"
 msgstr ""
 
@@ -780,4 +780,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/token/show.html.eex:33
 msgid "Total Supply"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:23
+msgid "API"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -326,7 +326,7 @@ msgstr ""
 msgid "Internal Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:27
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:32
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
@@ -533,17 +533,17 @@ msgid "Contract Creation"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:34
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:39
 msgid "Mainnet"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:38
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:43
 msgid "POA Core"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:37
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:42
 msgid "POA Sokol"
 msgstr ""
 
@@ -792,4 +792,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/token/show.html.eex:33
 msgid "Total Supply"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:23
+msgid "API"
 msgstr ""

--- a/apps/explorer_web/assets/js/lib/loading_element.js
+++ b/apps/explorer_web/assets/js/lib/loading_element.js
@@ -3,7 +3,6 @@ import $ from 'jquery'
 $('button[data-loading="animation"]').click(event => {
   const clickedButton = $(event.target)
 
-  clickedButton.addClass("d-none")
-  $('#loading').removeClass("d-none")
-
+  clickedButton.addClass('d-none')
+  $('#loading').removeClass('d-none')
 })


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/138

## Motivation

* For users to be able to click through to the API docs page, we want to add a link to to the top navigation bar.

## Changelog

### Enhancements
* Adding API link to `_topnav.html.eex`
* Regenerating gettext files.
* Fixing ESLint errors that sneaked into master.

### Bug Fixes
n/a

### Incompatible Changes
n/a

## Upgrading
n/a
