### PR TITLE
"Tokens" tab in address page

### DIFF
--- a/apps/block_scout_web/assets/css/components/_tile.scss
+++ b/apps/block_scout_web/assets/css/components/_tile.scss
@@ -1,7 +1,6 @@
 .tile {
   font-size: 12px;
   color: $text-muted;
-  border-radius: 2px;
   line-height: 1.4rem;
   border: 1px solid $border-color;
   border-left: 4px solid $primary;
@@ -48,7 +47,7 @@
       }
     }
 
-    &-token {
+    &-token-transfer {
       border-left: 4px solid $orange;
       padding-bottom: 10px;
 

--- a/apps/block_scout_web/assets/css/components/_tile.scss
+++ b/apps/block_scout_web/assets/css/components/_tile.scss
@@ -49,7 +49,6 @@
 
     &-token {
       border: 1px solid $border-color;
-
     }
 
     &-token-transfer {
@@ -114,6 +113,7 @@
   &-hash {
     font-weight: 300;
   }
+
   &-lg {
     font-size: 16px;
     color: $body-color;

--- a/apps/block_scout_web/assets/css/components/_tile.scss
+++ b/apps/block_scout_web/assets/css/components/_tile.scss
@@ -47,6 +47,11 @@
       }
     }
 
+    &-token {
+      border: 1px solid $border-color;
+
+    }
+
     &-token-transfer {
       border-left: 4px solid $orange;
       padding-bottom: 10px;
@@ -108,6 +113,10 @@
 
   &-hash {
     font-weight: 300;
+  }
+  &-lg {
+    font-size: 16px;
+    color: $body-color;
   }
 }
 

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -12,7 +12,7 @@ defmodule BlockScoutWeb.Chain do
       string_to_transaction_hash: 1
     ]
 
-  alias Explorer.Chain.{Address, Block, InternalTransaction, Log, TokenTransfer, Transaction}
+  alias Explorer.Chain.{Address, Block, InternalTransaction, Log, Token, TokenTransfer, Transaction}
   alias Explorer.PagingOptions
 
   @page_size 50
@@ -118,6 +118,9 @@ defmodule BlockScoutWeb.Chain do
   def paging_options(%{"inserted_at" => inserted_at}),
     do: [paging_options: %{@default_paging_options | key: inserted_at}]
 
+  def paging_options(%{"token_name" => name, "token_type" => type, "token_inserted_at" => inserted_at}),
+    do: [paging_options: %{@default_paging_options | key: {name, type, inserted_at}}]
+
   def paging_options(_params), do: [paging_options: @default_paging_options]
 
   def param_to_block_number(formatted_number) when is_binary(formatted_number) do
@@ -165,6 +168,15 @@ defmodule BlockScoutWeb.Chain do
       |> DateTime.to_iso8601()
 
     %{"inserted_at" => inserted_at_datetime}
+  end
+
+  defp paging_params(%Token{name: name, type: type, inserted_at: inserted_at}) do
+    inserted_at_datetime =
+      inserted_at
+      |> DateTime.from_naive!("Etc/UTC")
+      |> DateTime.to_iso8601()
+
+    %{"token_name" => name, "token_type" => type, "token_inserted_at" => inserted_at_datetime}
   end
 
   defp transaction_from_param(param) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_controller.ex
@@ -1,0 +1,33 @@
+defmodule BlockScoutWeb.AddressTokenController do
+  use BlockScoutWeb, :controller
+
+  alias Explorer.{Chain, Market}
+  alias Explorer.ExchangeRates.Token
+
+  import BlockScoutWeb.AddressController, only: [transaction_count: 1]
+  import BlockScoutWeb.Chain, only: [next_page_params: 3, paging_options: 1, split_list_by_page: 1]
+
+  def index(conn, %{"address_id" => address_hash_string} = params) do
+    with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
+         {:ok, address} <- Chain.hash_to_address(address_hash) do
+      tokens_plus_one = Chain.tokens_with_number_of_transfers_from_address(address_hash, paging_options(params))
+      {tokens, next_page} = split_list_by_page(tokens_plus_one)
+
+      render(
+        conn,
+        "index.html",
+        address: address,
+        exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
+        transaction_count: transaction_count(address),
+        next_page_params: next_page_params(next_page, tokens, params),
+        tokens: tokens
+      )
+    else
+      :error ->
+        unprocessable_entity(conn)
+
+      {:error, :not_found} ->
+        not_found(conn)
+    end
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -91,6 +91,13 @@ defmodule BlockScoutWeb.Router do
       )
 
       resources(
+        "/tokens",
+        AddressTokenController,
+        only: [:index],
+        as: :token
+      )
+
+      resources(
         "/token_balances",
         AddressTokenBalanceController,
         only: [:index],

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
@@ -9,7 +9,14 @@
           <%= link(
                 gettext("Transactions"),
                 class: "nav-link",
-                to: address_transaction_path(@conn, :index, @conn.params["address_id"])
+                to: address_transaction_path(@conn, :index, @address.hash)
+              ) %>
+        </li>
+        <li class="nav-item">
+          <%= link(
+                gettext("Tokens"),
+                class: "nav-link",
+                to: address_token_path(@conn, :index, @address.hash)
               ) %>
         </li>
         <li class="nav-item">
@@ -17,12 +24,12 @@
                 gettext("Internal Transactions"),
                 class: "nav-link",
                 "data-test": "internal_transactions_tab_link",
-                to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
+                to: address_internal_transaction_path(@conn, :index, @address.hash)
               ) %>
         </li>
         <li class="nav-item">
           <%= link(
-              to: address_contract_path(@conn, :index, @conn.params["address_id"]),
+              to: address_contract_path(@conn, :index, @address.hash),
               class: "nav-link active") do %>
             <%= gettext("Code") %>
 
