### PR TITLE
Remove I18n locales from URL

### DIFF
--- a/apps/block_scout_web/assets/js/locale.js
+++ b/apps/block_scout_web/assets/js/locale.js
@@ -1,7 +1,8 @@
 import moment from 'moment'
 import numeral from 'numeral'
 import 'numeral/locales'
-import router from './router'
 
-moment.locale(router.locale)
-numeral.locale(router.locale)
+export const locale = 'en'
+
+moment.locale(locale)
+numeral.locale(locale)

--- a/apps/block_scout_web/assets/js/router.js
+++ b/apps/block_scout_web/assets/js/router.js
@@ -2,13 +2,10 @@ import Path from 'path-parser'
 import URI from 'urijs'
 import humps from 'humps'
 
-const { locale } = Path.createPath('/:locale').partialTest(window.location.pathname) || { locale: 'en' }
-
 export default {
-  locale,
   when (pattern, { exactPathMatch } = { exactPathMatch: false }) {
     return new Promise((resolve) => {
-      const path = Path.createPath(`/:locale${pattern}`)
+      const path = Path.createPath(pattern || '/')
       const match = exactPathMatch ? path.test(window.location.pathname) : path.partialTest(window.location.pathname)
       if (match) {
         const routeParams = humps.camelizeKeys(match)

--- a/apps/block_scout_web/assets/js/socket.js
+++ b/apps/block_scout_web/assets/js/socket.js
@@ -1,7 +1,7 @@
 import {Socket} from 'phoenix'
-import router from './router'
+import {locale} from './locale'
 
-const socket = new Socket('/socket', {params: {locale: router.locale}})
+const socket = new Socket('/socket', {params: {locale: locale}})
 socket.connect()
 
 export default socket

--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -24,7 +24,6 @@ defmodule BlockScoutWeb.AddressChannel do
       View.render_to_string(
         AddressView,
         "_balance_card.html",
-        locale: socket.assigns.locale,
         address: address,
         exchange_rate: exchange_rate
       )
@@ -48,7 +47,6 @@ defmodule BlockScoutWeb.AddressChannel do
       View.render_to_string(
         AddressTransactionView,
         "_transaction.html",
-        locale: socket.assigns.locale,
         address: address,
         transaction: transaction
       )

--- a/apps/block_scout_web/lib/block_scout_web/channels/block_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/block_channel.ex
@@ -20,7 +20,6 @@ defmodule BlockScoutWeb.BlockChannel do
       View.render_to_string(
         BlockView,
         "_tile.html",
-        locale: socket.assigns.locale,
         block: block
       )
 
@@ -28,7 +27,6 @@ defmodule BlockScoutWeb.BlockChannel do
       View.render_to_string(
         ChainView,
         "_block.html",
-        locale: socket.assigns.locale,
         block: block
       )
 

--- a/apps/block_scout_web/lib/block_scout_web/channels/transaction_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/transaction_channel.ex
@@ -20,7 +20,6 @@ defmodule BlockScoutWeb.TransactionChannel do
       View.render_to_string(
         TransactionView,
         "_tile.html",
-        locale: socket.assigns.locale,
         transaction: transaction
       )
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
@@ -18,12 +18,11 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
 
   def create(conn, %{
         "address_id" => address_hash_string,
-        "smart_contract" => smart_contract,
-        "locale" => locale
+        "smart_contract" => smart_contract
       }) do
     case Publisher.publish(address_hash_string, smart_contract) do
       {:ok, _smart_contract} ->
-        redirect(conn, to: address_contract_path(conn, :index, locale, address_hash_string))
+        redirect(conn, to: address_contract_path(conn, :index, address_hash_string))
 
       {:error, changeset} ->
         {:ok, compiler_versions} = CompilerVersion.fetch_versions()

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
@@ -4,8 +4,8 @@ defmodule BlockScoutWeb.AddressController do
   alias Explorer.Chain
   alias Explorer.Chain.Address
 
-  def show(conn, %{"id" => id, "locale" => locale}) do
-    redirect(conn, to: address_transaction_path(conn, :index, locale, id))
+  def show(conn, %{"id" => id}) do
+    redirect(conn, to: address_transaction_path(conn, :index, id))
   end
 
   def transaction_count(%Address{} = address) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_controller.ex
@@ -23,7 +23,7 @@ defmodule BlockScoutWeb.BlockController do
     render(conn, "index.html", blocks: blocks, next_page_params: next_page_params(next_page, blocks, params))
   end
 
-  def show(conn, %{"id" => number, "locale" => locale}) do
-    redirect(conn, to: block_transaction_path(conn, :index, locale, number))
+  def show(conn, %{"id" => number}) do
+    redirect(conn, to: block_transaction_path(conn, :index, number))
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
@@ -61,11 +61,11 @@ defmodule BlockScoutWeb.ChainController do
   end
 
   defp redirect_search_results(conn, %Address{} = item) do
-    redirect(conn, to: address_path(conn, :show, Gettext.get_locale(), item))
+    redirect(conn, to: address_path(conn, :show, item))
   end
 
   defp redirect_search_results(conn, %Block{} = item) do
-    redirect(conn, to: block_path(conn, :show, Gettext.get_locale(), item))
+    redirect(conn, to: block_path(conn, :show, item))
   end
 
   defp redirect_search_results(conn, %Transaction{} = item) do
@@ -75,7 +75,6 @@ defmodule BlockScoutWeb.ChainController do
         transaction_path(
           conn,
           :show,
-          Gettext.get_locale(),
           item
         )
     )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
@@ -33,13 +33,13 @@ defmodule BlockScoutWeb.TransactionController do
     )
   end
 
-  def show(conn, %{"id" => id, "locale" => locale}) do
+  def show(conn, %{"id" => id}) do
     {:ok, transaction_hash} = Chain.string_to_transaction_hash(id)
 
     if Chain.transaction_has_token_transfers?(transaction_hash) do
-      redirect(conn, to: transaction_token_transfer_path(conn, :index, locale, id))
+      redirect(conn, to: transaction_token_transfer_path(conn, :index, id))
     else
-      redirect(conn, to: transaction_internal_transaction_path(conn, :index, locale, id))
+      redirect(conn, to: transaction_internal_transaction_path(conn, :index, id))
     end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -13,10 +13,6 @@ defmodule BlockScoutWeb.Router do
     plug(:accepts, ["json"])
   end
 
-  pipeline :set_locale do
-    plug(SetLocale, gettext: BlockScoutWeb.Gettext, default_locale: "en")
-  end
-
   scope "/api/v1", BlockScoutWeb.API.V1, as: :api_v1 do
     pipe_through(:api)
 
@@ -39,13 +35,7 @@ defmodule BlockScoutWeb.Router do
 
   scope "/", BlockScoutWeb do
     pipe_through(:browser)
-    pipe_through(:set_locale)
-    resources("/", ChainController, only: [:show], singleton: true, as: :chain)
-  end
 
-  scope "/:locale", BlockScoutWeb do
-    pipe_through(:browser)
-    pipe_through(:set_locale)
     resources("/", ChainController, only: [:show], singleton: true, as: :chain)
 
     resources "/blocks", BlockController, only: [:index, :show] do

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_balance_card.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_balance_card.html.eex
@@ -9,7 +9,7 @@
         data-usd-exchange-rate="<%= @exchange_rate.usd_value %>">
       </span>
 
-      <div class="mt-3" data-token-balance-dropdown data-api_path="<%= address_token_balance_path(@conn, :index, :en, @address.hash) %>">
+      <div class="mt-3" data-token-balance-dropdown data-api_path="<%= address_token_balance_path(@conn, :index, @address.hash) %>">
           <p data-loading class="mb-0 text-light" style="display: none;">
             <i class="fa fa-spinner fa-spin"></i>
             <%= gettext("Fetching tokens...") %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_link.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_link.html.eex
@@ -1,5 +1,5 @@
 <%= if @address_hash do %>
-  <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @locale, @address_hash), "data-test": "address_hash_link" do %>
+  <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @address_hash), "data-test": "address_hash_link" do %>
     <%= render BlockScoutWeb.AddressView, "_responsive_hash.html", address_hash: @address_hash, contract: @contract, truncate: assigns[:truncate] %>
   <% end %>
 <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -28,7 +28,6 @@
                       to: address_path(
                         BlockScoutWeb.Endpoint,
                         :show,
-                        @locale,
                         @address.contracts_creation_internal_transaction.from_address_hash
                       )
                     ) %>
@@ -40,7 +39,6 @@
                       to: transaction_path(
                         BlockScoutWeb.Endpoint,
                         :show,
-                        @locale,
                         @address.contracts_creation_internal_transaction.transaction_hash
                       ),
                       "data-test": "transaction_hash_link"

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
@@ -9,7 +9,7 @@
           <%= link(
                 gettext("Transactions"),
                 class: "nav-link",
-                to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                to: address_transaction_path(@conn, :index, @conn.params["address_id"])
               ) %>
         </li>
         <li class="nav-item">
@@ -17,12 +17,12 @@
                 gettext("Internal Transactions"),
                 class: "nav-link",
                 "data-test": "internal_transactions_tab_link",
-                to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
               ) %>
         </li>
         <li class="nav-item">
           <%= link(
-              to: address_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+              to: address_contract_path(@conn, :index, @conn.params["address_id"]),
               class: "nav-link active") do %>
             <%= gettext("Code") %>
 
@@ -35,7 +35,7 @@
           <li class="nav-item">
             <%= link(
                 gettext("Read Contract"),
-                to: address_read_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+                to: address_read_contract_path(@conn, :index, @conn.params["address_id"]),
                 class: "nav-link")%>
           </li>
         <% end %>
@@ -46,7 +46,7 @@
       <%= if !smart_contract_verified?(@address) do %>
         <%= link(
               gettext("Verify and Publish"),
-              to: address_verify_contract_path(@conn, :new, @conn.assigns.locale, @conn.params["address_id"]),
+              to: address_verify_contract_path(@conn, :new, @conn.params["address_id"]),
               class: "button button--primary button--sm float-right ml-3",
               "data-test": "verify_and_publish"
             ) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
@@ -5,7 +5,7 @@
       <h1 class="card-title">New Smart Contract</h1>
 
       <%= form_for @changeset,
-          address_verify_contract_path(@conn, :create, @conn.assigns.locale, @conn.params["address_id"]),
+          address_verify_contract_path(@conn, :create, @conn.params["address_id"]),
           fn f -> %>
 
         <div class="form-group">
@@ -60,7 +60,7 @@
         <%= reset "Reset", class: "button button--secondary button--sm mr-2" %>
         <%= link(
             "Cancel",
-            to: address_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+            to: address_contract_path(@conn, :index, @conn.params["address_id"]),
             class: "button button--sm") %>
       <% end %>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/_internal_transaction.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/_internal_transaction.html.eex
@@ -4,18 +4,18 @@
       <%=  gettext("Internal Transaction") %>
     </div>
     <div class="col-md-8 col-lg-8 d-flex flex-column text-nowrap pr-2 pr-sm-2 pr-md-0">
-      <%= render BlockScoutWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @internal_transaction.transaction_hash %>
+      <%= render BlockScoutWeb.TransactionView, "_link.html", transaction_hash: @internal_transaction.transaction_hash %>
       <span class="text-nowrap">
         <%= if @address.hash == @internal_transaction.from_address_hash do %>
           <%= render BlockScoutWeb.AddressView, "_responsive_hash.html", address_hash: @internal_transaction.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@internal_transaction.from_address) %>
         <% else %>
-          <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @internal_transaction.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@internal_transaction.from_address), locale: @locale %>
+          <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @internal_transaction.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@internal_transaction.from_address) %>
         <% end %>
         &rarr;
         <%= if @address.hash == BlockScoutWeb.InternalTransactionView.to_address_hash(@internal_transaction) do %>
           <%= render BlockScoutWeb.AddressView, "_responsive_hash.html", address_hash: BlockScoutWeb.InternalTransactionView.to_address_hash(@internal_transaction), contract: BlockScoutWeb.AddressView.contract?(@internal_transaction.to_address) %>
         <% else %>
-          <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: BlockScoutWeb.InternalTransactionView.to_address_hash(@internal_transaction), contract: BlockScoutWeb.AddressView.contract?(@internal_transaction.to_address), locale: @locale %>
+          <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: BlockScoutWeb.InternalTransactionView.to_address_hash(@internal_transaction), contract: BlockScoutWeb.AddressView.contract?(@internal_transaction.to_address) %>
         <% end %>
       </span>
       <span class="tile-title text-truncate mt-3 mt-md-0">

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
@@ -12,7 +12,7 @@
             <%= link(
                   gettext("Transactions"),
                   class: "nav-link",
-                  to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                  to: address_transaction_path(@conn, :index, @conn.params["address_id"])
                 ) %>
           </li>
           <li class="nav-item">
