### PR TITLE
Set error log path

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,3 +6,5 @@ config :logger, :console, level: :info
 config :logger, :ecto,
   level: :debug,
   path: "logs/dev/ecto.log"
+
+config :logger, :error, path: "logs/dev/error.log"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,3 +7,5 @@ config :logger, :console, level: :info
 config :logger, :ecto,
   level: :info,
   path: "logs/prod/ecto.log"
+
+config :logger, :error, path: "logs/prod/error.log"

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,6 +8,8 @@ config :logger, :ecto,
   level: :warn,
   path: "logs/test/ecto.log"
 
+config :logger, :error, path: "logs/test/error.log"
+
 config :explorer, Explorer.ExchangeRates,
   source: Explorer.ExchangeRates.Source.NoOpSource,
   store: :none


### PR DESCRIPTION
# Changelog
## Bug Fix
* Forgot to set the path to the error log in #608.  Errors were only being shown in console and not written to `logs/<Mix.env>/error.log` during #193 testing.  Tested that it worked because I was able to trigger an error during #193 testing and the `error.log` was produced after the change.