@@ -35,7 +42,7 @@
           <li class="nav-item">
             <%= link(
                 gettext("Read Contract"),
-                to: address_read_contract_path(@conn, :index, @conn.params["address_id"]),
+                to: address_read_contract_path(@conn, :index, @address.hash),
                 class: "nav-link")%>
           </li>
         <% end %>
@@ -46,7 +53,7 @@
       <%= if !smart_contract_verified?(@address) do %>
         <%= link(
               gettext("Verify and Publish"),
-              to: address_verify_contract_path(@conn, :new, @conn.params["address_id"]),
+              to: address_verify_contract_path(@conn, :new, @address.hash),
               class: "button button-primary button-sm float-right ml-3",
               "data-test": "verify_and_publish"
             ) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
@@ -12,7 +12,14 @@
             <%= link(
                   gettext("Transactions"),
                   class: "nav-link",
-                  to: address_transaction_path(@conn, :index, @conn.params["address_id"])
+                  to: address_transaction_path(@conn, :index, @address.hash)
+                ) %>
+          </li>
+          <li class="nav-item">
+            <%= link(
+                  gettext("Tokens"),
+                  class: "nav-link",
+                  to: address_token_path(@conn, :index, @address.hash)
                 ) %>
           </li>
           <li class="nav-item">
@@ -20,13 +27,13 @@
                   gettext("Internal Transactions"),
                   class: "nav-link active",
                   "data-test": "internal_transactions_tab_link",
-                  to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
+                  to: address_internal_transaction_path(@conn, :index, @address.hash)
                 ) %>
           </li>
           <%= if contract?(@address) do %>
             <li class="nav-item">
               <%= link(
-                  to: address_contract_path(@conn, :index, @conn.params["address_id"]),
+                  to: address_contract_path(@conn, :index, @address.hash),
                   class: "nav-link") do %>
                 <%= gettext("Code") %>
 
@@ -40,7 +47,7 @@
             <li class="nav-item">
               <%= link(
                   gettext("Read Contract"),
-                  to: address_read_contract_path(@conn, :index, @conn.params["address_id"]),
+                  to: address_read_contract_path(@conn, :index, @address.hash),
                   class: "nav-link")%>
             </li>
           <% end %>
@@ -54,17 +61,22 @@
               <%= link(
                     gettext("Transactions"),
                     class: "dropdown-item",
-                    to: address_transaction_path(@conn, :index, @conn.params["address_id"])
+                    to: address_transaction_path(@conn, :index, @address.hash)
+                  ) %>
+              <%= link(
+                    gettext("Tokens"),
+                    class: "dropdown-item",
+                    to: address_token_path(@conn, :index, @address.hash)
                   ) %>
               <%= link(
                     gettext("Internal Transactions"),
                     class: "dropdown-item",
                     "data-test": "internal_transactions_tab_link",
-                    to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
+                    to: address_internal_transaction_path(@conn, :index, @address.hash)
                   ) %>
               <%= if contract?(@address) do %>
                 <%= link(
-                    to: address_contract_path(@conn, :index, @conn.params["address_id"]),
+                    to: address_contract_path(@conn, :index, @address.hash),
                     class: "dropdown-item") do %>
                   <%= gettext("Code") %>
 
@@ -96,7 +108,7 @@
           <div class="dropdown-menu dropdown-menu-right filter" aria-labelledby="dropdownMenu2">
             <%= link(
               gettext("All"),
-              to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"]),
+              to: address_internal_transaction_path(@conn, :index, @address.hash),
               class: "address__link address__link--active dropdown-item",
               "data-test": "filter_option"
             ) %>
@@ -105,7 +117,7 @@
               to: address_internal_transaction_path(
                 @conn,
                 :index,
-                @conn.params["address_id"],
+                @address.hash,
                 filter: "to"
               ),
               class: "address__link address__link--active dropdown-item",
@@ -116,7 +128,7 @@
               to: address_internal_transaction_path(
                 @conn,
                 :index,
-                @conn.params["address_id"],
+                @address.hash,
                 filter: "from"
               ),
               class: "address__link address__link--active dropdown-item",

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_read_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_read_contract/index.html.eex
@@ -9,7 +9,14 @@
           <%= link(
                 gettext("Transactions"),
                 class: "nav-link",
-                to: address_transaction_path(@conn, :index, @conn.params["address_id"])
+                to: address_transaction_path(@conn, :index, @address.hash)
+              ) %>
+        </li>
+        <li class="nav-item">
+          <%= link(
+                gettext("Tokens"),
+                class: "nav-link",
+                to: address_token_path(@conn, :index, @address.hash)
               ) %>
         </li>
         <li class="nav-item">
@@ -17,12 +24,12 @@
                 gettext("Internal Transactions"),
                 class: "nav-link",
                 "data-test": "internal_transactions_tab_link",
-                to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
+                to: address_internal_transaction_path(@conn, :index, @address.hash)
               ) %>
         </li>
         <li class="nav-item">
           <%= link(
-              to: address_contract_path(@conn, :index, @conn.params["address_id"]),
+              to: address_contract_path(@conn, :index, @address.hash),
               class: "nav-link") do %>
             <%= gettext("Code") %>
 