@@ -20,13 +20,13 @@
                   gettext("Internal Transactions"),
                   class: "nav-link active",
                   "data-test": "internal_transactions_tab_link",
-                  to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                  to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
                 ) %>
           </li>
           <%= if contract?(@address) do %>
             <li class="nav-item">
               <%= link(
-                  to: address_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+                  to: address_contract_path(@conn, :index, @conn.params["address_id"]),
                   class: "nav-link") do %>
                 <%= gettext("Code") %>
 
@@ -40,7 +40,7 @@
             <li class="nav-item">
               <%= link(
                   gettext("Read Contract"),
-                  to: address_read_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+                  to: address_read_contract_path(@conn, :index, @conn.params["address_id"]),
                   class: "nav-link")%>
             </li>
           <% end %>
@@ -54,17 +54,17 @@
               <%= link(
                     gettext("Transactions"),
                     class: "dropdown-item",
-                    to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                    to: address_transaction_path(@conn, :index, @conn.params["address_id"])
                   ) %>
               <%= link(
                     gettext("Internal Transactions"),
                     class: "dropdown-item",
                     "data-test": "internal_transactions_tab_link",
-                    to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                    to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
                   ) %>
               <%= if contract?(@address) do %>
                 <%= link(
-                    to: address_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+                    to: address_contract_path(@conn, :index, @conn.params["address_id"]),
                     class: "dropdown-item") do %>
                   <%= gettext("Code") %>
 
@@ -86,7 +86,7 @@
           <div class="dropdown-menu dropdown-menu-right filter" aria-labelledby="dropdownMenu2">
             <%= link(
               gettext("All"),
-              to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+              to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"]),
               class: "address__link address__link--active dropdown-item",
               "data-test": "filter_option"
             ) %>
@@ -95,7 +95,6 @@
               to: address_internal_transaction_path(
                 @conn,
                 :index,
-                @conn.assigns.locale,
                 @conn.params["address_id"],
                 filter: "to"
               ),
@@ -107,7 +106,6 @@
               to: address_internal_transaction_path(
                 @conn,
                 :index,
-                @conn.assigns.locale,
                 @conn.params["address_id"],
                 filter: "from"
               ),
@@ -119,7 +117,7 @@
         <h2 class="card-title"><%= gettext "Internal Transactions" %></h2>
         <%= if Enum.count(@internal_transactions) > 0 do %>
           <%= for internal_transaction <- @internal_transactions do %>
-            <%= render "_internal_transaction.html", locale: @locale, address: @address, internal_transaction: internal_transaction %>
+            <%= render "_internal_transaction.html", address: @address, internal_transaction: internal_transaction %>
           <% end %>
         <% else %>
           <div class="tile tile-muted text-center">
@@ -134,7 +132,6 @@
               to: address_internal_transaction_path(
                 @conn,
                 :index,
-                @conn.assigns.locale,
                 @address,
                 @next_page_params
               )

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_read_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_read_contract/index.html.eex
@@ -9,7 +9,7 @@
           <%= link(
                 gettext("Transactions"),
                 class: "nav-link",
-                to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                to: address_transaction_path(@conn, :index, @conn.params["address_id"])
               ) %>
         </li>
         <li class="nav-item">
@@ -17,12 +17,12 @@
                 gettext("Internal Transactions"),
                 class: "nav-link",
                 "data-test": "internal_transactions_tab_link",
-                to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
               ) %>
         </li>
         <li class="nav-item">
           <%= link(
-              to: address_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+              to: address_contract_path(@conn, :index, @conn.params["address_id"]),
               class: "nav-link") do %>
             <%= gettext("Code") %>
 
@@ -34,14 +34,14 @@
         <li class="nav-item">
           <%= link(
               gettext("Read Contract"),
-              to: address_read_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+              to: address_read_contract_path(@conn, :index, @conn.params["address_id"]),
               class: "nav-link active")%>
         </li>
       </ul>
     </div>
 
     <!-- loaded via AJAX -->
-    <div class="card-body" data-smart-contract-functions data-hash="<%= to_string(@address.hash) %>" data-url="<%= smart_contract_path(@conn, :index, :en) %>">
+    <div class="card-body" data-smart-contract-functions data-hash="<%= to_string(@address.hash) %>" data-url="<%= smart_contract_path(@conn, :index) %>">
       <i class="fa fa-spinner fa-spin"></i> <%= gettext("loading...") %>
     </div>
   </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_token_balances.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_token_balances.html.eex
@@ -31,7 +31,7 @@
             conn: @conn,
             token_balances: filter_by_type(@token_balances, "ERC-20"),
             type: "ERC-20"
-          )  %>
+          ) %>
     <% end %>
   </div>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_tokens.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_tokens.html.eex
@@ -4,7 +4,7 @@
 <%= for token_balance <- sort_by_name(@token_balances) do %>
   <div class="border-bottom">
     <%= link(
-          to: token_path(@conn, :show, :en, token_balance.token.contract_address_hash),
+          to: token_path(@conn, :show, token_balance.token.contract_address_hash),
           class: "dropdown-item"
         ) do %>
       <p class="mb-0"><%= token_name(token_balance.token) %></p>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/index.html.eex
@@ -12,7 +12,7 @@
             <%= link(
                   gettext("Transactions"),
                   class: "nav-link active",
-                  to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                  to: address_transaction_path(@conn, :index, @conn.params["address_id"])
                 ) %>
           </li>
           <li class="nav-item">
@@ -20,13 +20,13 @@
                   gettext("Internal Transactions"),
                   class: "nav-link",
                   "data-test": "internal_transactions_tab_link",
-                  to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                  to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
                 ) %>
           </li>
           <%= if contract?(@address) do %>
             <li class="nav-item">
               <%= link(
-                  to: address_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+                  to: address_contract_path(@conn, :index, @conn.params["address_id"]),
                   class: "nav-link") do %>
                 <%= gettext("Code") %>
 
@@ -40,7 +40,7 @@
             <li class="nav-item">
               <%= link(
                   gettext("Read Contract"),
-                  to: address_read_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+                  to: address_read_contract_path(@conn, :index, @conn.params["address_id"]),
                   class: "nav-link")%>
             </li>
           <% end %>
@@ -54,17 +54,17 @@
               <%= link(
                     gettext("Transactions"),
                     class: "dropdown-item",
-                    to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                    to: address_transaction_path(@conn, :index, @conn.params["address_id"])
                   ) %>
               <%= link(
                     gettext("Internal Transactions"),
                     class: "dropdown-item",
                     "data-test": "internal_transactions_tab_link",
-                    to: address_internal_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"])
+                    to: address_internal_transaction_path(@conn, :index, @conn.params["address_id"])
                   ) %>
               <%= if contract?(@address) do %>
                 <%= link(
-                    to: address_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+                    to: address_contract_path(@conn, :index, @conn.params["address_id"]),
                     class: "dropdown-item") do %>
                   <%= gettext("Code") %>
 
@@ -97,7 +97,7 @@
           <div class="dropdown-menu dropdown-menu-right filter" aria-labelledby="dropdownMenu2">
             <%= link(
               gettext("All"),
-              to: address_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["address_id"]),
+              to: address_transaction_path(@conn, :index, @conn.params["address_id"]),
               class: "address__link address__link--active dropdown-item",
               "data-test": "filter_option"
             ) %>
@@ -106,7 +106,6 @@
               to: address_transaction_path(
                 @conn,
                 :index,
-                @conn.assigns.locale,
                 @conn.params["address_id"],
                 filter: "to"
               ),
@@ -118,7 +117,6 @@
               to: address_transaction_path(
                 @conn,
                 :index,
-                @conn.assigns.locale,
                 @conn.params["address_id"],
                 filter: "from"
               ),
@@ -131,7 +129,7 @@
           <h2 class="card-title"><%= gettext "Transactions" %></h2>
           <span data-selector="transactions-list">
             <%= for transaction <- @transactions do %>
-              <%= render(BlockScoutWeb.TransactionView, "_tile.html", locale: @locale, current_address: @address, transaction: transaction) %>
+              <%= render(BlockScoutWeb.TransactionView, "_tile.html", current_address: @address, transaction: transaction) %>
             <% end %>
           </span>
         <% else %>
@@ -147,7 +145,6 @@
             to: address_transaction_path(
               @conn,
               :index,
-              @conn.assigns.locale,
               @address,
               @next_page_params
             )

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/_tile.html.eex
@@ -5,7 +5,7 @@
       <%= link(
             @block,
             class: "tile-title",
-            to: block_path(BlockScoutWeb.Endpoint, :show, @locale, @block),
+            to: block_path(BlockScoutWeb.Endpoint, :show, @block),
             "data-test": "block_number",
             "data-block-number": to_string(@block.number)
           ) %>
@@ -23,7 +23,7 @@
         <!-- validator -->
         <%= gettext "Miner" %>
         <span class="ml-2">
-          <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @locale, @block.miner_hash) do %>
+          <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @block.miner_hash) do %>
             <%= @block.miner_hash %>
           <% end %>
         </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/index.html.eex
@@ -6,7 +6,7 @@
 
       <span data-selector="blocks-list">
         <%= for block <- @blocks do %>
-          <%= render BlockScoutWeb.BlockView, "_tile.html", locale: @locale, block: block %>
+          <%= render BlockScoutWeb.BlockView, "_tile.html", block: block %>
         <% end %>
       </span>
 
@@ -17,7 +17,6 @@
           to: block_path(
             @conn,
             :index,
-            @conn.assigns.locale,
             @next_page_params
           )
         ) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
@@ -35,7 +35,7 @@
               <%= link(
                   @block.parent_hash,
                   class: "block__link",
-                  to: block_path(@conn, :show, @conn.assigns.locale, @block.number - 1)
+                  to: block_path(@conn, :show, @block.number - 1)
                 ) %>
             </dd>
           </dl>
@@ -71,7 +71,7 @@
           <div class="text-right">
             <!-- Validator's Name -->
             <!-- Until we can get the validator's name we are using the Validator's address hash -->
-            <h3 class="text-white text-truncate"> <%= link @block.miner, class: "text-white", to: address_path(BlockScoutWeb.Endpoint, :show, @locale, @block.miner) %> </h3>
+            <h3 class="text-white text-truncate"> <%= link @block.miner, class: "text-white", to: address_path(BlockScoutWeb.Endpoint, :show, @block.miner) %> </h3>
             <!-- Validator's address hash -->
             <span class="text-light text-truncate"> </span>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/index.html.eex
@@ -12,7 +12,7 @@
             <%= link(
                   gettext("Transactions"),
                   class: "nav-link active",
-                  to: block_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["block_id"])
+                  to: block_transaction_path(@conn, :index, @conn.params["block_id"])
                 ) %>
           </li>
         </ul>
@@ -25,7 +25,7 @@
               <%= link(
                     gettext("Transactions"),
                     class: "dropdown-item",
-                    to: block_transaction_path(@conn, :index, @conn.assigns.locale, @conn.params["block_id"])
+                    to: block_transaction_path(@conn, :index, @conn.params["block_id"])
                   ) %>
             </div>
           </li>
@@ -36,7 +36,7 @@
           <h2 class="card-title"><%= gettext "Transactions" %></h2>
           <span data-selector="transactions-list">
             <%= for transaction <- @transactions do %>
-              <%= render BlockScoutWeb.TransactionView, "_tile.html", locale: @locale, transaction: transaction %>
+              <%= render BlockScoutWeb.TransactionView, "_tile.html", transaction: transaction %>
             <% end %>
           </span>
         <% else %>
@@ -52,7 +52,6 @@
             to: transaction_path(
               @conn,
               :index,
-              @conn.assigns.locale,
               @next_page_params
             )
           ) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/chain/_block.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/chain/_block.html.eex
@@ -1,13 +1,13 @@
 <div class="col-sm-3 fade-up-blocks-chain mb-3 mb-sm-0" data-selector="chain-block" data-block-number="<%= @block.number %>">
   <div class="tile d-flex flex-column">
-    <%= link(@block, to: block_path(BlockScoutWeb.Endpoint, :show, @locale, @block), class: "tile-title") %>
+    <%= link(@block, to: block_path(BlockScoutWeb.Endpoint, :show, @block), class: "tile-title") %>
     <div>
       <span class="mr-2"> <%= Enum.count(@block.transactions) %> Transactions </span>
       <span class="text-nowrap" data-from-now="<%= @block.timestamp %>"> </span>
     </div>
     <span class="text-truncate">
       <%= gettext "Miner" %>
