### PR TITLE
Orders account#getminedblocks by block number

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -1680,12 +1680,12 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
 
       address = insert(:address)
 
-      block1 = insert(:block, number: block_number1, miner: address)
-      _block2 = insert(:block, number: block_number2, miner: address)
+      _block1 = insert(:block, number: block_number1, miner: address)
+      block2 = insert(:block, number: block_number2, miner: address)
 
       :transaction
       |> insert(gas_price: 2)
-      |> with_block(block1, gas_used: 2)
+      |> with_block(block2, gas_used: 2)
 
       expected_reward =
         block_reward.reward
@@ -1705,8 +1705,8 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
 
       expected_result = [
         %{
-          "blockNumber" => to_string(block1.number),
-          "timeStamp" => to_string(block1.timestamp),
+          "blockNumber" => to_string(block2.number),
+          "timeStamp" => to_string(block2.timestamp),
           "blockReward" => to_string(expected_reward.value)
         }
       ]

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -144,6 +144,7 @@ defmodule Explorer.Etherscan do
         inner_join: r in Reward,
         on: fragment("? <@ ?", b.number, r.block_range),
         where: b.miner_hash == ^address_hash,
+        order_by: [desc: b.number],
         group_by: b.number,
         group_by: b.timestamp,
         group_by: r.reward,

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -983,13 +983,13 @@ defmodule Explorer.EtherscanTest do
       |> insert(gas_price: 3)
       |> with_block(block2, gas_used: 3)
 
-      expected_reward1 =
+      expected_reward_block1 =
         block_reward.reward
         |> Wei.to(:wei)
         |> Decimal.add(Decimal.new(8))
         |> Wei.from(:wei)
 
-      expected_reward2 =
+      expected_reward_block2 =
         block_reward.reward
         |> Wei.to(:wei)
         |> Decimal.add(Decimal.new(18))
@@ -997,14 +997,14 @@ defmodule Explorer.EtherscanTest do
 
       expected = [
         %{
-          number: block1.number,
-          timestamp: block1.timestamp,
-          reward: expected_reward1
-        },
-        %{
           number: block2.number,
           timestamp: block2.timestamp,
-          reward: expected_reward2
+          reward: expected_reward_block2
+        },
+        %{
+          number: block1.number,
+          timestamp: block1.timestamp,
+          reward: expected_reward_block1
         }
       ]
 
@@ -1035,17 +1035,17 @@ defmodule Explorer.EtherscanTest do
 
       expected1 = [
         %{
-          number: block1.number,
-          timestamp: block1.timestamp,
-          reward: expected_reward
+          number: block2.number,
+          timestamp: block2.timestamp,
+          reward: block_reward.reward
         }
       ]
 
       expected2 = [
         %{
-          number: block2.number,
-          timestamp: block2.timestamp,
-          reward: block_reward.reward
+          number: block1.number,
+          timestamp: block1.timestamp,
+          reward: expected_reward
         }
       ]
 


### PR DESCRIPTION
## Motivation

* To match Etherscan's API we want to ensure blocks returned by the
`account#getminedblocks` API endpoint are ordered by descending block
number. We noticed this wasn't the case when looking into a couple of
flaky tests on CI. This commit should also make sure the tests don't
randomly fail any more. These are the two tests:
  - test/block_scout_web/controllers/api/rpc/address_controller_test.exs:1674
  - test/explorer/etherscan_test.exs:1014

## Changelog

### Enhancements
* Editing `Explorer.Etherscan.list_blocks/1` to order blocks by
descending block number.
* Related tests were edited according to the change above.