### PR TITLE
Increase Indexer.TokenBalance.Fetcher timeout and add treatment error

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -195,6 +195,9 @@ defmodule Explorer.Chain.Import do
       * `:timeout` - the timeout for inserting all transactions found in the params lists across all
         types. Defaults to `#{@insert_transactions_timeout}` milliseconds.
       * `:with` - the changeset function on `Explorer.Chain.Transaction` to use validate `:params`.
+    * `:token_balances`
+      * `:params` - `list` of params for `Explorer.Chain.TokenBalance.changeset/2`
+    * `:timeout` - the timeout for `Repo.transaction`. Defaults to `#{@transaction_timeout}` milliseconds.
   """
   @spec all(all_options()) :: all_result()
   def all(options) when is_map(options) do

--- a/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
@@ -102,7 +102,8 @@ defmodule Indexer.InternalTransaction.Fetcher do
         with {:ok, %{addresses: address_hashes}} <-
                Chain.import(%{
                  addresses: %{params: addresses_params},
-                 internal_transactions: %{params: internal_transactions_params}
+                 internal_transactions: %{params: internal_transactions_params},
+                 timeout: :infinity
                }) do
           address_hashes
           |> Enum.map(fn address_hash ->

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -81,6 +81,7 @@ defmodule Indexer.TokenBalance.Fetcher do
     case Chain.import(%{token_balances: %{params: token_balances_params}, timeout: :infinity}) do
       {:ok, _} ->
         :ok
+
       {:error, reason} ->
         Logger.debug(fn -> "failed to import #{length(token_balances_params)} token balances, #{inspect(reason)}" end)
 

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -78,9 +78,9 @@ defmodule Indexer.TokenBalance.Fetcher do
   end
 
   def import_token_balances(token_balances_params) do
-    with {:ok, _} <- Chain.import(%{token_balances: %{params: token_balances_params}}) do
-      :ok
-    else
+    case Chain.import(%{token_balances: %{params: token_balances_params}, timeout: :infinity}) do
+      {:ok, _} ->
+        :ok
       {:error, reason} ->
         Logger.debug(fn -> "failed to import #{length(token_balances_params)} token balances, #{inspect(reason)}" end)
 

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -21,7 +21,7 @@ defmodule Indexer.TokenBalance.Fetcher do
 
   @spec async_fetch([%TokenBalance{}]) :: :ok
   def async_fetch(token_balances_params) do
-    BufferedTask.buffer(__MODULE__, token_balances_params)
+    BufferedTask.buffer(__MODULE__, token_balances_params, :infinity)
   end
 
   @doc false

--- a/apps/indexer/test/indexer/token_balance/fetcher_test.exs
+++ b/apps/indexer/test/indexer/token_balance/fetcher_test.exs
@@ -50,4 +50,26 @@ defmodule Indexer.TokenBalance.FetcherTest do
       assert token_balance_updated.value_fetched_at != nil
     end
   end
+
+  describe "import_token_balances/1" do
+    test "ignores when it receives a empty list" do
+      assert TokenBalance.Fetcher.import_token_balances([]) == :ok
+    end
+
+    test "returns :error when the token balances has invalid data" do
+      token_balance = insert(:token_balance, value_fetched_at: nil, value: nil)
+
+      token_balances_params = [
+        %{
+          address_hash: nil,
+          block_number: nil,
+          token_contract_address_hash: to_string(token_balance.token_contract_address_hash),
+          value: nil,
+          value_fetched_at: nil
+        }
+      ]
+
+      assert TokenBalance.Fetcher.import_token_balances(token_balances_params) == :error
+    end
+  end
 end


### PR DESCRIPTION
Resolves #698

## Motivation

The `Indexer.TokenBalance.Fetcher` was being shut down when importing lots of token balances.

```
04:20:01.092 [error] Task #PID<0.13677.6> started from #PID<0.13236.6> terminating
** (stop) exited in: GenServer.call(Indexer.TokenBalanceFetcher, {:buffer, [ ... (truncated)
```

It was also raising an exception when the `Chain.import` returned an empty list.

```
`** (MatchError) no match of right hand side value: {:ok, %{token_balances: []}}`
```

## Changelog

### Bug Fixes

* Increase the `timeout` used by the `GenServer.call` at the `BufferedTask.buffer` so it doesn't exit when the token balances list is too long.
* Add `error` treatment when something unexpected happens with the `Chain.import` at the `Indexer.TokenBalance.Fetcher` 