-      <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @locale, @block.miner),
+      <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @block.miner),
         "data-toggle": "tooltip",
         "data-placement": "top",
         title: @block.miner do %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
@@ -52,11 +52,11 @@
 <section class="container">
   <div class="card card-chain-blocks">
     <div class="card-body">
-      <%= link(gettext("View All Blocks →"), to: block_path(BlockScoutWeb.Endpoint, :index, Gettext.get_locale), class: "button button--secondary button--xsmall float-right") %>
+      <%= link(gettext("View All Blocks →"), to: block_path(BlockScoutWeb.Endpoint, :index), class: "button button--secondary button--xsmall float-right") %>
       <h2 class="card-title"><%= gettext "Blocks" %></h2>
       <div class="row" data-selector="chain-block-list">
         <%= for block <- @blocks do %>
-          <%= render BlockScoutWeb.ChainView, "_block.html", locale: @locale, block: block %>
+          <%= render BlockScoutWeb.ChainView, "_block.html", block: block %>
         <% end %>
       </div>
     </div>
@@ -69,11 +69,11 @@
           <a href="#" class="alert-link"><span data-selector="channel-batching-count"></span> <%= gettext "More transactions have come in" %></a>
         </div>
       </div>
-      <%= link(gettext("View All Transactions →"), to: transaction_path(BlockScoutWeb.Endpoint, :index, Gettext.get_locale), class: "button button--secondary button--xsmall float-right") %>
+      <%= link(gettext("View All Transactions →"), to: transaction_path(BlockScoutWeb.Endpoint, :index), class: "button button--secondary button--xsmall float-right") %>
       <h2 class="card-title"><%= gettext "Transactions" %></h2>
       <span data-selector="transactions-list">
         <%= for transaction <- @transactions do %>
-          <%= render BlockScoutWeb.TransactionView, "_tile.html", locale: @locale, transaction: transaction %>
+          <%= render BlockScoutWeb.TransactionView, "_tile.html", transaction: transaction %>
         <% end %>
       </span>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -9,22 +9,22 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav mr-auto">
         <li class="nav-item">
-          <%= link to: block_path(@conn, :index, Gettext.get_locale), class: "nav-link topnav-nav-link" do %>
+          <%= link to: block_path(@conn, :index), class: "nav-link topnav-nav-link" do %>
             <%= gettext("Blocks") %>
           <% end %>
         </li>
         <li class="nav-item">
-          <%= link to: transaction_path(@conn, :index, Gettext.get_locale), class: "nav-link topnav-nav-link" do %>
+          <%= link to: transaction_path(@conn, :index), class: "nav-link topnav-nav-link" do %>
             <%= gettext("Transactions") %>
           <% end %>
         </li>
         <li class="nav-item">
-          <%= link to: api_docs_path(@conn, :index, Gettext.get_locale), class: "nav-link topnav-nav-link" do %>
+          <%= link to: api_docs_path(@conn, :index), class: "nav-link topnav-nav-link" do %>
             <%= gettext("API") %>
           <% end %>
         </li>
       </ul>
-      <%= form_for @conn, chain_path(@conn, :search, Gettext.get_locale), [class: "form-inline my-2 my-lg-0", method: :get, enforce_utf8: false], fn f -> %>
+      <%= form_for @conn, chain_path(@conn, :search), [class: "form-inline my-2 my-lg-0", method: :get, enforce_utf8: false], fn f -> %>
         <div class="input-group">
           <div class="input-group-prepend">
             <span class="input-group-text" id="search-icon"><i class="fas fa-search"></i></span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= @conn.assigns.locale %>">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/block_scout_web/lib/block_scout_web/templates/pending_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/pending_transaction/index.html.eex
@@ -8,7 +8,7 @@
           <%= link(
                 gettext("Validated"),
                 class: "nav-link",
-                to: transaction_path(@conn, :index, @conn.assigns.locale)
+                to: transaction_path(@conn, :index)
               ) %>
         </li>
         <li class="nav-item">
@@ -16,7 +16,7 @@
                 gettext("Pending"),
                 class: "nav-link active",
                 "data-test": "pending_transactions_link",
-                to: pending_transaction_path(@conn, :index, @conn.assigns.locale)
+                to: pending_transaction_path(@conn, :index)
               ) %>
         </li>
       </ul>
@@ -29,13 +29,13 @@
             <%= link(
                   gettext("Validated"),
                   class: "dropdown-item",
-                  to: transaction_path(@conn, :index, @conn.assigns.locale)
+                  to: transaction_path(@conn, :index)
                 ) %>
             <%= link(
                   gettext("Pending"),
                   class: "dropdown-item",
                   "data-test": "pending_transactions_link",
-                  to: pending_transaction_path(@conn, :index, @conn.assigns.locale)
+                  to: pending_transaction_path(@conn, :index)
                 ) %>
           </div>
         </li>
@@ -54,12 +54,12 @@
               <div class="tile-status-label ml-2 ml-md-0" data-test="transaction_status"><%= BlockScoutWeb.TransactionView.formatted_status(transaction) %></div>
             </div>
             <div class="col-md-7 col-lg-8 d-flex flex-column pr-2 pr-sm-2 pr-md-0">
-              <%= render BlockScoutWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: transaction.hash %>
+              <%= render BlockScoutWeb.TransactionView, "_link.html", transaction_hash: transaction.hash %>
               <span class="text-nowrap">
-                <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: transaction.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(transaction.from_address), locale: @locale %>
+                <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: transaction.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(transaction.from_address) %>
                 &rarr;
                 <%= if transaction.to_address_hash do %>
-                  <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: transaction.to_address_hash, contract: BlockScoutWeb.AddressView.contract?(transaction.to_address), locale: @locale %>
+                  <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: transaction.to_address_hash, contract: BlockScoutWeb.AddressView.contract?(transaction.to_address) %>
                 <% else %>
                   <%= gettext("Contract Address Pending") %>
                 <% end %>
@@ -80,7 +80,6 @@
           to: pending_transaction_path(
             @conn,
             :index,
-            @conn.assigns.locale,
             @next_page_params
           )
         ) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -10,7 +10,7 @@
 
     <%= if queryable?(function["inputs"]) do %>
       <div class="">
-        <form class="form-inline" data-function-form data-url="<%= smart_contract_path(@conn, :show, :en, @address.hash) %>">
+        <form class="form-inline" data-function-form data-url="<%= smart_contract_path(@conn, :show, @address.hash) %>">
           <input type="hidden" name="function_name" value='<%= function["name"] %>' />
 
           <%= for input <- function["inputs"] do %>
@@ -38,7 +38,7 @@
           <%= if address?(output["type"]) do %>
             <%= link(
                output["value"],
-               to: address_path(@conn, :show, @conn.assigns.locale, output["value"])
+               to: address_path(@conn, :show, output["value"])
              ) %>
           <% else %>
             <%= output["value"] %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
@@ -16,14 +16,14 @@
             <%= link(
                   gettext("Token Transfers"),
                   class: "nav-link",
-                  to: token_path(@conn, :show, @conn.assigns.locale, @conn.params["token_id"])
+                  to: token_path(@conn, :show, @conn.params["token_id"])
                 ) %>
           </li>
 
           <li class="nav-item">
             <%= link(
                 gettext("Read Contract"),
-                to: token_read_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["token_id"]),
+                to: token_read_contract_path(@conn, :index, @conn.params["token_id"]),
                 class: "nav-link active")%>
           </li>
         </ul>
@@ -36,7 +36,7 @@
               <%= link(
                     gettext("Token Transfers"),
                     class: "nav-link active",
-                    to: token_path(@conn, :show, @conn.assigns.locale, "1")
+                    to: token_path(@conn, :show, "1")
                   ) %>
               <%= link(
                   gettext("Read Contract"),
@@ -48,7 +48,7 @@
       </div>
 
       <!-- loaded via AJAX -->
-      <div class="card-body" data-smart-contract-functions data-hash="<%= to_string(@token.contract_address.hash) %>" data-url="<%= smart_contract_path(@conn, :index, :en) %>">
+      <div class="card-body" data-smart-contract-functions data-hash="<%= to_string(@token.contract_address.hash) %>" data-url="<%= smart_contract_path(@conn, :index) %>">
         <i class="fa fa-spinner fa-spin"></i> <%= gettext("loading...") %>
       </div>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
@@ -36,7 +36,7 @@
               <%= link(
                     gettext("Token Transfers"),
                     class: "nav-link active",
-                    to: token_path(@conn, :show, "1")
+                    to: token_path(@conn, :show, @token.contract_address_hash)
                   ) %>
               <%= link(
                   gettext("Read Contract"),

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex
@@ -6,22 +6,20 @@
 
     <div class="col-md-7 col-lg-8 d-flex flex-column">
       <p class="tile-title text-truncate">
-        <%= render BlockScoutWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @transfer.transaction_hash %>
+        <%= render BlockScoutWeb.TransactionView, "_link.html", transaction_hash: @transfer.transaction_hash %>
       </p>
       <span>
         <%= render BlockScoutWeb.AddressView,
           "_link.html",
           address_hash: to_string(@transfer.from_address_hash),
-          contract: BlockScoutWeb.AddressView.contract?(@transfer.from_address),
-          locale: @locale %>
+          contract: BlockScoutWeb.AddressView.contract?(@transfer.from_address) %>
 
         &rarr;
 
         <%= render BlockScoutWeb.AddressView,
           "_link.html",
           address_hash: to_string(@transfer.to_address_hash),
-          contract: BlockScoutWeb.AddressView.contract?(@transfer.to_address),
-          locale: @locale %>
+          contract: BlockScoutWeb.AddressView.contract?(@transfer.to_address) %>
       </span>
 
       <span>
@@ -40,7 +38,7 @@
               number: @transfer.transaction.block_number
             ),
             class: "mr-2 mr-sm-0 text-muted",
-            to: block_path(BlockScoutWeb.Endpoint, :show, @locale, @transfer.transaction.block_number)
+            to: block_path(BlockScoutWeb.Endpoint, :show, @transfer.transaction.block_number)
           ) %>
         </span>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/show.html.eex
@@ -16,7 +16,7 @@
             <%= link(
                   gettext("Token Transfers"),
                   class: "nav-link active",
-                  to: token_path(@conn, :show, "1")
+                  to: token_path(@conn, :show, @token.contract_address_hash)
                 ) %>
           </li>
 
