### PR TITLE
Fetch TokenBalances values in Realtime and Catchup Indexers

### DIFF
--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
@@ -372,9 +372,97 @@ defmodule EthereumJSONRPCTest do
       end
 
       assert {:ok, subscription} = EthereumJSONRPC.subscribe("newHeads", [], subscribe_named_arguments)
+
       assert :ok = EthereumJSONRPC.unsubscribe(subscription)
 
       assert {:error, :not_found} = EthereumJSONRPC.unsubscribe(subscription)
+    end
+  end
+
+  describe "execute_contract_functions/3" do
+    test "executes the functions with the block_number" do
+      json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+
+      functions = [
+        %{
+          contract_address: "0x0000000000000000000000000000000000000000",
+          data: "0x6d4ce63c",
+          id: "get"
+        }
+      ]
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
+          {:ok,
+           [
+             %{
+               id: id,
+               jsonrpc: "2.0",
+               result: "0x0000000000000000000000000000000000000000000000000000000000000000"
+             }
+           ]}
+        end
+      )
+
+      blockchain_result =
+        {:ok,
+         [
+           %{
+             id: "get",
+             jsonrpc: "2.0",
+             result: "0x0000000000000000000000000000000000000000000000000000000000000000"
+           }
+         ]}
+
+      assert EthereumJSONRPC.execute_contract_functions(
+               functions,
+               json_rpc_named_arguments,
+               block_number: 1000
+             ) == blockchain_result
+    end
+
+    test "executes the functions even when the block_number is not given" do
+      json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+
+      functions = [
+        %{
+          contract_address: "0x0000000000000000000000000000000000000000",
+          data: "0x6d4ce63c",
+          id: "get"
+        }
+      ]
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [%{id: id, method: _, params: [%{data: _, to: _}]}], _options ->
+          {:ok,
+           [
+             %{
+               id: id,
+               jsonrpc: "2.0",
+               result: "0x0000000000000000000000000000000000000000000000000000000000000000"
+             }
+           ]}
+        end
+      )
+
+      blockchain_result =
+        {:ok,
+         [
+           %{
+             id: "get",
+             jsonrpc: "2.0",
+             result: "0x0000000000000000000000000000000000000000000000000000000000000000"
+           }
+         ]}
+
+      assert EthereumJSONRPC.execute_contract_functions(
+               functions,
+               json_rpc_named_arguments
+             ) == blockchain_result
     end
   end
 

--- a/apps/explorer/config/dev/parity.exs
+++ b/apps/explorer/config/dev/parity.exs
@@ -7,6 +7,7 @@ config :explorer,
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: "https://sokol.poa.network",
       method_to_url: [
+        eth_call: "https://sokol-trace.poa.network",
         eth_getBalance: "https://sokol-trace.poa.network",
         trace_replayTransaction: "https://sokol-trace.poa.network"
       ],

--- a/apps/explorer/config/prod/parity.exs
+++ b/apps/explorer/config/prod/parity.exs
@@ -7,6 +7,7 @@ config :explorer,
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: "https://sokol.poa.network",
       method_to_url: [
+        eth_call: "https://sokol-trace.poa.network",
         eth_getBalance: "https://sokol-trace.poa.network",
         trace_replayTransaction: "https://sokol-trace.poa.network"
       ],

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -66,12 +66,10 @@ defmodule Explorer.Chain.Import do
           optional(:on_conflict) => :nothing | :replace_all,
           optional(:timeout) => timeout
         }
