### PR TITLE
New log file for TokenBalances interaction errors

### DIFF
--- a/apps/indexer/config/dev.exs
+++ b/apps/indexer/config/dev.exs
@@ -4,6 +4,11 @@ config :logger, :indexer,
   level: :debug,
   path: Path.absname("logs/dev/indexer.log")
 
+config :logger, :indexer_token_balances,
+  level: :debug,
+  path: Path.absname("logs/dev/indexer/token_balances/error.log"),
+  metadata_filter: [fetcher: :token_balances]
+
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
     "parity"

--- a/apps/indexer/config/prod.exs
+++ b/apps/indexer/config/prod.exs
@@ -4,6 +4,11 @@ config :logger, :indexer,
   level: :info,
   path: Path.absname("logs/prod/indexer.log")
 
+config :logger, :indexer_token_balances,
+  level: :debug,
+  path: Path.absname("logs/prod/indexer/token_balances/error.log"),
+  metadata_filter: [fetcher: :token_balances]
+
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
     "parity"

--- a/apps/indexer/config/test.exs
+++ b/apps/indexer/config/test.exs
@@ -3,3 +3,8 @@ use Mix.Config
 config :logger, :indexer,
   level: :warn,
   path: Path.absname("logs/test/indexer.log")
+
+config :logger, :indexer_token_balances,
+  level: :debug,
+  path: Path.absname("logs/test/indexer/token_balances/error.log"),
+  metadata_filter: [fetcher: :token_balances]

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -146,6 +146,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
            |> put_in([Access.key(:internal_transactions, %{}), :params], internal_transactions_params)
            |> put_in([Access.key(:token_balances), :params], token_balances),
          {:ok, results} = ok <- Chain.import(chain_import_options) do
+      TokenBalances.log_fetching_errors(__MODULE__, token_balances)
       async_import_remaining_block_data(results)
       ok
     end

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -69,12 +69,14 @@ defmodule Indexer.TokenBalance.Fetcher do
   end
 
   def fetch_from_blockchain(token_balances) do
-    {:ok, token_balances_params} =
+    {:ok, token_balances} =
       token_balances
       |> Stream.map(&format_params/1)
       |> TokenBalances.fetch_token_balances_from_blockchain()
 
-    token_balances_params
+    TokenBalances.log_fetching_errors(__MODULE__, token_balances)
+
+    token_balances
   end
 
   def import_token_balances(token_balances_params) do

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,8 @@ config :logger,
     # only :explorer, but all levels
     {LoggerFileBackend, :explorer},
     # only :indexer, but all levels
-    {LoggerFileBackend, :indexer}
+    {LoggerFileBackend, :indexer},
+    {LoggerFileBackend, :indexer_token_balances}
   ]
 
 config :logger, :console,


### PR DESCRIPTION
Resolves #720 

## Motivation

We've created a new log file that will write all errors, that doesn't break the code, that occurs while interacting with smart contracts when fetching a specific Address token balance. 

The errors will be logged during the Realtime indexer, that fetches the token balances synchronously, and the TokenBalance fetcher, that is triggered by the Catchup indexer and processed asynchronously. 

The logs are avaiable in: 

- `logs/dev/indexer/token_balances/error.log`
- `logs/test/indexer/token_balances/error.log`
- `logs/prod/indexer/token_balances/error.log`

The messages will look like:

```md
15:42:21.936 [debug] <Elixir.Indexer.TokenBalance.Fetcher> Errors while fetching TokenBalances through Contract interaction: 
<address_hash: 0xbfde6246df72d3ca86419628cac46a9d2b60393c, contract_address_hash: 0x0000000000000000000000000000000000000000, block_number: 6355786, error: (-32015) VM execution error.> 
```

The errors each log record may have multiple errors, because we're collecting all errors from the fetching process and log them at once. Also, the logs are contextualized by which module it was called.

## Changelog

- Added a new Logger process using [LoggerFileBackend](https://github.com/onkel-dirtus/logger_file_backend) in order to write the logs in a specific file.
- Changed the token_balance_param map, to include an error attribute so we can keep the interaction errors there.