@@ -38,7 +38,7 @@
               <%= link(
                     gettext("Token Transfers"),
                     class: "nav-link active",
-                    to: token_path(@conn, :show, "1")
+                    to: token_path(@conn, :show, @token.contract_address_hash)
                   ) %>
               <%= if smart_contract_with_read_only_functions?(@token) do %>
                   <%= link(

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/show.html.eex
@@ -16,7 +16,7 @@
             <%= link(
                   gettext("Token Transfers"),
                   class: "nav-link active",
-                  to: token_path(@conn, :show, @conn.assigns.locale, "1")
+                  to: token_path(@conn, :show, "1")
                 ) %>
           </li>
 
@@ -24,7 +24,7 @@
             <li class="nav-item">
               <%= link(
                   gettext("Read Contract"),
-                  to: token_read_contract_path(@conn, :index, @conn.assigns.locale, @conn.params["id"]),
+                  to: token_read_contract_path(@conn, :index, @conn.params["id"]),
                   class: "nav-link")%>
             </li>
           <% end %>
@@ -38,7 +38,7 @@
               <%= link(
                     gettext("Token Transfers"),
                     class: "nav-link active",
-                    to: token_path(@conn, :show, @conn.assigns.locale, "1")
+                    to: token_path(@conn, :show, "1")
                   ) %>
               <%= if smart_contract_with_read_only_functions?(@token) do %>
                   <%= link(
@@ -56,7 +56,7 @@
 
         <%= if Enum.any?(@transfers) do %>
           <%= for transfer <- @transfers do %>
-            <%= render("_token_transfer.html", locale: @locale, token: @token, transfer: transfer) %>
+            <%= render("_token_transfer.html", token: @token, transfer: transfer) %>
           <% end %>
         <% else %>
           <div class="tile tile-muted text-center">
@@ -70,7 +70,7 @@
           <%= link(
             gettext("Older"),
             class: "button button--secondary button--small float-right mt-4",
-            to: token_path(@conn, :show, @conn.assigns.locale, @token.contract_address_hash, @next_page_params)
+            to: token_path(@conn, :show, @token.contract_address_hash, @next_page_params)
           ) %>
         <% end %>
       </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_link.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_link.html.eex
@@ -1,4 +1,4 @@
 <%= link(@transaction_hash,
-    to: transaction_path(BlockScoutWeb.Endpoint, :show, @locale, @transaction_hash),
+    to: transaction_path(BlockScoutWeb.Endpoint, :show, @transaction_hash),
     "data-test": "transaction_hash_link",
     class: "text-truncate") %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tile.html.eex
@@ -9,14 +9,14 @@
       </span>
     </div>
     <div class="col-md-7 col-lg-8 d-flex flex-column pr-2 pr-sm-2 pr-md-0">
-      <%= render "_link.html", locale: @locale, transaction_hash: @transaction.hash %>
+      <%= render "_link.html", transaction_hash: @transaction.hash %>
       <span class="text-nowrap">
-        <%= BlockScoutWeb.AddressView.display_address_hash(assigns[:current_address], @transaction.from_address, @locale) %>
+        <%= BlockScoutWeb.AddressView.display_address_hash(assigns[:current_address], @transaction.from_address) %>
         &rarr;
         <%= if assigns[:current_address] && assigns[:current_address].hash == to_address_hash(@transaction) do %>
           <%= render BlockScoutWeb.AddressView, "_responsive_hash.html", address_hash: to_address_hash(@transaction), contract: BlockScoutWeb.AddressView.contract?(@transaction.to_address) %>
         <% else %>
-          <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: to_address_hash(@transaction), contract: BlockScoutWeb.AddressView.contract?(@transaction.to_address), locale: @locale %>
+          <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: to_address_hash(@transaction), contract: BlockScoutWeb.AddressView.contract?(@transaction.to_address) %>
         <% end %>
       </span>
       <span class="d-flex flex-md-row flex-column mt-3 mt-md-0">
@@ -32,7 +32,7 @@
       <span class="mr-2 mr-md-0 order-1">
         <%= link(
           gettext("Block #%{number}", number: to_string(@transaction.block.number)),
-          to: block_path(BlockScoutWeb.Endpoint, :show, @locale, @transaction.block)
+          to: block_path(BlockScoutWeb.Endpoint, :show, @transaction.block)
         ) %>
       </span>
       <span class="mr-2 mr-md-0 order-2" data-from-now="<%= @transaction.block.timestamp %>"></span>
@@ -54,10 +54,10 @@
     <%= if involves_token_transfers?(@transaction) do %>
       <div class="offset-md-2 col-md-10 col-lg-8 d-flex flex-column mt-2 mb-2">
         <% [first_token_transfer | remaining_token_transfers]= @transaction.token_transfers %>
-        <%= render "_token_transfer.html", address: assigns[:current_address], locale: @locale, token_transfer: first_token_transfer %>
+        <%= render "_token_transfer.html", address: assigns[:current_address], token_transfer: first_token_transfer %>
         <div class="collapse token-transfer-toggle" id="<%= @transaction.hash %>">
           <%= for token_transfer <- remaining_token_transfers do %>
-            <%= render "_token_transfer.html", address: assigns[:current_address], locale: @locale, token_transfer: token_transfer %>
+            <%= render "_token_transfer.html", address: assigns[:current_address], token_transfer: token_transfer %>
           <% end %>
         </div>
       </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
@@ -11,12 +11,12 @@
         </span>
       <% end %>
     <% end %>
-    <%= BlockScoutWeb.AddressView.display_address_hash(@address, @token_transfer.from_address, @locale, true) %>
+    <%= BlockScoutWeb.AddressView.display_address_hash(@address, @token_transfer.from_address, true) %>
     &rarr;
-    <%= BlockScoutWeb.AddressView.display_address_hash(@address, @token_transfer.to_address, @locale, true) %>
+    <%= BlockScoutWeb.AddressView.display_address_hash(@address, @token_transfer.to_address, true) %>
   </span>
   <span class="col-12 col-md-7 ml-3 ml-sm-0">
   <%= token_transfer_amount(@token_transfer) %>
-  <%= link(token_symbol(@token_transfer.token), to: token_path(BlockScoutWeb.Endpoint, :show, @locale, @token_transfer.token.contract_address_hash)) %>
+  <%= link(token_symbol(@token_transfer.token), to: token_path(BlockScoutWeb.Endpoint, :show, @token_transfer.token.contract_address_hash)) %>
   </span>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/index.html.eex
@@ -8,7 +8,7 @@
           <%= link(
                 gettext("Validated"),
                 class: "nav-link active",
-                to: transaction_path(@conn, :index, @conn.assigns.locale)
+                to: transaction_path(@conn, :index)
               ) %>
         </li>
         <li class="nav-item">
@@ -16,7 +16,7 @@
                 gettext("Pending"),
                 class: "nav-link",
                 "data-test": "pending_transactions_link",
-                to: pending_transaction_path(@conn, :index, @conn.assigns.locale)
+                to: pending_transaction_path(@conn, :index)
               ) %>
         </li>
       </ul>
@@ -29,13 +29,13 @@
             <%= link(
                   gettext("Validated"),
                   class: "dropdown-item",
-                  to: transaction_path(@conn, :index, @conn.assigns.locale)
+                  to: transaction_path(@conn, :index)
                 ) %>
             <%= link(
                   gettext("Pending"),
                   class: "dropdown-item",
                   "data-test": "pending_transactions_link",
-                  to: pending_transaction_path(@conn, :index, @conn.assigns.locale)
+                  to: pending_transaction_path(@conn, :index)
                 ) %>
           </div>
         </li>
@@ -57,7 +57,7 @@
       <p><%= gettext("Showing") %> <span data-selector="transaction-count"><%= Cldr.Number.to_string!(@transaction_estimated_count, format: "#,###") %></span> <%= gettext("Validated Transactions") %></p>
       <span data-selector="transactions-list">
         <%= for transaction <- @transactions do %>
-          <%= render BlockScoutWeb.TransactionView, "_tile.html", locale: @locale, transaction: transaction %>
+          <%= render BlockScoutWeb.TransactionView, "_tile.html", transaction: transaction %>
         <% end %>
       </span>
 
@@ -68,7 +68,6 @@
           to: transaction_path(
             @conn,
             :index,
-            @conn.assigns.locale,
             @next_page_params
           )
         ) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -8,10 +8,10 @@
           <h1 class="card-title"><%= gettext "Transaction Details" %> </h1>
           <h3 data-test="transaction_detail_hash"><%= @transaction %> </h3>
           <span class="d-block mb-2">
-            <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @transaction.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@transaction.from_address), locale: @locale %>
+            <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @transaction.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@transaction.from_address) %>
             <span class="text-muted">  &rarr; </span>
             <%= if @transaction.to_address_hash do %>
-              <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @transaction.to_address_hash, contract: BlockScoutWeb.AddressView.contract?(@transaction.to_address), locale: @locale %>
+              <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @transaction.to_address_hash, contract: BlockScoutWeb.AddressView.contract?(@transaction.to_address) %>
             <% else %>
               <%= gettext("Contract Address Pending") %>
             <% end %>
@@ -34,7 +34,7 @@
                 <%= link(
                       block,
                       class: "transaction__link",
-                      to: block_path(@conn, :show, @conn.assigns.locale, block)
+                      to: block_path(@conn, :show, block)
                     ) %>
               <% else %>
                 <%= gettext "Pending" %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/_internal_transaction.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/_internal_transaction.html.eex
@@ -4,11 +4,11 @@
       <%=  gettext("Internal Transaction") %>
     </div>
     <div class="col-md-9 col-lg-10 d-flex flex-column text-nowrap">
-      <%= render BlockScoutWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @internal_transaction.transaction_hash %>
+      <%= render BlockScoutWeb.TransactionView, "_link.html", transaction_hash: @internal_transaction.transaction_hash %>
       <span class="text-nowrap">
-        <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @internal_transaction.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@internal_transaction.from_address), locale: @locale %>
+        <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @internal_transaction.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@internal_transaction.from_address) %>
         &rarr;
-        <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: BlockScoutWeb.InternalTransactionView.to_address_hash(@internal_transaction), contract: BlockScoutWeb.AddressView.contract?(@internal_transaction.to_address), locale: @locale %>
+        <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: BlockScoutWeb.InternalTransactionView.to_address_hash(@internal_transaction), contract: BlockScoutWeb.AddressView.contract?(@internal_transaction.to_address) %>
       </span>
 
       <span class="tile-title text-truncate">

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex
@@ -11,7 +11,7 @@
                 <%= link(
                       gettext("Token Transfers"),
                       class: "nav-link",
-                      to: transaction_token_transfer_path(@conn, :index, @conn.assigns.locale, @transaction)
+                      to: transaction_token_transfer_path(@conn, :index, @transaction)
                     ) %>
               </li>
             <% end %>
@@ -19,14 +19,14 @@
               <%= link(
                     gettext("Internal Transactions"),
                     class: "nav-link active",
-                    to: transaction_internal_transaction_path(@conn, :index, @conn.assigns.locale, @transaction)
+                    to: transaction_internal_transaction_path(@conn, :index, @transaction)
                   ) %>
             </li>
             <li class="nav-item">
               <%= link(
                     gettext("Logs"),
                     class: "nav-link",
-                    to: transaction_log_path(@conn, :index, @conn.assigns.locale, @transaction),
+                    to: transaction_log_path(@conn, :index, @transaction),
                     "data-test": "transaction_logs_link"
                   ) %>
             </li>
@@ -41,19 +41,19 @@
                   <%= link(
                         gettext("Token Transfers"),
                         class: "dropdown-item",
-                        to: transaction_token_transfer_path(@conn, :index, @conn.assigns.locale, @transaction),
+                        to: transaction_token_transfer_path(@conn, :index, @transaction),
                         "data-test": "transaction_token_transfer_link"
                       ) %>
                  <% end %>
                 <%= link(
                       gettext("Internal Transactions"),
                       class: "dropdown-item",
-                      to: transaction_internal_transaction_path(@conn, :index, @conn.assigns.locale, @transaction)
+                      to: transaction_internal_transaction_path(@conn, :index, @transaction)
                     ) %>
                     <%= link(
                           gettext("Logs"),
                           class: "dropdown-item",
-                          to: transaction_log_path(@conn, :index, @conn.assigns.locale, @transaction),
+                          to: transaction_log_path(@conn, :index, @transaction),
                           "data-test": "transaction_logs_link"
                     ) %>
               </div>
@@ -64,7 +64,7 @@
           <h2 class="card-title"><%= gettext "Internal Transactions" %></h2>
           <%= if Enum.count(@internal_transactions) > 0 do %>
             <%= for internal_transaction <- @internal_transactions do %>
-              <%= render "_internal_transaction.html", locale: @locale, internal_transaction: internal_transaction %>
+              <%= render "_internal_transaction.html", internal_transaction: internal_transaction %>
             <% end %>
           <% else %>
             <div class="tile tile-muted text-center">
@@ -79,7 +79,6 @@
               to: transaction_internal_transaction_path(
                 @conn,
                 :index,
-                @conn.assigns.locale,
                 @transaction,
                 @next_page_params
               )

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/index.html.eex
@@ -12,7 +12,7 @@
               <%= link(
                     gettext("Token Transfers"),
                     class: "nav-link",
-                    to: transaction_token_transfer_path(@conn, :index, @conn.assigns.locale, @transaction)
+                    to: transaction_token_transfer_path(@conn, :index, @transaction)
                   ) %>
             <% end %>
           </li>
@@ -20,14 +20,14 @@
             <%= link(
                   gettext("Internal Transactions"),
                   class: "nav-link",
-                  to: transaction_internal_transaction_path(@conn, :index, @conn.assigns.locale, @transaction)
+                  to: transaction_internal_transaction_path(@conn, :index, @transaction)
                 ) %>
           </li>
           <li class="nav-item">
             <%= link(
                   gettext("Logs"),
                   class: "nav-link active",
-                  to: transaction_log_path(@conn, :index, @conn.assigns.locale, @transaction)
+                  to: transaction_log_path(@conn, :index, @transaction)
                 ) %>
           </li>
         </ul>
@@ -41,19 +41,19 @@
                   <%= link(
                         gettext("Token Transfers"),
                         class: "dropdown-item",
-                        to: transaction_token_transfer_path(@conn, :index, @conn.assigns.locale, @transaction),
+                        to: transaction_token_transfer_path(@conn, :index, @transaction),
                         "data-test": "transaction_token_transfer_link"
                       ) %>
                  <% end %>
               <%= link(
                     gettext("Internal Transactions"),
                     class: "dropdown-item",
-                    to: transaction_path(@conn, :show, @conn.assigns.locale, @transaction)
+                    to: transaction_path(@conn, :show, @transaction)
                   ) %>
               <%= link(
                     gettext("Logs"),
                     class: "dropdown-item",
-                    to: transaction_log_path(@conn, :index, @conn.assigns.locale, @transaction),
+                    to: transaction_log_path(@conn, :index, @transaction),
                     "data-test": "transaction_logs_link"
                   ) %>
             </div>
