### PR TITLE
Use CTE for optimized address transactions query

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -179,13 +179,10 @@ defmodule Explorer.Chain do
       when is_list(options) do
     direction = Keyword.get(options, :direction)
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
-    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    # Added transaction.hash to order_by to force postgres to not use `transactions_recent_collated_index` for an
-    # index_scan before filtering based on the WHERE clauses (i.e. to speed up the query)
-    Transaction
-    |> order_by([transaction], desc: transaction.block_number, desc: transaction.index, asc: transaction.hash)
-    |> handle_paging_options(paging_options)
+    options
+    |> Keyword.get(:paging_options, @default_paging_options)
+    |> fetch_transactions()
     |> Transaction.where_address_fields_match(address_hash, direction)
     |> join_associations(necessity_by_association)
     |> Transaction.preload_token_transfers(address_hash)


### PR DESCRIPTION
Resolves #521 

## Motivation
Address page needs to load quickly (postgres needs to consistently pick the fastest query plan)

## Changelog

### Enhancements
* Use Common Table Expression to force postgres to build a temporary table of transaction hashes that match the address

Before:
```sql
SELECT * FROM "transactions" AS t0 WHERE (t0."hash" = ANY(
	(
	  SELECT t0.hash AS hash
	  FROM transactions AS t0
	  WHERE t0.to_address_hash = $1 OR t0.from_address_hash = $1 OR t0.created_contract_address_hash = $1
	)
	UNION
	(
	  SELECT tt.transaction_hash AS hash
	  FROM token_transfers AS tt
	  WHERE tt.to_address_hash = $1 OR tt.from_address_hash = $1
	)
))
ORDER BY t0.block_number DESC, t0.index DESC, t0.hash
LIMIT 50
```

Query Plan:
```
Limit  (cost=818157.59..818157.71 rows=50 width=310) (actual time=12495.738..12495.775 rows=50 loops=1)
  ->  Sort  (cost=818157.59..823078.50 rows=1968364 width=310) (actual time=12495.736..12495.753 rows=50 loops=1)
        Sort Key: t0.block_number DESC, t0.index DESC, t0.hash
        Sort Method: top-N heapsort  Memory: 50kB
        ->  Hash Join  (cost=182711.71..752769.95 rows=1968364 width=310) (actual time=2231.684..12433.842 rows=101856 loops=1)
              Hash Cond: (t0.hash = t0_1.hash)
              ->  Seq Scan on transactions t0  (cost=0.00..230722.27 rows=3936727 width=310) (actual time=0.021..3167.176 rows=4145421 loops=1)
              ->  Hash  (cost=180831.39..180831.39 rows=97225 width=32) (actual time=2127.996..2127.996 rows=101856 loops=1)
                    Buckets: 65536  Batches: 2  Memory Usage: 3760kB
                    ->  Unique  (cost=179373.02..179859.14 rows=97225 width=32) (actual time=2005.071..2090.523 rows=101856 loops=1)
                          ->  Sort  (cost=179373.02..179616.08 rows=97225 width=32) (actual time=2005.070..2041.914 rows=101856 loops=1)
                                Sort Key: t0_1.hash
                                Sort Method: external merge  Disk: 4272kB
                                ->  Append  (cost=4199.75..168990.89 rows=97225 width=32) (actual time=47.396..1910.951 rows=101856 loops=1)
                                      ->  Bitmap Heap Scan on transactions t0_1  (cost=4199.75..167982.49 rows=97217 width=33) (actual time=47.395..1871.992 rows=101856 loops=1)
                                            Recheck Cond: ((to_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea) OR (from_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea) OR (created_contract_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea))
                                            Heap Blocks: exact=16931
                                            ->  BitmapOr  (cost=4199.75..4199.75 rows=97240 width=0) (actual time=44.520..44.520 rows=0 loops=1)
                                                  ->  Bitmap Index Scan on transactions_to_address_hash_index  (cost=0.00..4082.95 rows=96319 width=0) (actual time=44.473..44.473 rows=101855 loops=1)
                                                        Index Cond: (to_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea)
                                                  ->  Bitmap Index Scan on transactions_from_address_hash_index  (cost=0.00..39.45 rows=920 width=0) (actual time=0.027..0.027 rows=0 loops=1)
                                                        Index Cond: (from_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea)
                                                  ->  Bitmap Index Scan on transactions_created_contract_address_hash_index  (cost=0.00..4.44 rows=1 width=0) (actual time=0.018..0.018 rows=1 loops=1)
                                                        Index Cond: (created_contract_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea)
                                      ->  Bitmap Heap Scan on token_transfers tt  (cost=8.62..36.16 rows=8 width=33) (actual time=0.038..0.038 rows=0 loops=1)
                                            Recheck Cond: ((to_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea) OR (from_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea))
                                            ->  BitmapOr  (cost=8.62..8.62 rows=8 width=0) (actual time=0.037..0.037 rows=0 loops=1)
                                                  ->  Bitmap Index Scan on token_transfers_hash_to_hash  (cost=0.00..4.30 rows=3 width=0) (actual time=0.024..0.024 rows=0 loops=1)
                                                        Index Cond: (to_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea)
                                                  ->  Bitmap Index Scan on token_transfers_hash_from_hash  (cost=0.00..4.32 rows=5 width=0) (actual time=0.011..0.011 rows=0 loops=1)
                                                        Index Cond: (from_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea)
Planning time: 5.981 ms
Execution time: 12497.813 ms
```

