### PR TITLE
Design cleanup items

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
@@ -55,51 +55,41 @@
           </dl>
 
           <!-- Nonce -->
-          <dl class="row">
+          <dl class="row mb-0">
             <dt class="col-sm-3 text-muted"> <%= gettext "Nonce" %> </dt>
-            <dd class="col-sm-9 mb-0"> <%= to_string(@block.nonce) %> </dd>
+            <dd class="col-sm-9"> <%= to_string(@block.nonce) %> </dd>
           </dl>
         </div>
       </div>
     </div>
 
-    <div class="col-md-12 col-lg-4">
-      <div class="row">
-        <div class="col-md-6 col-lg-12">
+    <div class="col-md-12 col-lg-4 d-flex flex-column flex-md-row flex-lg-column">
       <!-- Validator -->
-          <div class="card card-primary">
-            <div class="card-body">
-              <h2 class="card-title text-white"> <%= gettext "Miner" %> </h2>
-              <div class="text-right">
-                <!-- Validator's Name -->
-                <!-- Until we can get the validator's name we are using the Validator's address hash -->
-                <h3 class="text-white text-truncate"> <%= link @block.miner, class: "text-white", to: address_path(BlockScoutWeb.Endpoint, :show, @locale, @block.miner) %> </h3>
-                <!-- Validator's address hash -->
-                <span class="text-light text-truncate"> </span>
-              </div>
-            </div>
+      <div class="card card-primary flex-grow-1">
+        <div class="card-body">
+          <h2 class="card-title text-white"> <%= gettext "Miner" %> </h2>
+          <div class="text-right">
+            <!-- Validator's Name -->
+            <!-- Until we can get the validator's name we are using the Validator's address hash -->
+            <h3 class="text-white text-truncate"> <%= link @block.miner, class: "text-white", to: address_path(BlockScoutWeb.Endpoint, :show, @locale, @block.miner) %> </h3>
+            <!-- Validator's address hash -->
+            <span class="text-light text-truncate"> </span>
           </div>
         </div>
-        <div class="col-md-6 col-lg-12">
+      </div>
+
       <!-- Gas -->
-          <div class="card">
-            <div class="card-body">
-              <h2 class="card-title"> <%= gettext "Gas Used" %> </h2>
-              <div class="text-right">
-                <!-- Gas Used -->
-                <h3>
-                  <%= @block.gas_used |> Cldr.Number.to_string! %>
-                  <span class="text-muted"> (<%= (@block.gas_used / @block.gas_limit) |> Cldr.Number.to_string!(format: "#.#%") %>) </span>
-                </h3>
-                <!-- Gas Limit -->
-                <span class="text-muted"> <%= @block.gas_limit |> Cldr.Number.to_string! %> <%= gettext "Gas Limit" %> </span>
-                <!-- Progress bar -->
-                <div class="progress w-100 mt-3 mb-1">
-                  <div class="progress-bar" role="progressbar" style="width: <%= formatted_gas(@block.gas_used / @block.gas_limit, format: "#.#%") %>;" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">
-                  </div>
-                </div>
-              </div>
-            </div>
+      <div class="card flex-grow-1 ml-0 ml-md-5 ml-lg-0">
+        <div class="card-body">
+          <h2 class="card-title"> <%= gettext "Gas Used" %> </h2>
+          <div class="text-right">
+            <!-- Gas Used -->
+            <h3>
+              <%= @block.gas_used |> Cldr.Number.to_string! %>
+              <span class="text-muted"> (<%= (@block.gas_used / @block.gas_limit) |> Cldr.Number.to_string!(format: "#.#%") %>) </span>
+            </h3>
+            <!-- Gas Limit -->
+            <span class="text-muted"> <%= @block.gas_limit |> Cldr.Number.to_string! %> <%= gettext "Gas Limit" %> </span>
           </div>
         </div>
       </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
@@ -55,9 +55,9 @@
           </dl>
 
           <!-- Nonce -->
