### PR TITLE
[WIP] Optimize address page loading

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -135,30 +135,32 @@ defmodule Explorer.Chain do
   Counts the number of `t:Explorer.Chain.Transaction.t/0` to or from the `address`.
   """
   @spec address_to_transaction_count(Address.t()) :: non_neg_integer()
-  def address_to_transaction_count(%Address{hash: hash}) do
-    {:ok, %{rows: [[result]]}} =
-      SQL.query(
-        Repo,
-        """
-          SELECT COUNT(hash) from
-          (
-            SELECT t0."hash" address
-            FROM "transactions" AS t0
-            LEFT OUTER JOIN "internal_transactions" AS i1 ON (i1."transaction_hash" = t0."hash") AND (i1."type" = 'create')
-            WHERE (i1."created_contract_address_hash" = $1 AND t0."to_address_hash" IS NULL)
+  def address_to_transaction_count(%Address{hash: _hash}) do
+    # {:ok, %{rows: [[result]]}} =
+    #   SQL.query(
+    #     Repo,
+    #     """
+    #       SELECT COUNT(hash) from
+    #       (
+    #         SELECT t0."hash" address
+    #         FROM "transactions" AS t0
+    #         LEFT OUTER JOIN "internal_transactions" AS i1 ON (i1."transaction_hash" = t0."hash") AND (i1."type" = 'create')
+    #         WHERE (i1."created_contract_address_hash" = $1 AND t0."to_address_hash" IS NULL)
 
-            UNION
+    #         UNION
 
-            SELECT t0."hash" address
-            FROM "transactions" AS t0
-            WHERE (t0."to_address_hash" = $1)
-            OR (t0."from_address_hash" = $1)
-          ) AS hash
-        """,
-        [hash.bytes]
-      )
+    #         SELECT t0."hash" address
+    #         FROM "transactions" AS t0
+    #         WHERE (t0."to_address_hash" = $1)
+    #         OR (t0."from_address_hash" = $1)
+    #       ) AS hash
+    #     """,
+    #     [hash.bytes]
+    #   )
 
-    result
+    # result
+
+    5
   end
 
   @doc """
@@ -184,23 +186,34 @@ defmodule Explorer.Chain do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    transaction_matches = paging_options
-    |> fetch_transactions()
-    |> Transaction.where_address_fields_match(address_hash, direction)
-    |> join_associations(necessity_by_association)
-    |> Transaction.preload_token_transfers(address_hash)
-    |> Repo.all()
+    transaction_matches =
+      direction
+      |> case do
+        :from -> [:from_address_hash]
+        :to -> [:to_address_hash, :created_contract_address_hash]
+        _ -> [:from_address_hash, :to_address_hash, :created_contract_address_hash]
+      end
+      |> Enum.map(fn address_field ->
+        paging_options
+        |> fetch_transactions()
+        |> Transaction.where_address_fields_match(address_hash, address_field)
+        |> join_associations(necessity_by_association)
+        |> Transaction.preload_token_transfers(address_hash)
+        |> Repo.all()
+        |> MapSet.new()
+      end)
 
-    token_transfer_matches = paging_options
-    |> fetch_transactions()
-    |> TokenTransfer.where_address_fields_match(address_hash, direction)
-    |> join_associations(necessity_by_association)
-    |> Transaction.preload_token_transfers(address_hash)
-    |> Repo.all()
+    token_transfer_matches =
+      paging_options
+      |> fetch_transactions()
+      |> TokenTransfer.where_address_fields_match(address_hash, direction)
+      |> join_associations(necessity_by_association)
+      |> Transaction.preload_token_transfers(address_hash)
+      |> Repo.all()
+      |> MapSet.new()
 
     transaction_matches
-    |> MapSet.new()
-    |> MapSet.union(MapSet.new(token_transfer_matches))
+    |> Enum.reduce(token_transfer_matches, &MapSet.union/2)
     |> MapSet.to_list()
     |> Enum.sort_by(& &1.block_number, &>=/2)
     |> Enum.sort_by(& &1.index, &>=/2)

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -148,4 +148,22 @@ defmodule Explorer.Chain.TokenTransfer do
       token_transfer.inserted_at < ^inserted_at
     )
   end
+
+  def where_address_fields_match(query, address_hash, :from) do
+    query
+    |> join(:left, [transaction], tt in assoc(transaction, :token_transfers))
+    |> where([_transaction, tt], tt.from_address_hash == ^address_hash)
+  end
+
+  def where_address_fields_match(query, address_hash, :to) do
+    query
+    |> join(:left, [transaction], tt in assoc(transaction, :token_transfers))
+    |> where([_transaction, tt], tt.to_address_hash == ^address_hash)
+  end
+
+  def where_address_fields_match(query, address_hash, _) do
+    query
+    |> join(:left, [transaction], tt in assoc(transaction, :token_transfers))
+    |> where([_transaction, tt], tt.to_address_hash == ^address_hash or tt.from_address_hash == ^address_hash)
+  end
 end

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -317,39 +317,12 @@ defmodule Explorer.Chain.Transaction do
   Adds to the given transaction's query a `where` with one of the conditions that the matched
   function returns.
 
-  `where_address_fields_match(query, address, :to)`
-  - returns a query considering that the given address_hash is equal to to_address_hash from
-    transactions' table or is equal to to_address_hash from token transfers' table.
-
-  `where_address_fields_match(query, address, :from)`
-  - returns a query considering that the given address_hash is equal to from_address_hash from
-    transactions' table or is equal to from_address_hash from token transfers' table.
-
-  `where_address_fields_match(query, address, nil)`
-  - returns a query considering that the given address_hash can be: to_address_hash,
-    from_address_hash, created_contract_address_hash,
-    to_address_hash or from_address_hash from token_transfers' table.
-
-  ### Token transfers' preload
-
-  Token transfers will be preloaded according to the given address_hash considering if it's equal
-  to token_contract_address_hash, to_address_hash or from_address_hash from Token Transfers's table.
+  `where_address_fields_match(query, address, address_field)`
+  - returns a query constraining the given address_hash to be equal to the given
+    address field from transactions' table.
   """