After:
```sql
SELECT * FROM transactions AS t0
INNER JOIN (WITH hashes AS (
	  (
	    SELECT t0.hash AS hash
	    FROM transactions AS t0
	    WHERE t0.to_address_hash = $1 OR t0.from_address_hash = $1 OR t0.created_contract_address_hash = $1
	  )
	  UNION ALL
	  (
	    SELECT tt.transaction_hash AS hash
	    FROM token_transfers AS tt
	    WHERE tt.to_address_hash = $1 OR tt.from_address_hash = $1
	  )
	)
SELECT * FROM hashes) AS f1 ON t0.hash = f1.hash
ORDER BY t0.block_number DESC, t0.index DESC
LIMIT 50
```

Query Plan:
```
Limit  (cost=3397.75..3397.88 rows=50 width=386) (actual time=0.205..0.205 rows=0 loops=1)
  ->  Sort  (cost=3397.75..3398.46 rows=282 width=386) (actual time=0.204..0.204 rows=0 loops=1)
        Sort Key: t0.block_number DESC, t0.index DESC
        Sort Method: quicksort  Memory: 25kB
        ->  Nested Loop  (cost=1057.45..3388.38 rows=282 width=386) (actual time=0.112..0.112 rows=0 loops=1)
              ->  CTE Scan on hashes  (cost=1057.02..1062.66 rows=282 width=32) (actual time=0.111..0.111 rows=0 loops=1)
                    CTE hashes
                      ->  Append  (cost=19.54..1057.02 rows=282 width=33) (actual time=0.110..0.110 rows=0 loops=1)
                            ->  Bitmap Heap Scan on transactions t0_1  (cost=19.54..1021.45 rows=275 width=33) (actual time=0.082..0.082 rows=0 loops=1)
                                  Recheck Cond: ((to_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea) OR (from_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea) OR (created_contract_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea))
                                  ->  BitmapOr  (cost=19.54..19.54 rows=275 width=0) (actual time=0.077..0.077 rows=0 loops=1)
                                        ->  Bitmap Index Scan on transactions_to_address_hash_index  (cost=0.00..4.72 rows=40 width=0) (actual time=0.028..0.028 rows=0 loops=1)
                                              Index Cond: (to_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea)
                                        ->  Bitmap Index Scan on transactions_from_address_hash_index  (cost=0.00..10.18 rows=234 width=0) (actual time=0.027..0.027 rows=0 loops=1)
                                              Index Cond: (from_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea)
                                        ->  Bitmap Index Scan on transactions_created_contract_address_hash_index  (cost=0.00..4.43 rows=1 width=0) (actual time=0.022..0.022 rows=0 loops=1)
                                              Index Cond: (created_contract_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea)
                            ->  Bitmap Heap Scan on token_transfers tt  (cost=8.62..32.76 rows=7 width=33) (actual time=0.028..0.028 rows=0 loops=1)
                                  Recheck Cond: ((to_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea) OR (from_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea))
                                  ->  BitmapOr  (cost=8.62..8.62 rows=7 width=0) (actual time=0.028..0.028 rows=0 loops=1)
                                        ->  Bitmap Index Scan on token_transfers_to_address_hash_index  (cost=0.00..4.30 rows=3 width=0) (actual time=0.017..0.017 rows=0 loops=1)
                                              Index Cond: (to_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea)
                                        ->  Bitmap Index Scan on token_transfers_from_address_hash_index  (cost=0.00..4.31 rows=4 width=0) (actual time=0.011..0.011 rows=0 loops=1)
                                              Index Cond: (from_address_hash = '\x698bf6943bab687b2756394624aa183f434f65da'::bytea)
              ->  Index Scan using transactions_pkey on transactions t0  (cost=0.42..8.23 rows=1 width=354) (never executed)
                    Index Cond: (hash = hashes.hash)
Planning time: 3.132 ms
Execution time: 3.896 ms
```