### PR TITLE
Add transaction#getstatus API endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
@@ -1,13 +1,27 @@
 defmodule BlockScoutWeb.API.RPC.TransactionController do
   use BlockScoutWeb, :controller
 
-  alias Explorer.Chain
+  alias Explorer.{Chain, Etherscan}
 
   def gettxreceiptstatus(conn, params) do
     with {:txhash_param, {:ok, txhash_param}} <- fetch_txhash(params),
          {:format, {:ok, transaction_hash}} <- to_transaction_hash(txhash_param) do
       status = to_transaction_status(transaction_hash)
       render(conn, :gettxreceiptstatus, %{status: status})
+    else
+      {:txhash_param, :error} ->
+        render(conn, :error, error: "Query parameter txhash is required")
+
+      {:format, :error} ->
+        render(conn, :error, error: "Invalid txhash format")
+    end
+  end
+
+  def getstatus(conn, params) do
+    with {:txhash_param, {:ok, txhash_param}} <- fetch_txhash(params),
+         {:format, {:ok, transaction_hash}} <- to_transaction_hash(txhash_param) do
+      error = Etherscan.get_transaction_error(transaction_hash)
+      render(conn, :getstatus, %{error: error})
     else
       {:txhash_param, :error} ->
         render(conn, :error, error: "Query parameter txhash is required")

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -304,6 +304,21 @@ defmodule BlockScoutWeb.Etherscan do
     "result" => nil
   }
 
+  @transaction_getstatus_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    "result" => %{
+      "isError" => "1",
+      "errDescription" => "Out of gas"
+    }
+  }
+
+  @transaction_getstatus_example_value_error %{
+    "status" => "0",
+    "message" => "Query parameter txhash is required",
+    "result" => nil
+  }
+
   @status_type %{
     type: "status",
     enum: ~s(["0", "1"]),
@@ -670,6 +685,21 @@ defmodule BlockScoutWeb.Etherscan do
         type: "status",
         enum: ~s(["0", "1"]),
         enum_interpretation: %{"0" => "fail", "1" => "pass"}
+      }
+    }
+  }
+
+  @transaction_status_model %{
+    name: "TransactionStatus",
+    fields: %{
+      isError: %{
+        type: "isError",
+        enum: ~s(["0", "1"]),
+        enum_interpretation: %{"0" => "pass", "1" => "error"}
+      },
+      errDescription: %{
+        type: "string",
+        example: ~s("Out of gas")
       }
     }
   }
@@ -1367,6 +1397,43 @@ defmodule BlockScoutWeb.Etherscan do
     ]
   }
 
