### PR TITLE
Add stop propagation to links in API docs page

### DIFF
--- a/apps/block_scout_web/assets/js/app.js
+++ b/apps/block_scout_web/assets/js/app.js
@@ -31,6 +31,7 @@ import './lib/pretty_json'
 import './lib/try_api'
 import './lib/token_balance_dropdown'
 import './lib/token_transfers_toggle'
+import './lib/stop_propagation'
 
 import './pages/address'
 import './pages/block'

--- a/apps/block_scout_web/assets/js/lib/stop_propagation.js
+++ b/apps/block_scout_web/assets/js/lib/stop_propagation.js
@@ -1,0 +1,3 @@
+import $ from 'jquery'
+
+$('[data-selector="stop-propagation"]').click((event) => event.stopPropagation())

--- a/apps/block_scout_web/lib/block_scout_web/templates/api_docs/_action_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/api_docs/_action_tile.html.eex
@@ -7,7 +7,7 @@
         <span class="badge badge-primary tile-badge float-right mr-1"><%= gettext "GET" %></span>
         <strong class="tile-label"><%= @action.name %></strong>
       </h3>
-      <h4 class="text-dark"><%= raw @action.description %></h4>
+      <h4 class="text-dark"><span data-selector="stop-propagation"><%= raw @action.description %></span></h4>
       <code><%= raw query_params(@module_name, @action) %></code>
     </button>
   </div>


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/647

## Motivation

* For API users not to show/hide an API action's details without meaning
to when clicking on a link within an action's description, within the API docs page.

## Changelog

### Enhancements
* Adding `stop_progation.js` to stop clicks from bubbling up on elements
with `data-selector=stop-propagation`.
* Adding a span element with `data-selector=stop-propagation` that wraps
around API action descriptions.