@@ -34,7 +41,7 @@
         <li class="nav-item">
           <%= link(
               gettext("Read Contract"),
-              to: address_read_contract_path(@conn, :index, @conn.params["address_id"]),
+              to: address_read_contract_path(@conn, :index, @address.hash),
               class: "nav-link active")%>
         </li>
       </ul>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token/_tokens.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token/_tokens.html.eex
@@ -1,0 +1,10 @@
+<div class="tile tile-type-token">
+  <div class="row justify-content">
+    <div class="col-md-12 d-flex flex-column tile-label">
+      <%= link(to: token_path(@conn, :show, @token.contract_address_hash), class: "tile-title-lg") do %>
+        <%= token_name(@token) %>
+      <% end %>
+      <span><%= @token.type %> - <%= number_of_transfers(@token) %></span>
+    </div>
+  </div>
+</div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token/index.html.eex
@@ -1,0 +1,132 @@
+<section class="container">
+  <%= render BlockScoutWeb.AddressView, "overview.html", assigns %>
+
+  <section>
+    <div class="card">
+      <div class="card-header">
+        <!-- DESKTOP TAB NAV -->
+        <ul class="nav nav-tabs card-header-tabs d-none d-md-inline-flex">
+          <li class="nav-item">
+            <%= link(
+                  gettext("Transactions"),
+                  class: "nav-link",
+                  to: address_transaction_path(@conn, :index, @address.hash)
+                ) %>
+          </li>
+
+          <li class="nav-item">
+            <%= link(
+                  gettext("Tokens"),
+                  class: "nav-link active",
+                  to: address_token_path(@conn, :index, @address.hash)
+                ) %>
+          </li>
+
+          <li class="nav-item"> <%= link(
+                  gettext("Internal Transactions"),
+                  class: "nav-link",
+                  "data-test": "internal_transactions_tab_link",
+                  to: address_internal_transaction_path(@conn, :index, @address.hash)
+                ) %>
+          </li>
+
+          <%= if AddressView.contract?(@address) do %>
+            <li class="nav-item">
+              <%= link(
+                  to: address_contract_path(@conn, :index, @address.hash),
+                  class: "nav-link") do %>
+                <%= gettext("Code") %>
+
+                <%= if AddressView.smart_contract_verified?(@address) do %>
+                  <i class="far fa-check-circle"></i>
+                <% end %>
+              <% end %>
+            </li>
+          <% end %>
+
+          <%= if AddressView.smart_contract_with_read_only_functions?(@address) do %>
+            <li class="nav-item">
+              <%= link(
+                  gettext("Read Contract"),
+                  to: address_read_contract_path(@conn, :index, @address.hash),
+                  class: "nav-link")%>
+            </li>
+          <% end %>
+          <%= if AddressView.smart_contract_with_read_only_functions?(@address) do %>
+            <li class="nav-item">
+              <%= link(
+                  gettext("Read Contract"),
+                  to: address_read_contract_path(@conn, :index, @address.hash),
+                  class: "nav-link")%>
+            </li>
+          <% end %>
+        </ul>
+
+        <!-- MOBILE DROPDOWN NAV -->
+        <ul class="nav nav-tabs card-header-tabs d-md-none">
+          <li class="nav-item dropdown flex-fill text-center">
+            <a class="nav-link active dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">Tokens</a>
+
+            <div class="dropdown-menu">
+              <%= link(
+                    gettext("Transactions"),
+                    class: "dropdown-item",
+                    to: address_transaction_path(@conn, :index, @address.hash)
+                  ) %>
+              <%= link(
+                    gettext("Tokens"),
+                    class: "dropdown-item",
+                    to: address_token_path(@conn, :index, @address.hash)
+                  ) %>
+              <%= link(
+                    gettext("Internal Transactions"),
+                    class: "dropdown-item",
+                    "data-test": "internal_transactions_tab_link",
+                    to: address_internal_transaction_path(@conn, :index, @address.hash)
+                  ) %>
+              <%= if AddressView.contract?(@address) do %>
+                <%= link(
+                    to: address_contract_path(@conn, :index, @address.hash),
+                    class: "dropdown-item") do %>
+                  <%= gettext("Code") %>
+
+                  <%= if AddressView.smart_contract_verified?(@address) do %>
+                    <i class="far fa-check-circle"></i>
+                  <% end %>
+                <% end %>
+              <% end %>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="card-body">
+        <h2 class="card-title"><%= gettext "Tokens" %></h2>
+        <%= if Enum.any?(@tokens) do %>
+          <%= for token <- @tokens do %>
+            <%= render "_tokens.html", conn: @conn, token: token %>
+          <% end %>
+        <% else %>
+          <div class="tile tile-muted text-center">
+            <span><%= gettext "There are no tokens for this address." %></span>
+          </div>
+        <% end %>
+
+        <div>
+          <%= if @next_page_params do %>
+            <%= link(
+              gettext("Next"),
+              class: "button button-secondary button-sm float-right",
+              to: address_token_path(
+                @conn,
+                :index,
+                @address,
+                @next_page_params
+              )
+            ) %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </section>
+</section>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/index.html.eex
@@ -12,7 +12,14 @@
             <%= link(
                   gettext("Transactions"),
                   class: "nav-link active",
-                  to: address_transaction_path(@conn, :index, @conn.params["address_id"])
+                  to: address_transaction_path(@conn, :index, @address.hash)
+                ) %>
+          </li>
+          <li class="nav-item">
+            <%= link(
+                  gettext("Tokens"),
+                  class: "nav-link",
+                  to: address_token_path(@conn, :index, @address.hash)
                 ) %>
           </li>
           <li class="nav-item">
