### PR TITLE
Fix Token Holders' link from Read Smart Contract page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
@@ -25,7 +25,7 @@
             <li class="nav-item">
               <%= link(
                   gettext("Read Contract"),
-                  to: token_read_contract_path(@conn, :index, @conn.params["id"]),
+                  to: token_read_contract_path(@conn, :index, @token.contract_address_hash),
                   class: "nav-link")%>
             </li>
           <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/show.html.eex
@@ -25,7 +25,7 @@
             <li class="nav-item">
               <%= link(
                   gettext("Read Contract"),
-                  to: token_read_contract_path(@conn, :index, @conn.params["id"]),
+                  to: token_read_contract_path(@conn, :index, @token.contract_address_hash),
                   class: "nav-link")%>
             </li>
           <% end %>


### PR DESCRIPTION
### Bug fix
We used `conn.params['id']` instead of `conn.params['token_id']`. To fix it I'm changing to use `@token.contract_address_hash` for it doesn't depend from URL params anymore.