### PR TITLE
Fix token balances' query to always consider the last block even when the value is 0.

### DIFF
--- a/apps/explorer/lib/explorer/chain/address/token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/token_balance.ex
@@ -65,18 +65,20 @@ defmodule Explorer.Chain.Address.TokenBalance do
   end
 
   @doc """
-  Builds an `Ecto.Query` to fetch the last token balances.
+  Builds an `Ecto.Query` to fetch the last token balances that have value greater than 0.
 
   The last token balances from an Address is the last block indexed.
   """
   def last_token_balances(address_hash) do
-    from(
-      tb in TokenBalance,
-      where: tb.address_hash == ^address_hash and tb.value > 0,
-      distinct: :token_contract_address_hash,
-      order_by: [desc: :block_number],
-      preload: :token
-    )
+    query =
+      from(
+        tb in TokenBalance,
+        where: tb.address_hash == ^address_hash,
+        distinct: :token_contract_address_hash,
+        order_by: [desc: :block_number]
+      )
+
+    from(tb in subquery(query), where: tb.value > 0, preload: :token)
   end
 
   @doc """

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2665,6 +2665,29 @@ defmodule Explorer.ChainTest do
 
       assert Chain.fetch_last_token_balances(address.hash) == []
     end
+
+    test "does not consider other blocks when the last block has the value 0" do
+      address = insert(:address)
+      token = insert(:token, contract_address: build(:contract_address))
+
+      insert(
+        :token_balance,
+        address: address,
+        block_number: 1000,
+        token_contract_address_hash: token.contract_address_hash,
+        value: 5000
+      )
+
+      insert(
+        :token_balance,
+        address: address,
+        block_number: 1001,
+        token_contract_address_hash: token.contract_address_hash,
+        value: 0
+      )
+
+      assert Chain.fetch_last_token_balances(address.hash) == []
+    end
   end
 
   describe "fetch_token_holders_from_token_hash/2" do


### PR DESCRIPTION
### Bug fix
The query that gets the last token balances based on the block number was considering the next-to-last token balance when the last one had the value 0.

In order to this work properly, I'm moving the query that gets token balances from the last block to a sub-query and moving the condition to consider just values greater than 0 to the main query.  This way we are sure that we always are considering the last block and we are skipping the ones that have the value equal to 0.

#### Before
![image](https://user-images.githubusercontent.com/27698968/45376182-8fc86c00-b5cd-11e8-9b45-bdd88f296fad.png)

#### After
![image](https://user-images.githubusercontent.com/27698968/45376144-758e8e00-b5cd-11e8-81e8-e8eeadac673c.png)
