### PR TITLE
Better error message when receipt cannot be converted to elixir

### DIFF
--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/receipt_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/receipt_test.exs
@@ -1,5 +1,47 @@
 defmodule EthereumJSONRPC.ReceiptTest do
   use ExUnit.Case, async: true
 
-  doctest EthereumJSONRPC.Receipt
+  alias EthereumJSONRPC.Receipt
+
+  doctest Receipt
+
+  describe "to_elixir/1" do
+    test "with status with nil raises ArgumentError with full receipt" do
+      assert_raise ArgumentError,
+                   """
+                   Could not convert receipt to elixir
+
+                   Receipt:
+                     %{"status" => nil, "transactionHash" => "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"}
+
+                   Errors:
+                     {:unknown_value, %{key: "status", value: nil}}
+                   """,
+                   fn ->
+                     Receipt.to_elixir(%{
+                       "status" => nil,
+                       "transactionHash" => "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"
+                     })
+                   end
+    end
+
+    test "with new key raise ArgumentError with full receipt" do
+      assert_raise ArgumentError,
+                   """
+                   Could not convert receipt to elixir
+
+                   Receipt:
+                     %{"new_key" => "new_value", "transactionHash" => "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"}
+
+                   Errors:
+                     {:unknown_key, %{key: "new_key", value: "new_value"}}
+                   """,
+                   fn ->
+                     Receipt.to_elixir(%{
+                       "new_key" => "new_value",
+                       "transactionHash" => "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"
+                     })
+                   end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #618

**NOTE: This is an improved logging bug fix.  It does not fix why we're getting a `nil` "status`, which indicated `"status":null` in the JSON, but instead adds enough additional information to the exception to recover the block number or transaction hash so that we can use that information for further triage and bug reproduction.  #618 could turn out to be a bug in the node configuration, but we can't know that we the stacktraces we're getting now.**

# Changelog
## Bug Fixes
* Use the validation pattern of reducing all entries while ok, but then switching to accumulating all errors once any error occurs. Finally, because the fields that identify the receipt precisely, such as
the transactionHash or blockNumber may not have an error, include the full receipt the `ArgumentError` exception.