### PR TITLE
Add stats#ethprice API endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.API.RPC.StatsController do
   use BlockScoutWeb, :controller
 
-  alias Explorer.Chain
+  alias Explorer.{Chain, ExchangeRates}
   alias Explorer.Chain.Wei
 
   def tokensupply(conn, params) do
@@ -30,6 +30,13 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
       |> Decimal.to_string()
 
     render(conn, "ethsupply.json", total_supply: wei_total_supply)
+  end
+
+  def ethprice(conn, _params) do
+    symbol = Application.get_env(:explorer, :coin)
+    rates = ExchangeRates.lookup(symbol)
+
+    render(conn, "ethprice.json", rates: rates)
   end
 
   defp fetch_contractaddress(params) do

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -221,6 +221,17 @@ defmodule BlockScoutWeb.Etherscan do
     "result" => "101959776311500000000000000"
   }
 
+  @stats_ethprice_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    "result" => %{
+      "ethbtc" => "0.03246",
+      "ethbtc_timestamp" => "1537212510",
+      "ethusd" => "204",
+      "ethusd_timestamp" => "1537212513"
+    }
+  }
+
   @block_getblockreward_example_value %{
     "status" => "1",
     "message" => "OK",
@@ -706,6 +717,32 @@ defmodule BlockScoutWeb.Etherscan do
       errDescription: %{
         type: "string",
         example: ~s("Out of gas")
+      }
+    }
+  }
+
+  @eth_price_model %{
+    name: "EthPrice",
+    fields: %{
+      ethbtc: %{
+        type: "ethbtc",
+        definition: &__MODULE__.ethbtc_type_definition/1,
+        example: ~s("0.03161")
+      },
+      ethbtc_timestamp: %{
+        type: "timestamp",
+        definition: "Last updated timestamp.",
+        example: ~s("1537234460")
+      },
+      ethusd: %{
+        type: "ethusd",
+        definition: &__MODULE__.ethusd_type_definition/1,
+        example: ~s("197.57")
+      },
+      ethusd_timestamp: %{
+        type: "timestamp",
+        definition: "Last updated timestamp.",
+        example: ~s("1537234460")
       }
     }
   }
@@ -1281,6 +1318,31 @@ defmodule BlockScoutWeb.Etherscan do
     ]
   }
 
+  @stats_ethprice_action %{
+    name: "ethprice",
+    description: "Get latest price in USD and BTC.",
+    required_params: [],
+    optional_params: [],
+    responses: [
+      %{
+        code: "200",
+        description: "successful operation",
+        example_value: Jason.encode!(@stats_ethprice_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: %{
+              type: "model",
+              model: @eth_price_model
+            }
+          }
+        }
+      }
+    ]
+  }
+
   @block_getblockreward_action %{
     name: "getblockreward",
     description: "Get block reward by block number.",
@@ -1493,7 +1555,8 @@ defmodule BlockScoutWeb.Etherscan do
     name: "stats",
     actions: [
       @stats_tokensupply_action,
-      @stats_ethsupply_action
+      @stats_ethsupply_action,
+      @stats_ethprice_action
     ]
   }
 
@@ -1536,5 +1599,13 @@ defmodule BlockScoutWeb.Etherscan do
     "The smallest subdenomination of #{coin}, " <>
       "and thus the one in which all integer values of the currency are counted, is the Wei. " <>
       "One #{coin} is defined as being 10<sup>18</sup> Wei."
+  end
+
+  def ethbtc_type_definition(coin) do
+    "#{coin} price in Bitcoin."
+  end
+
+  def ethusd_type_definition(coin) do
+    "#{coin} price in US dollars."
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
@@ -11,7 +11,22 @@ defmodule BlockScoutWeb.API.RPC.StatsView do
     RPCView.render("show.json", data: total_supply)
   end
 
+  def render("ethprice.json", %{rates: rates}) do
+    RPCView.render("show.json", data: prepare_rates(rates))
+  end
+
   def render("error.json", assigns) do
     RPCView.render("error.json", assigns)
+  end
+
+  defp prepare_rates(rates) do
+    timestamp = rates.last_updated |> DateTime.to_unix() |> to_string()
+
+    %{
+      "ethbtc" => to_string(rates.btc_value),
+      "ethbtc_timestamp" => timestamp,
+      "ethusd" => to_string(rates.usd_value),
+      "ethusd_timestamp" => timestamp
+    }
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -1,8 +1,11 @@
 defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
   use BlockScoutWeb.ConnCase
 
-  alias Explorer.Chain
-  alias Explorer.Chain.Wei
+  import Mox
+
+  alias Explorer.ExchangeRates
+  alias Explorer.ExchangeRates.Token
+  alias Explorer.ExchangeRates.Source.TestSource
 
   describe "tokensupply" do
     test "with missing contract address", %{conn: conn} do
@@ -91,6 +94,65 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
                |> json_response(200)
 
       assert response["result"] == "252460800000000000000000000"
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+  end
+
+  describe "ethprice" do
+    setup :set_mox_global
+
+    setup do
+      # Use TestSource mock for this test set
+      configuration = Application.get_env(:explorer, Explorer.ExchangeRates)
+      Application.put_env(:explorer, Explorer.ExchangeRates, source: TestSource)
+
+      ExchangeRates.init([])
+
+      :ok
+
+      on_exit(fn ->
+        Application.put_env(:explorer, Explorer.ExchangeRates, configuration)
+      end)
+    end
+
+    test "returns the configured coin's price information", %{conn: conn} do
+      symbol = Application.get_env(:explorer, :coin)
+
+      eth = %Token{
+        available_supply: Decimal.new("1000000.0"),
+        btc_value: Decimal.new("1.000"),
+        id: "test",
+        last_updated: DateTime.utc_now(),
+        market_cap_usd: Decimal.new("1000000.0"),
+        name: "test",
+        symbol: symbol,
+        usd_value: Decimal.new("1.0"),
+        volume_24h_usd: Decimal.new("1000.0")
+      }
+
+      ExchangeRates.handle_info({nil, {:ok, [eth]}}, %{})
+
+      params = %{
+        "module" => "stats",
+        "action" => "ethprice"
+      }
+
+      expected_timestamp = eth.last_updated |> DateTime.to_unix() |> to_string()
+
+      expected_result = %{
+        "ethbtc" => to_string(eth.btc_value),
+        "ethbtc_timestamp" => expected_timestamp,
+        "ethusd" => to_string(eth.usd_value),
+        "ethusd_timestamp" => expected_timestamp
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
       assert response["status"] == "1"
       assert response["message"] == "OK"
     end


### PR DESCRIPTION
Part of: https://github.com/poanetwork/blockscout/issues/138

## Motivation
* For API users to be able to get the latest coin price in BTC and USD.
    Example usage:
    ```
      /api?module=stats&action=ethprice
    ```

## Changelog

### Enhancements
* Adding `API.RPC.StatsController.ethprice/2` action to handle requests
to the `stats#ethrpice` endpoint.
* Editing `API.RPC.View` to include render function clause to render
responses for `stats#ethprice` API endpoint as required.
* Adding `stats#ethprice` to API docs page. API docs data lives in
`BlockScoutWeb.Etherscan`