@@ -20,13 +27,13 @@
                   gettext("Internal Transactions"),
                   class: "nav-link",
                   "data-test": "internal_transactions_tab_link",
-                  to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
+                  to: address_internal_transaction_path(@conn, :index, @address.hash)
                 ) %>
           </li>
           <%= if contract?(@address) do %>
             <li class="nav-item">
               <%= link(
-                  to: address_contract_path(@conn, :index, @conn.params["address_id"]),
+                  to: address_contract_path(@conn, :index, @address.hash),
                   class: "nav-link") do %>
                 <%= gettext("Code") %>
 
@@ -40,7 +47,7 @@
             <li class="nav-item">
               <%= link(
                   gettext("Read Contract"),
-                  to: address_read_contract_path(@conn, :index, @conn.params["address_id"]),
+                  to: address_read_contract_path(@conn, :index, @address.hash),
                   class: "nav-link")%>
             </li>
           <% end %>
@@ -54,17 +61,22 @@
               <%= link(
                     gettext("Transactions"),
                     class: "dropdown-item",
-                    to: address_transaction_path(@conn, :index, @conn.params["address_id"])
+                    to: address_transaction_path(@conn, :index, @address.hash)
+                  ) %>
+              <%= link(
+                    gettext("Tokens"),
+                    class: "dropdown-item",
+                    to: address_token_path(@conn, :index, @address.hash)
                   ) %>
               <%= link(
                     gettext("Internal Transactions"),
                     class: "dropdown-item",
                     "data-test": "internal_transactions_tab_link",
-                    to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
+                    to: address_internal_transaction_path(@conn, :index, @address.hash)
                   ) %>
               <%= if contract?(@address) do %>
                 <%= link(
-                    to: address_contract_path(@conn, :index, @conn.params["address_id"]),
+                    to: address_contract_path(@conn, :index, @address.hash),
                     class: "dropdown-item") do %>
                   <%= gettext("Code") %>
 
@@ -97,7 +109,7 @@
           <div class="dropdown-menu dropdown-menu-right filter" aria-labelledby="dropdownMenu2">
             <%= link(
               gettext("All"),
-              to: address_transaction_path(@conn, :index, @conn.params["address_id"]),
+              to: address_transaction_path(@conn, :index, @address.hash),
               class: "address__link address__link--active dropdown-item",
               "data-test": "filter_option"
             ) %>
@@ -106,7 +118,7 @@
               to: address_transaction_path(
                 @conn,
                 :index,
-                @conn.params["address_id"],
+                @address.hash,
                 filter: "to"
               ),
               class: "address__link address__link--active dropdown-item",
@@ -117,7 +129,7 @@
               to: address_transaction_path(
                 @conn,
                 :index,
-                @conn.params["address_id"],
+                @address.hash,
                 filter: "from"
               ),
               class: "address__link address__link--active dropdown-item",

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
@@ -23,8 +23,6 @@
             <% end %>
           </h1>
 
-
-
           <h3><%= to_string(@token.contract_address_hash) %></h3>
 
           <div class="d-flex flex-row justify-content-start text-muted">

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex
@@ -1,4 +1,4 @@
-<div class="tile tile-type-token fade-in mb-10">
+<div class="tile tile-type-token-transfer fade-in">
   <div class="row">
     <div class="pl-5 col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center">
       <span class="tile-label"><%= gettext "Token Transfer" %></span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/_token_transfer.html.eex
@@ -1,4 +1,4 @@
-<div class="tile tile-type-token fade-in">
+<div class="tile tile-type-token-transfer fade-in">
   <div class="row justify-content-end">
     <div class="col-12 col-md-4 col-lg-2 d-flex align-items-center justify-content-start justify-content-lg-center tile-label">
       <%=  gettext("Token Transfer") %>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_token_view.ex
@@ -1,0 +1,9 @@
+defmodule BlockScoutWeb.AddressTokenView do
+  use BlockScoutWeb, :view
+
+  alias BlockScoutWeb.AddressView
+
+  def number_of_transfers(token) do
+    ngettext("%{count} transfer", "%{count} transfers", token.number_of_transfers)
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -105,7 +105,7 @@ defmodule BlockScoutWeb.TransactionView do
 
   def type_suffix(%Transaction{} = transaction) do
     cond do
-      involves_token_transfers?(transaction) -> "token"
+      involves_token_transfers?(transaction) -> "token-transfer"
       contract_creation?(transaction) -> "contract-creation"
       involves_contract?(transaction) -> "contract-call"
       true -> "transaction"

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -35,11 +35,13 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:21
 #: lib/block_scout_web/templates/address_contract/index.html.eex:10
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:13
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:55
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:62
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:10
+#: lib/block_scout_web/templates/address_token/index.html.eex:11
+#: lib/block_scout_web/templates/address_token/index.html.eex:72
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:13
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:55
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:129
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:62
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:141
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:26
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:36
@@ -134,8 +136,8 @@ msgstr ""
 msgid "Address"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:115
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:116
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:127
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:128
 #: lib/block_scout_web/views/address_internal_transaction_view.ex:10
 #: lib/block_scout_web/views/address_transaction_view.ex:10
 msgid "From"
@@ -150,8 +152,8 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:104
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:105
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:116
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:117
 #: lib/block_scout_web/views/address_internal_transaction_view.ex:9
 #: lib/block_scout_web/views/address_transaction_view.ex:9
 msgid "To"