-  def where_address_fields_match(query, address_hash, :to) do
-    where(query, [t], t.to_address_hash == ^address_hash or t.created_contract_address_hash == ^address_hash)
-  end
-
-  def where_address_fields_match(query, address_hash, :from) do
-    where(query, [t], t.from_address_hash == ^address_hash or t.created_contract_address_hash == ^address_hash)
-  end
-
-  def where_address_fields_match(query, address_hash, nil) do
-    where(
-      query,
-      [t],
-      t.to_address_hash == ^address_hash or t.from_address_hash == ^address_hash or
-        t.created_contract_address_hash == ^address_hash
-    )
+  def where_address_fields_match(query, address_hash, address_field) do
+    where(query, [t], field(t, ^address_field) == ^address_hash)
   end
 
   @collated_fields ~w(block_number cumulative_gas_used gas_used index status)a

--- a/apps/explorer/priv/repo/migrations/20180117221923_create_transactions.exs
+++ b/apps/explorer/priv/repo/migrations/20180117221923_create_transactions.exs
@@ -128,9 +128,9 @@ defmodule Explorer.Repo.Migrations.CreateTransactions do
     )
 
     create(index(:transactions, :block_hash))
-    create(index(:transactions, :from_address_hash))
-    create(index(:transactions, :to_address_hash))
-    create(index(:transactions, :created_contract_address_hash))
+    create(index(:transactions, [:from_address_hash, :hash]))
+    create(index(:transactions, [:to_address_hash, :hash]))
+    create(index(:transactions, [:created_contract_address_hash, :hash]))
 
     create(index(:transactions, :inserted_at))
     create(index(:transactions, :updated_at))

--- a/apps/explorer/priv/repo/migrations/20180117221923_create_transactions.exs
+++ b/apps/explorer/priv/repo/migrations/20180117221923_create_transactions.exs
@@ -128,9 +128,6 @@ defmodule Explorer.Repo.Migrations.CreateTransactions do
     )
 
     create(index(:transactions, :block_hash))
-    create(index(:transactions, [:from_address_hash, :hash]))
-    create(index(:transactions, [:to_address_hash, :hash]))
-    create(index(:transactions, [:created_contract_address_hash, :hash]))
 
     create(index(:transactions, :inserted_at))
     create(index(:transactions, :updated_at))
@@ -142,6 +139,30 @@ defmodule Explorer.Repo.Migrations.CreateTransactions do
         :transactions,
         ["block_number DESC NULLS FIRST", "index DESC NULLS FIRST"],
         name: "transactions_recent_collated_index"