-
-  @type token_balances :: %{
+  @type token_balances_options :: %{
           required(:params) => params,
           optional(:timeout) => timeout
         }
-
   @type all_options :: %{
           optional(:addresses) => addresses_options,
           optional(:balances) => balances_options,
@@ -83,8 +81,8 @@ defmodule Explorer.Chain.Import do
           optional(:timeout) => timeout,
           optional(:token_transfers) => token_transfers_options,
           optional(:tokens) => tokens_options,
-          optional(:transactions) => transactions_options,
-          optional(:token_balances) => token_balances
+          optional(:token_balances) => token_balances_options,
+          optional(:transactions) => transactions_options
         }
   @type all_result ::
           {:ok,
@@ -101,6 +99,7 @@ defmodule Explorer.Chain.Import do
              optional(:receipts) => [Hash.Full.t()],
              optional(:token_transfers) => [TokenTransfer.t()],
              optional(:tokens) => [Token.t()],
+             optional(:token_balances) => [TokenBalance.t()],
              optional(:transactions) => [Hash.Full.t()]
            }}
           | {:error, [Changeset.t()]}

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -7,7 +7,7 @@ defmodule Explorer.SmartContract.Reader do
   """
 
   alias Explorer.Chain
-  alias Explorer.Chain.Hash
+  alias Explorer.Chain.{Block, Hash}
   alias EthereumJSONRPC.Encoder
 
   @typedoc """

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -22,8 +22,22 @@ defmodule Explorer.SmartContract.Reader do
 
   @typedoc """
   Options that can be forwarded when calling the Ethereum JSON RPC.
+
+  ## Required
+
+  * `:json_rpc_named_arguments` - the named arguments to `EthereumJSONRPC.json_rpc/2`.
+
+  ## Optional
+
+  * `:block_number` - the block in which to execute the function. Defaults to the `nil` to indicate
+  the latest block as determined by the remote node, which may differ from the latest block number
+  in `Explorer.Chain`.
   """
-  @type contract_call_options :: [{:json_rpc_named_arguments, EthereumJSONRPC.json_rpc_named_arguments()}]
+  @type contract_call_options :: [
+          {:json_rpc_named_arguments, EthereumJSONRPC.json_rpc_named_arguments()},
+          {:block_number, Block.block_number()}
+        ]
+
   @doc """
   Queries the contract functions on the blockchain and returns the call results.
 
@@ -52,8 +66,6 @@ defmodule Explorer.SmartContract.Reader do
   """
   @spec query_verified_contract(Hash.Address.t(), functions()) :: functions_results()
   def query_verified_contract(address_hash, functions) do
-    json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
-
     contract_address = Hash.to_string(address_hash)
 
     abi =
@@ -61,7 +73,7 @@ defmodule Explorer.SmartContract.Reader do
       |> Chain.address_hash_to_smart_contract()
       |> Map.get(:abi)
 
