### PR TITLE
API account#txlist filterby=from support

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
@@ -322,7 +322,7 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
 
   defp put_filter_by(options, params) do
     case params do
-      %{"filterby" => filter_by} when filter_by in ["to"] ->
+      %{"filterby" => filter_by} when filter_by in ["from", "to"] ->
         Map.put(options, :filter_by, filter_by)
 
       _ ->

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -661,7 +661,7 @@ defmodule BlockScoutWeb.Etherscan do
         description: """
         A string representing the field to filter by. If none is given
         it returns transactions that match to, from, or contract address.
-        Available values: to
+        Available values: to, from
         """
       }
     ],

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -226,6 +226,10 @@ defmodule Explorer.Etherscan do
     where(query, [t], t.to_address_hash == ^address_hash)
   end
 
+  defp where_address_match(query, address_hash, %{filter_by: "from"}) do
+    where(query, [t], t.from_address_hash == ^address_hash)
+  end
+
   defp where_address_match(query, address_hash, _) do
     query
     |> where([t], t.to_address_hash == ^address_hash)

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -379,6 +379,39 @@ defmodule Explorer.EtherscanTest do
 
       assert length(found_transactions) == 0
     end
+
+    test "with filter_by: 'from' option with one matching transaction" do
+      address = insert(:address)
+
+      :transaction
+      |> insert(to_address: address)
+      |> with_block()
+
+      :transaction
+      |> insert(from_address: address)
+      |> with_block()
+
+      options = %{filter_by: "from"}
+
+      found_transactions = Etherscan.list_transactions(address.hash, options)
+
+      assert length(found_transactions) == 1
+    end
+
+    test "with filter_by: 'from' option with non-matching transaction" do
+      address = insert(:address)
+      other_address = insert(:address)
+
+      :transaction
+      |> insert(from_address: other_address, to_address: nil)
+      |> with_block()
+
+      options = %{filter_by: "from"}
+
+      found_transactions = Etherscan.list_transactions(address.hash, options)
+
+      assert length(found_transactions) == 0
+    end
   end
 
   describe "list_internal_transactions/1" do


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/635


## Motivation

* For API users to be able to get a list of transactions in which a
given address is the 'sender' (address is the 'from' in transaction).

  Example usage:
    ```
      /api?module=account&action&txlist&address={someAddress}&filterby=from
    ```

## Changelog

### Enhancements
* Editing `where_address_match/3` in `Explorer.Etherscan` to support
`filter_by: "from"` option.
* Editing `put_filter_by/2` in `API.RPC.AddressController` to support
'from' as an allowed value of the `filterby` parameter.