### PR TITLE
Add API txlistinternal action for account module

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -37,7 +37,7 @@ defmodule BlockScoutWeb.Etherscan do
   @account_txlist_example_value %{
     "status" => "1",
     "message" => "OK",
-    result: [
+    "result" => [
       %{
         "blockNumber" => "65204",
         "timeStamp" => "1439232889",
@@ -68,10 +68,37 @@ defmodule BlockScoutWeb.Etherscan do
     "result" => []
   }
 
+  @account_txlistinternal_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    "result" => [
+      %{
+        "blockNumber" => "6153702",
+        "timeStamp" => "1534362606",
+        "from" => "0x2ca1e3f250f56f1761b9a52bc42db53986085eff",
+        "to" => "",
+        "value" => "5488334153118633",
+        "contractAddress" => "0x883103875d905c11f9ac7dacbfc16deb39655361",
+        "input" => "",
+        "type" => "create",
+        "gas" => "814937",
+        "gasUsed" => "536262",
+        "isError" => "0",
+        "errCode" => ""
+      }
+    ]
+  }
+
+  @account_txlistinternal_example_value_error %{
+    "status" => "0",
+    "message" => "No internal transactions found",
+    "result" => []
+  }
+
   @logs_getlogs_example_value %{
     "status" => "1",
     "message" => "OK",
-    result: [
+    "result" => [
       %{
         "address" => "0x33990122638b9132ca29c723bdf037f1a891a70c",
         "topics" => [
@@ -195,6 +222,44 @@ defmodule BlockScoutWeb.Etherscan do
         type: "confirmations",
         definition: "A number equal to the current block height minus the transaction's block-number.",
         example: ~s("6005998")
+      }
+    }
+  }
+
+  @internal_transaction %{
+    name: "InternalTransaction",
+    fields: %{
+      blockNumber: @block_number_type,
+      timeStamp: %{
+        type: "timestamp",
+        definition: "The transaction's block-timestamp.",
+        example: ~s("1439232889")
+      },
+      from: @address_hash_type,
+      to: @address_hash_type,
+      value: @wei_type,
+      contractAddress: @address_hash_type,
+      input: %{
+        type: "input",
+        definition: "Data sent along with the call. A variable-byte-length binary.",
+        example: ~s("0x797af627d02e23b68e085092cd0d47d6cfb54be025f37b5989c0264398f534c08af7dea9")
+      },
+      type: %{
+        type: "type",
+        definition: ~s(Possible values: "create", "call", "reward", or "suicide"),
+        example: ~s("create")
+      },
+      gas: @gas_type,
+      gasUsed: @gas_type,
+      isError: %{
+        type: "error",
+        enum: ~s(["0", "1"]),
+        enum_interpretation: %{"0" => "ok", "1" => "rejected/cancelled"}
+      },
+      errCode: %{
+        type: "string",
+        definition: "Error message when call type error.",
+        example: ~s("Out of gas")
       }
     }
   }
@@ -383,6 +448,43 @@ defmodule BlockScoutWeb.Etherscan do
     ]
   }
 
+  @account_txlistinternal_action %{
+    name: "txlistinternal",
+    description: "Get internal transactions by transaction hash. Up to a maximum of 10,000 internal transactions.",
+    required_params: [
+      %{
+        key: "txhash",
+        placeholder: "transactionHash",
+        type: "string",
+        description: "Transaction hash. Hash of contents of the transaction."
+      }
+    ],
+    optional_params: [],
+    responses: [
+      %{
+        code: "200",
+        description: "successful operation",
+        example_value: Jason.encode!(@account_txlistinternal_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: %{
+              type: "array",
+              array_type: @internal_transaction
+            }
+          }
+        }
+      },
+      %{
+        code: "200",
+        description: "error",
+        example_value: Jason.encode!(@account_txlistinternal_example_value_error)
+      }
+    ]
+  }
+
   @logs_getlogs_action %{
     name: "getLogs",
     description: "Get event logs for an address and/or topics. Up to a maximum of 1,000 event logs.",
@@ -503,7 +605,8 @@ defmodule BlockScoutWeb.Etherscan do
     actions: [
       @account_balance_action,
       @account_balancemulti_action,
-      @account_txlist_action
+      @account_txlist_action,
+      @account_txlistinternal_action
     ]
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -28,6 +28,11 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
     RPCView.render("show.json", data: data)
   end
 
+  def render("txlistinternal.json", %{internal_transactions: internal_transactions}) do
+    data = Enum.map(internal_transactions, &prepare_internal_transaction/1)
+    RPCView.render("show.json", data: data)
+  end
+
   def render("error.json", assigns) do
     RPCView.render("error.json", assigns)
   end
@@ -52,6 +57,23 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "cumulativeGasUsed" => "#{transaction.cumulative_gas_used}",
       "gasUsed" => "#{transaction.gas_used}",
       "confirmations" => "#{transaction.confirmations}"
+    }
+  end
+
+  defp prepare_internal_transaction(internal_transaction) do
+    %{
+      "blockNumber" => "#{internal_transaction.block_number}",
+      "timeStamp" => "#{DateTime.to_unix(internal_transaction.block_timestamp)}",
+      "from" => "#{internal_transaction.from_address_hash}",
+      "to" => "#{internal_transaction.to_address_hash}",
+      "value" => "#{internal_transaction.value.value}",
+      "contractAddress" => "#{internal_transaction.created_contract_address_hash}",
+      "input" => "#{internal_transaction.input}",
+      "type" => "#{internal_transaction.type}",
+      "gas" => "#{internal_transaction.gas}",
+      "gasUsed" => "#{internal_transaction.gas_used}",
+      "isError" => if(internal_transaction.error, do: "1", else: "0"),
+      "errCode" => "#{internal_transaction.error}"
     }
   end
 end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1461,7 +1461,17 @@ defmodule Explorer.Chain do
     where(query, [transaction], transaction.index < ^index)
   end
 
-  defp where_transaction_has_multiple_internal_transactions(query) do
+  @doc """
+  Ensures the following conditions are true:
+
+    * excludes internal transactions of type call with no siblings in the
+      transaction
+    * includes internal transactions of type create, reward, or suicide
+      even when they are alone in the parent transaction
+
+  """
+  @spec where_transaction_has_multiple_internal_transactions(Ecto.Query.t()) :: Ecto.Query.t()
+  def where_transaction_has_multiple_internal_transactions(query) do
     where(
       query,
       [internal_transaction, transaction],

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -853,6 +853,32 @@ defmodule Explorer.ChainTest do
       assert actual.id == expected.id
     end
 
+    test "includes internal transactions of type `reward` even when they are alone in the parent transaction" do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      expected = insert(:internal_transaction, index: 0, transaction: transaction, type: :reward)
+
+      actual = Enum.at(Chain.transaction_to_internal_transactions(transaction), 0)
+
+      assert actual.id == expected.id
+    end
+
+    test "includes internal transactions of type `suicide` even when they are alone in the parent transaction" do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      expected = insert(:internal_transaction, index: 0, transaction: transaction, gas: nil, type: :suicide)
+
+      actual = Enum.at(Chain.transaction_to_internal_transactions(transaction), 0)
+
+      assert actual.id == expected.id
+    end
+
     test "returns the internal transactions in ascending index order" do
       transaction =
         :transaction


### PR DESCRIPTION
* Issue link: https://github.com/poanetwork/blockscout/issues/138

## Motivation
* For users to be able to get a list of internal transactions for a
given transaction hash (Etherscan-compatible).

## Changelog

### Enhancements
* Adding `Explorer.Etherscan.list_internal_transactions/1` to fetch
internal transactions data as needed to be Etherscan-compatible.
* Adding `txlistinternal/2` action to `API.RPC.AddressController`
* Adding `txlistinternal.json` `render/2` function head to
`API.RPC.AddressView` to render internal transaction lists as needed.
* Adding documentation for the new action. Documentation data lives in
`BlockScoutWeb.Etherscan`
* Making `where_transaction_has_multiple_internal_transactions/1` a
public function and adding doc, spec, and two new tests for it. This was
necessary to use it from
`Explorer.Etherscan.list_internal_transactions/1`.

### Bug Fixes
n/a

### Incompatible Changes
n/a

## Upgrading
n/a