@@ -72,7 +72,7 @@
                   <h3 class="">
                     <%= link(
                         log.address,
-                        to: address_path(@conn, :show, @conn.assigns.locale, log.address),
+                        to: address_path(@conn, :show, log.address),
                         "data-test": "log_address_link",
                         "data-address-hash": log.address
                       ) %>
@@ -124,7 +124,6 @@
             to: transaction_log_path(
               @conn,
               :index,
-              @conn.assigns.locale,
               @transaction,
               @next_page_params
             )

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/_token_transfer.html.eex
@@ -5,16 +5,16 @@
     </div>
 
     <div class="col-12 col-md-8 col-lg-10 d-flex flex-column text-nowrap">
-      <%= render BlockScoutWeb.TransactionView, "_link.html", locale: @locale, transaction_hash: @token_transfer.transaction_hash %>
+      <%= render BlockScoutWeb.TransactionView, "_link.html", transaction_hash: @token_transfer.transaction_hash %>
       <span class="text-nowrap">
-        <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @token_transfer.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@token_transfer.from_address), locale: @locale %>
+        <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @token_transfer.from_address_hash, contract: BlockScoutWeb.AddressView.contract?(@token_transfer.from_address) %>
         &rarr;
-        <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @token_transfer.to_address_hash, contract: BlockScoutWeb.AddressView.contract?(@token_transfer.to_address), locale: @locale %>
+        <%= render BlockScoutWeb.AddressView, "_link.html", address_hash: @token_transfer.to_address_hash, contract: BlockScoutWeb.AddressView.contract?(@token_transfer.to_address) %>
       </span>
 
       <span class="tile-title text-truncate">
         <%= token_transfer_amount(@token_transfer) %>
-        <%= link(token_symbol(@token_transfer.token), to: token_path(@conn, :show, @locale, @token_transfer.token.contract_address_hash)) %>
+        <%= link(token_symbol(@token_transfer.token), to: token_path(@conn, :show, @token_transfer.token.contract_address_hash)) %>
       </span>
     </div>
   </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/index.html.eex
@@ -10,21 +10,21 @@
           <%= link(
                 gettext("Token Transfers"),
                 class: "nav-link active",
-                to: transaction_token_transfer_path(@conn, :index, @conn.assigns.locale, @transaction)
+                to: transaction_token_transfer_path(@conn, :index, @transaction)
           ) %>
         </li>
         <li class="nav-item">
           <%= link(
                 gettext("Internal Transactions"),
                 class: "nav-link",
-                to: transaction_internal_transaction_path(@conn, :index, @conn.assigns.locale, @transaction)
+                to: transaction_internal_transaction_path(@conn, :index, @transaction)
           ) %>
         </li>
         <li class="nav-item">
           <%= link(
                 gettext("Logs"),
                 class: "nav-link",
-                to: transaction_log_path(@conn, :index, @conn.assigns.locale, @transaction)
+                to: transaction_log_path(@conn, :index, @transaction)
           ) %>
         </li>
       </ul>
@@ -37,17 +37,17 @@
             <%= link(
                   gettext("Token Transfers"),
                   class: "dropdown-item",
-                  to: transaction_token_transfer_path(@conn, :index, @conn.assigns.locale, @transaction)
+                  to: transaction_token_transfer_path(@conn, :index, @transaction)
             ) %>
             <%= link(
                   gettext("Internal Transactions"),
                   class: "dropdown-item",
-                  to: transaction_internal_transaction_path(@conn, :index, @conn.assigns.locale, @transaction)
+                  to: transaction_internal_transaction_path(@conn, :index, @transaction)
             ) %>
             <%= link(
                   gettext("Logs"),
                   class: "dropdown-item",
-                  to: transaction_log_path(@conn, :index, @conn.assigns.locale, @transaction)
+                  to: transaction_log_path(@conn, :index, @transaction)
             ) %>
           </div>
         </li>
@@ -58,7 +58,7 @@
       <h2 class="card-title"><%= gettext "Token Transfers" %></h2>
       <%= if Enum.any?(@token_transfers) do %>
         <%= for token_transfer <- @token_transfers do %>
-          <%= render "_token_transfer.html", locale: @locale, token_transfer: token_transfer, conn: @conn %>
+          <%= render "_token_transfer.html", token_transfer: token_transfer, conn: @conn %>
         <% end %>
       <% else %>
         <div class="tile tile-muted text-center">
@@ -74,7 +74,6 @@
       to: transaction_token_transfer_path(
         @conn,
         :index,
-        @conn.assigns.locale,
         @transaction,
         @next_page_params
       )

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -62,25 +62,23 @@ defmodule BlockScoutWeb.AddressView do
 
   def smart_contract_with_read_only_functions?(%Address{smart_contract: nil}), do: false
 
-  def display_address_hash(current_address, target_address, locale, truncate \\ false)
+  def display_address_hash(current_address, target_address, truncate \\ false)
 
-  def display_address_hash(nil, target_address, locale, truncate) do
+  def display_address_hash(nil, target_address, truncate) do
     render(
       "_link.html",
       address_hash: target_address.hash,
       contract: contract?(target_address),
-      locale: locale,
       truncate: truncate
     )
   end
 
-  def display_address_hash(current_address, target_address, locale, truncate) do
+  def display_address_hash(current_address, target_address, truncate) do
     if current_address.hash == target_address.hash do
       render(
         "_responsive_hash.html",
         address_hash: current_address.hash,
         contract: contract?(current_address),
-        locale: locale,
         truncate: truncate
       )
     else
@@ -88,7 +86,6 @@ defmodule BlockScoutWeb.AddressView do
         "_link.html",
         address_hash: target_address.hash,
         contract: contract?(target_address),
-        locale: locale,
         truncate: truncate
       )
     end

--- a/apps/block_scout_web/mix.exs
+++ b/apps/block_scout_web/mix.exs
@@ -52,7 +52,6 @@ defmodule BlockScoutWeb.Mixfile do
       :timex,
       :timex_ecto,
       :crontab,
-      :set_locale,
       :logger,
       :runtime_tools
     ]
@@ -89,8 +88,6 @@ defmodule BlockScoutWeb.Mixfile do
       {:phoenix_live_reload, "~> 1.0", only: [:dev]},
       {:phoenix_pubsub, "~> 1.0"},
       {:postgrex, ">= 0.0.0"},
-      # Waiting on https://github.com/smeevil/set_locale/pull/9
-      {:set_locale, github: "minifast/set_locale", branch: "master"},
       {:sobelow, ">= 0.7.0", only: [:dev, :test], runtime: false},
       {:timex, "~> 3.1.24"},
       {:timex_ecto, "~> 3.2.1"},

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -39,7 +39,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:10
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:55
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:131
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:129
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:26
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:36
@@ -134,8 +134,8 @@ msgstr ""
 msgid "Address"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:106
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:117
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:105
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:116
 #: lib/block_scout_web/views/address_internal_transaction_view.ex:10
 #: lib/block_scout_web/views/address_transaction_view.ex:10
 msgid "From"
@@ -305,7 +305,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract/index.html.eex:17
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:20
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:60
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:119
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:117
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:17
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:20
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:60
@@ -476,8 +476,8 @@ msgstr ""
 msgid "There are no Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:132
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:145
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:130
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:143
 #: lib/block_scout_web/templates/block/index.html.eex:15
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:78
@@ -601,17 +601,17 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:13
-#: lib/block_scout_web/templates/address/overview.html.eex:66
+#: lib/block_scout_web/templates/address/overview.html.eex:64
 msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:126
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:124
 msgid "There are no internal transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:139
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:137
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:44
 msgid "There are no transactions for this address."
 msgstr ""
@@ -633,12 +633,12 @@ msgid "Contract created by"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:36
+#: lib/block_scout_web/templates/address/overview.html.eex:35
 msgid "at"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex:38
+#: lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex:36
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:34
 msgid "Block #%{number}"
 msgstr ""
@@ -685,7 +685,7 @@ msgid "Block Height #%{height}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:75
+#: lib/block_scout_web/templates/address/overview.html.eex:73
 msgid "Close"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -51,7 +51,7 @@ msgstr "BlockScout"
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:10
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:55
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:131
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:129
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:26
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:36
@@ -146,8 +146,8 @@ msgstr "%{count} transactions in this block"
 msgid "Address"
 msgstr "Address"
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:106
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:117
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:105
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:116
 #: lib/block_scout_web/views/address_internal_transaction_view.ex:10
 #: lib/block_scout_web/views/address_transaction_view.ex:10
 msgid "From"
@@ -317,7 +317,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract/index.html.eex:17
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:20
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:60
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:119
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:117
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:17
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:20
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:60
@@ -488,8 +488,8 @@ msgstr ""
 msgid "There are no Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:132
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:145
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:130
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:143
 #: lib/block_scout_web/templates/block/index.html.eex:15
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:78
@@ -613,17 +613,17 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:13
-#: lib/block_scout_web/templates/address/overview.html.eex:66
+#: lib/block_scout_web/templates/address/overview.html.eex:64
 msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:126
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:124
 msgid "There are no internal transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:139
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:137
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:44
 msgid "There are no transactions for this address."
 msgstr ""
@@ -645,12 +645,12 @@ msgid "Contract created by"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:36
+#: lib/block_scout_web/templates/address/overview.html.eex:35
 msgid "at"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex:38
+#: lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex:36
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:34
 msgid "Block #%{number}"
 msgstr ""
@@ -697,7 +697,7 @@ msgid "Block Height #%{height}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:75
+#: lib/block_scout_web/templates/address/overview.html.eex:73
 msgid "Close"
 msgstr ""
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_contract_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.AddressContractControllerTest do
   use BlockScoutWeb.ConnCase
 
-  import BlockScoutWeb.Router.Helpers, only: [address_contract_path: 4]
+  import BlockScoutWeb.Router.Helpers, only: [address_contract_path: 3]
 
   alias Explorer.Factory
   alias Explorer.Chain.Hash
@@ -11,7 +11,7 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
     test "returns not found for unexistent address", %{conn: conn} do
       unexistent_address_hash = Hash.to_string(Factory.address_hash())
 
-      conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, :en, unexistent_address_hash))
+      conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, unexistent_address_hash))
 
       assert html_response(conn, 404)
     end
@@ -19,7 +19,7 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
     test "returns not found given an invalid address hash ", %{conn: conn} do
       invalid_hash = "invalid_hash"
 
-      conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, :en, invalid_hash))
+      conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, invalid_hash))
 
       assert html_response(conn, 404)
     end
@@ -27,7 +27,7 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
     test "returns not found when the address isn't a contract", %{conn: conn} do
       address = insert(:address)
 
-      conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, :en, address))
+      conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, address))
 
       assert html_response(conn, 404)
     end
@@ -44,7 +44,7 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
         created_contract_address: address
       )
 
-      conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, :en, address))
+      conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, address))
 
       assert html_response(conn, 200)
       assert address.hash == conn.assigns.address.hash

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_controller_test.exs
@@ -5,7 +5,7 @@ defmodule BlockScoutWeb.AddressControllerTest do
     test "redirects to address/:address_id/transactions", %{conn: conn} do
       insert(:address, hash: "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")
 
-      conn = get(conn, "/en/address/0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")
+      conn = get(conn, "/address/0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")
 
       assert redirected_to(conn) =~ "/en/address/0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed/transactions"
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
   use BlockScoutWeb.ConnCase
 
-  import BlockScoutWeb.Router.Helpers, only: [address_internal_transaction_path: 4]
+  import BlockScoutWeb.Router.Helpers, only: [address_internal_transaction_path: 3]
 
   alias Explorer.Chain.{Block, InternalTransaction, Transaction}
   alias Explorer.ExchangeRates.Token
@@ -10,14 +10,13 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
     test "with invalid address hash", %{conn: conn} do
       conn =
         conn
-        |> get(address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, "invalid_address"))
+        |> get(address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, "invalid_address"))
 
       assert html_response(conn, 404)
     end
 
     test "with valid address hash without address", %{conn: conn} do
-      conn =
-        get(conn, address_internal_transaction_path(conn, :index, :en, "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"))
+      conn = get(conn, address_internal_transaction_path(conn, :index, "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"))
 
       assert html_response(conn, 404)
     end
