### PR TITLE
Fix uniqueness/on_conflict for address_token_balances

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -757,7 +757,7 @@ defmodule Explorer.Chain.Import do
     {:ok, _} =
       insert_changes_list(
         ordered_changes_list,
-        conflict_target: [:address_hash, :block_number],
+        conflict_target: ~w(address_hash token_contract_address_hash block_number)a,
         on_conflict: :replace_all,
         for: TokenBalance,
         returning: true,

--- a/apps/explorer/priv/repo/migrations/20180817021704_create_address_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20180817021704_create_address_token_balances.exs
@@ -18,12 +18,12 @@ defmodule Explorer.Repo.Migrations.CreateAddressTokenBalances do
       timestamps(null: false, type: :utc_datetime)
     end
 
-    create(unique_index(:address_token_balances, [:address_hash, :block_number]))
+    create(unique_index(:address_token_balances, ~w(address_hash token_contract_address_hash block_number)a))
 
     create(
       unique_index(
         :address_token_balances,
-        [:address_hash, :block_number],
+        ~w(address_hash token_contract_address_hash block_number)a,
         name: :unfetched_token_balances,
         where: "value_fetched_at IS NULL"
       )

--- a/apps/indexer/lib/indexer/address/token_balances.ex
+++ b/apps/indexer/lib/indexer/address/token_balances.ex
@@ -1,0 +1,39 @@
+defmodule Indexer.Address.TokenBalances do
+  @moduledoc """
+  Extracts `Explorer.Address.TokenBalance` params from other schema's params.
+  """
+
+  def params_set(%{} = import_options) do
+    Enum.reduce(import_options, MapSet.new(), &reducer/2)
+  end
+
+  defp reducer({:token_transfers_params, token_transfers_params}, initial) when is_list(token_transfers_params) do
+    Enum.reduce(token_transfers_params, initial, fn %{
+                                                      block_number: block_number,
+                                                      from_address_hash: from_address_hash,
+                                                      to_address_hash: to_address_hash,
+                                                      token_contract_address_hash: token_contract_address_hash
+                                                    },
+                                                    acc
+                                                    when is_integer(block_number) and is_binary(from_address_hash) and
+                                                           is_binary(to_address_hash) and
+                                                           is_binary(token_contract_address_hash) ->
+      acc
+      |> MapSet.put(%{
+        address_hash: from_address_hash,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: block_number
+      })
+      |> MapSet.put(%{
+        address_hash: to_address_hash,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: block_number
+      })
+      |> MapSet.put(%{
+        address_hash: token_contract_address_hash,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: block_number
+      })
+    end)
+  end
+end

--- a/apps/indexer/lib/indexer/balances.ex
+++ b/apps/indexer/lib/indexer/balances.ex
@@ -1,6 +1,6 @@
 defmodule Indexer.Balances do
   @moduledoc """
-  Extracts `Explorer.Chain.Balance` params from other schema's params
+  Extracts `Explorer.Chain.Balance` params from other schema's params.
   """
 
   def params_set(%{} = import_options) do
@@ -25,36 +25,6 @@ defmodule Indexer.Balances do
     Enum.into(logs_params, acc, fn %{address_hash: address_hash, block_number: block_number}
                                    when is_binary(address_hash) and is_integer(block_number) ->
       %{address_hash: address_hash, block_number: block_number}
-    end)
-  end
-
-  defp reducer({:token_transfers_params, token_transfers_params}, initial) when is_list(token_transfers_params) do
-    Enum.reduce(token_transfers_params, initial, fn %{
-                                                      block_number: block_number,
-                                                      from_address_hash: from_address_hash,
-                                                      to_address_hash: to_address_hash,
-                                                      token_contract_address_hash: token_contract_address_hash
-                                                    },
-                                                    acc
-                                                    when is_integer(block_number) and is_binary(from_address_hash) and
-                                                           is_binary(to_address_hash) and
-                                                           is_binary(token_contract_address_hash) ->
-      acc
-      |> MapSet.put(%{
-        address_hash: from_address_hash,
-        token_contract_address_hash: token_contract_address_hash,
-        block_number: block_number
-      })
-      |> MapSet.put(%{
-        address_hash: to_address_hash,
-        token_contract_address_hash: token_contract_address_hash,
-        block_number: block_number
-      })
-      |> MapSet.put(%{
-        address_hash: token_contract_address_hash,
-        token_contract_address_hash: token_contract_address_hash,
-        block_number: block_number
-      })
     end)
   end
 

--- a/apps/indexer/lib/indexer/block_fetcher.ex
+++ b/apps/indexer/lib/indexer/block_fetcher.ex
@@ -7,6 +7,7 @@ defmodule Indexer.BlockFetcher do
 
   alias Explorer.Chain.{Block, Import}
   alias Indexer.{AddressExtraction, Balances, TokenTransfers}
+  alias Indexer.Address.TokenBalances
   alias Indexer.BlockFetcher.Receipts
 
   @type address_hash_to_fetched_balance_block_number :: %{String.t() => Block.block_number()}
@@ -108,7 +109,7 @@ defmodule Indexer.BlockFetcher do
              logs_params: logs,
              transactions_params: transactions_with_receipts
            }),