-    query_contract(contract_address, abi, functions, json_rpc_named_arguments)
+    query_contract(contract_address, abi, functions)
   end
 
   @doc """
@@ -82,20 +94,24 @@ defmodule Explorer.SmartContract.Reader do
       ) do
     contract_address = Hash.to_string(address)
 
+    query_contract(contract_address, abi, functions, opts)
+  end
+
+  @spec query_contract(
+          String.t(),
+          term(),
+          functions(),
+          contract_call_options()
+        ) :: functions_results()
+  def query_contract(contract_address, abi, functions, opts \\ []) do
     json_rpc_named_arguments =
       Keyword.get(opts, :json_rpc_named_arguments) || Application.get_env(:explorer, :json_rpc_named_arguments)
 
-    query_contract(contract_address, abi, functions, json_rpc_named_arguments)
-  end
-
-  @spec query_contract(String.t(), term(), functions(), EthereumJSONRPC.json_rpc_named_arguments()) ::
-          functions_results()
-  defp query_contract(contract_address, abi, functions, json_rpc_named_arguments) do
     blockchain_result =
       abi
       |> Encoder.encode_abi(functions)
       |> Enum.map(&setup_call_payload(&1, contract_address))
-      |> EthereumJSONRPC.execute_contract_functions(json_rpc_named_arguments)
+      |> EthereumJSONRPC.execute_contract_functions(json_rpc_named_arguments, opts)
 
     Encoder.decode_abi_results(blockchain_result, abi, functions)
   rescue
@@ -164,7 +180,11 @@ defmodule Explorer.SmartContract.Reader do
     |> Enum.reverse()
   end
 
-  def fetch_current_value_from_blockchain([%{"inputs" => []} = function | tail], contract_address_hash, acc) do
+  def fetch_current_value_from_blockchain(
+        [%{"inputs" => []} = function | tail],
+        contract_address_hash,
+        acc
+      ) do
     values =
       fetch_from_blockchain(contract_address_hash, %{
         name: function["name"],
@@ -204,7 +224,11 @@ defmodule Explorer.SmartContract.Reader do
       |> Enum.filter(fn function -> function["name"] == name end)
       |> List.first()
 
-    fetch_from_blockchain(contract_address_hash, %{name: name, args: args, outputs: function["outputs"]})
+    fetch_from_blockchain(contract_address_hash, %{
+      name: name,
+      args: args,
+      outputs: function["outputs"]
+    })
   end
 
   defp fetch_from_blockchain(contract_address_hash, %{name: name, args: args, outputs: outputs}) do

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1592,6 +1592,15 @@ defmodule Explorer.ChainTest do
     end
   end
 
+  describe "stream_unfetched_token_balances/2" do
+    test "returns only the token balances that have value_fetched_at nil" do
+      token_balance = insert(:token_balance, value_fetched_at: nil)
+      insert(:token_balance)
+
+      assert Chain.stream_unfetched_token_balances([], &[&1.block_number | &2]) == {:ok, [token_balance.block_number]}
+    end
+  end
+
   test "total_supply/0" do
     height = 2_000_000
     insert(:block, number: height)

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -10,6 +10,7 @@ defmodule Explorer.Factory do
 
   alias Explorer.Chain.{
     Address,
+    Address.TokenBalance,
     Balance,
     Block,
     Data,
@@ -437,6 +438,16 @@ defmodule Explorer.Factory do
           "type" => "function"
         }
       ]
+    }
+  end
+
+  def token_balance_factory() do
+    %TokenBalance{
+      address: build(:address),
+      token: build(:token),
+      block_number: block_number(),
+      value: Enum.random(1..100_000),
+      value_fetched_at: DateTime.utc_now()
     }
   end
 

--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -10,7 +10,8 @@ defmodule Indexer.Application do
     BlockFetcher,
     InternalTransactionFetcher,
     PendingTransactionFetcher,
-    TokenFetcher
+    TokenFetcher,
+    TokenBalanceFetcher
   }
 
   @impl Application
@@ -33,6 +34,7 @@ defmodule Indexer.Application do
       {InternalTransactionFetcher,
        name: InternalTransactionFetcher, json_rpc_named_arguments: json_rpc_named_arguments},
       {TokenFetcher, name: TokenFetcher, json_rpc_named_arguments: json_rpc_named_arguments},
+      {TokenBalanceFetcher, name: TokenBalanceFetcher, json_rpc_named_arguments: json_rpc_named_arguments},
       {BlockFetcher.Supervisor, [block_fetcher_supervisor_named_arguments, [name: BlockFetcher.Supervisor]]}
     ]
 

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -29,7 +29,7 @@ defmodule Indexer.BlockFetcher do
                 broadcast: boolean,
                 logs: Import.logs_options(),
                 receipts: Import.receipts_options(),
-                token_balances: Import.token_balances(),
+                token_balances: Import.token_balances_options(),
                 token_transfers: Import.token_transfers_options(),
                 tokens: Import.tokens_options(),
                 transactions: Import.transactions_options()

--- a/apps/indexer/lib/indexer/block_fetcher/catchup.ex
+++ b/apps/indexer/lib/indexer/block_fetcher/catchup.ex
@@ -14,7 +14,8 @@ defmodule Indexer.BlockFetcher.Catchup do
     BlockFetcher,
     InternalTransactionFetcher,
     Sequence,
-    TokenFetcher
+    TokenFetcher,
+    TokenBalanceFetcher
   }
 
   @behaviour BlockFetcher
@@ -113,7 +114,12 @@ defmodule Indexer.BlockFetcher.Catchup do
   end
 
   defp async_import_remaining_block_data(
-         %{transactions: transaction_hashes, addresses: address_hashes, tokens: tokens},
+         %{
+           transactions: transaction_hashes,
+           addresses: address_hashes,
+           tokens: tokens,
+           token_balances: token_balances
+         },
          %{
            address_hash_to_fetched_balance_block_number: address_hash_to_block_number,
            transaction_hash_to_block_number: transaction_hash_to_block_number
@@ -136,6 +142,8 @@ defmodule Indexer.BlockFetcher.Catchup do
     tokens
     |> Enum.map(& &1.contract_address_hash)
     |> TokenFetcher.async_fetch()
+
+    TokenBalanceFetcher.async_fetch(token_balances)
   end
 
   defp stream_fetch_and_import(%__MODULE__{blocks_concurrency: blocks_concurrency} = state, sequence)

--- a/apps/indexer/lib/indexer/token_balance_fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance_fetcher.ex
@@ -1,0 +1,75 @@
+defmodule Indexer.TokenBalanceFetcher do
+  @moduledoc """
+  Fetches the token balances values.
+  """
+
+  alias Indexer.{BufferedTask, TokenBalances}
+  alias Explorer.Chain
+  alias Explorer.Chain.{Hash, Address.TokenBalance}
+
+  @behaviour BufferedTask
+
+  @defaults [
+    flush_interval: 300,
+    max_batch_size: 1,
+    max_concurrency: 10,
+    init_chunk_size: 1,
+    task_supervisor: Indexer.TaskSupervisor
+  ]
+
+  def async_fetch(token_balances_params) do
+    BufferedTask.buffer(__MODULE__, token_balances_params)
+  end
+
+  @doc false
+  def child_spec(provided_opts) do
+    {state, mergable_opts} = Keyword.pop(provided_opts, :json_rpc_named_arguments)
+
+    unless state do
+      raise ArgumentError,
+            ":json_rpc_named_arguments must be provided to `#{__MODULE__}.child_spec " <>
+              "to allow for json_rpc calls when running."
+    end
+
+    opts =
+      @defaults
+      |> Keyword.merge(mergable_opts)
+      |> Keyword.put(:state, state)
+
+    Supervisor.child_spec({BufferedTask, {__MODULE__, opts}}, id: __MODULE__)
+  end
+
+  @impl BufferedTask
+  def init(initial, reducer, _) do
+    {:ok, final} =
+      Chain.stream_unfetched_token_balances(initial, fn token_balances_params, acc ->
+        reducer.(token_balances_params, acc)
+      end)
+
+    final
+  end
+
+  @impl BufferedTask
+  def run(token_balances, _retries, _json_rpc_named_arguments) do
+    {:ok, token_balances_params} =
+      token_balances
+      |> Stream.map(&format_params/1)
+      |> TokenBalances.fetch_token_balances_from_blockchain()
+
+    {:ok, %{token_balances: [_]}} = Chain.import(%{token_balances: %{params: token_balances_params}})
+
+    :ok
+  end
+
+  defp format_params(%TokenBalance{
+         token_contract_address_hash: token_contract_address_hash,
+         address_hash: address_hash,
+         block_number: block_number
+       }) do
+    %{
+      token_contract_address_hash: Hash.to_string(token_contract_address_hash),
+      address_hash: Hash.to_string(address_hash),
+      block_number: block_number
+    }
+  end
+end

--- a/apps/indexer/lib/indexer/token_balances.ex
+++ b/apps/indexer/lib/indexer/token_balances.ex
@@ -1,0 +1,38 @@
+defmodule Indexer.TokenBalances do
+  @moduledoc """
+  Reads Token's balances using Smart Contract functions from the blockchain.
+  """
+
+  alias Explorer.Token.BalanceReader
+
+  def fetch_token_balances_from_blockchain(token_balances) do
+    result =
+      token_balances
+      |> Task.async_stream(&fetch_token_balance/1)
+      |> Enum.map(&format_result/1)
+
+    {:ok, result}
+  end
+
+  defp fetch_token_balance(
+         %{
+           token_contract_address_hash: token_contract_address_hash,
+           address_hash: address_hash,
+           block_number: block_number
+         } = token_balance
+       ) do
+    token_contract_address_hash
+    |> BalanceReader.get_balance_of(address_hash, block_number)
+    |> set_token_balance_value(token_balance)
+  end
+
+  defp set_token_balance_value({:ok, balance}, token_balance) do
+    Map.merge(token_balance, %{value: balance, value_fetched_at: DateTime.utc_now()})
+  end
+
+  defp set_token_balance_value({:error, _}, token_balance) do
+    Map.merge(token_balance, %{value: nil, value_fetched_at: nil})
+  end
+
+  def format_result({_, token_balance}), do: token_balance
+end

--- a/apps/indexer/test/indexer/block_fetcher/catchup/supervisor_test.exs
+++ b/apps/indexer/test/indexer/block_fetcher/catchup/supervisor_test.exs
@@ -13,7 +13,8 @@ defmodule Indexer.BlockFetcher.Catchup.SupervisorTest do
     BlockFetcher,
     BoundInterval,
     InternalTransactionFetcherCase,
-    TokenFetcherCase
+    TokenFetcherCase,
+    TokenBalanceFetcherCase
   }
 
   alias Indexer.BlockFetcher.Catchup
@@ -209,6 +210,7 @@ defmodule Indexer.BlockFetcher.Catchup.SupervisorTest do
       AddressBalanceFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       InternalTransactionFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       TokenFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+      TokenBalanceFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
 
       start_supervised!(
         {Catchup.Supervisor, [%{block_fetcher: %BlockFetcher{json_rpc_named_arguments: json_rpc_named_arguments}}, []]}
@@ -256,6 +258,7 @@ defmodule Indexer.BlockFetcher.Catchup.SupervisorTest do
       AddressBalanceFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       InternalTransactionFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       TokenFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+      TokenBalanceFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       # from `setup :state`
       assert_received :catchup_index
 
@@ -326,6 +329,7 @@ defmodule Indexer.BlockFetcher.Catchup.SupervisorTest do
       AddressBalanceFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       InternalTransactionFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       TokenFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+      TokenBalanceFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       # from `setup :state`
       assert_received :catchup_index
 

--- a/apps/indexer/test/indexer/block_fetcher_test.exs
+++ b/apps/indexer/test/indexer/block_fetcher_test.exs
@@ -16,7 +16,8 @@ defmodule Indexer.BlockFetcherTest do
     BufferedTask,
     InternalTransactionFetcher,
     InternalTransactionFetcherCase,
-    TokenFetcherCase
+    TokenFetcherCase,
+    TokenBalanceFetcherCase
   }
 
   @moduletag capture_log: true
@@ -51,6 +52,7 @@ defmodule Indexer.BlockFetcherTest do
       AddressBalanceFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       InternalTransactionFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       TokenFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+      TokenBalanceFetcherCase.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
 
       %{
         block_fetcher: %BlockFetcher{

--- a/apps/indexer/test/indexer/token_balance_fetcher_test.exs
+++ b/apps/indexer/test/indexer/token_balance_fetcher_test.exs
@@ -1,0 +1,54 @@
+defmodule Indexer.TokenBalanceFetcherTest do
+  use EthereumJSONRPC.Case
+  use Explorer.DataCase
+
+  import Mox
+
+  alias Explorer.Chain.{Address.TokenBalance}
+  alias Indexer.TokenBalanceFetcher
+
+  setup :verify_on_exit!
+  setup :set_mox_global
+
+  describe "init/3" do
+    test "returns unfetched token balances" do
+      %TokenBalance{address_hash: address_hash} =
+        insert(:token_balance, block_number: 1_000, value_fetched_at: nil)
+
+      insert(:token_balance, value_fetched_at: DateTime.utc_now())
+
+      assert TokenBalanceFetcher.init([], &[&1.address_hash| &2], nil) == [address_hash]
+    end
+  end
+
+  describe "run/3" do
+    test "imports the given token balances" do
+      token_balance = insert(:token_balance, value_fetched_at: nil, value: nil)
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [%{id: _, method: _, params: [%{data: _, to: _}, _]}], _options ->
+          {:ok,
+           [
+             %{
+               id: "balanceOf",
+               jsonrpc: "2.0",
+               result: "0x00000000000000000000000000000000000000000000d3c21bcecceda1000000"
+             }
+           ]}
+        end
+      )
+
+      assert TokenBalanceFetcher.run([token_balance], 0, nil) == :ok
+
+      token_balance_updated =
+        TokenBalance
+        |> Explorer.Repo.get_by(address_hash: token_balance.address_hash)
+
+      {:ok, wei_value} = Explorer.Chain.Wei.cast(1_000_000_000_000_000_000_000_000)
+      assert token_balance_updated.value == wei_value
+      assert token_balance_updated.value_fetched_at != nil
+    end
+  end
+end

--- a/apps/indexer/test/indexer/token_balance_fetcher_test.exs
+++ b/apps/indexer/test/indexer/token_balance_fetcher_test.exs
@@ -12,12 +12,11 @@ defmodule Indexer.TokenBalanceFetcherTest do
 
   describe "init/3" do
     test "returns unfetched token balances" do
-      %TokenBalance{address_hash: address_hash} =
-        insert(:token_balance, block_number: 1_000, value_fetched_at: nil)
+      %TokenBalance{address_hash: address_hash} = insert(:token_balance, block_number: 1_000, value_fetched_at: nil)
 
       insert(:token_balance, value_fetched_at: DateTime.utc_now())
 
-      assert TokenBalanceFetcher.init([], &[&1.address_hash| &2], nil) == [address_hash]
+      assert TokenBalanceFetcher.init([], &[&1.address_hash | &2], nil) == [address_hash]
     end
   end
 

--- a/apps/indexer/test/indexer/token_balances_test.exs
+++ b/apps/indexer/test/indexer/token_balances_test.exs
@@ -1,0 +1,98 @@
+defmodule Indexer.TokenBalancesTest do
+  use EthereumJSONRPC.Case
+  use Explorer.DataCase
+
+  doctest Indexer.TokenBalances
+
+  alias Indexer.TokenBalances
+  alias Explorer.Chain.Hash
+
+  import Mox
+
+  setup :verify_on_exit!
+  setup :set_mox_global
+
+  describe "fetch_token_balances_from_blockchain/2" do
+    test "fetches balances of tokens given the address hash" do
+      address = insert(:address)
+      token = insert(:token, contract_address: build(:contract_address))
+      address_hash_string = Hash.to_string(address.hash)
+
+      data = %{
+        token_contract_address_hash: Hash.to_string(token.contract_address_hash),
+        address_hash: address_hash_string,
+        block_number: 1_000
+      }
+
+      get_balance_from_blockchain()
+
+      {:ok, result} = TokenBalances.fetch_token_balances_from_blockchain([data])
+
+      assert %{
+               value: 1_000_000_000_000_000_000_000_000,
+               token_contract_address_hash: token_contract_address_hash,
+               address_hash: address_hash,
+               block_number: 1_000,
+               value_fetched_at: _
+             } = List.first(result)
+    end
+
+    test "does not ignore calls that were returned with error" do
+      address = insert(:address)
+      token = insert(:token, contract_address: build(:contract_address))
+      address_hash_string = Hash.to_string(address.hash)
+
+      data = %{
+        token_contract_address_hash: token.contract_address_hash,
+        address_hash: address_hash_string,
+        block_number: 1_000
+      }
+
+      get_balance_from_blockchain_with_error()
+
+      {:ok, result} = TokenBalances.fetch_token_balances_from_blockchain([data])
+
+      assert %{
+               value: nil,
+               token_contract_address_hash: token_contract_address_hash,
+               address_hash: address_hash,
+               block_number: 1_000,
+               value_fetched_at: nil
+             } = List.first(result)
+    end
+  end
+
+  defp get_balance_from_blockchain() do
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn [%{id: _, method: _, params: [%{data: _, to: _}, _]}], _options ->
+        {:ok,
+         [
+           %{
+             id: "balanceOf",
+             jsonrpc: "2.0",
+             result: "0x00000000000000000000000000000000000000000000d3c21bcecceda1000000"
+           }
+         ]}
+      end
+    )
+  end
+
+  defp get_balance_from_blockchain_with_error() do
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn [%{id: _, method: _, params: [%{data: _, to: _}, _]}], _options ->
+        {:ok,
+         [
+           %{
+             error: %{code: -32015, data: "Reverted 0x", message: "VM execution error."},
+             id: "balanceOf",
+             jsonrpc: "2.0"
+           }
+         ]}
+      end
+    )
+  end
+end

--- a/apps/indexer/test/support/indexer/token_balance_fetcher_case.ex
+++ b/apps/indexer/test/support/indexer/token_balance_fetcher_case.ex
@@ -1,0 +1,16 @@
+defmodule Indexer.TokenBalanceFetcherCase do
+  alias Indexer.TokenBalanceFetcher
+
+  def start_supervised!(options \\ []) when is_list(options) do
+    options
+    |> Keyword.merge(
+      flush_interval: 50,
+      init_chunk_size: 1,
+      max_batch_size: 1,
+      max_concurrency: 1,
+      name: TokenBalanceFetcher
+    )
+    |> TokenBalanceFetcher.child_spec()
+    |> ExUnit.Callbacks.start_supervised!()
+  end
+end


### PR DESCRIPTION
#514 

## Motivation

This PR makes the Indexers to fetch the TokenBalances `value` and `value_fetched_at` both in their own way:
- The Realtime indexer fetches the data synchronously
- The Catchup indexer fetches the data assynchronously


## WIP

- The values are already fetching the values after we've tested it local, but the code still needs some improvements and tests.