@@ -35,7 +34,7 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
 
       to_internal_transaction = insert(:internal_transaction, transaction: transaction, to_address: address, index: 2)
 
-      path = address_internal_transaction_path(conn, :index, :en, address)
+      path = address_internal_transaction_path(conn, :index, address)
       conn = get(conn, path)
 
       actual_transaction_ids =
@@ -49,7 +48,7 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
     test "includes USD exchange rate value for address in assigns", %{conn: conn} do
       address = insert(:address)
 
-      conn = get(conn, address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, address.hash))
 
       assert %Token{} = conn.assigns.exchange_rate
     end
@@ -118,7 +117,7 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
         |> insert(transaction: transaction_3, from_address: address, index: 11)
 
       conn =
-        get(conn, address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, address.hash), %{
+        get(conn, address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, address.hash), %{
           "block_number" => Integer.to_string(b_block.number),
           "transaction_index" => Integer.to_string(transaction_3.index),
           "index" => Integer.to_string(index)
@@ -152,7 +151,7 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
         )
       end)
 
-      conn = get(conn, address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, address.hash))
 
       assert %{"block_number" => ^number, "index" => 11, "transaction_index" => ^transaction_index} =
                conn.assigns.next_page_params
@@ -176,7 +175,7 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
         )
       end)
 
-      conn = get(conn, address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, address.hash))
 
       refute conn.assigns.next_page_params
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_read_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_read_contract_controller_test.exs
@@ -5,7 +5,7 @@ defmodule BlockScoutWeb.AddressReadContractControllerTest do
 
   describe "GET index/3" do
     test "with invalid address hash", %{conn: conn} do
-      conn = get(conn, address_read_contract_path(BlockScoutWeb.Endpoint, :index, :en, "invalid_address"))
+      conn = get(conn, address_read_contract_path(BlockScoutWeb.Endpoint, :index, "invalid_address"))
 
       assert html_response(conn, 404)
     end
@@ -13,7 +13,7 @@ defmodule BlockScoutWeb.AddressReadContractControllerTest do
     test "with valid address that is not a contract", %{conn: conn} do
       address = insert(:address)
 
-      conn = get(conn, address_read_contract_path(BlockScoutWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_read_contract_path(BlockScoutWeb.Endpoint, :index, address.hash))
 
       assert html_response(conn, 404)
     end
@@ -32,7 +32,7 @@ defmodule BlockScoutWeb.AddressReadContractControllerTest do
 
       insert(:smart_contract, address_hash: contract_address.hash)
 
-      conn = get(conn, address_read_contract_path(BlockScoutWeb.Endpoint, :index, :en, contract_address.hash))
+      conn = get(conn, address_read_contract_path(BlockScoutWeb.Endpoint, :index, contract_address.hash))
 
       assert html_response(conn, 200)
       assert contract_address.hash == conn.assigns.address.hash

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_transaction_controller_test.exs
@@ -1,20 +1,20 @@
 defmodule BlockScoutWeb.AddressTransactionControllerTest do
   use BlockScoutWeb.ConnCase
 
-  import BlockScoutWeb.Router.Helpers, only: [address_transaction_path: 4]
+  import BlockScoutWeb.Router.Helpers, only: [address_transaction_path: 3]
 
   alias Explorer.Chain.{Block, Transaction}
   alias Explorer.ExchangeRates.Token
 
   describe "GET index/2" do
     test "with invalid address hash", %{conn: conn} do
-      conn = get(conn, address_transaction_path(conn, :index, :en, "invalid_address"))
+      conn = get(conn, address_transaction_path(conn, :index, "invalid_address"))
 
       assert html_response(conn, 422)
     end
 
     test "with valid address hash without address", %{conn: conn} do
-      conn = get(conn, address_transaction_path(conn, :index, :en, "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"))
+      conn = get(conn, address_transaction_path(conn, :index, "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"))
 
       assert html_response(conn, 404)
     end
@@ -34,7 +34,7 @@ defmodule BlockScoutWeb.AddressTransactionControllerTest do
         |> insert(to_address: address)
         |> with_block(block)
 
-      conn = get(conn, address_transaction_path(conn, :index, :en, address))
+      conn = get(conn, address_transaction_path(conn, :index, address))
 
       actual_transaction_hashes =
         conn.assigns.transactions
@@ -50,7 +50,7 @@ defmodule BlockScoutWeb.AddressTransactionControllerTest do
 
       insert(:transaction, from_address: address, to_address: address)
 
-      conn = get(conn, address_transaction_path(BlockScoutWeb.Endpoint, :index, :en, address))
+      conn = get(conn, address_transaction_path(BlockScoutWeb.Endpoint, :index, address))
 
       assert html_response(conn, 200)
       assert conn.status == 200
@@ -62,7 +62,7 @@ defmodule BlockScoutWeb.AddressTransactionControllerTest do
     test "includes USD exchange rate value for address in assigns", %{conn: conn} do
       address = insert(:address)
 
-      conn = get(conn, address_transaction_path(BlockScoutWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_path(BlockScoutWeb.Endpoint, :index, address.hash))
 
       assert %Token{} = conn.assigns.exchange_rate
     end
@@ -82,7 +82,7 @@ defmodule BlockScoutWeb.AddressTransactionControllerTest do
         |> with_block()
 
       conn =
-        get(conn, address_transaction_path(BlockScoutWeb.Endpoint, :index, :en, address.hash), %{
+        get(conn, address_transaction_path(BlockScoutWeb.Endpoint, :index, address.hash), %{
           "block_number" => Integer.to_string(block_number),
           "index" => Integer.to_string(index)
         })
@@ -103,7 +103,7 @@ defmodule BlockScoutWeb.AddressTransactionControllerTest do
       |> insert_list(:transaction, from_address: address)
       |> with_block(block)
 
-      conn = get(conn, address_transaction_path(BlockScoutWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_path(BlockScoutWeb.Endpoint, :index, address.hash))
 
       assert %{"block_number" => ^number, "index" => 10} = conn.assigns.next_page_params
     end
@@ -115,7 +115,7 @@ defmodule BlockScoutWeb.AddressTransactionControllerTest do
       |> insert(from_address: address)
       |> with_block()
 
-      conn = get(conn, address_transaction_path(BlockScoutWeb.Endpoint, :index, :en, address.hash))
+      conn = get(conn, address_transaction_path(BlockScoutWeb.Endpoint, :index, address.hash))
 
       refute conn.assigns.next_page_params
     end
@@ -138,7 +138,7 @@ defmodule BlockScoutWeb.AddressTransactionControllerTest do
         transaction: transaction
       )
 
-      conn = get(conn, address_transaction_path(conn, :index, :en, address))
+      conn = get(conn, address_transaction_path(conn, :index, address))
 
       assert [transaction] == conn.assigns.transactions
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api_docs_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api_docs_controller_test.exs
@@ -1,11 +1,11 @@
 defmodule BlockScoutWeb.APIDocsControllerTest do
   use BlockScoutWeb.ConnCase
 
-  import BlockScoutWeb.Router.Helpers, only: [api_docs_path: 3]
+  import BlockScoutWeb.Router.Helpers, only: [api_docs_path: 2]
 
   describe "GET index/2" do
     test "renders documentation tiles for each API module#action", %{conn: conn} do
-      conn = get(conn, api_docs_path(BlockScoutWeb.Endpoint, :index, :en))
+      conn = get(conn, api_docs_path(BlockScoutWeb.Endpoint, :index))
 
       documentation = BlockScoutWeb.Etherscan.get_documentation()
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/block_controller_test.exs
@@ -2,13 +2,11 @@ defmodule BlockScoutWeb.BlockControllerTest do
   use BlockScoutWeb.ConnCase
   alias Explorer.Chain.Block
 
-  @locale "en"
-
   describe "GET show/2" do
     test "with block redirects to block transactions route", %{conn: conn} do
       insert(:block, number: 3)
-      conn = get(conn, "/en/blocks/3")
-      assert redirected_to(conn) =~ "/en/blocks/3/transactions"
+      conn = get(conn, "/blocks/3")
+      assert redirected_to(conn) =~ "/blocks/3/transactions"
     end
   end
 
@@ -20,7 +18,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
         |> Stream.map(fn block -> block.number end)
         |> Enum.reverse()
 
-      conn = get(conn, block_path(conn, :index, @locale))
+      conn = get(conn, block_path(conn, :index))
 
       assert conn.assigns.blocks |> Enum.map(fn block -> block.number end) == block_ids
     end
@@ -32,7 +30,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
       |> insert_list(:transaction)
       |> with_block(block)
 
-      conn = get(conn, block_path(conn, :index, @locale))
+      conn = get(conn, block_path(conn, :index))
 
       assert conn.assigns.blocks |> Enum.count() == 1
     end
@@ -46,7 +44,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
       block = insert(:block)
 
       conn =
-        get(conn, block_path(conn, :index, @locale), %{
+        get(conn, block_path(conn, :index), %{
           "block_number" => Integer.to_string(block.number)
         })
 
@@ -64,7 +62,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
         |> insert_list(:block)
         |> Enum.fetch!(10)
 
-      conn = get(conn, block_path(conn, :index, @locale))
+      conn = get(conn, block_path(conn, :index))
 
       assert %{"block_number" => ^number} = conn.assigns.next_page_params
     end
@@ -72,7 +70,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
     test "next_page_params are empty if on last page", %{conn: conn} do
       insert(:block)
 
-      conn = get(conn, block_path(conn, :index, @locale))
+      conn = get(conn, block_path(conn, :index))
 
       refute conn.assigns.next_page_params
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/block_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/block_transaction_controller_test.exs
@@ -2,17 +2,17 @@ defmodule BlockScoutWeb.BlockTransactionControllerTest do
   use BlockScoutWeb.ConnCase
 
   alias Explorer.Chain.Block
-  import BlockScoutWeb.Router.Helpers, only: [block_transaction_path: 4]
+  import BlockScoutWeb.Router.Helpers, only: [block_transaction_path: 3]
 
   describe "GET index/2" do
     test "with invalid block number", %{conn: conn} do
-      conn = get(conn, block_transaction_path(conn, :index, :en, "unknown"))
+      conn = get(conn, block_transaction_path(conn, :index, "unknown"))
 
       assert html_response(conn, 404)
     end
 
     test "with valid block number without block", %{conn: conn} do
-      conn = get(conn, block_transaction_path(conn, :index, :en, "1"))
+      conn = get(conn, block_transaction_path(conn, :index, "1"))
 
       assert html_response(conn, 404)
     end
@@ -23,7 +23,7 @@ defmodule BlockScoutWeb.BlockTransactionControllerTest do
       :transaction |> insert() |> with_block(block)
       :transaction |> insert(to_address: nil) |> with_block(block)
 
-      conn = get(conn, block_transaction_path(BlockScoutWeb.Endpoint, :index, :en, block.number))
+      conn = get(conn, block_transaction_path(BlockScoutWeb.Endpoint, :index, block.number))
 
       assert html_response(conn, 200)
       assert 2 == Enum.count(conn.assigns.transactions)
@@ -33,7 +33,7 @@ defmodule BlockScoutWeb.BlockTransactionControllerTest do
       insert(:transaction)
       block = insert(:block)
 
-      conn = get(conn, block_transaction_path(BlockScoutWeb.Endpoint, :index, :en, block))
+      conn = get(conn, block_transaction_path(BlockScoutWeb.Endpoint, :index, block))
 
       assert html_response(conn, 200)
       assert Enum.empty?(conn.assigns.transactions)
@@ -43,7 +43,7 @@ defmodule BlockScoutWeb.BlockTransactionControllerTest do
       block = insert(:block)
       insert(:transaction)
 
-      conn = get(conn, block_transaction_path(BlockScoutWeb.Endpoint, :index, :en, block))
+      conn = get(conn, block_transaction_path(BlockScoutWeb.Endpoint, :index, block))
 
       assert html_response(conn, 200)
       assert Enum.empty?(conn.assigns.transactions)
@@ -56,7 +56,7 @@ defmodule BlockScoutWeb.BlockTransactionControllerTest do
       |> insert_list(:transaction)
       |> with_block(block)
 
-      conn = get(conn, block_transaction_path(BlockScoutWeb.Endpoint, :index, :en, block))
+      conn = get(conn, block_transaction_path(BlockScoutWeb.Endpoint, :index, block))
 
       assert %{"block_number" => ^number, "index" => 10} = conn.assigns.next_page_params
     end
@@ -68,7 +68,7 @@ defmodule BlockScoutWeb.BlockTransactionControllerTest do
       |> insert()
       |> with_block(block)
 
-      conn = get(conn, block_transaction_path(BlockScoutWeb.Endpoint, :index, :en, block))
+      conn = get(conn, block_transaction_path(BlockScoutWeb.Endpoint, :index, block))
 
       refute conn.assigns.next_page_params
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
@@ -1,26 +1,18 @@
 defmodule BlockScoutWeb.ChainControllerTest do
   use BlockScoutWeb.ConnCase
 
-  import BlockScoutWeb.Router.Helpers, only: [chain_path: 3, block_path: 4, transaction_path: 4, address_path: 4]
+  import BlockScoutWeb.Router.Helpers, only: [chain_path: 2, block_path: 3, transaction_path: 3, address_path: 3]
 
-  describe "GET index/2 without a locale" do
-    test "redirects to the en locale", %{conn: conn} do
-      conn = get(conn, "/")
-
-      assert(redirected_to(conn) == "/en")
-    end
-  end
-
-  describe "GET index/2 with a locale" do
+  describe "GET index/2" do
     test "returns a welcome message", %{conn: conn} do
-      conn = get(conn, chain_path(BlockScoutWeb.Endpoint, :show, %{locale: :en}))
+      conn = get(conn, chain_path(BlockScoutWeb.Endpoint, :show))
 
       assert(html_response(conn, 200) =~ "POA")
     end
 
     test "returns a block", %{conn: conn} do
       insert(:block, %{number: 23})
-      conn = get(conn, "/en")
+      conn = get(conn, "/")
 
       assert(List.first(conn.assigns.blocks).number == 23)
     end
@@ -28,7 +20,7 @@ defmodule BlockScoutWeb.ChainControllerTest do
     test "excludes all but the most recent five blocks", %{conn: conn} do
       old_block = insert(:block)
       insert_list(5, :block)
-      conn = get(conn, "/en")
+      conn = get(conn, "/")
 
       refute(Enum.member?(conn.assigns.blocks, old_block))
     end
@@ -41,7 +33,7 @@ defmodule BlockScoutWeb.ChainControllerTest do
 
       unassociated = insert(:transaction)
 
-      conn = get(conn, "/en")
+      conn = get(conn, "/")
 
       transaction_hashes = Enum.map(conn.assigns.transactions, fn transaction -> transaction.hash end)
 
@@ -55,7 +47,7 @@ defmodule BlockScoutWeb.ChainControllerTest do
         |> insert()
         |> with_block()
 
-      conn = get(conn, "/en")
+      conn = get(conn, "/")
 
       assert(List.first(conn.assigns.transactions).hash == transaction.hash)
     end
@@ -64,7 +56,7 @@ defmodule BlockScoutWeb.ChainControllerTest do
       today = Date.utc_today()
       for day <- -40..0, do: insert(:market_history, date: Date.add(today, day))
 
-      conn = get(conn, "/en")
+      conn = get(conn, "/")
 
       assert Map.has_key?(conn.assigns, :market_history_data)
       assert length(conn.assigns.market_history_data) == 30
@@ -74,9 +66,9 @@ defmodule BlockScoutWeb.ChainControllerTest do
   describe "GET q/2" do
     test "finds a block by block number", %{conn: conn} do
       insert(:block, number: 37)
-      conn = get(conn, "/en/search?q=37")
+      conn = get(conn, "/search?q=37")
 
-      assert redirected_to(conn) == block_path(conn, :show, "en", "37")
+      assert redirected_to(conn) == block_path(conn, :show, "37")
     end
 
     test "finds a transaction by hash", %{conn: conn} do
@@ -85,27 +77,27 @@ defmodule BlockScoutWeb.ChainControllerTest do
         |> insert()
         |> with_block()
 
-      conn = get(conn, "/en/search?q=#{to_string(transaction.hash)}")
+      conn = get(conn, "/search?q=#{to_string(transaction.hash)}")
 
-      assert redirected_to(conn) == transaction_path(conn, :show, "en", transaction)
+      assert redirected_to(conn) == transaction_path(conn, :show, transaction)
     end
 
     test "finds an address by hash", %{conn: conn} do
       address = insert(:address)
-      conn = get(conn, "en/search?q=#{to_string(address.hash)}")
+      conn = get(conn, "search?q=#{to_string(address.hash)}")
 
-      assert redirected_to(conn) == address_path(conn, :show, "en", address)
+      assert redirected_to(conn) == address_path(conn, :show, address)
     end
 
     test "finds an address by hash when there are extra spaces", %{conn: conn} do
       address = insert(:address)
-      conn = get(conn, "en/search?q=#{to_string(address.hash)}    ")
+      conn = get(conn, "search?q=#{to_string(address.hash)}")
 
-      assert redirected_to(conn) == address_path(conn, :show, "en", address)
+      assert redirected_to(conn) == address_path(conn, :show, address)
     end
 
     test "redirects to 404 when it finds nothing", %{conn: conn} do
-      conn = get(conn, "en/search?q=zaphod")
+      conn = get(conn, "search?q=zaphod")
       assert conn.status == 404
     end
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/pending_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/pending_transaction_controller_test.exs
@@ -2,7 +2,7 @@ defmodule BlockScoutWeb.PendingTransactionControllerTest do
   use BlockScoutWeb.ConnCase
   alias Explorer.Chain.{Hash, Transaction}
 
-  import BlockScoutWeb.Router.Helpers, only: [pending_transaction_path: 3]
+  import BlockScoutWeb.Router.Helpers, only: [pending_transaction_path: 2]
 
   describe "GET index/2" do
     test "returns no transactions that are in a block", %{conn: conn} do
@@ -10,7 +10,7 @@ defmodule BlockScoutWeb.PendingTransactionControllerTest do
       |> insert()
       |> with_block()
 
-      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index, :en))
+      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index))
 
       assert html_response(conn, 200)
       assert Enum.empty?(conn.assigns.transactions)
@@ -21,7 +21,7 @@ defmodule BlockScoutWeb.PendingTransactionControllerTest do
       |> insert()
       |> with_block()
 
-      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index, :en))
+      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index))
 
       assert html_response(conn, 200)
       assert Enum.empty?(conn.assigns.transactions)
