### PR TITLE
Contributors sees token transfers on the home page

### DIFF
--- a/apps/block_scout_web/assets/css/components/_card.scss
+++ b/apps/block_scout_web/assets/css/components/_card.scss
@@ -34,7 +34,9 @@
 }
 
 .card-chain-transactions {
-  height: 694px;
+  min-height: 694px;
 
-  @media (max-width: 767px) { height: 1231px; }
+  @media (max-width: 767px) {
+    min-height: 1231px;
+  }
 }

--- a/apps/block_scout_web/assets/css/components/_tile.scss
+++ b/apps/block_scout_web/assets/css/components/_tile.scss
@@ -138,3 +138,23 @@
     margin: 0;
   }
 }
+
+.tile-separator {
+  min-width: 13.75rem;
+  height: .4375rem;
+  margin-top: .5rem;
+  border-top: 1px solid $border-color;
+  border-bottom: 1px solid $border-color;
+
+  &:first-child {
+    margin-right: .3125rem;
+  }
+
+  &:not(:first-child) {
+    margin-left: .3125rem;
+  }
+
+  & + a {
+    width: 14.375rem;
+  }
+}

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tile.html.eex
@@ -1,4 +1,4 @@
-<div class="tile tile-type-<%= BlockScoutWeb.TransactionView.type_suffix(@transaction) %> tile-status--<%= BlockScoutWeb.TransactionView.status(@transaction) %> fade-up" data-test="<%= BlockScoutWeb.TransactionView.type_suffix(@transaction) %>" data-transaction-hash="<%= @transaction.hash %>">
+<div class="tile tile-type-<%= BlockScoutWeb.TransactionView.type_suffix(@transaction) %> tile-status--<%= BlockScoutWeb.TransactionView.status(@transaction) %>" data-test="<%= BlockScoutWeb.TransactionView.type_suffix(@transaction) %>" data-transaction-hash="<%= @transaction.hash %>">
   <div class="row" data-test="chain_transaction">
     <div class="col-md-2 d-flex flex-row flex-md-column align-items-left justify-content-start justify-content-lg-center mb-1 mb-md-0 pl-md-4">
       <span class="tile-label" data-test="transaction_type">
@@ -10,19 +10,25 @@
     </div>
     <div class="col-md-7 col-lg-8 d-flex flex-column pr-2 pr-sm-2 pr-md-0">
       <%= render BlockScoutWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @transaction.hash %>
-      <span class="text-nowrap">
-        <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @transaction.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@transaction.from_address), locale: @locale %>
-        &rarr;
-        <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: BlockScoutWeb.TransactionView.to_address_hash(@transaction), contract: BlockScoutWeb.AddressView.contract?(@transaction.to_address), locale: @locale %>
-      </span>
-      <span class="d-flex flex-md-row flex-column mt-3 mt-md-0">
-        <span class="tile-title">
-          <%= BlockScoutWeb.TransactionView.value(@transaction, include_label: false) %> <%= gettext "Ether" %>
+
+      <%= if BlockScoutWeb.TransactionView.display_transaction_info?(@transaction) do %>
+        <span class="text-nowrap">
+          <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @transaction.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@transaction.from_address), locale: @locale %>
+          &rarr;
+          <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: BlockScoutWeb.TransactionView.to_address_hash(@transaction), contract: BlockScoutWeb.AddressView.contract?(@transaction.to_address), locale: @locale %>
         </span>
-        <span class="ml-0 ml-md-1 text-nowrap"> <%= BlockScoutWeb.TransactionView.formatted_fee(@transaction, denomination: :ether, include_label: false) %> <%= gettext "TX Fee" %></span>
-      </span>
+
+        <span class="d-flex flex-md-row flex-column mt-3 mt-md-0">
+          <span class="tile-title">
+            <%= BlockScoutWeb.TransactionView.value(@transaction, include_label: false) %> <%= gettext "Ether" %>
+          </span>
+          <span class="ml-0 ml-md-1 text-nowrap">
+            <%= BlockScoutWeb.TransactionView.formatted_fee(@transaction, denomination: :ether, include_label: false) %> <%= gettext "TX Fee" %>
+          </span>
+        </span>
+      <% end %>
     </div>
