### PR TITLE
Allow blocks.gas_used and gas_limit to be numeric to support higher limits on private chains

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/block/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/_tile.html.eex
@@ -35,12 +35,12 @@
       <!-- Gas Used -->
       <div class="mr-3 mr-md-0">
         <%= formatted_gas(@block.gas_used) %>
-        (<%= formatted_gas(@block.gas_used / @block.gas_limit, format: "#.#%") %>)
+        (<%= formatted_gas(Decimal.to_integer(@block.gas_used) / Decimal.to_integer(@block.gas_limit), format: "#.#%") %>)
         <%= gettext "Gas Used" %>
       </div>
       <!-- Progress bar -->
       <div class="progress w-100 mt-3 mt-md-0">
-        <div class="progress-bar" role="progressbar" style="width: <%= formatted_gas(@block.gas_used / @block.gas_limit, format: "#.#%") %>;" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">
+        <div class="progress-bar" role="progressbar" style="width: <%= formatted_gas(Decimal.to_integer(@block.gas_used) / Decimal.to_integer(@block.gas_limit), format: "#.#%") %>;" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">
         </div>
       </div>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
@@ -86,7 +86,7 @@
             <!-- Gas Used -->
             <h3>
               <%= @block.gas_used |> Cldr.Number.to_string! %>
-              <span class="text-muted"> (<%= (@block.gas_used / @block.gas_limit) |> Cldr.Number.to_string!(format: "#.#%") %>) </span>
+              <span class="text-muted"> (<%= (Decimal.to_integer(@block.gas_used) / Decimal.to_integer(@block.gas_limit)) |> Cldr.Number.to_string!(format: "#.#%") %>) </span>
             </h3>
             <!-- Gas Limit -->
             <span class="text-muted"> <%= @block.gas_limit |> Cldr.Number.to_string! %> <%= gettext "Gas Limit" %> </span>

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -61,8 +61,8 @@ defmodule Explorer.Chain.Block do
   @primary_key {:hash, Hash.Full, autogenerate: false}
   schema "blocks" do
     field(:difficulty, :decimal)
-    field(:gas_limit, :integer)
-    field(:gas_used, :integer)
+    field(:gas_limit, :decimal)
+    field(:gas_used, :decimal)
     field(:nonce, Hash.Nonce)
     field(:number, :integer)
     field(:size, :integer)

--- a/apps/explorer/priv/repo/migrations/20180831231919_modify_block_gas.exs
+++ b/apps/explorer/priv/repo/migrations/20180831231919_modify_block_gas.exs
@@ -1,0 +1,10 @@
+defmodule Explorer.Repo.Migrations.ModifyBlockGas do
+  use Ecto.Migration
+
+  def change do
+    alter table(:blocks) do
+      modify(:gas_used, :numeric, precision: 100)
+      modify(:gas_limit, :numeric, precision: 100)
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -153,6 +153,8 @@ defmodule Explorer.Chain.ImportTest do
       difficulty = Decimal.new(340_282_366_920_938_463_463_374_607_431_768_211_454)
       total_difficulty = Decimal.new(12_590_447_576_074_723_148_144_860_474_975_121_280_509)
       token_transfer_amount = Decimal.new(1_000_000_000_000_000_000)
+      gas_limit = Decimal.new(6_946_336)
+      gas_used = Decimal.new(50450)
 
       assert {:ok,
               %{
@@ -190,8 +192,8 @@ defmodule Explorer.Chain.ImportTest do
                 blocks: [
                   %Block{
                     difficulty: ^difficulty,
-                    gas_limit: 6_946_336,
-                    gas_used: 50450,
+                    gas_limit: ^gas_limit,
+                    gas_used: ^gas_used,
                     hash: %Hash{
                       byte_count: 32,
                       bytes:

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -773,6 +773,8 @@ defmodule Explorer.ChainTest do
       difficulty = Decimal.new(340_282_366_920_938_463_463_374_607_431_768_211_454)
       total_difficulty = Decimal.new(12_590_447_576_074_723_148_144_860_474_975_121_280_509)
       token_transfer_amount = Decimal.new(1_000_000_000_000_000_000)
+      gas_limit = Decimal.new(6_946_336)
+      gas_used = Decimal.new(50450)
 
       assert {:ok,
               %{
@@ -810,8 +812,8 @@ defmodule Explorer.ChainTest do
                 blocks: [
                   %Block{
                     difficulty: ^difficulty,
-                    gas_limit: 6_946_336,
-                    gas_used: 50450,
+                    gas_limit: ^gas_limit,
+                    gas_used: ^gas_used,
                     hash: %Hash{
                       byte_count: 32,
                       bytes:


### PR DESCRIPTION
## Changelog

### Bug Fixes
* `blocks.gas_used` and `blocks.gas_limit` need be larger to support private chains with higher limits than Ethereum mainnet (8 million), which fit in `integer`.

## Upgrading

The column type can be converted from `integer` to `numeric` **without** a database reset, so you **only need to run `mix ecto.migrate`**.