### PR TITLE
Improve Smart Contract's function response CSS style

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_function_response.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_function_response.html.eex
@@ -1,16 +1,20 @@
 <div class="tile tile-muted tile-function-response monospace">
-  [ <%= @function_name %> method Response ]
+  <pre class="pre-wrap">
+    <code>
+      [ <%= @function_name %> method Response ]
 
-  <p class="text-dark">
-    [
-      <%= for item <- @outputs do %>
-        <span class="text-dark function-response-item">
-          <%= if named_argument?(item) do %>
-            <%= item["name"] %>
+      <p class="text-dark">
+        [
+          <%= for item <- @outputs do %>
+            <span class="text-dark function-response-item">
+              <%= if named_argument?(item) do %>
+                <%= item["name"] %>
+              <% end %>
+              (<%= item["type"] %>) : <%= values(item["value"]) %>
+            </span>
           <% end %>
-          (<%= item["type"] %>) : <%= values(item["value"]) %>
-        </span>
-      <% end %>
-    ]
-  </p>
+        ]
+      </p>
+    </code>
+  </pre>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -9,7 +9,7 @@
     </div>
 
     <%= if queryable?(function["inputs"]) do %>
-      <div style="overflow: auto">
+      <div>
         <form class="form-inline" data-function-form data-url="<%= smart_contract_path(@conn, :show, @address.hash) %>">
           <input type="hidden" name="function_name" value='<%= function["name"] %>' />
 


### PR DESCRIPTION
### Motivation
Is just an improvement for the https://github.com/poanetwork/blockscout/pull/726 according [to this comment](https://github.com/poanetwork/blockscout/pull/726#discussion_r217708620).

### Enhancements
We used `overflow: auto` to deal with overflow width/hight. We could handle it better using `pre-wrap` since the overflow is just in the code area.

For the User, the final result is the same as before.

![image](https://user-images.githubusercontent.com/27698968/45558269-e0caa100-b815-11e8-87f0-57e9fe9133ca.png)
