### PR TITLE
Use Path.absname in config so that log paths are stable during reload of Application env

### DIFF
--- a/apps/block_scout_web/config/dev.exs
+++ b/apps/block_scout_web/config/dev.exs
@@ -50,7 +50,7 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
 
 config :logger, :block_scout_web,
   level: :debug,
-  path: "logs/dev/block_scout_web.log"
+  path: Path.absname("logs/dev/block_scout_web.log")
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/apps/block_scout_web/config/prod.exs
+++ b/apps/block_scout_web/config/prod.exs
@@ -26,4 +26,4 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
 
 config :logger, :block_scout_web,
   level: :info,
-  path: "logs/prod/block_scout_web.log"
+  path: Path.absname("logs/prod/block_scout_web.log")

--- a/apps/block_scout_web/config/test.exs
+++ b/apps/block_scout_web/config/test.exs
@@ -11,7 +11,7 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
 
 config :logger, :block_scout_web,
   level: :warn,
-  path: "logs/test/block_scout_web.log"
+  path: Path.absname("logs/test/block_scout_web.log")
 
 # Configure wallaby
 config :wallaby, screenshot_on_failure: true

--- a/apps/ethereum_jsonrpc/config/dev.exs
+++ b/apps/ethereum_jsonrpc/config/dev.exs
@@ -2,4 +2,4 @@ use Mix.Config
 
 config :logger, :ethereum_jsonrpc,
   level: :debug,
-  path: "logs/dev/ethereum_jsonrpc.log"
+  path: Path.absname("logs/dev/ethereum_jsonrpc.log")

--- a/apps/ethereum_jsonrpc/config/prod.exs
+++ b/apps/ethereum_jsonrpc/config/prod.exs
@@ -2,4 +2,4 @@ use Mix.Config
 
 config :logger, :ethereum_jsonrpc,
   level: :info,
-  path: "logs/prod/ethereum_jsonrpc.log"
+  path: Path.absname("logs/prod/ethereum_jsonrpc.log")

--- a/apps/ethereum_jsonrpc/config/test.exs
+++ b/apps/ethereum_jsonrpc/config/test.exs
@@ -2,4 +2,4 @@ use Mix.Config
 
 config :logger, :ethereum_jsonrpc,
   level: :warn,
-  path: "logs/test/ethereum_jsonrpc.log"
+  path: Path.absname("logs/test/ethereum_jsonrpc.log")

--- a/apps/explorer/config/dev.exs
+++ b/apps/explorer/config/dev.exs
@@ -11,7 +11,7 @@ config :explorer, Explorer.Repo,
 
 config :logger, :explorer,
   level: :debug,
-  path: "logs/dev/explorer.log"
+  path: Path.absname("logs/dev/explorer.log")
 
 import_config "dev.secret.exs"
 

--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -11,7 +11,7 @@ config :explorer, Explorer.Repo,
 
 config :logger, :explorer,
   level: :info,
-  path: "logs/prod/explorer.log"
+  path: Path.absname("logs/prod/explorer.log")
 
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -19,7 +19,7 @@ config :explorer, Explorer.Market.History.Cataloger, enabled: false
 
 config :logger, :explorer,
   level: :warn,
-  path: "logs/test/explorer.log"
+  path: Path.absname("logs/test/explorer.log")
 
 if File.exists?(file = "test.secret.exs") do
   import_config file

--- a/apps/indexer/config/dev.exs
+++ b/apps/indexer/config/dev.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :logger, :indexer,
   level: :debug,
-  path: "logs/dev/indexer.log"
+  path: Path.absname("logs/dev/indexer.log")
 
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do

--- a/apps/indexer/config/prod.exs
+++ b/apps/indexer/config/prod.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :logger, :indexer,
   level: :info,
-  path: "logs/prod/indexer.log"
+  path: Path.absname("logs/prod/indexer.log")
 
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do

--- a/apps/indexer/config/test.exs
+++ b/apps/indexer/config/test.exs
@@ -2,4 +2,4 @@ use Mix.Config
 
 config :logger, :indexer,
   level: :warn,
-  path: "logs/test/indexer.log"
+  path: Path.absname("logs/test/indexer.log")

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,6 +5,6 @@ config :logger, :console, level: :info
 
 config :logger, :ecto,
   level: :debug,
-  path: "logs/dev/ecto.log"
+  path: Path.absname("logs/dev/ecto.log")
 
-config :logger, :error, path: "logs/dev/error.log"
+config :logger, :error, path: Path.absname("logs/dev/error.log")

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -6,6 +6,6 @@ config :logger, :console, level: :info
 
 config :logger, :ecto,
   level: :info,
-  path: "logs/prod/ecto.log"
+  path: Path.absname("logs/prod/ecto.log")
 
-config :logger, :error, path: "logs/prod/error.log"
+config :logger, :error, path: Path.absname("logs/prod/error.log")

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,9 +6,9 @@ config :logger, :console, level: :warn
 
 config :logger, :ecto,
   level: :warn,
-  path: "logs/test/ecto.log"
+  path: Path.absname("logs/test/ecto.log")
 
-config :logger, :error, path: "logs/test/error.log"
+config :logger, :error, path: Path.absname("logs/test/error.log")
 
 config :explorer, Explorer.ExchangeRates,
   source: Explorer.ExchangeRates.Source.NoOpSource,


### PR DESCRIPTION
Fixes #628

## Changelog
### Bug Fixes
* The `Phoenix.CodeReloader` causes the file loggers to restart and reload their config, but when they reload, the current working directory has shifted from the project root to the OTP app root, so it produces log files under each OTP app (`apps/APP_NAME/logs`).  We don't want this, so compute the absolute path in the config files, so that the loaded `Application` environment has an absolute path in it that can't shift when the working directory changes.