@@ -302,13 +304,15 @@ msgstr ""
 msgid "Gwei"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:17
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:20
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:60
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:127
-#: lib/block_scout_web/templates/address_read_contract/index.html.eex:17
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:20
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:60
+#: lib/block_scout_web/templates/address_contract/index.html.eex:24
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:27
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:72
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:139
+#: lib/block_scout_web/templates/address_read_contract/index.html.eex:24
+#: lib/block_scout_web/templates/address_token/index.html.eex:26
+#: lib/block_scout_web/templates/address_token/index.html.eex:82
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:27
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:72
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:20
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:38
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:49
@@ -354,8 +358,8 @@ msgstr ""
 msgid "Wei"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:98
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:99
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:110
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:111
 #: lib/block_scout_web/views/address_internal_transaction_view.ex:11
 #: lib/block_scout_web/views/address_transaction_view.ex:11
 msgid "All"
@@ -433,7 +437,15 @@ msgstr ""
 msgid "TXNs"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:29
+#: lib/block_scout_web/templates/address_contract/index.html.eex:17
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:20
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:67
+#: lib/block_scout_web/templates/address_read_contract/index.html.eex:17
+#: lib/block_scout_web/templates/address_token/index.html.eex:19
+#: lib/block_scout_web/templates/address_token/index.html.eex:77
+#: lib/block_scout_web/templates/address_token/index.html.eex:104
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:20
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:67
 msgid "Tokens"
 msgstr ""
 
@@ -476,8 +488,8 @@ msgstr ""
 msgid "There are no Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:142
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:143
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:154
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:155
 #: lib/block_scout_web/templates/block/index.html.eex:15
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:78
@@ -491,16 +503,18 @@ msgstr ""
 msgid "Contract Source Code"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:48
+#: lib/block_scout_web/templates/address_contract/index.html.eex:55
 msgid "Verify and Publish"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:27
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:31
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:69
-#: lib/block_scout_web/templates/address_read_contract/index.html.eex:27
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:31
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:69
+#: lib/block_scout_web/templates/address_contract/index.html.eex:34
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:38
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:81
+#: lib/block_scout_web/templates/address_read_contract/index.html.eex:34
+#: lib/block_scout_web/templates/address_token/index.html.eex:38
+#: lib/block_scout_web/templates/address_token/index.html.eex:91
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:38
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:81
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:122
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
 msgid "Code"
@@ -581,7 +595,7 @@ msgid "Wallet addresses"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:89
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:101
 #: lib/block_scout_web/templates/transaction/index.html.eex:53
 msgid "Connection Lost, click to load newer transactions"
 msgstr ""
@@ -603,17 +617,17 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:13
 #: lib/block_scout_web/templates/address/overview.html.eex:64
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:13
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:73
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:71
 msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:136
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:148
 msgid "There are no internal transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:137
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:149
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:44
 msgid "There are no transactions for this address."
 msgstr ""
@@ -665,10 +679,12 @@ msgid "Query"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:37
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:42
-#: lib/block_scout_web/templates/address_read_contract/index.html.eex:36
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:42
+#: lib/block_scout_web/templates/address_contract/index.html.eex:44
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:49
+#: lib/block_scout_web/templates/address_read_contract/index.html.eex:43
+#: lib/block_scout_web/templates/address_token/index.html.eex:50
+#: lib/block_scout_web/templates/address_token/index.html.eex:58
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:49
 #: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:25
 #: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:42
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:26
@@ -688,7 +704,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:73
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:82
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:80
 msgid "Close"
 msgstr ""
 
@@ -731,7 +747,7 @@ msgid "Token Transfer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:33
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:31
 msgid "Transfers"
 msgstr ""
 
@@ -743,7 +759,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:84
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:96
 #: lib/block_scout_web/templates/chain/show.html.eex:69
 #: lib/block_scout_web/templates/transaction/index.html.eex:48
 msgid "More transactions have come in"
@@ -788,17 +804,17 @@ msgid "Token Transfers"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:32
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:30
 msgid "addresses"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:35
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:33
 msgid "decimals"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:46
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:44
 msgid "Total Supply"
 msgstr ""
 
@@ -813,7 +829,7 @@ msgid "There are no token transfers for this transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_read_contract/index.html.eex:45
+#: lib/block_scout_web/templates/address_read_contract/index.html.eex:52
 #: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:52
 msgid "loading..."
 msgstr ""
@@ -1005,12 +1021,12 @@ msgid "Max of"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:88
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:100
 msgid "Connection Lost, click to load newer internal transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:83
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:95
 msgid "More internal transactions have come in"
 msgstr ""
 
@@ -1022,4 +1038,21 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/overview.html.eex:10
 msgid "Copy Txn Hash"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/address_token_view.ex:7
+msgid "%{count} transfer"
+msgid_plural "%{count} transfers"
+msgstr[0] ""
+msgstr[1] ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_token/index.html.eex:118
+msgid "Next"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_token/index.html.eex:111
+msgid "There are no tokens for this address."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -47,11 +47,13 @@ msgstr "BlockScout"
 #: lib/block_scout_web/templates/address/overview.html.eex:21
 #: lib/block_scout_web/templates/address_contract/index.html.eex:10
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:13
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:55
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:62
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:10
+#: lib/block_scout_web/templates/address_token/index.html.eex:11
+#: lib/block_scout_web/templates/address_token/index.html.eex:72
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:13
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:55
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:129
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:62
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:141
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:26
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:36
@@ -146,8 +148,8 @@ msgstr "%{count} transactions in this block"
 msgid "Address"
 msgstr "Address"
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:115
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:116
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:127
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:128
 #: lib/block_scout_web/views/address_internal_transaction_view.ex:10
 #: lib/block_scout_web/views/address_transaction_view.ex:10
 msgid "From"