-    <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column justify-content-start text-md-right mt-3 mt-md-0">
+    <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column flex-nowrap justify-content-start text-md-right mt-3 mt-md-0">
       <span class="mr-2 mr-md-0">
         <%= link(
           gettext("Block #%{number}", number: to_string(@transaction.block.number)),
@@ -31,5 +37,30 @@
       </span>
       <span data-from-now="<%= @transaction.block.timestamp %>"></span>
     </div>
+
+    <%= if BlockScoutWeb.TransactionView.involves_token_transfers?(@transaction) do %>
+      <div class="offset-md-2 col-md-10">
+        <hr class="mt-3 mb-3 w-100" />
+        <p class="tile-title"><%= gettext "Transfers" %></p>
+      </div>
+
+      <%= render(
+            BlockScoutWeb.TransactionView,
+            "_token_transfer.html",
+            locale: @locale,
+            token_transfer: BlockScoutWeb.TransactionView.first_token_transfer(@transaction)) %>
+
+      <%= if more_than_one_token_transfer?(@transaction) do %>
+        <div class="offset-md-2 col-10 col-md-10 col-lg-8 d-flex flex-row mt-1 mb-2 pr-0">
+          <span class="tile-separator"></span>
+          <%= link(
+            gettext("View %{number} more transfers in this transaction", number: token_transfers_left_to_show(@transaction)),
+            to: transaction_path(BlockScoutWeb.Endpoint, :show, @locale, @transaction.hash),
+            class: "text-center"
+          )%>
+          <span class="tile-separator"></span>
+        </div>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
@@ -1,0 +1,12 @@
+<div class="offset-md-2 col-md-10 col-lg-8 d-flex flex-column mt-1 mb-2">
+  <span class="text-nowrap">
+    <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @token_transfer.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@token_transfer.from_address), locale: @locale %>
+    &rarr;
+    <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @token_transfer.to_address_hash, contract: BlockScoutWeb.AddressView.contract?(@token_transfer.to_address), locale: @locale %>
+  </span>
+
+  <span class="tile-title">
+    <%= token_transfer_amount(@token_transfer) %>
+    <%= link(token_symbol(@token_transfer.token), to: token_path(BlockScoutWeb.Endpoint, :show, @locale, @token_transfer.token.contract_address_hash)) %>
+  </span>
+</div>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -291,7 +291,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/_internal_transaction.html.eex:22
 #: lib/block_scout_web/templates/address_transaction/_transaction.html.eex:31
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:68
-#: lib/block_scout_web/templates/transaction/_tile.html.eex:20
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:23
 #: lib/block_scout_web/templates/transaction/overview.html.eex:84
 #: lib/block_scout_web/templates/transaction_internal_transaction/_internal_transaction.html.eex:16
 #: lib/block_scout_web/views/wei_helpers.ex:72
@@ -455,7 +455,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address_transaction/_transaction.html.eex:34
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:69
-#: lib/block_scout_web/templates/transaction/_tile.html.eex:22
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:26
 #: lib/block_scout_web/templates/transaction/overview.html.eex:57
 msgid "TX Fee"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_transaction/_transaction.html.eex:41
 #: lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex:38
-#: lib/block_scout_web/templates/transaction/_tile.html.eex:28
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:34
 msgid "Block #%{number}"
 msgstr ""
 
@@ -733,6 +733,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_transaction/_transaction.html.eex:64
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:18
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:44
 msgid "Transfers"
 msgstr ""
 
@@ -983,6 +984,11 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:38
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:53
 msgid "string"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:57
+msgid "View %{number} more transfers in this transaction"
 msgstr ""
 
 #, elixir-format

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -303,7 +303,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/_internal_transaction.html.eex:22
 #: lib/block_scout_web/templates/address_transaction/_transaction.html.eex:31
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:68
-#: lib/block_scout_web/templates/transaction/_tile.html.eex:20
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:23
 #: lib/block_scout_web/templates/transaction/overview.html.eex:84
 #: lib/block_scout_web/templates/transaction_internal_transaction/_internal_transaction.html.eex:16
 #: lib/block_scout_web/views/wei_helpers.ex:72
@@ -467,7 +467,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address_transaction/_transaction.html.eex:34
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:69
-#: lib/block_scout_web/templates/transaction/_tile.html.eex:22
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:26
 #: lib/block_scout_web/templates/transaction/overview.html.eex:57
 msgid "TX Fee"
 msgstr ""
@@ -652,7 +652,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_transaction/_transaction.html.eex:41
 #: lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex:38