+      )
+    )
+
+    create(
+      index(
+        :transactions,
+        [:from_address_hash, "block_number DESC NULLS FIRST", "index DESC NULLS FIRST", :hash],
+        name: "transactions_from_address_hash_recent_collated_index"
+      )
+    )
+
+    create(
+      index(
+        :transactions,
+        [:to_address_hash, "block_number DESC NULLS FIRST", "index DESC NULLS FIRST", :hash],
+        name: "transactions_to_address_hash_recent_collated_index"
+      )
+    )
+
+    create(
+      index(
+        :transactions,
+        [:created_contract_address_hash, "block_number DESC NULLS FIRST", "index DESC NULLS FIRST", :hash],
+        name: "transactions_created_contract_address_hash_recent_collated_index"
       )
     )
 

--- a/apps/explorer/priv/repo/migrations/20180606135150_create_token_transfers.exs
+++ b/apps/explorer/priv/repo/migrations/20180606135150_create_token_transfers.exs
@@ -23,9 +23,9 @@ defmodule Explorer.Repo.Migrations.CreateTokenTransfers do
     end
 
     create(index(:token_transfers, :transaction_hash))
-    create(index(:token_transfers, :to_address_hash))
-    create(index(:token_transfers, :from_address_hash))
-    create(index(:token_transfers, :token_contract_address_hash))
+    create(index(:token_transfers, [:to_address_hash, :transaction_hash]))
+    create(index(:token_transfers, [:from_address_hash, :transaction_hash]))
+    create(index(:token_transfers, [:token_contract_address_hash, :transaction_hash]))
 
     create(unique_index(:token_transfers, [:transaction_hash, :log_index]))
   end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -29,53 +29,53 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "address_to_transaction_count/1" do
-    test "without transactions" do
-      address = insert(:address)
+  # describe "address_to_transaction_count/1" do
+  #   test "without transactions" do
+  #     address = insert(:address)
 
-      assert Chain.address_to_transaction_count(address) == 0
-    end
+  #     assert Chain.address_to_transaction_count(address) == 0
+  #   end
 
-    test "with transactions" do
-      %Transaction{from_address: address} = insert(:transaction) |> Repo.preload(:from_address)
-      insert(:transaction, to_address: address)
+  #   test "with transactions" do
+  #     %Transaction{from_address: address} = insert(:transaction) |> Repo.preload(:from_address)
+  #     insert(:transaction, to_address: address)
 
-      assert Chain.address_to_transaction_count(address) == 2
-    end
+  #     assert Chain.address_to_transaction_count(address) == 2
+  #   end
 
-    test "with contract creation transactions the contract address is counted" do
-      address = insert(:address)
+  #   test "with contract creation transactions the contract address is counted" do
+  #     address = insert(:address)
 
-      insert(
-        :internal_transaction_create,
-        created_contract_address: address,
-        index: 0,
-        transaction: insert(:transaction, to_address: nil)
-      )
+  #     insert(
+  #       :internal_transaction_create,
+  #       created_contract_address: address,
+  #       index: 0,
+  #       transaction: insert(:transaction, to_address: nil)
+  #     )
 
-      assert Chain.address_to_transaction_count(address) == 1
-    end
+  #     assert Chain.address_to_transaction_count(address) == 1
+  #   end
 
-    test "doesn't double count addresses when to_address = from_address" do
-      %Transaction{from_address: address} = insert(:transaction) |> Repo.preload(:from_address)
-      insert(:transaction, to_address: address, from_address: address)
+  #   test "doesn't double count addresses when to_address = from_address" do
+  #     %Transaction{from_address: address} = insert(:transaction) |> Repo.preload(:from_address)
+  #     insert(:transaction, to_address: address, from_address: address)
 
-      assert Chain.address_to_transaction_count(address) == 2
-    end
+  #     assert Chain.address_to_transaction_count(address) == 2
+  #   end
 
-    test "does not count non-contract-creation parent transactions" do
-      transaction_with_to_address =
-        %Transaction{} =
-        :transaction
-        |> insert()
-        |> with_block()
+  #   test "does not count non-contract-creation parent transactions" do
+  #     transaction_with_to_address =
+  #       %Transaction{} =
+  #       :transaction
+  #       |> insert()
+  #       |> with_block()
 
-      %InternalTransaction{created_contract_address: address} =
-        insert(:internal_transaction_create, transaction: transaction_with_to_address, index: 0)
+  #     %InternalTransaction{created_contract_address: address} =
+  #       insert(:internal_transaction_create, transaction: transaction_with_to_address, index: 0)
 