@@ -162,8 +164,8 @@ msgstr "Overview"
 msgid "Success"
 msgstr "Success"
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:104
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:105
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:116
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:117
 #: lib/block_scout_web/views/address_internal_transaction_view.ex:9
 #: lib/block_scout_web/views/address_transaction_view.ex:9
 msgid "To"
@@ -314,13 +316,15 @@ msgstr "POA"
 msgid "Gwei"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:17
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:20
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:60
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:127
-#: lib/block_scout_web/templates/address_read_contract/index.html.eex:17
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:20
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:60
+#: lib/block_scout_web/templates/address_contract/index.html.eex:24
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:27
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:72
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:139
+#: lib/block_scout_web/templates/address_read_contract/index.html.eex:24
+#: lib/block_scout_web/templates/address_token/index.html.eex:26
+#: lib/block_scout_web/templates/address_token/index.html.eex:82
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:27
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:72
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:20
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:38
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:49
@@ -366,8 +370,8 @@ msgstr ""
 msgid "Wei"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:98
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:99
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:110
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:111
 #: lib/block_scout_web/views/address_internal_transaction_view.ex:11
 #: lib/block_scout_web/views/address_transaction_view.ex:11
 msgid "All"
@@ -445,7 +449,15 @@ msgstr ""
 msgid "TXNs"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:29
+#: lib/block_scout_web/templates/address_contract/index.html.eex:17
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:20
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:67
+#: lib/block_scout_web/templates/address_read_contract/index.html.eex:17
+#: lib/block_scout_web/templates/address_token/index.html.eex:19
+#: lib/block_scout_web/templates/address_token/index.html.eex:77
+#: lib/block_scout_web/templates/address_token/index.html.eex:104
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:20
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:67
 msgid "Tokens"
 msgstr ""
 
@@ -488,8 +500,8 @@ msgstr ""
 msgid "There are no Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:142
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:143
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:154
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:155
 #: lib/block_scout_web/templates/block/index.html.eex:15
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:78
@@ -503,16 +515,18 @@ msgstr ""
 msgid "Contract Source Code"
 msgstr "Contract Source Code"
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:48
+#: lib/block_scout_web/templates/address_contract/index.html.eex:55
 msgid "Verify and Publish"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:27
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:31
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:69
-#: lib/block_scout_web/templates/address_read_contract/index.html.eex:27
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:31
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:69
+#: lib/block_scout_web/templates/address_contract/index.html.eex:34
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:38
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:81
+#: lib/block_scout_web/templates/address_read_contract/index.html.eex:34
+#: lib/block_scout_web/templates/address_token/index.html.eex:38
+#: lib/block_scout_web/templates/address_token/index.html.eex:91
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:38
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:81
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:122
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
 msgid "Code"
@@ -593,7 +607,7 @@ msgid "Wallet addresses"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:89
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:101
 #: lib/block_scout_web/templates/transaction/index.html.eex:53
 msgid "Connection Lost, click to load newer transactions"
 msgstr ""
@@ -615,17 +629,17 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:13
 #: lib/block_scout_web/templates/address/overview.html.eex:64
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:13
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:73
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:71
 msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:136
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:148
 msgid "There are no internal transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:137
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:149
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:44
 msgid "There are no transactions for this address."
 msgstr ""
@@ -677,10 +691,12 @@ msgid "Query"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:37
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:42
-#: lib/block_scout_web/templates/address_read_contract/index.html.eex:36
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:42
+#: lib/block_scout_web/templates/address_contract/index.html.eex:44
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:49
+#: lib/block_scout_web/templates/address_read_contract/index.html.eex:43
+#: lib/block_scout_web/templates/address_token/index.html.eex:50
+#: lib/block_scout_web/templates/address_token/index.html.eex:58
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:49
 #: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:25
 #: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:42
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:26
@@ -700,7 +716,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:73
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:82
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:80
 msgid "Close"
 msgstr ""
 
@@ -743,7 +759,7 @@ msgid "Token Transfer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:33
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:31
 msgid "Transfers"
 msgstr ""
 
@@ -755,7 +771,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:84
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:96
 #: lib/block_scout_web/templates/chain/show.html.eex:69
 #: lib/block_scout_web/templates/transaction/index.html.eex:48
 msgid "More transactions have come in"
@@ -800,17 +816,17 @@ msgid "Token Transfers"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:32
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:30
 msgid "addresses"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:35
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:33
 msgid "decimals"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:46
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:44
 msgid "Total Supply"
 msgstr ""
 
@@ -825,7 +841,7 @@ msgid "There are no token transfers for this transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_read_contract/index.html.eex:45
+#: lib/block_scout_web/templates/address_read_contract/index.html.eex:52
 #: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:52
 msgid "loading..."
 msgstr ""
@@ -1017,12 +1033,12 @@ msgid "Max of"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:88
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:100
 msgid "Connection Lost, click to load newer internal transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:83
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:95
 msgid "More internal transactions have come in"
 msgstr ""
 
@@ -1034,4 +1050,21 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/overview.html.eex:10
 msgid "Copy Txn Hash"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/address_token_view.ex:7
