### PR TITLE
Fix copy contract source code tooltip text

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
@@ -72,7 +72,7 @@
           <div class="d-flex justify-content-between align-items-baseline">
             <h3>Contract source code</h3>
             <span class="icon-links" data-clipboard-text="<%= @address.smart_contract.contract_source_code %>">
-              <button type="button" class="button button--secondary button--sm" id="button" data-toggle="tooltip" data-placement="top" title="<%= gettext("Copy Address") %>" aria-label="Copy Address">
+              <button type="button" class="button button--secondary button--sm" id="button" data-toggle="tooltip" data-placement="top" title="<%= gettext("Copy Contract Source Code") %>" aria-label="Copy Contract Source Code">
                 Copy Contract Source Code
               </button>
             </span>


### PR DESCRIPTION
Resolves: #552 

## Motivation

The "Copy Contract Source Code" button's tooltip was displaying the incorrect text.

## Changelog

### Enhancements
* Change the tooltip interaction so that it is not visible when hovering over the parent element, but still displays as "Copied" when the parent element is clicked.  
