### PR TITLE
Alter Token decimals column to bigint

### DIFF
--- a/apps/explorer/priv/repo/migrations/20180919175123_alter_token_decimals_to_bigint.exs
+++ b/apps/explorer/priv/repo/migrations/20180919175123_alter_token_decimals_to_bigint.exs
@@ -1,0 +1,15 @@
+defmodule Explorer.Repo.Migrations.AlterTokenDecimalsToBigint do
+  use Ecto.Migration
+
+  def up do
+    alter table("tokens") do
+      modify(:decimals, :bigint)
+    end
+  end
+
+  def down do
+    alter table("tokens") do
+      modify(:decimals, :smallint)
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2602,6 +2602,20 @@ defmodule Explorer.ChainTest do
       Chain.update_token(token, update_params)
       refute Repo.get_by(Address.Name, address_hash: token.contract_address_hash)
     end
+
+    test "stores token with big 'decimals' values" do
+      token = insert(:token, name: nil, symbol: nil, total_supply: nil, decimals: nil, cataloged: false)
+
+      update_params = %{
+        name: "Hodl Token",
+        symbol: "HT",
+        total_supply: 10,
+        decimals: 1_000_000_000_000_000_000,
+        cataloged: true
+      }
+
+      assert {:ok, updated_token} = Chain.update_token(token, update_params)
+    end
   end
 
   describe "fetch_last_token_balances/1" do


### PR DESCRIPTION
Fixes #758

There are some decimals with bigger values than the supported by the `smallint` type.
https://www.postgresql.org/docs/9.1/static/datatype-numeric.html

This PR adds a new migration to alter the `Token` table column, so we don't drop and re-index the whole database just for this type.

### Bug Fixes

When indexing a new chain some errors appeared in the `Token.Fetcher`, related to the size of the column `decimals`.

```
22:44:14.500 [error] Task #PID<0.10175.0> started from Indexer.Token.Fetcher terminating
** (ArgumentError) Postgrex expected an integer in -32768..32767, got 1000000000000000000. Please make sure the value you are passing matches the definition in your table or in your query or convert the value accordingly.
```




