### PR TITLE
Preload contract addresses names for transaction push

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -51,6 +51,7 @@ defmodule BlockScoutWeb.Notifier do
     |> Chain.hashes_to_transactions(
       necessity_by_association: %{
         :block => :required,
+        [created_contract_address: :names] => :optional,
         [from_address: :names] => :optional,
         [to_address: :names] => :optional,
         :token_transfers => :optional


### PR DESCRIPTION
Fixes #739.

## Motivation

This fixes an issue where `created_contract_address` is expected to be preloaded for most view-related rendering but isn't preloaded for new transactions pushed over channels.

## Changelog

### Bug Fixes
* Preload contract address names for new transactions pushed over channels