+  @transaction_getstatus_action %{
+    name: "getstatus",
+    description: "Get error status and error message.",
+    required_params: [
+      %{
+        key: "txhash",
+        placeholder: "transactionHash",
+        type: "string",
+        description: "Transaction hash. Hash of contents of the transaction."
+      }
+    ],
+    optional_params: [],
+    responses: [
+      %{
+        code: "200",
+        description: "successful operation",
+        example_value: Jason.encode!(@transaction_getstatus_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: %{
+              type: "model",
+              model: @transaction_status_model
+            }
+          }
+        }
+      },
+      %{
+        code: "200",
+        description: "error",
+        example_value: Jason.encode!(@transaction_getstatus_example_value_error)
+      }
+    ]
+  }
+
   @account_module %{
     name: "account",
     actions: [
@@ -1410,7 +1477,10 @@ defmodule BlockScoutWeb.Etherscan do
 
   @transaction_module %{
     name: "transaction",
-    actions: [@transaction_gettxreceiptstatus_action]
+    actions: [
+      @transaction_gettxreceiptstatus_action,
+      @transaction_getstatus_action
+    ]
   }
 
   @documentation [

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/transaction_view.ex
@@ -8,6 +8,10 @@ defmodule BlockScoutWeb.API.RPC.TransactionView do
     RPCView.render("show.json", data: %{"status" => prepared_status})
   end
 
+  def render("getstatus.json", %{error: error}) do
+    RPCView.render("show.json", data: prepare_error(error))
+  end
+
   def render("error.json", assigns) do
     RPCView.render("error.json", assigns)
   end
@@ -19,4 +23,18 @@ defmodule BlockScoutWeb.API.RPC.TransactionView do
   defp prepare_tx_receipt_status(:ok), do: "1"
 
   defp prepare_tx_receipt_status(_), do: "0"
+
+  defp prepare_error(nil) do
+    %{
+      "isError" => "0",
+      "errDescription" => ""
+    }
+  end
+
+  defp prepare_error(error) do
+    %{
+      "isError" => "1",
+      "errDescription" => error
+    }
+  end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
@@ -121,4 +121,152 @@ defmodule BlockScoutWeb.API.RPC.TransactionControllerTest do
       assert response["message"] == "OK"
     end
   end
+
+  describe "getstatus" do
+    test "with missing txhash", %{conn: conn} do
+      params = %{
+        "module" => "transaction",
+        "action" => "getstatus"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "txhash is required"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with an invalid txhash", %{conn: conn} do
+      params = %{
+        "module" => "transaction",
+        "action" => "getstatus",
+        "txhash" => "badhash"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "Invalid txhash format"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with a txhash that doesn't exist", %{conn: conn} do
+      params = %{
+        "module" => "transaction",
+        "action" => "getstatus",
+        "txhash" => "0x40eb908387324f2b575b4879cd9d7188f69c8fc9d87c901b9e2daaea4b442170"
+      }
+
+      expected_result = %{
+        "isError" => "0",
+        "errDescription" => ""
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "with a txhash with ok status", %{conn: conn} do
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block, status: :ok)
+
+      params = %{
+        "module" => "transaction",
+        "action" => "getstatus",
+        "txhash" => "#{transaction.hash}"
+      }
+
+      expected_result = %{
+        "isError" => "0",
+        "errDescription" => ""
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "with a txhash with error status", %{conn: conn} do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(status: :error)
+
+      internal_transaction_details = [
+        transaction: transaction,
+        index: 0,
+        type: :reward,
+        error: "some error"
+      ]
+
+      insert(:internal_transaction, internal_transaction_details)
+
+      params = %{
+        "module" => "transaction",
+        "action" => "getstatus",
+        "txhash" => "#{transaction.hash}"
+      }
+
+      expected_result = %{
+        "isError" => "1",
+        "errDescription" => "some error"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "with a txhash with nil status", %{conn: conn} do
+      transaction = insert(:transaction, status: nil)
+
+      params = %{
+        "module" => "transaction",
+        "action" => "getstatus",
+        "txhash" => "#{transaction.hash}"
+      }
+
+      expected_result = %{
+        "isError" => "0",
+        "errDescription" => ""
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+  end
 end

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -183,6 +183,24 @@ defmodule Explorer.Etherscan do
     Repo.one(query)
   end
 
+  @doc """
+  Gets the error for a given transaction hash
+  (`t:Explorer.Chain.Hash.Full.t/0`). Returns nil if no error is found.
+
+  """
+  @spec get_transaction_error(Hash.Full.t()) :: String.t() | nil
+  def get_transaction_error(%Hash{byte_count: unquote(Hash.Full.byte_count())} = transaction_hash) do
+    query =
+      from(it in InternalTransaction,
+        where: it.transaction_hash == ^transaction_hash,
+        order_by: [desc: :index],
+        limit: 1,
+        select: it.error
+      )
+
+    Repo.one(query)
+  end
+
   @transaction_fields ~w(
     block_hash
     block_number

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -1103,4 +1103,36 @@ defmodule Explorer.EtherscanTest do
       assert found_token_balance.id == token_balance2.id
     end
   end
+
+  describe "get_transaction_error/1" do
+    test "with a transaction that doesn't exist" do
+      transaction = build(:transaction)
+
+      refute Etherscan.get_transaction_error(transaction.hash)
+    end
+
+    test "with a transaction with no errors" do
+      transaction = insert(:transaction)
+
+      refute Etherscan.get_transaction_error(transaction.hash)
+    end
+
+    test "with a transaction with an error" do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(status: :error)
+
+      internal_transaction_details = [
+        transaction: transaction,
+        index: 0,
+        type: :reward,
+        error: "some error"
+      ]
+
+      insert(:internal_transaction, internal_transaction_details)
+
+      assert Etherscan.get_transaction_error(transaction.hash) == "some error"
+    end
+  end
 end


### PR DESCRIPTION
Part of: https://github.com/poanetwork/blockscout/issues/138

## Motivation
* For API users to be able to get the error for a given transaction
hash.

  Example usage:
    ```
      /api?module=transaction&action=getstatus&txhash={transactionHash}
    ```

## Changelog

### Enhancements
* Adding `Explorer.Etherscan.get_transaction_error/1` to get the error
for a given transaction hash.
* Adding `API.RPC.TransactionController.getstatus/2` action to
process requests made to the `transaction#getstatus` API
endpoint.
* Editing `API.RPC.TransactionView` to render transaction errors
('status') as required.
* Adding `transaction#getstatus` API endpoint to the API docs
page. Docs data lives in `BlockScoutWeb.Etherscan`.