### PR TITLE
Fix dropdown hover bg color

### DIFF
--- a/apps/block_scout_web/assets/css/theme/_poa_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_poa_variables.scss
@@ -568,7 +568,7 @@ $dropdown-box-shadow:               0 .5rem 1rem rgba($black, .175) !default;
 
 $dropdown-link-color:               $gray-900 !default;
 $dropdown-link-hover-color:         darken($gray-900, 5%) !default;
-$dropdown-link-hover-bg:            $gray-100 !default;
+$dropdown-link-hover-bg:            $primary !default;
 
 $dropdown-link-active-color:        $component-active-color !default;
 $dropdown-link-active-bg:           $component-active-bg !default;


### PR DESCRIPTION
Fixes #550 

## Motivation

The network drop-down links were the same color as the background color and could not be viewed.

## Before
<img width="234" alt="screen shot 2018-08-15 at 12 50 31 pm" src="https://user-images.githubusercontent.com/17620007/44160978-0a16d680-a08a-11e8-8051-729e2c6caaeb.png">

## After
<img width="310" alt="screen shot 2018-08-15 at 12 50 18 pm" src="https://user-images.githubusercontent.com/17620007/44160994-113de480-a08a-11e8-92b3-beeaabf0a7c4.png">


## Changelog

- Changed the `dropdown-item:hover` attribute to `$primary`

