### PR TITLE
Add transaction#gettxreceiptstatus API endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
@@ -1,0 +1,34 @@
+defmodule BlockScoutWeb.API.RPC.TransactionController do
+  use BlockScoutWeb, :controller
+
+  alias Explorer.Chain
+
+  def gettxreceiptstatus(conn, params) do
+    with {:txhash_param, {:ok, txhash_param}} <- fetch_txhash(params),
+         {:format, {:ok, transaction_hash}} <- to_transaction_hash(txhash_param) do
+      status = to_transaction_status(transaction_hash)
+      render(conn, :gettxreceiptstatus, %{status: status})
+    else
+      {:txhash_param, :error} ->
+        render(conn, :error, error: "Query parameter txhash is required")
+
+      {:format, :error} ->
+        render(conn, :error, error: "Invalid txhash format")
+    end
+  end
+
+  defp fetch_txhash(params) do
+    {:txhash_param, Map.fetch(params, "txhash")}
+  end
+
+  defp to_transaction_hash(transaction_hash_string) do
+    {:format, Chain.string_to_transaction_hash(transaction_hash_string)}
+  end
+
+  defp to_transaction_status(transaction_hash) do
+    case Chain.hash_to_transaction(transaction_hash) do
+      {:error, :not_found} -> ""
+      {:ok, transaction} -> transaction.status
+    end
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -290,6 +290,20 @@ defmodule BlockScoutWeb.Etherscan do
     "result" => nil
   }
 
+  @transaction_gettxreceiptstatus_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    "result" => %{
+      "status" => "1"
+    }
+  }
+
+  @transaction_gettxreceiptstatus_example_value_error %{
+    "status" => "0",
+    "message" => "Query parameter txhash is required",
+    "result" => nil
+  }
+
   @status_type %{
     type: "status",
     enum: ~s(["0", "1"]),
@@ -645,6 +659,17 @@ defmodule BlockScoutWeb.Etherscan do
         type: "optimization used",
         enum: ~s(["0", "1"]),
         enum_interpretation: %{"0" => "false", "1" => "true"}
+      }
+    }
+  }
+
+  @transaction_receipt_status_model %{
+    name: "TransactionReceiptStatus",
+    fields: %{
+      status: %{
+        type: "status",
+        enum: ~s(["0", "1"]),
+        enum_interpretation: %{"0" => "fail", "1" => "pass"}
       }
     }
   }
@@ -1305,6 +1330,43 @@ defmodule BlockScoutWeb.Etherscan do
     ]
   }
 
+  @transaction_gettxreceiptstatus_action %{
+    name: "gettxreceiptstatus",
+    description: "Get transaction receipt status.",
+    required_params: [
+      %{
+        key: "txhash",
+        placeholder: "transactionHash",
+        type: "string",
+        description: "Transaction hash. Hash of contents of the transaction."
+      }
+    ],
+    optional_params: [],
+    responses: [
+      %{
+        code: "200",
+        description: "successful operation",
+        example_value: Jason.encode!(@transaction_gettxreceiptstatus_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: %{
+              type: "model",
+              model: @transaction_receipt_status_model
+            }
+          }
+        }
+      },
+      %{
+        code: "200",
+        description: "error",
+        example_value: Jason.encode!(@transaction_gettxreceiptstatus_example_value_error)
+      }
+    ]
+  }
+
   @account_module %{
     name: "account",
     actions: [
@@ -1346,13 +1408,19 @@ defmodule BlockScoutWeb.Etherscan do
     ]
   }
 
+  @transaction_module %{
+    name: "transaction",
+    actions: [@transaction_gettxreceiptstatus_action]
+  }
+
   @documentation [
     @account_module,
     @logs_module,
     @token_module,
     @stats_module,
     @block_module,
-    @contract_module
+    @contract_module,
+    @transaction_module
   ]
 
   def get_documentation do

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -30,7 +30,8 @@ defmodule BlockScoutWeb.Router do
       "logs" => RPC.LogsController,
       "token" => RPC.TokenController,
       "stats" => RPC.StatsController,
-      "contract" => RPC.ContractController
+      "contract" => RPC.ContractController,
+      "transaction" => RPC.TransactionController
     })
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/transaction_view.ex
@@ -1,0 +1,22 @@
+defmodule BlockScoutWeb.API.RPC.TransactionView do
+  use BlockScoutWeb, :view
+
+  alias BlockScoutWeb.API.RPC.RPCView
+
+  def render("gettxreceiptstatus.json", %{status: status}) do
+    prepared_status = prepare_tx_receipt_status(status)
+    RPCView.render("show.json", data: %{"status" => prepared_status})
+  end
+
+  def render("error.json", assigns) do
+    RPCView.render("error.json", assigns)
+  end
+
+  defp prepare_tx_receipt_status(""), do: ""
+
+  defp prepare_tx_receipt_status(nil), do: ""
+
+  defp prepare_tx_receipt_status(:ok), do: "1"
+
+  defp prepare_tx_receipt_status(_), do: "0"
+end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
@@ -1,0 +1,124 @@
+defmodule BlockScoutWeb.API.RPC.TransactionControllerTest do
+  use BlockScoutWeb.ConnCase
+
+  describe "gettxreceiptstatus" do
+    test "with missing txhash", %{conn: conn} do
+      params = %{
+        "module" => "transaction",
+        "action" => "gettxreceiptstatus"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "txhash is required"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with an invalid txhash", %{conn: conn} do
+      params = %{
+        "module" => "transaction",
+        "action" => "gettxreceiptstatus",
+        "txhash" => "badhash"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "Invalid txhash format"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with a txhash that doesn't exist", %{conn: conn} do
+      params = %{
+        "module" => "transaction",
+        "action" => "gettxreceiptstatus",
+        "txhash" => "0x40eb908387324f2b575b4879cd9d7188f69c8fc9d87c901b9e2daaea4b442170"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == %{"status" => ""}
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "with a txhash with ok status", %{conn: conn} do
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block, status: :ok)
+
+      params = %{
+        "module" => "transaction",
+        "action" => "gettxreceiptstatus",
+        "txhash" => "#{transaction.hash}"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == %{"status" => "1"}
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "with a txhash with error status", %{conn: conn} do
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block, status: :error)
+
+      params = %{
+        "module" => "transaction",
+        "action" => "gettxreceiptstatus",
+        "txhash" => "#{transaction.hash}"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == %{"status" => "0"}
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "with a txhash with nil status", %{conn: conn} do
+      transaction = insert(:transaction, status: nil)
+
+      params = %{
+        "module" => "transaction",
+        "action" => "gettxreceiptstatus",
+        "txhash" => "#{transaction.hash}"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == %{"status" => ""}
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+  end
+end


### PR DESCRIPTION
Part of: https://github.com/poanetwork/blockscout/issues/138

## Motivation
* For API users to be able to check the 'receipt status' for a given
transaction hash.

  Example usage:
    ```
      /api?module=transaction&action=gettxreceiptstatus&txhash={transactionHash}
    ```

## Changelog

### Enhancements
* Editing router to support the new `transaction#gettxreceiptstatus` API
endpoint.
* Adding `API.RPC.TransactionController.gettxreceipstatus/2` action to
process requests made to the `transaction#gettxreceiptstatus` API
endpoint.
* Adding `API.RPC.TransactionView` to render transaction controller
responses as required.
* Adding `transaction#gettxreceiptstatus` API endpoint to the API docs
page. Docs data lives in `BlockScoutWeb.Etherscan`.