-          <dl class="row mb-0">
+          <dl class="row">
             <dt class="col-sm-3 text-muted"> <%= gettext "Nonce" %> </dt>
-            <dd class="col-sm-9"> <%= to_string(@block.nonce) %> </dd>
+            <dd class="col-sm-9 mb-0"> <%= to_string(@block.nonce) %> </dd>
           </dl>
         </div>
       </div>
@@ -93,6 +93,11 @@
                 </h3>
                 <!-- Gas Limit -->
                 <span class="text-muted"> <%= @block.gas_limit |> Cldr.Number.to_string! %> <%= gettext "Gas Limit" %> </span>
+                <!-- Progress bar -->
+                <div class="progress w-100 mt-3 mb-1">
+                  <div class="progress-bar" role="progressbar" style="width: <%= formatted_gas(@block.gas_used / @block.gas_limit, format: "#.#%") %>;" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/index.html.eex
@@ -44,19 +44,20 @@
             <span data-selector="empty-transactions-list"><%= gettext "There are no transactions for this address." %></span>
           </div>
         <% end %>
+
+        <%= if @next_page_params do %>
+          <%= link(
+            gettext("Older"),
+            class: "button button--secondary button--sm float-right mt-3",
+            to: transaction_path(
+              @conn,
+              :index,
+              @conn.assigns.locale,
+              @next_page_params
+            )
+          ) %>
+        <% end %>
       </div>
     </div>
-    <%= if @next_page_params do %>
-      <%= link(
-        gettext("Older"),
-        class: "button button--secondary button--sm u-float-right mt-3",
-        to: transaction_path(
-          @conn,
-          :index,
-          @conn.assigns.locale,
-          @next_page_params
-        )
-      ) %>
-    <% end %>
   </section>
 </section>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex
@@ -30,7 +30,7 @@
       </span>
     </div>
 
-    <div class="p-4 col-md-2 col-lg-2 d-flex flex-row flex-md-column justify-content-start align-items-end text-md-right">
+    <div class="col-md-2 col-lg-2 d-flex flex-row flex-md-column justify-content-start align-items-end text-md-right">
         <span class="ml-1 mr-sm-0 text-muted" data-from-now="<%= @transfer.transaction.block.timestamp %>"></span>
 
         <span class="ml-2">

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -75,42 +75,36 @@
       </div>
     </div>
 
-    <div class="col-md-12 col-lg-4">
-      <div class="row">
-        <div class="col-md-6 col-lg-12">
-          <!-- Value -->
-          <div class="card card-primary ">
-            <div class="card-body">
-              <h2 class="card-title text-white"><%= gettext "Ether" %> <%= gettext "Value" %></h2>
-              <div class="text-right">
-                <h3 class="text-white"> <%= value(@transaction) %></h3>
-                <span class="text-light"> <%= formatted_usd_value(@transaction, @exchange_rate) %></span>
-              </div>
-            </div>
+    <div class="col-md-12 col-lg-4 d-flex flex-column flex-md-row flex-lg-column">
+      <!-- Value -->
+      <div class="card card-primary flex-grow-1">
+        <div class="card-body">
+          <h2 class="card-title text-white"><%= gettext "Ether" %> <%= gettext "Value" %></h2>
+          <div class="text-right">
+            <h3 class="text-white"> <%= value(@transaction) %></h3>
+            <span class="text-light"> <%= formatted_usd_value(@transaction, @exchange_rate) %></span>
           </div>
         </div>
+      </div>
 
