### PR TITLE
Add stats#ethsupply API endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
   use BlockScoutWeb, :controller
 
   alias Explorer.Chain
+  alias Explorer.Chain.Wei
 
   def tokensupply(conn, params) do
     with {:contractaddress_param, {:ok, contractaddress_param}} <- fetch_contractaddress(params),
@@ -18,6 +19,17 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
       {:token, {:error, :not_found}} ->
         render(conn, :error, error: "contractaddress not found")
     end
+  end
+
+  def ethsupply(conn, _params) do
+    wei_total_supply =
+      Chain.total_supply()
+      |> Decimal.new()
+      |> Wei.from(:ether)
+      |> Wei.to(:wei)
+      |> Decimal.to_string()
+
+    render(conn, "ethsupply.json", total_supply: wei_total_supply)
   end
 
   defp fetch_contractaddress(params) do

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -215,6 +215,12 @@ defmodule BlockScoutWeb.Etherscan do
     "result" => "21265524714464"
   }
 
+  @stats_ethsupply_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    "result" => "101959776311500000000000000"
+  }
+
   @block_getblockreward_example_value %{
     "status" => "1",
     "message" => "OK",
@@ -1249,6 +1255,32 @@ defmodule BlockScoutWeb.Etherscan do
     ]
   }
 
+  @stats_ethsupply_action %{
+    name: "ethsupply",
+    description: "Get total supply in Wei.",
+    required_params: [],
+    optional_params: [],
+    responses: [
+      %{
+        code: "200",
+        description: "successful operation",
+        example_value: Jason.encode!(@stats_ethsupply_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: %{
+              type: "integer",
+              description: "The total supply.",
+              example: ~s("101959776311500000000000000")
+            }
+          }
+        }
+      }
+    ]
+  }
+
   @block_getblockreward_action %{
     name: "getblockreward",
     description: "Get block reward by block number.",
@@ -1459,7 +1491,10 @@ defmodule BlockScoutWeb.Etherscan do
 
   @stats_module %{
     name: "stats",
-    actions: [@stats_tokensupply_action]
+    actions: [
+      @stats_tokensupply_action,
+      @stats_ethsupply_action
+    ]
   }
 
   @block_module %{

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
@@ -7,6 +7,10 @@ defmodule BlockScoutWeb.API.RPC.StatsView do
     RPCView.render("show.json", data: token_supply)
   end
 
+  def render("ethsupply.json", %{total_supply: total_supply}) do
+    RPCView.render("show.json", data: total_supply)
+  end
+
   def render("error.json", assigns) do
     RPCView.render("error.json", assigns)
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -1,6 +1,9 @@
 defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
   use BlockScoutWeb.ConnCase
 
+  alias Explorer.Chain
+  alias Explorer.Chain.Wei
+
   describe "tokensupply" do
     test "with missing contract address", %{conn: conn} do
       params = %{
@@ -70,6 +73,24 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
                |> json_response(200)
 
       assert response["result"] == to_string(token.total_supply)
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+  end
+
+  describe "ethsupply" do
+    test "returns total supply", %{conn: conn} do
+      params = %{
+        "module" => "stats",
+        "action" => "ethsupply"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == "252460800000000000000000000"
       assert response["status"] == "1"
       assert response["message"] == "OK"
     end


### PR DESCRIPTION
Part of: https://github.com/poanetwork/blockscout/issues/138

## Motivation
* For API users to get the total supply in Wei.

  Example usage:
    ```
      /api?module=transaction&action=ethsupply
    ```
## Changelog

### Enhancements
* Adding `API.RPC.StatsController.ethsupply/2` action to process
`stats#ethsupply` requests.
* Editing `API.RPC.StatsView` to render `ethsupply` responses as
required.
* Adding `stats#ethsupply` API endpoint to API docs page. API docs data
lives in `BlockScoutWeb.Etherscan`