### PR TITLE
Add stats#tokensupply API endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -1,0 +1,30 @@
+defmodule BlockScoutWeb.API.RPC.StatsController do
+  use BlockScoutWeb, :controller
+
+  alias Explorer.Chain
+
+  def tokensupply(conn, params) do
+    with {:contractaddress_param, {:ok, contractaddress_param}} <- fetch_contractaddress(params),
+         {:format, {:ok, address_hash}} <- to_address_hash(contractaddress_param),
+         {:token, {:ok, token}} <- {:token, Chain.token_from_address_hash(address_hash)} do
+      render(conn, "tokensupply.json", token.total_supply)
+    else
+      {:contractaddress_param, :error} ->
+        render(conn, :error, error: "Query parameter contractaddress is required")
+
+      {:format, :error} ->
+        render(conn, :error, error: "Invalid contractaddress format")
+
+      {:token, {:error, :not_found}} ->
+        render(conn, :error, error: "contractaddress not found")
+    end
+  end
+
+  defp fetch_contractaddress(params) do
+    {:contractaddress_param, Map.fetch(params, "contractaddress")}
+  end
+
+  defp to_address_hash(address_hash_string) do
+    {:format, Chain.string_to_address_hash(address_hash_string)}
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -144,6 +144,12 @@ defmodule BlockScoutWeb.Etherscan do
     "result" => nil
   }
 
+  @stats_tokensupply_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    "result" => "21265524714464"
+  }
+
   @status_type %{
     type: "status",
     enum: ~s(["0", "1"]),
@@ -694,6 +700,44 @@ defmodule BlockScoutWeb.Etherscan do
     ]
   }
 
+  @stats_tokensupply_action %{
+    name: "tokensupply",
+    description: "Get an ERC-20 or ERC-721 token total supply by contract address.",
+    required_params: [
+      %{
+        key: "contractaddress",
+        placeholder: "contractAddressHash",
+        type: "string",
+        description: "A 160-bit code used for identifying contracts."
+      }
+    ],
+    optional_params: [],
+    responses: [
+      %{
+        code: "200",
+        description: "successful operation",
+        example_value: Jason.encode!(@stats_tokensupply_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: %{
+              type: "integer",
+              definition: "The total supply of the token.",
+              example: ~s("1000000000")
+            }
+          }
+        }
+      },
+      %{
+        code: "200",
+        description: "error",
+        example_value: Jason.encode!(@token_gettoken_example_value_error)
+      }
+    ]
+  }
+
   @account_module %{
     name: "account",
     actions: [
@@ -714,7 +758,12 @@ defmodule BlockScoutWeb.Etherscan do
     actions: [@token_gettoken_action]
   }
 
-  @documentation [@account_module, @logs_module, @token_module]
+  @stats_module %{
+    name: "stats",
+    actions: [@stats_tokensupply_action]
+  }
+
+  @documentation [@account_module, @logs_module, @token_module, @stats_module]
 
   def get_documentation do
     @documentation

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -32,7 +32,8 @@ defmodule BlockScoutWeb.Router do
       "block" => RPC.BlockController,
       "account" => RPC.AddressController,
       "logs" => RPC.LogsController,
-      "token" => RPC.TokenController
+      "token" => RPC.TokenController,
+      "stats" => RPC.StatsController
     })
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
@@ -1,0 +1,13 @@
+defmodule BlockScoutWeb.API.RPC.StatsView do
+  use BlockScoutWeb, :view
+
+  alias BlockScoutWeb.API.RPC.RPCView
+
+  def render("tokensupply.json", token_supply) do
+    RPCView.render("show.json", data: token_supply)
+  end
+
+  def render("error.json", assigns) do
+    RPCView.render("error.json", assigns)
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -1,0 +1,77 @@
+defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
+  use BlockScoutWeb.ConnCase
+
+  describe "tokensupply" do
+    test "with missing contract address", %{conn: conn} do
+      params = %{
+        "module" => "stats",
+        "action" => "tokensupply"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "contractaddress is required"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with an invalid contractaddress hash", %{conn: conn} do
+      params = %{
+        "module" => "stats",
+        "action" => "tokensupply",
+        "contractaddress" => "badhash"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "Invalid contractaddress format"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with a contractaddress that doesn't exist", %{conn: conn} do
+      params = %{
+        "module" => "stats",
+        "action" => "tokensupply",
+        "contractaddress" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "contractaddress not found"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with valid contractaddress", %{conn: conn} do
+      token = insert(:token)
+
+      params = %{
+        "module" => "stats",
+        "action" => "tokensupply",
+        "contractaddress" => to_string(token.contract_address_hash)
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == to_string(token.total_supply)
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+  end
+end


### PR DESCRIPTION
Issue link: https://github.com/poanetwork/blockscout/issues/571

## Motivation

* For API users to be able to get a token's total supply. Note that API
users are probably better off using the `token#getToken` endpoint which
returns a token's total supply plus other token related data they'll
probably need. Etherscan doesn't support `token#getToken` as of this
writing. This endpoint (`stats#tokensupply`) was added for
Etherscan-compatibility.
  Example usage:

    ```
    /api?module=stats&action=tokensupply&contractAddress={addressHash}
    ```

## Changelog

### Enhancements
* Creating `API.RPC.StatsController` to process tokensupply requests.
* Editing router to route /api?module=stats&... requests to
`API.RPC.StatsController`
* Creating `API.RPC.StatsView` to render responses for the new API
endpoint as needed.
* Adding docs for the new stats#tokensupply endpoint. Documentation data
lives in `BlockScoutWeb.Etherscan`.
 locally.  A common upgrading step is "Database reset and re-index required".*