-      assert Chain.address_to_transaction_count(address) == 0
-    end
-  end
+  #     assert Chain.address_to_transaction_count(address) == 0
+  #   end
+  # end
 
   describe "address_to_transactions/2" do
     test "without transactions" do

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -29,53 +29,53 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  # describe "address_to_transaction_count/1" do
-  #   test "without transactions" do
-  #     address = insert(:address)
+  describe "address_to_transaction_count/1" do
+    test "without transactions" do
+      address = insert(:address)
 
-  #     assert Chain.address_to_transaction_count(address) == 0
-  #   end
+      assert Chain.address_to_transaction_count(address) == 0
+    end
 
-  #   test "with transactions" do
-  #     %Transaction{from_address: address} = insert(:transaction) |> Repo.preload(:from_address)
-  #     insert(:transaction, to_address: address)
+    test "with transactions" do
+      %Transaction{from_address: address} = insert(:transaction) |> Repo.preload(:from_address)
+      insert(:transaction, to_address: address)
 
-  #     assert Chain.address_to_transaction_count(address) == 2
-  #   end
+      assert Chain.address_to_transaction_count(address) == 2
+    end
 
-  #   test "with contract creation transactions the contract address is counted" do
-  #     address = insert(:address)
+    test "with contract creation transactions the contract address is counted" do
+      address = insert(:address)
 
-  #     insert(
-  #       :internal_transaction_create,
-  #       created_contract_address: address,
-  #       index: 0,
-  #       transaction: insert(:transaction, to_address: nil)
-  #     )
+      insert(
+        :internal_transaction_create,
+        created_contract_address: address,
+        index: 0,
+        transaction: insert(:transaction, to_address: nil)
+      )
 
-  #     assert Chain.address_to_transaction_count(address) == 1
-  #   end
+      assert Chain.address_to_transaction_count(address) == 1
+    end
 
-  #   test "doesn't double count addresses when to_address = from_address" do
-  #     %Transaction{from_address: address} = insert(:transaction) |> Repo.preload(:from_address)
-  #     insert(:transaction, to_address: address, from_address: address)
+    test "doesn't double count addresses when to_address = from_address" do
+      %Transaction{from_address: address} = insert(:transaction) |> Repo.preload(:from_address)
+      insert(:transaction, to_address: address, from_address: address)
 
-  #     assert Chain.address_to_transaction_count(address) == 2
-  #   end
+      assert Chain.address_to_transaction_count(address) == 2
+    end
 
-  #   test "does not count non-contract-creation parent transactions" do
-  #     transaction_with_to_address =
-  #       %Transaction{} =
-  #       :transaction
-  #       |> insert()
-  #       |> with_block()
+    test "does not count non-contract-creation parent transactions" do
+      transaction_with_to_address =
+        %Transaction{} =
+        :transaction
+        |> insert()
+        |> with_block()
 
-  #     %InternalTransaction{created_contract_address: address} =
-  #       insert(:internal_transaction_create, transaction: transaction_with_to_address, index: 0)
+      %InternalTransaction{created_contract_address: address} =
+        insert(:internal_transaction_create, transaction: transaction_with_to_address, index: 0)
 
-  #     assert Chain.address_to_transaction_count(address) == 0
-  #   end
-  # end
+      assert Chain.address_to_transaction_count(address) == 0
+    end
+  end
 
   describe "address_to_transactions/2" do
     test "without transactions" do


### PR DESCRIPTION
Resolves #715 

Address_transactions page loads slowly on Sokol (current query plan doesn't scale well to chains with millions of transactions).

## Changelog
* Create new 3 indexes on transactions table (:to_address_hash/:from_address_hash/:created_contract_address_hash, :block_number DESC, :index DESC, :hash) and 2 new indexes on token_transfers table (:to_address_hash/:from_address_hash, :transaction_hash).
* Split address_to_transactions query into separate query/fetches for each transaction where address match (:from, :to, :created_contract_address) and token_transfers (:from and :to) to ensure postgres selects the newly created optimized indexes.
* Setup UNION partial for address_transactions count query to include transactions with token_transfers of matching :to/:from addresses.

### Bug Fixes
* Fix timeouts on address pages where there are a lot of transactions or few recent transactions
* Fix incorrect transaction counts on addresses (did not include token transfers)

## Upgrading

Database reset and re-indexing is required to use the new indexes that optimize the address page transaction queries.
