### PR TITLE
Index TokenBalances

### DIFF
--- a/apps/explorer/lib/explorer/chain/address/token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/token_balance.ex
@@ -1,0 +1,62 @@
+defmodule Explorer.Chain.Address.TokenBalance do
+  @moduledoc """
+  Represents a token balance from an address.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Explorer.Chain.Address.TokenBalance
+  alias Explorer.Chain.{Address, Block, Hash, Token, Wei}
+
+  @typedoc """
+   *  `address` - The `t:Explorer.Chain.Address.t/0` that is the balance's owner.
+   *  `address_hash` - The address hash foreign key.
+   *  `token` - The `t:Explorer.Chain.Token/0` so that the address has the balance.
+   *  `token_contract_address_hash` - The contract address hash foreign key.
+   *  `block_number` - The block's number that the transfer took place.
+   *  `value` - The value that's represents the balance.
+  """
+  @type t :: %__MODULE__{
+          address: %Ecto.Association.NotLoaded{} | Address.t(),
+          address_hash: Hash.Address.t(),
+          token: %Ecto.Association.NotLoaded{} | Token.t(),
+          token_contract_address_hash: Hash.Address,
+          block_number: Block.block_number(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t(),
+          value: Wei.t() | nil
+        }
+
+  schema "address_token_balances" do
+    field(:value, Wei)
+    field(:block_number, :integer)
+    field(:value_fetched_at, :utc_datetime)
+
+    belongs_to(:address, Address, foreign_key: :address_hash, references: :hash, type: Hash.Address)
+
+    belongs_to(
+      :token,
+      Token,
+      foreign_key: :token_contract_address_hash,
+      references: :contract_address_hash,
+      type: Hash.Address
+    )
+
+    timestamps()
+  end
+
+  @optional_fields ~w(value value_fetched_at)a
+  @required_fields ~w(address_hash block_number token_contract_address_hash)a
+  @allowed_fields @optional_fields ++ @required_fields
+
+  @doc false
+  def changeset(%TokenBalance{} = token_balance, attrs) do
+    token_balance
+    |> cast(attrs, @allowed_fields)
+    |> validate_required(@required_fields)
+    |> foreign_key_constraint(:address_hash)
+    |> foreign_key_constraint(:token_contract_address_hash)
+    |> unique_constraint(:block_number, name: :token_balances_address_hash_block_number_index)
+  end
+end

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -9,6 +9,7 @@ defmodule Explorer.Chain.Import do
 
   alias Explorer.Chain.{
     Address,
+    Address.TokenBalance,
     Balance,
     Block,
     Hash,
@@ -66,6 +67,11 @@ defmodule Explorer.Chain.Import do
           optional(:timeout) => timeout
         }
 
+  @type token_balances :: %{
+          required(:params) => params,
+          optional(:timeout) => timeout
+        }
+
   @type all_options :: %{
           optional(:addresses) => addresses_options,
           optional(:balances) => balances_options,
@@ -77,7 +83,8 @@ defmodule Explorer.Chain.Import do
           optional(:timeout) => timeout,
           optional(:token_transfers) => token_transfers_options,
           optional(:tokens) => tokens_options,
-          optional(:transactions) => transactions_options
+          optional(:transactions) => transactions_options,
+          optional(:token_balances) => token_balances
         }
   @type all_result ::
           {:ok,
@@ -112,6 +119,7 @@ defmodule Explorer.Chain.Import do
   @insert_internal_transactions_timeout 60_000
   @insert_logs_timeout 60_000
   @insert_token_transfers_timeout 60_000
+  @insert_token_balances_timeout 60_000
   @insert_tokens_timeout 60_000
   @insert_transactions_timeout 60_000
 
@@ -269,6 +277,7 @@ defmodule Explorer.Chain.Import do
     internal_transactions: InternalTransaction,
     logs: Log,
     token_transfers: TokenTransfer,
+    token_balances: TokenBalance,
     tokens: Token,
     transactions: Transaction
   }
@@ -287,6 +296,7 @@ defmodule Explorer.Chain.Import do
     |> run_logs(ecto_schema_module_to_changes_list_map, full_options)
     |> run_tokens(ecto_schema_module_to_changes_list_map, full_options)
     |> run_token_transfers(ecto_schema_module_to_changes_list_map, full_options)
+    |> run_token_balances(ecto_schema_module_to_changes_list_map, full_options)
   end
 
   defp run_addresses(multi, ecto_schema_module_to_changes_list_map, options)
@@ -463,6 +473,27 @@ defmodule Explorer.Chain.Import do
             token_transfers_changes,
             %{
               timeout: options[:token_transfers][:timeout] || @insert_token_transfers_timeout,
+              timestamps: timestamps
+            }
+          )
+        end)
+
+      _ ->
+        multi
+    end
+  end
+
+  defp run_token_balances(multi, ecto_schema_module_to_changes_list, options)
+       when is_map(ecto_schema_module_to_changes_list) and is_map(options) do
+    case ecto_schema_module_to_changes_list do
+      %{TokenBalance => token_balances_changes} ->
+        timestamps = Map.fetch!(options, :timestamps)
+
+        Multi.run(multi, :token_balances, fn _ ->
+          insert_token_balances(
+            token_balances_changes,
+            %{
+              timeout: options[:token_balances][:timeout] || @insert_token_balances_timeout,
               timestamps: timestamps
             }
           )
@@ -706,6 +737,29 @@ defmodule Explorer.Chain.Import do
         conflict_target: [:transaction_hash, :log_index],
         on_conflict: :replace_all,
         for: TokenTransfer,
+        returning: true,
+        timeout: timeout,
+        timestamps: timestamps
+      )
+  end
+
+  @spec insert_token_balances([map()], %{
+          required(:timeout) => timeout(),
+          required(:timestamps) => timestamps()
+        }) ::
+          {:ok, [TokenBalance.t()]}
+          | {:error, [Changeset.t()]}
+  def insert_token_balances(changes_list, %{timeout: timeout, timestamps: timestamps})
+      when is_list(changes_list) do
+    # order so that row ShareLocks are grabbed in a consistent order
+    ordered_changes_list = Enum.sort_by(changes_list, &{&1.address_hash, &1.block_number})
+
+    {:ok, _} =
+      insert_changes_list(
+        ordered_changes_list,
+        conflict_target: [:address_hash, :block_number],
+        on_conflict: :replace_all,
+        for: TokenBalance,
         returning: true,
         timeout: timeout,
         timestamps: timestamps

--- a/apps/explorer/priv/repo/migrations/20180817021704_create_address_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20180817021704_create_address_token_balances.exs
@@ -1,0 +1,32 @@
+defmodule Explorer.Repo.Migrations.CreateAddressTokenBalances do
+  use Ecto.Migration
+
+  def change do
+    create table(:address_token_balances) do
+      add(:address_hash, references(:addresses, column: :hash, type: :bytea), null: false)
+      add(:block_number, :bigint, null: false)
+
+      add(
+        :token_contract_address_hash,
+        references(:tokens, column: :contract_address_hash, type: :bytea),
+        null: false
+      )
+
+      add(:value, :numeric, precision: 100, default: fragment("NULL"), null: true)
+      add(:value_fetched_at, :utc_datetime, default: fragment("NULL"), null: true)
+
+      timestamps(null: false, type: :utc_datetime)
+    end
+
+    create(unique_index(:address_token_balances, [:address_hash, :block_number]))
+
+    create(
+      unique_index(
+        :address_token_balances,
+        [:address_hash, :block_number],
+        name: :unfetched_token_balances,
+        where: "value_fetched_at IS NULL"
+      )
+    )
+  end
+end

--- a/apps/explorer/test/explorer/import_test.exs
+++ b/apps/explorer/test/explorer/import_test.exs
@@ -5,6 +5,7 @@ defmodule Explorer.Chain.ImportTest do
 
   alias Explorer.Chain.{
     Address,
+    Address.TokenBalance,
     Block,
     Data,
     Log,
@@ -305,6 +306,52 @@ defmodule Explorer.Chain.ImportTest do
                   }
                 ]
               }} = Import.all(@import_data)
+    end
+
+    test "inserts a token_balance" do
+      params = %{
+        addresses: %{
+          params: [
+            %{hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca"},
+            %{hash: "0x515c09c5bba1ed566b02a5b0599ec5d5d0aee73d"},
+            %{hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"}
+          ]
+        },
+        tokens: %{
+          on_conflict: :nothing,
+          params: [
+            %{
+              contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+              type: "ERC-20"
+            }
+          ]
+        },
+        token_balances: %{
+          params: [
+            %{
+              address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+              token_contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+              block_number: "37"
+            },
+            %{
+              address_hash: "0x515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+              token_contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+              block_number: "37"
+            },
+            %{
+              address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+              token_contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+              block_number: "37"
+            }
+          ]
+        }
+      }
+
+      Import.all(params)
+
+      count = Explorer.Repo.one(Ecto.Query.from(t in TokenBalance, select: count(t.id)))
+
+      assert 3 == count
     end
 
     test "with empty map" do

--- a/apps/indexer/lib/indexer/balances.ex
+++ b/apps/indexer/lib/indexer/balances.ex
@@ -40,9 +40,21 @@ defmodule Indexer.Balances do
                                                            is_binary(to_address_hash) and
                                                            is_binary(token_contract_address_hash) ->
       acc
-      |> MapSet.put(%{address_hash: from_address_hash, block_number: block_number})
-      |> MapSet.put(%{address_hash: to_address_hash, block_number: block_number})
-      |> MapSet.put(%{address_hash: token_contract_address_hash, block_number: block_number})
+      |> MapSet.put(%{
+        address_hash: from_address_hash,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: block_number
+      })
+      |> MapSet.put(%{
+        address_hash: to_address_hash,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: block_number
+      })
+      |> MapSet.put(%{
+        address_hash: token_contract_address_hash,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: block_number
+      })
     end)
   end
 

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -213,7 +213,6 @@ defmodule Indexer.BlockFetcher do
         Balances.params_set(%{
           blocks_params: blocks,
           logs_params: logs,
-          token_transfers_params: token_transfers,
           transactions_params: transactions_with_receipts
         })
 

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -42,6 +42,7 @@ defmodule Indexer.BlockFetcher do
                 broadcast: boolean,
                 logs: Import.logs_options(),
                 receipts: Import.receipts_options(),
+                token_balances: Import.token_balances(),
                 token_transfers: Import.token_transfers_options(),
                 tokens: Import.tokens_options(),
                 transactions: Import.transactions_options()
@@ -216,12 +217,15 @@ defmodule Indexer.BlockFetcher do
           transactions_params: transactions_with_receipts
         })
 
+      token_balances = Balances.params_set(%{token_transfers_params: token_transfers})
+
       insert(
         state,
         %{
           range: range,
           addresses: %{params: addresses},
           balances: %{params: balances_params_set},
+          token_balances: %{params: token_balances},
           blocks: %{params: blocks},
           logs: %{params: logs},
           receipts: %{params: receipts},

--- a/apps/indexer/test/indexer/supervisor_test.exs
+++ b/apps/indexer/test/indexer/supervisor_test.exs
@@ -27,6 +27,8 @@ defmodule Indexer.BlockFetcher.SupervisorTest do
   setup :verify_on_exit!
 
   describe "start_link/1" do
+    # See https://github.com/poanetwork/blockscout/issues/597
+    @tag :no_geth
     test "starts fetching blocks from latest and goes down", %{json_rpc_named_arguments: json_rpc_named_arguments} do
       if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
         case Keyword.fetch!(json_rpc_named_arguments, :variant) do


### PR DESCRIPTION
#514 

## Motivation

This PR builds TokenBalances from TokenTransfer already existent data structure and creates in the database.

A TokenBalance is one of the 3 Addresses present in a TokenTransfer: `to_address_hash`, `from_address_hash` and `token_contract_address_hash`.  Every TokenTransfer is broken down and translated into this new entity.

In this PR only the records will be created in the database without their values (`value` and `value_fetched_at`), which will be fetched in the Realtime and Catchup indexers in a different PR, in order to unblock other issues that depend on this schema and improve the changes for the code review.

When the (already in progress #583) TokenBalanceFetcher is plugged to the indexers this infos will be fetched and updated.

## Changelog

### Enhancements

- We'll stop creating `Chain.Balance`s out of TokenTransfers, since TokenTransfer doesn't transfer Coin. If there's a Coin transfer in the same transaction where there is a TokenTransfer a Balance will be created from the Transaction.