@@ -30,7 +30,7 @@ defmodule BlockScoutWeb.PendingTransactionControllerTest do
     test "returns pending transactions", %{conn: conn} do
       transaction = insert(:transaction)
 
-      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index, :en))
+      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index))
 
       actual_transaction_hashes =
         conn.assigns.transactions
@@ -43,14 +43,14 @@ defmodule BlockScoutWeb.PendingTransactionControllerTest do
     test "returns a count of pending transactions", %{conn: conn} do
       insert(:transaction)
 
-      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index, :en))
+      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index))
 
       assert html_response(conn, 200)
       assert 1 == conn.assigns.pending_transaction_count
     end
 
     test "works when there are no transactions", %{conn: conn} do
-      conn = get(conn, pending_transaction_path(conn, :index, :en))
+      conn = get(conn, pending_transaction_path(conn, :index))
 
       assert html_response(conn, 200)
     end
@@ -64,7 +64,7 @@ defmodule BlockScoutWeb.PendingTransactionControllerTest do
       %Transaction{inserted_at: inserted_at, hash: hash} = insert(:transaction)
 
       conn =
-        get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index, :en), %{
+        get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index), %{
           "inserted_at" => DateTime.to_iso8601(inserted_at),
           "hash" => Hash.to_string(hash)
         })
@@ -85,7 +85,7 @@ defmodule BlockScoutWeb.PendingTransactionControllerTest do
 
       converted_date = DateTime.to_iso8601(inserted_at)
 
-      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index, :en))
+      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index))
 
       assert %{"inserted_at" => ^converted_date, "hash" => ^hash} = conn.assigns.next_page_params
     end
@@ -93,7 +93,7 @@ defmodule BlockScoutWeb.PendingTransactionControllerTest do
     test "next_page_params are empty if on last page", %{conn: conn} do
       insert(:transaction)
 
-      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index, :en))
+      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index))
 
       refute conn.assigns.next_page_params
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
     test "only responds to ajax requests", %{conn: conn} do
       smart_contract = insert(:smart_contract)
 
-      path = smart_contract_path(BlockScoutWeb.Endpoint, :index, :en, hash: smart_contract.address_hash)
+      path = smart_contract_path(BlockScoutWeb.Endpoint, :index, hash: smart_contract.address_hash)
 
       conn = get(conn, path)
 
@@ -23,7 +23,7 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
 
       blockchain_get_function_mock()
 
-      path = smart_contract_path(BlockScoutWeb.Endpoint, :index, :en, hash: token_contract_address.hash)
+      path = smart_contract_path(BlockScoutWeb.Endpoint, :index, hash: token_contract_address.hash)
 
       conn =
         build_conn()
@@ -43,7 +43,6 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
         smart_contract_path(
           BlockScoutWeb.Endpoint,
           :show,
-          :en,
           smart_contract.address_hash,
           function_name: "get",
           args: []
@@ -63,7 +62,6 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
         smart_contract_path(
           BlockScoutWeb.Endpoint,
           :show,
-          :en,
           smart_contract.address_hash,
           function_name: "get",
           args: []
@@ -79,7 +77,6 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
       assert %{
                function_name: "get",
                layout: false,
-               locale: "en",
                outputs: [%{"name" => "", "type" => "uint256", "value" => 0}]
              } = conn.assigns
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/tokens/read_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/tokens/read_contract_controller_test.exs
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.Tokens.ReadContractControllerTest do
 
   describe "GET index/3" do
     test "with invalid address hash", %{conn: conn} do
-      conn = get(conn, token_read_contract_path(BlockScoutWeb.Endpoint, :index, :en, "invalid_address"))
+      conn = get(conn, token_read_contract_path(BlockScoutWeb.Endpoint, :index, "invalid_address"))
 
       assert html_response(conn, 404)
     end
@@ -26,7 +26,7 @@ defmodule BlockScoutWeb.Tokens.ReadContractControllerTest do
         token: token
       )
 
-      conn = get(conn, token_read_contract_path(BlockScoutWeb.Endpoint, :index, :en, token.contract_address_hash))
+      conn = get(conn, token_read_contract_path(BlockScoutWeb.Endpoint, :index, token.contract_address_hash))
 
       assert html_response(conn, 200)
       assert token.contract_address_hash == conn.assigns.token.contract_address_hash

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_controller_test.exs
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.TransactionControllerTest do
   alias Explorer.Chain.{Block, Transaction}
 
   import BlockScoutWeb.Router.Helpers,
-    only: [transaction_path: 4, transaction_internal_transaction_path: 4, transaction_token_transfer_path: 4]
+    only: [transaction_path: 3, transaction_internal_transaction_path: 3, transaction_token_transfer_path: 3]
 
   describe "GET index/2" do
     test "returns a collated transactions", %{conn: conn} do
@@ -12,7 +12,7 @@ defmodule BlockScoutWeb.TransactionControllerTest do
         |> insert()
         |> with_block()
 
-      conn = get(conn, "/en/txs")
+      conn = get(conn, "/txs")
 
       assert List.first(conn.assigns.transactions).hash == transaction.hash
     end
@@ -22,7 +22,7 @@ defmodule BlockScoutWeb.TransactionControllerTest do
       |> insert()
       |> with_block()
 
-      conn = get(conn, "/en/txs")
+      conn = get(conn, "/txs")
 
       assert is_integer(conn.assigns.transaction_estimated_count)
     end
@@ -35,7 +35,7 @@ defmodule BlockScoutWeb.TransactionControllerTest do
 
       insert(:transaction)
 
-      conn = get(conn, "/en/txs")
+      conn = get(conn, "/txs")
 
       assert [%Transaction{hash: ^hash}] = conn.assigns.transactions
     end
@@ -53,7 +53,7 @@ defmodule BlockScoutWeb.TransactionControllerTest do
         |> with_block()
 
       conn =
-        get(conn, "/en/txs", %{
+        get(conn, "/txs", %{
           "block_number" => Integer.to_string(block_number),
           "index" => Integer.to_string(index)
         })
@@ -74,7 +74,7 @@ defmodule BlockScoutWeb.TransactionControllerTest do
       |> insert_list(:transaction, from_address: address)
       |> with_block(block)
 
-      conn = get(conn, "/en/txs")
+      conn = get(conn, "/txs")
 
       assert %{"block_number" => ^number, "index" => 10} = conn.assigns.next_page_params
     end
@@ -86,13 +86,13 @@ defmodule BlockScoutWeb.TransactionControllerTest do
       |> insert(from_address: address)
       |> with_block()
 
-      conn = get(conn, "/en/txs")
+      conn = get(conn, "/txs")
 
       refute conn.assigns.next_page_params
     end
 
     test "works when there are no transactions", %{conn: conn} do
-      conn = get(conn, "/en/txs")
+      conn = get(conn, "/txs")
 
       assert conn.assigns.transactions == []
     end
@@ -100,23 +100,20 @@ defmodule BlockScoutWeb.TransactionControllerTest do
 
   describe "GET show/3" do
     test "redirects to transactions/:transaction_id/token_transfers when there are token transfers", %{conn: conn} do
-      locale = "en"
       transaction = insert(:transaction)
       insert(:token_transfer, transaction: transaction)
-      conn = get(conn, transaction_path(BlockScoutWeb.Endpoint, :show, locale, transaction))
+      conn = get(conn, transaction_path(BlockScoutWeb.Endpoint, :show, transaction))
 
-      assert redirected_to(conn) =~ transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, locale, transaction)
+      assert redirected_to(conn) =~ transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, transaction)
     end
 
     test "redirects to transactions/:transaction_id/internal_transactions when there are no token transfers", %{
       conn: conn
     } do
-      locale = "en"
       transaction = insert(:transaction)
-      conn = get(conn, transaction_path(BlockScoutWeb.Endpoint, :show, locale, transaction))
+      conn = get(conn, transaction_path(BlockScoutWeb.Endpoint, :show, transaction))
 
-      assert redirected_to(conn) =~
-               transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, locale, transaction)
+      assert redirected_to(conn) =~ transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, transaction)
     end
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_internal_transaction_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
   use BlockScoutWeb.ConnCase
 