-        <div class="col-md-6 col-lg-12">
-          <!-- Gas -->
-          <div class="card">
-            <div class="card-body">
-              <h2 class="card-title"> <%= gettext "Gas" %> </h2>
-              <div class="text-right">
-                <!-- Gas Used -->
-                <h3>
-                  <span>
-                    <%= gettext "Used" %>
-                    <%= gas_used(@transaction) %> @
-                    <%= gas_price(@transaction, :gwei) %>
-                  </span>
-                </h3>
-                <!-- Gas Limit -->
-                <span class="text-muted">
-                  <%= gettext "Limit" %>
-                  <%= format_gas_limit(@transaction.gas) %>
-                </span>
-              </div>
-            </div>
+      <!-- Gas -->
+      <div class="card flex-grow-1 ml-0 ml-md-5 ml-lg-0">
+        <div class="card-body">
+          <h2 class="card-title"> <%= gettext "Gas" %> </h2>
+          <div class="text-right">
+            <!-- Gas Used -->
+            <h3>
+              <span>
+                <%= gettext "Used" %>
+                <%= gas_used(@transaction) %> @
+                <%= gas_price(@transaction, :gwei) %>
+              </span>
+            </h3>
+            <!-- Gas Limit -->
+            <span class="text-muted">
+              <%= gettext "Limit" %>
+              <%= format_gas_limit(@transaction.gas) %>
+            </span>
           </div>
         </div>
       </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex
@@ -71,19 +71,21 @@
               <span><%= gettext "There are no internal transactions for this transaction." %></span>
             </div>
           <% end %>
+
+          <%= if @next_page_params do %>
+            <%= link(
+              gettext("Newer"),
+              class: "button button--secondary button--sm float-right mt-3",
+              to: transaction_internal_transaction_path(
+                @conn,
+                :index,
+                @conn.assigns.locale,
+                @transaction,
+                @next_page_params
+              )
+            ) %>
+          <% end %>
         </div>
       </div>
-      <%= if @next_page_params do %>
-        <%= link(
-          gettext("Newer"),
-          class: "button button--secondary button--sm u-float-right mt-3",
-          to: transaction_internal_transaction_path(
-            @conn,
-            :index,
-            @conn.assigns.locale,
-            @transaction,
-            @next_page_params
-          )
-        ) %>
-      <% end %>
+
       </section>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -16,7 +16,7 @@ msgid "Copyright %{year} POA"
 msgstr ""
 
 #: lib/block_scout_web/templates/block/_tile.html.eex:39
-#: lib/block_scout_web/templates/block/overview.html.eex:87
+#: lib/block_scout_web/templates/block/overview.html.eex:84
 msgid "Gas Used"
 msgstr ""
 
@@ -50,7 +50,7 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/transaction/overview.html.eex:84
+#: lib/block_scout_web/templates/transaction/overview.html.eex:82
 msgid "Value"
 msgstr ""
 
@@ -63,12 +63,12 @@ msgid "Difficulty"
 msgstr ""
 
 #: lib/block_scout_web/templates/block/_tile.html.eex:34
-#: lib/block_scout_web/templates/block/overview.html.eex:95
+#: lib/block_scout_web/templates/block/overview.html.eex:92
 msgid "Gas Limit"
 msgstr ""
 
 #: lib/block_scout_web/templates/block/_tile.html.eex:24
-#: lib/block_scout_web/templates/block/overview.html.eex:72
+#: lib/block_scout_web/templates/block/overview.html.eex:70
 #: lib/block_scout_web/templates/chain/_block.html.eex:9
 msgid "Miner"
 msgstr ""
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Cumulative Gas Used"
 msgstr ""
 
-#: lib/block_scout_web/templates/transaction/overview.html.eex:97
+#: lib/block_scout_web/templates/transaction/overview.html.eex:93
 msgid "Gas"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/_internal_transaction.html.eex:22
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:68
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:24
-#: lib/block_scout_web/templates/transaction/overview.html.eex:84
+#: lib/block_scout_web/templates/transaction/overview.html.eex:82
 #: lib/block_scout_web/templates/transaction_internal_transaction/_internal_transaction.html.eex:16
 #: lib/block_scout_web/views/wei_helpers.ex:72
 msgid "Ether"
@@ -698,7 +698,7 @@ msgid "Block Confirmations"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:109
+#: lib/block_scout_web/templates/transaction/overview.html.eex:105
 msgid "Limit"
 msgstr ""
 
@@ -714,7 +714,7 @@ msgid "There are no logs for this transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:102
+#: lib/block_scout_web/templates/transaction/overview.html.eex:98
 msgid "Used"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -477,7 +477,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:132
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:145
 #: lib/block_scout_web/templates/block/index.html.eex:15