-#: lib/block_scout_web/templates/transaction/_tile.html.eex:28
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:34
 msgid "Block #%{number}"
 msgstr ""
 
@@ -745,6 +745,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_transaction/_transaction.html.eex:64
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:18
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:44
 msgid "Transfers"
 msgstr ""
 
@@ -995,6 +996,11 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:38
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:53
 msgid "string"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:57
+msgid "View %{number} more transfers in this transaction"
 msgstr ""
 
 #, elixir-format

--- a/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.ChainControllerTest do
 
   import BlockScoutWeb.Router.Helpers, only: [chain_path: 3, block_path: 4, transaction_path: 4, address_path: 4]
 
-  describe "GET index/2 without a locale" do
+  describe "GET show/2 without a locale" do
     test "redirects to the en locale", %{conn: conn} do
       conn = get(conn, "/")
 
@@ -11,7 +11,7 @@ defmodule BlockScoutWeb.ChainControllerTest do
     end
   end
 
-  describe "GET index/2 with a locale" do
+  describe "GET show/2 with a locale" do
     test "returns a welcome message", %{conn: conn} do
       conn = get(conn, chain_path(BlockScoutWeb.Endpoint, :show, %{locale: :en}))
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -639,6 +639,7 @@ defmodule Explorer.Chain do
     fetch_transactions()
     |> where([transaction], transaction.hash in ^hashes)
     |> join_associations(necessity_by_association)
+    |> preload([{:token_transfers, [:token, :from_address, :to_address]}])
     |> Repo.all()
   end
 
@@ -1047,6 +1048,7 @@ defmodule Explorer.Chain do
     |> where([transaction], not is_nil(transaction.block_number) and not is_nil(transaction.index))
     |> order_by([transaction], desc: transaction.block_number, desc: transaction.index)
     |> join_associations(necessity_by_association)
+    |> preload([{:token_transfers, [:token, :from_address, :to_address]}])
     |> Repo.all()
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -528,6 +528,38 @@ defmodule Explorer.ChainTest do
              |> Chain.hashes_to_transactions(necessity_by_association: %{block: :optional})
              |> Enum.all?(&(&1.hash in [hash_without_index1, hash_without_index2]))
     end
+
+    test "returns transactions with token_transfers preloaded" do
+      token_contract_address = insert(:contract_address)
+
+      token = insert(:token, contract_address: token_contract_address)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(
+        :token_transfer,
+        to_address: build(:address),
+        transaction: transaction,
+        token_contract_address: token_contract_address,
+        token: token
+      )
+
+      insert(
+        :token_transfer,
+        to_address: build(:address),
+        transaction: transaction,
+        token_contract_address: token_contract_address,
+        token: token
+      )
+
+      fetched_transaction = List.first(Explorer.Chain.recent_collated_transactions())
+
+      assert fetched_transaction.hash == transaction.hash
+      refute fetched_transaction.token_transfers == []
+    end
   end
 
   describe "list_blocks/2" do
@@ -1105,6 +1137,38 @@ defmodule Explorer.ChainTest do
     test "it excludes pending transactions" do
       insert(:transaction)
       assert [] == Explorer.Chain.recent_collated_transactions()
+    end
+
+    test "returns recent transactions with token_transfers preloaded" do
+      token_contract_address = insert(:contract_address)
+
+      token = insert(:token, contract_address: token_contract_address)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(
+        :token_transfer,
+        to_address: build(:address),
+        transaction: transaction,
+        token_contract_address: token_contract_address,
+        token: token
+      )
+
+      insert(
+        :token_transfer,
+        to_address: build(:address),
+        transaction: transaction,
+        token_contract_address: token_contract_address,
+        token: token
+      )
+
+      fetched_transaction = List.first(Explorer.Chain.recent_collated_transactions())
+
+      assert fetched_transaction.hash == transaction.hash
+      refute fetched_transaction.token_transfers == []
     end
   end
 


### PR DESCRIPTION
resolves #565 

![screen shot 2018-08-22 at 11 26 21](https://user-images.githubusercontent.com/840531/44469628-4c966100-a5fe-11e8-8f78-a766d43cd749.png)


## Motivation

When a contributor is visiting the Home page, when a Token Transfer takes place, they need to see 
 a Token Transfer card instead of the Contract Call card.

### Enhancements

The `token_transfers` association is necessary to determine either if the card is a transfer or a contract creation call.