-         token_balances = Balances.params_set(%{token_transfers_params: token_transfers}),
+         token_balances = TokenBalances.params_set(%{token_transfers_params: token_transfers}),
          {:ok, inserted} <-
            import_range(
              state,

--- a/apps/indexer/test/indexer/address/token_balances_test.exs
+++ b/apps/indexer/test/indexer/address/token_balances_test.exs
@@ -1,0 +1,38 @@
+defmodule Indexer.Address.TokenBalancesTest do
+  use ExUnit.Case, async: true
+
+  alias Explorer.Factory
+  alias Indexer.Address.TokenBalances
+
+  describe "params_set/1" do
+    test "with token transfer extract from_address, to_address, and token_contract_address_hash" do
+      block_number = 1
+
+      from_address_hash =
+        Factory.address_hash()
+        |> to_string()
+
+      to_address_hash =
+        Factory.address_hash()
+        |> to_string()
+
+      token_contract_address_hash =
+        Factory.address_hash()
+        |> to_string()
+
+      token_transfer_params = %{
+        block_number: block_number,
+        from_address_hash: from_address_hash,
+        to_address_hash: to_address_hash,
+        token_contract_address_hash: token_contract_address_hash
+      }
+
+      params_set = TokenBalances.params_set(%{token_transfers_params: [token_transfer_params]})
+
+      assert MapSet.size(params_set) == 3
+      assert %{address_hash: from_address_hash, block_number: block_number}
+      assert %{address_hash: to_address_hash, block_number: block_number}
+      assert %{address_hash: token_contract_address_hash, block_number: block_number}
+    end
+  end
+end

--- a/apps/indexer/test/indexer/balances_test.exs
+++ b/apps/indexer/test/indexer/balances_test.exs
@@ -107,36 +107,6 @@ defmodule Indexer.BalancesTest do
       assert %{address_hash: address_hash, block_number: block_number}
     end
 
-    test "with token transfer extract from_address, to_address, and token_contract_address_hash" do
-      block_number = 1
-
-      from_address_hash =
-        Factory.address_hash()
-        |> to_string()
-
-      to_address_hash =
-        Factory.address_hash()
-        |> to_string()
-
-      token_contract_address_hash =
-        Factory.address_hash()
-        |> to_string()
-
-      token_transfer_params = %{
-        block_number: block_number,
-        from_address_hash: from_address_hash,
-        to_address_hash: to_address_hash,
-        token_contract_address_hash: token_contract_address_hash
-      }
-
-      params_set = Balances.params_set(%{token_transfers_params: [token_transfer_params]})
-
-      assert MapSet.size(params_set) == 3
-      assert %{address_hash: from_address_hash, block_number: block_number}
-      assert %{address_hash: to_address_hash, block_number: block_number}
-      assert %{address_hash: token_contract_address_hash, block_number: block_number}
-    end
-
     test "with transaction without to_address_hash extracts from_address_hash" do
       block_number = 1
 


### PR DESCRIPTION
Fixes #614

## Test Report

I ran this code as part of #193's branch against Ethereum Mainnet, which was trigger #614 immediately and the blocks were able to insert:

```
16:56:58.343 application=indexer [debug] realtime indexer fetched and imported block 6229871
16:56:58.427 application=indexer [debug] fetching 24 transaction receipts
16:56:59.897 application=indexer [debug] realtime indexer fetched and imported block 6229872
```

Before the changes in this PR, no blocks could be imported because the first one contains token balances that triggered #614.  Token usage seems to be much heavier on Ethereum Mainnet than on Sokol if you need something to test Token support against in the future.

## Changelog

### Enhancements
* Port `on_conflict` from `Balance` to `TokenBalance` so that same, explicit rules are used instead of last-write-wins of `:replace_all`.

### Bug Fixes
*  Separate `Indexer.Address.TokenBalances` from `Indexer.Balances` because `TokenBalances` needs to extract 3 fields, while `Balances` only need 2, so they shouldn't be mixed together in the same module since the expected params in the set differs.
*  Correct uniqueness of token balances: Token balances, unlike balances which have `2` fields, use `3` fields for uniqueness because `1` `address` can have a separate value for **EACH** `token_contract_address_hash` at **EACH** `block_number`. 

### Incompatible Changes
* The unique indexes for `address_token_balances` copied `balances`, but this means they left of the `token_contract_address_hash` and the table needs to be recreated with the correct indexes.

## Upgrading

To fix the unique indexes on `address_token_balances`, a database reset and reindex is required.

1. `mix do ecto.drop, ecto.create, ecto.migrate`
2. `iex -S mix`

You will need to manually reset the test database too

1. `MIX_ENV=test mix do ecto.drop, ecto.create, ecto.migrate`