-  import BlockScoutWeb.Router.Helpers, only: [transaction_internal_transaction_path: 4]
+  import BlockScoutWeb.Router.Helpers, only: [transaction_internal_transaction_path: 3]
 
   alias Explorer.Chain.{Block, InternalTransaction, Transaction}
   alias Explorer.ExchangeRates.Token
@@ -9,13 +9,13 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
   describe "GET index/3" do
     test "with missing transaction", %{conn: conn} do
       hash = transaction_hash()
-      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, hash))
+      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, hash))
 
       assert html_response(conn, 404)
     end
 
     test "with invalid transaction hash", %{conn: conn} do
-      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, "nope"))
+      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, "nope"))
 
       assert html_response(conn, 404)
     end
@@ -28,7 +28,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
         |> insert()
         |> with_block(block)
 
-      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash))
+      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
 
       assert html_response(conn, 200)
       assert conn.assigns.transaction.hash == transaction.hash
@@ -39,7 +39,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
       expected_internal_transaction = insert(:internal_transaction, transaction: transaction, index: 0)
       insert(:internal_transaction, transaction: transaction, index: 1)
 
-      path = transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash)
+      path = transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, transaction.hash)
 
       conn = get(conn, path)
 
@@ -55,7 +55,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
     test "includes USD exchange rate value for address in assigns", %{conn: conn} do
       transaction = insert(:transaction)
 
-      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash))
+      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
 
       assert %Token{} = conn.assigns.exchange_rate
     end
@@ -80,7 +80,6 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
           transaction_internal_transaction_path(
             BlockScoutWeb.Endpoint,
             :index,
-            :en,
             internal_transaction.transaction_hash
           )
         )
@@ -102,7 +101,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
         |> Enum.map(& &1.index)
 
       conn =
-        get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash), %{
+        get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, transaction.hash), %{
           "index" => Integer.to_string(index)
         })
 
@@ -131,7 +130,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
         )
       end)
 
-      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash))
+      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
 
       assert %{"block_number" => ^number, "index" => 50, "transaction_index" => ^transaction_index} =
                conn.assigns.next_page_params
@@ -152,7 +151,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
         )
       end)
 
-      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash))
+      conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
 
       refute conn.assigns.next_page_params
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_log_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_log_controller_test.exs
@@ -1,13 +1,13 @@
 defmodule BlockScoutWeb.TransactionLogControllerTest do
   use BlockScoutWeb.ConnCase
 
-  import BlockScoutWeb.Router.Helpers, only: [transaction_log_path: 4]
+  import BlockScoutWeb.Router.Helpers, only: [transaction_log_path: 3]
 
   alias Explorer.ExchangeRates.Token
 
   describe "GET index/2" do
     test "with invalid transaction hash", %{conn: conn} do
-      conn = get(conn, transaction_log_path(conn, :index, :en, "invalid_transaction_string"))
+      conn = get(conn, transaction_log_path(conn, :index, "invalid_transaction_string"))
 
       assert html_response(conn, 404)
     end
@@ -16,7 +16,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
       conn =
         get(
           conn,
-          transaction_log_path(conn, :index, :en, "0x3a3eb134e6792ce9403ea4188e5e79693de9e4c94e499db132be086400da79e6")
+          transaction_log_path(conn, :index, "0x3a3eb134e6792ce9403ea4188e5e79693de9e4c94e499db132be086400da79e6")
         )
 
       assert html_response(conn, 404)
@@ -31,7 +31,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
       address = insert(:address)
       insert(:log, address: address, transaction: transaction)
 
-      conn = get(conn, transaction_log_path(conn, :index, :en, transaction))
+      conn = get(conn, transaction_log_path(conn, :index, transaction))
 
       first_log = List.first(conn.assigns.logs)
 
@@ -47,7 +47,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
       address = insert(:address)
       insert(:log, address: address, transaction: transaction)
 
-      conn = get(conn, transaction_log_path(conn, :index, :en, transaction))
+      conn = get(conn, transaction_log_path(conn, :index, transaction))
 
       first_log = List.first(conn.assigns.logs)
 
@@ -56,7 +56,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
 
     test "assigns no logs when there are none", %{conn: conn} do
       transaction = insert(:transaction)
-      path = transaction_log_path(conn, :index, :en, transaction)
+      path = transaction_log_path(conn, :index, transaction)
 
       conn = get(conn, path)
 
@@ -77,7 +77,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
         |> Enum.map(& &1.index)
 
       conn =
-        get(conn, transaction_log_path(conn, :index, :en, transaction), %{
+        get(conn, transaction_log_path(conn, :index, transaction), %{
           "index" => Integer.to_string(log.index)
         })
 
@@ -95,7 +95,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
       1..60
       |> Enum.map(fn index -> insert(:log, transaction: transaction, index: index) end)
 
-      conn = get(conn, transaction_log_path(conn, :index, :en, transaction))
+      conn = get(conn, transaction_log_path(conn, :index, transaction))
 
       assert %{"index" => 50} = conn.assigns.next_page_params
     end
@@ -106,7 +106,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
         |> insert()
         |> with_block()
 
-      conn = get(conn, transaction_log_path(conn, :index, :en, transaction))
+      conn = get(conn, transaction_log_path(conn, :index, transaction))
 
       refute conn.assigns.next_page_params
     end
@@ -115,7 +115,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
   test "includes USD exchange rate value for address in assigns", %{conn: conn} do
     transaction = insert(:transaction)
 
-    conn = get(conn, transaction_log_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash))
+    conn = get(conn, transaction_log_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
 
     assert %Token{} = conn.assigns.exchange_rate
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_token_transfer_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_token_transfer_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
   use BlockScoutWeb.ConnCase
 
-  import BlockScoutWeb.Router.Helpers, only: [transaction_token_transfer_path: 4]
+  import BlockScoutWeb.Router.Helpers, only: [transaction_token_transfer_path: 3]
 
   alias Explorer.ExchangeRates.Token
 
@@ -10,20 +10,20 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
       transaction = insert(:transaction)
       token_transfer = insert(:token_transfer, transaction: transaction)
 
-      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash))
+      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
 
       assert List.first(conn.assigns.transaction.token_transfers).id == token_transfer.id
     end
 
     test "with missing transaction", %{conn: conn} do
       hash = transaction_hash()
-      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, :en, hash))
+      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, hash))
 
       assert html_response(conn, 404)
     end
 
     test "with invalid transaction hash", %{conn: conn} do
-      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, :en, "nope"))
+      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, "nope"))
 
       assert html_response(conn, 404)
     end
@@ -36,7 +36,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
         |> insert()
         |> with_block(block)
 
-      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash))
+      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
 
       assert html_response(conn, 200)
       assert conn.assigns.transaction.hash == transaction.hash
@@ -49,7 +49,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
 
       insert(:token_transfer, transaction: transaction)
 
-      path = transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash)
+      path = transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, transaction.hash)
 
       conn = get(conn, path)
 
@@ -65,7 +65,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
     test "includes USD exchange rate value for address in assigns", %{conn: conn} do
       transaction = insert(:transaction)
 
-      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash))
+      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
 
       assert %Token{} = conn.assigns.exchange_rate
     end
@@ -86,7 +86,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
       end)
 
       conn =
-        get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash), %{
+        get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, transaction.hash), %{
           "inserted_at" => first_transfer_time |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_iso8601()
         })
 
@@ -112,7 +112,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
         )
       end)
 
-      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash))
+      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
 
       assert Enum.any?(conn.assigns.next_page_params)
     end
@@ -132,7 +132,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
         )
       end)
 
-      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, :en, transaction.hash))
+      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
 
       assert is_nil(conn.assigns.next_page_params)
     end

--- a/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
@@ -74,7 +74,7 @@ defmodule BlockScoutWeb.AddressPage do
   def visit_page(session, %Address{hash: address_hash}), do: visit_page(session, address_hash)
 
   def visit_page(session, address_hash) do
-    visit(session, "/en/address/#{address_hash}")
+    visit(session, "/address/#{address_hash}")
   end
 
   def token_transfer(%Transaction{hash: transaction_hash}, %Address{hash: address_hash}, count: count) do

--- a/apps/block_scout_web/test/block_scout_web/features/pages/block_list_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/block_list_page.ex
@@ -8,7 +8,7 @@ defmodule BlockScoutWeb.BlockListPage do
   alias Explorer.Chain.Block
 
   def visit_page(session) do
-    visit(session, "/en/blocks")
+    visit(session, "/blocks")
   end
 
   def block(%Block{number: block_number}) do

--- a/apps/block_scout_web/test/block_scout_web/features/pages/block_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/block_page.ex
@@ -32,6 +32,6 @@ defmodule BlockScoutWeb.BlockPage do
   end
 
   def visit_page(session, %Block{number: block_number}) do
-    visit(session, "/en/blocks/#{block_number}/transactions")
+    visit(session, "/blocks/#{block_number}/transactions")
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/features/pages/transaction_list_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/transaction_list_page.ex
@@ -32,6 +32,6 @@ defmodule BlockScoutWeb.TransactionListPage do
   end
 
   def visit_page(session) do
-    visit(session, "/en/txs")
+    visit(session, "/txs")
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/features/pages/transaction_logs_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/transaction_logs_page.ex
@@ -4,7 +4,7 @@ defmodule BlockScoutWeb.TransactionLogsPage do
   use Wallaby.DSL
 
   import Wallaby.Query, only: [css: 1, css: 2]
-  import BlockScoutWeb.Router.Helpers, only: [transaction_log_path: 4]
+  import BlockScoutWeb.Router.Helpers, only: [transaction_log_path: 3]
 
   alias Explorer.Chain.{Address, Transaction}
   alias BlockScoutWeb.Endpoint
@@ -14,7 +14,7 @@ defmodule BlockScoutWeb.TransactionLogsPage do
   end
 
   def visit_page(session, %Transaction{} = transaction) do
-    visit(session, transaction_log_path(Endpoint, :index, :en, transaction))
+    visit(session, transaction_log_path(Endpoint, :index, transaction))
   end
 
   def click_address(session, %Address{hash: address_hash}) do

--- a/apps/block_scout_web/test/block_scout_web/features/pages/transaction_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/transaction_page.ex
@@ -16,10 +16,10 @@ defmodule BlockScoutWeb.TransactionPage do
   end
 
   def visit_page(session, %Transaction{hash: transaction_hash}) do
-    visit(session, "/en/tx/#{transaction_hash}")
+    visit(session, "/tx/#{transaction_hash}")
   end
 
   def visit_page(session, transaction_hash = %Hash{}) do
-    visit(session, "/en/tx/#{transaction_hash}")
+    visit(session, "/tx/#{transaction_hash}")
   end
 end


### PR DESCRIPTION
#642

We're removing the locales from the our URLs. This had direct impact on how we use our link helpers, that ain't required anymore.

A few ideas emerged in #642 to use the locales in our headers and/or query string, but I didn't went that way since we don't have any other language right now.

## Changelog

- `set_locale` lib was removed from our dependencies. 
- Fix hard-coded token id in the token page.