-#: lib/block_scout_web/templates/block_transaction/index.html.eex:51
+#: lib/block_scout_web/templates/block_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:78
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:71
 #: lib/block_scout_web/templates/transaction/index.html.eex:66
@@ -518,7 +518,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:78
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:77
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:122
 msgid "Newer"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -489,7 +489,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:132
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:145
 #: lib/block_scout_web/templates/block/index.html.eex:15
-#: lib/block_scout_web/templates/block_transaction/index.html.eex:51
+#: lib/block_scout_web/templates/block_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:78
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:71
 #: lib/block_scout_web/templates/transaction/index.html.eex:66
@@ -530,7 +530,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:78
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:77
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:122
 msgid "Newer"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -28,7 +28,7 @@ msgid "Copyright %{year} POA"
 msgstr "%{year} POA Network Ltd. All rights reserved"
 
 #: lib/block_scout_web/templates/block/_tile.html.eex:39
-#: lib/block_scout_web/templates/block/overview.html.eex:87
+#: lib/block_scout_web/templates/block/overview.html.eex:84
 msgid "Gas Used"
 msgstr "Gas Used"
 
@@ -62,7 +62,7 @@ msgstr "BlockScout"
 msgid "Transactions"
 msgstr "Transactions"
 
-#: lib/block_scout_web/templates/transaction/overview.html.eex:84
+#: lib/block_scout_web/templates/transaction/overview.html.eex:82
 msgid "Value"
 msgstr "Value"
 
@@ -75,12 +75,12 @@ msgid "Difficulty"
 msgstr "Difficulty"
 
 #: lib/block_scout_web/templates/block/_tile.html.eex:34
-#: lib/block_scout_web/templates/block/overview.html.eex:95
+#: lib/block_scout_web/templates/block/overview.html.eex:92
 msgid "Gas Limit"
 msgstr "Gas Limit"
 
 #: lib/block_scout_web/templates/block/_tile.html.eex:24
-#: lib/block_scout_web/templates/block/overview.html.eex:72
+#: lib/block_scout_web/templates/block/overview.html.eex:70
 #: lib/block_scout_web/templates/chain/_block.html.eex:9
 msgid "Miner"
 msgstr "Validator"
@@ -122,7 +122,7 @@ msgstr "Transaction Details"
 msgid "Cumulative Gas Used"
 msgstr "Cumulative Gas Used"
 
-#: lib/block_scout_web/templates/transaction/overview.html.eex:97
+#: lib/block_scout_web/templates/transaction/overview.html.eex:93
 msgid "Gas"
 msgstr "Gas"
 
@@ -303,7 +303,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/_internal_transaction.html.eex:22
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:68
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:24
-#: lib/block_scout_web/templates/transaction/overview.html.eex:84
+#: lib/block_scout_web/templates/transaction/overview.html.eex:82
 #: lib/block_scout_web/templates/transaction_internal_transaction/_internal_transaction.html.eex:16
 #: lib/block_scout_web/views/wei_helpers.ex:72
 msgid "Ether"
@@ -710,7 +710,7 @@ msgid "Block Confirmations"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:109
+#: lib/block_scout_web/templates/transaction/overview.html.eex:105
 msgid "Limit"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgid "There are no logs for this transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:102
+#: lib/block_scout_web/templates/transaction/overview.html.eex:98
 msgid "Used"
 msgstr ""
 


### PR DESCRIPTION
Resolves: #598 

## Motivation

Small design cleanup items to improve the UI.

## Changelog

### Enhancements
- [x] Older/Newer pagination button location inconsistencies (Transaction Details, Address Page, Blocks Details)
- [x] Padding on Token Transfers tile for Token page is a little fat
- [x] Space / align token transfer 1-lines on Transaction tiles (and maybe look at the IN/OUT button size/color for address page)
- [x] Transaction Details and Block Details: align/resize the 2 blocks to the right with the main block to the left
