### PR TITLE
Log BadGateway responses in SmartContract interactions

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -6,6 +6,8 @@ defmodule Explorer.SmartContract.Reader do
   [wiki](https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI).
   """
 
+  require Logger
+
   alias Explorer.Chain
   alias Explorer.Chain.{Block, Hash}
   alias EthereumJSONRPC.Encoder
@@ -119,7 +121,14 @@ defmodule Explorer.SmartContract.Reader do
 
   defp decode_results({:ok, results}, abi, functions), do: Encoder.decode_abi_results(results, abi, functions)
 
-  defp decode_results({:error, {:bad_gateway, _request_url}}, _abi, functions) do
+  defp decode_results({:error, {:bad_gateway, request_url}}, _abi, functions) do
+    Logger.error(fn ->
+      [
+        "BadGateway in #{request_url} while interacting with Contract functions: ",
+        inspect(functions)
+      ]
+    end)
+
     format_error(functions, "Bad Gateway")
   end
 


### PR DESCRIPTION
## Motivation

The #692 issue 🐛 was caused because our code wasn't prepared to deal with `bad_gateway` responses making our code break. We've fixed that in #705 so now our code won't break but the function value won't be returned either.

For the scenario where the bug was caught (TokenBalance fetching) it means that no "balance" was returned and that the operation will be executed again. 

But this behavior ☝️ will "hide" a great number of errors that are occurring in our nodes and we've discussed in the #692 issue that we shouldn't fail silently.

## Enhancement

So we've included a Log in that specific point (that are happening very frequently in the eth mainnet) , which will look like this in our error.log file:

> 16:04:09.950 [error] BadGateway in `<url>` while interacting with Contract functions: %{"balanceOf" => ["`<data>`"]}