+msgid "%{count} transfer"
+msgid_plural "%{count} transfers"
+msgstr[0] ""
+msgstr[1] ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_token/index.html.eex:118
+msgid "Next"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_token/index.html.eex:111
+msgid "There are no tokens for this address."
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_token_controller_test.exs
@@ -1,0 +1,110 @@
+defmodule BlockScoutWeb.AddressTokenControllerTest do
+  use BlockScoutWeb.ConnCase
+
+  import BlockScoutWeb.Router.Helpers, only: [address_token_path: 3]
+
+  alias Explorer.Chain.{Token}
+
+  describe "GET index/2" do
+    test "with invalid address hash", %{conn: conn} do
+      conn = get(conn, address_token_path(conn, :index, "invalid_address"))
+
+      assert html_response(conn, 422)
+    end
+
+    test "with valid address hash without address", %{conn: conn} do
+      conn = get(conn, address_token_path(conn, :index, "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"))
+
+      assert html_response(conn, 404)
+    end
+
+    test "returns tokens for the address", %{conn: conn} do
+      address = insert(:address)
+
+      token1 =
+        :token
+        |> insert(name: "token1")
+
+      token2 =
+        :token
+        |> insert(name: "token2")
+
+      insert(
+        :token_transfer,
+        token_contract_address: token1.contract_address,
+        from_address: address,
+        to_address: build(:address)
+      )
+
+      insert(
+        :token_transfer,
+        token_contract_address: token2.contract_address,
+        from_address: build(:address),
+        to_address: address
+      )
+
+      conn = get(conn, address_token_path(conn, :index, address))
+
+      actual_token_hashes =
+        conn.assigns.tokens
+        |> Enum.map(& &1.contract_address_hash)
+
+      assert html_response(conn, 200)
+      assert Enum.member?(actual_token_hashes, token1.contract_address_hash)
+      assert Enum.member?(actual_token_hashes, token2.contract_address_hash)
+    end
+
+    test "returns next page of results based on last seen token", %{conn: conn} do
+      address = insert(:address)
+
+      second_page_tokens =
+        1..50
+        |> Enum.reduce([], fn i, acc ->
+          token = insert(:token, name: "A Token#{i}", type: "ERC-20")
+          insert(:token_transfer, token_contract_address: token.contract_address, from_address: address)
+          acc ++ [token.name]
+        end)
+        |> Enum.sort()
+
+      token = insert(:token, name: "Another Token", type: "ERC-721")
+      insert(:token_transfer, token: token, from_address: address)
+      %Token{name: name, type: type} = token
+
+      conn =
+        get(conn, address_token_path(BlockScoutWeb.Endpoint, :index, address.hash), %{
+          "name" => name,
+          "type" => type
+        })
+
+      actual_tokens =
+        conn.assigns.tokens
+        |> Enum.map(& &1.name)
+        |> Enum.sort()
+
+      assert second_page_tokens == actual_tokens
+    end
+
+    test "next_page_params exists if not on last page", %{conn: conn} do
+      address = insert(:address)
+
+      Enum.each(1..51, fn i ->
+        token = insert(:token, name: "A Token#{i}", type: "ERC-20")
+        insert(:token_transfer, token_contract_address: token.contract_address, from_address: address)
+      end)
+
+      conn = get(conn, address_token_path(BlockScoutWeb.Endpoint, :index, address.hash))
+
+      assert conn.assigns.next_page_params
+    end
+
+    test "next_page_params are empty if on last page", %{conn: conn} do
+      address = insert(:address)
+      token = insert(:token)
+      insert(:token_transfer, token_contract_address: token.contract_address, from_address: address)
+
+      conn = get(conn, address_token_path(BlockScoutWeb.Endpoint, :index, address.hash))
+
+      refute conn.assigns.next_page_params
+    end
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/views/address_token_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/address_token_view_test.exs
@@ -1,0 +1,25 @@
+defmodule BlockScoutWeb.AddressTokenViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.AddressTokenView
+
+  describe "number_of_transfers/1" do
+    test "returns the singular form when there is only one transfer" do
+      token = %{number_of_transfers: 1}
+
+      assert AddressTokenView.number_of_transfers(token) == "1 transfer"
+    end
+
+    test "returns the plural form when there is more than one transfer" do
+      token = %{number_of_transfers: 2}
+
+      assert AddressTokenView.number_of_transfers(token) == "2 transfers"
+    end
+
+    test "returns the plural form when there are 0 transfers" do
+      token = %{number_of_transfers: 0}
+
+      assert AddressTokenView.number_of_transfers(token) == "0 transfers"
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1647,10 +1647,17 @@ defmodule Explorer.Chain do
     Repo.one(query) != nil
   end
 
-  @spec fetch_tokens_from_address_hash(Hash.Address.t()) :: []
-  def fetch_tokens_from_address_hash(address_hash) do
+  @spec tokens_with_number_of_transfers_from_address(Hash.Address.t(), [any()]) :: []
+  def tokens_with_number_of_transfers_from_address(address_hash, paging_options \\ []) do
     address_hash
-    |> Token.with_transfers_by_address()
+    |> fetch_tokens_from_address_hash(paging_options)
+    |> add_number_of_transfers_to_tokens_from_address(address_hash)
+  end
+
+  @spec fetch_tokens_from_address_hash(Hash.Address.t(), [any()]) :: []
+  def fetch_tokens_from_address_hash(address_hash, paging_options \\ []) do
+    address_hash
+    |> Token.with_transfers_by_address(paging_options)
     |> Repo.all()
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1654,6 +1654,24 @@ defmodule Explorer.Chain do
     |> Repo.all()
   end
 
+  @spec add_number_of_transfers_to_tokens_from_address([Token], Hash.Address.t()) :: []
+  defp add_number_of_transfers_to_tokens_from_address(tokens, address_hash) do
+    Enum.map(tokens, fn token ->
+      Map.put(
+        token,
+        :number_of_transfers,
+        count_token_transfers_from_address_hash(token.contract_address_hash, address_hash)
+      )
+    end)
+  end
+
+  @spec count_token_transfers_from_address_hash(Hash.Address.t(), Hash.Address.t()) :: []
+  def count_token_transfers_from_address_hash(token_hash, address_hash) do
+    token_hash
+    |> Token.interactions_with_address(address_hash)
+    |> Repo.aggregate(:count, :name)
+  end
+
   @doc """
   Update a new `t:Token.t/0` record.
 

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -79,7 +79,7 @@ defmodule Explorer.Chain.Token do
   Builds an `Ecto.Query` to fetch tokens that the given address has interacted with.
 
   In order to fetch a token, the given address must have transfered tokens to or received tokens
-  from an another address.
+  from another address.
   """
   def with_transfers_by_address(address_hash) do
     from(
@@ -89,6 +89,19 @@ defmodule Explorer.Chain.Token do
       where: tt.to_address_hash == ^address_hash or tt.from_address_hash == ^address_hash,
       distinct: tt.token_contract_address_hash,
       select: token
+    )
+  end
+
+  @doc """
+  Builds an `Ecto.Query` to fetch the transactions between a token and an address.
+  """
+  def interactions_with_address(token_hash, address_hash) do
+    from(
+      t in Token,
+      join: tt in TokenTransfer,
+      on: tt.token_contract_address_hash == ^token_hash,
+      where: t.contract_address_hash == ^token_hash,
+      where: tt.to_address_hash == ^address_hash or tt.from_address_hash == ^address_hash
     )
   end
 end

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -20,7 +20,10 @@ defmodule Explorer.Chain.Token do
   use Ecto.Schema
 
   import Ecto.{Changeset, Query}
+  alias Explorer.PagingOptions
   alias Explorer.Chain.{Address, Hash, Token, TokenTransfer}
+
+  @default_paging_options %PagingOptions{page_size: 50}
 
   @typedoc """
   * `:name` - Name of the token
@@ -42,6 +45,8 @@ defmodule Explorer.Chain.Token do
           contract_address: %Ecto.Association.NotLoaded{} | Address.t(),
           contract_address_hash: Hash.Address.t()
         }
+
+  @typep paging_options :: {:paging_options, PagingOptions.t()}
 
   @primary_key false
   schema "tokens" do
@@ -79,17 +84,26 @@ defmodule Explorer.Chain.Token do
   Builds an `Ecto.Query` to fetch tokens that the given address has interacted with.
 
   In order to fetch a token, the given address must have transfered tokens to or received tokens
-  from another address.
+  from another address. This quey orders by the token type and name.
   """
-  def with_transfers_by_address(address_hash) do
-    from(
-      token in Token,
-      join: tt in TokenTransfer,
-      on: tt.token_contract_address_hash == token.contract_address_hash,
-      where: tt.to_address_hash == ^address_hash or tt.from_address_hash == ^address_hash,
-      distinct: tt.token_contract_address_hash,
-      select: token
-    )
+  @spec with_transfers_by_address(Hash.t(), [paging_options()]) :: %Ecto.Query{}
+  def with_transfers_by_address(address_hash, options \\ []) do
+    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
+
+    subquery =
+      from(
+        token in Token,
+        join: tt in TokenTransfer,
+        on: tt.token_contract_address_hash == token.contract_address_hash,
+        where: tt.to_address_hash == ^address_hash or tt.from_address_hash == ^address_hash,
+        distinct: [:contract_address_hash]
+      )
+
+    query = from(t in subquery(subquery), order_by: [desc: :type, asc: :name])
+
+    query
+    |> page_token(paging_options)
+    |> limit(^paging_options.page_size)
   end
 
   @doc """
@@ -99,9 +113,21 @@ defmodule Explorer.Chain.Token do
     from(
       t in Token,
       join: tt in TokenTransfer,
-      on: tt.token_contract_address_hash == ^token_hash,
+      on: tt.token_contract_address_hash == t.contract_address_hash,
       where: t.contract_address_hash == ^token_hash,
-      where: tt.to_address_hash == ^address_hash or tt.from_address_hash == ^address_hash
+      where: tt.to_address_hash == ^address_hash or tt.from_address_hash == ^address_hash,
+      select: tt
+    )
+  end
+
+  def page_token(query, %PagingOptions{key: nil}), do: query
+
+  def page_token(query, %PagingOptions{key: {name, type, inserted_at}}) do
+    where(
+      query,
+      [token],
+      token.type < ^type or (token.type == ^type and token.name > ^name) or
+        (token.type == ^type and token.name == ^name and token.inserted_at < ^inserted_at)
     )
   end
 end


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/410.

## Changelog

### Screenshots

<details>
<summary><b>Tokens tab</b></summary>

![](https://user-images.githubusercontent.com/10884247/45034164-0f35c880-b02d-11e8-9cec-3593c3d2469e.gif)

</details>

### Enhancements

- Add a token tab in the address page to list the tokens that address has interacted with;
- The query to get tokens that interacted with an Address now returns the result sorted first by type and then by name; it also supports pagination;
- Add a query that returns all the interactions between a token and an Address.

### Bug Fixes

- Typos.