### PR TITLE
Remove duplicated code from Transaction page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web.ex
+++ b/apps/block_scout_web/lib/block_scout_web.ex
@@ -46,6 +46,7 @@ defmodule BlockScoutWeb do
         ErrorHelpers,
         Gettext,
         Router.Helpers,
+        TabHelpers,
         Tokens.Helpers,
         WeiHelpers
       }

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
@@ -44,6 +44,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
         max_block_number: max_block_number,
         next_page_params: next_page_params(next_page, token_transfers, params),
         token_transfers: token_transfers,
+        show_token_transfers: true,
         transaction: transaction
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tabs.html.eex
@@ -1,0 +1,55 @@
+<!-- DESKTOP TAB NAV -->
+<ul class="nav nav-tabs card-header-tabs d-none d-lg-inline-flex">
+  <%= if @show_token_transfers do %>
+  <li class="nav-item">
+      <%= link(
+            gettext("Token Transfers"),
+            class: "nav-link #{tab_status("token_transfers", @conn.request_path)}",
+            to: transaction_token_transfer_path(@conn, :index, @transaction)
+          ) %>
+    </li>
+  <% end %>
+  <li class="nav-item">
+    <%= link(
+          gettext("Internal Transactions"),
+          class: "nav-link #{tab_status("internal_transactions", @conn.request_path)}",
+          to: transaction_internal_transaction_path(@conn, :index, @transaction)
+        ) %>
+  </li>
+  <li class="nav-item">
+    <%= link(
+          gettext("Logs"),
+          class: "nav-link #{tab_status("logs", @conn.request_path)}",
+          to: transaction_log_path(@conn, :index, @transaction),
+          "data-test": "transaction_logs_link"
+        ) %>
+  </li>
+</ul>
+
+<!-- MOBILE DROPDOWN NAV -->
+<ul class="nav nav-tabs card-header-tabs d-lg-none">
+  <li class="nav-item dropdown flex-fill text-center">
+    <a class="nav-link active dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><%= current_tab_name(@conn.request_path) %></a>
+    <div class="dropdown-menu">
+      <%= if @show_token_transfers do %>
+        <%= link(
+              gettext("Token Transfers"),
+              class: "dropdown-item #{tab_status("token_transfers", @conn.request_path)}",
+              to: transaction_token_transfer_path(@conn, :index, @transaction),
+              "data-test": "transaction_token_transfer_link"
+            ) %>
+       <% end %>
+      <%= link(
+            gettext("Internal Transactions"),
+            class: "dropdown-item #{tab_status("internal_transactions", @conn.request_path)}",
+            to: transaction_internal_transaction_path(@conn, :index, @transaction)
+          ) %>
+          <%= link(
+                gettext("Logs"),
+                class: "dropdown-item #{tab_status("logs", @conn.request_path)}",
+                to: transaction_log_path(@conn, :index, @transaction),
+                "data-test": "transaction_logs_link"
+          ) %>
+    </div>
+  </li>
+</ul>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex
@@ -1,90 +1,35 @@
 <section class="container">
   <%= render BlockScoutWeb.TransactionView, "overview.html", assigns %>
 
-      <div class="card">
-        <div class="card-header">
+  <div class="card">
+    <div class="card-header">
+      <%= render BlockScoutWeb.TransactionView, "_tabs.html", assigns %>
+    </div>
 
-          <!-- DESKTOP TAB NAV -->
-          <ul class="nav nav-tabs card-header-tabs d-none d-lg-inline-flex">
-            <%= if @show_token_transfers do %>
-            <li class="nav-item">
-                <%= link(
-                      gettext("Token Transfers"),
-                      class: "nav-link",
-                      to: transaction_token_transfer_path(@conn, :index, @transaction)
-                    ) %>
-              </li>
-            <% end %>
-            <li class="nav-item">
-              <%= link(
-                    gettext("Internal Transactions"),
-                    class: "nav-link active",
-                    to: transaction_internal_transaction_path(@conn, :index, @transaction)
-                  ) %>
-            </li>
-            <li class="nav-item">
-              <%= link(
-                    gettext("Logs"),
-                    class: "nav-link",
-                    to: transaction_log_path(@conn, :index, @transaction),
-                    "data-test": "transaction_logs_link"
-                  ) %>
-            </li>
-          </ul>
-
-          <!-- MOBILE DROPDOWN NAV -->
-          <ul class="nav nav-tabs card-header-tabs d-lg-none">
-            <li class="nav-item dropdown flex-fill text-center">
-              <a class="nav-link active dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><%= gettext("Internal Transactions") %></a>
-              <div class="dropdown-menu">
-                <%= if @show_token_transfers do %>
-                  <%= link(
-                        gettext("Token Transfers"),
-                        class: "dropdown-item",
-                        to: transaction_token_transfer_path(@conn, :index, @transaction),
-                        "data-test": "transaction_token_transfer_link"
-                      ) %>
-                 <% end %>
-                <%= link(
-                      gettext("Internal Transactions"),
-                      class: "dropdown-item active",
-                      to: transaction_internal_transaction_path(@conn, :index, @transaction)
-                    ) %>
-                    <%= link(
-                          gettext("Logs"),
-                          class: "dropdown-item",
-                          to: transaction_log_path(@conn, :index, @transaction),
-                          "data-test": "transaction_logs_link"
-                    ) %>
-              </div>
-            </li>
-          </ul>
+    <div class="card-body">
+      <h2 class="card-title"><%= gettext "Internal Transactions" %></h2>
+      <%= if Enum.count(@internal_transactions) > 0 do %>
+        <%= for internal_transaction <- @internal_transactions do %>
+          <%= render BlockScoutWeb.InternalTransactionView, "_tile.html", internal_transaction: internal_transaction %>
+        <% end %>
+      <% else %>
+        <div class="tile tile-muted text-center">
+          <span><%= gettext "There are no internal transactions for this transaction." %></span>
         </div>
-        <div class="card-body">
-          <h2 class="card-title"><%= gettext "Internal Transactions" %></h2>
-          <%= if Enum.count(@internal_transactions) > 0 do %>
-            <%= for internal_transaction <- @internal_transactions do %>
-              <%= render BlockScoutWeb.InternalTransactionView, "_tile.html", internal_transaction: internal_transaction %>
-            <% end %>
-          <% else %>
-            <div class="tile tile-muted text-center">
-              <span><%= gettext "There are no internal transactions for this transaction." %></span>
-            </div>
-          <% end %>
+      <% end %>
 
-          <%= if @next_page_params do %>
-            <%= link(
-              gettext("Newer"),
-              class: "button button-secondary button-sm float-right mt-3",
-              to: transaction_internal_transaction_path(
-                @conn,
-                :index,
-                @transaction,
-                @next_page_params
-              )
-            ) %>
-          <% end %>
-        </div>
-      </div>
-
-      </section>
+      <%= if @next_page_params do %>
+        <%= link(
+          gettext("Newer"),
+          class: "button button-secondary button-sm float-right mt-3",
+          to: transaction_internal_transaction_path(
+            @conn,
+            :index,
+            @transaction,
+            @next_page_params
+          )
+        ) %>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/index.html.eex
@@ -1,134 +1,80 @@
 <section class="container">
-
   <%= render BlockScoutWeb.TransactionView, "overview.html", assigns %>
 
-    <div class="card">
-      <div class="card-header">
-
-        <!-- DESKTOP TAB NAV -->
-        <ul class="nav nav-tabs card-header-tabs d-none d-lg-inline-flex">
-          <li class="nav-item">
-            <%= if @show_token_transfers do %>
-              <%= link(
-                    gettext("Token Transfers"),
-                    class: "nav-link",
-                    to: transaction_token_transfer_path(@conn, :index, @transaction)
-                  ) %>
-            <% end %>
-          </li>
-          <li class="nav-item">
-            <%= link(
-                  gettext("Internal Transactions"),
-                  class: "nav-link",
-                  to: transaction_internal_transaction_path(@conn, :index, @transaction)
-                ) %>
-          </li>
-          <li class="nav-item">
-            <%= link(
-                  gettext("Logs"),
-                  class: "nav-link active",
-                  to: transaction_log_path(@conn, :index, @transaction)
-                ) %>
-          </li>
-        </ul>
-
-        <!-- MOBILE DROPDOWN NAV -->
-        <ul class="nav nav-tabs card-header-tabs d-lg-none">
-          <li class="nav-item dropdown flex-fill text-center">
-            <a class="nav-link active dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><%= gettext("Logs") %></a>
-            <div class="dropdown-menu">
-                <%= if @show_token_transfers do %>
-                  <%= link(
-                        gettext("Token Transfers"),
-                        class: "dropdown-item",
-                        to: transaction_token_transfer_path(@conn, :index, @transaction),
-                        "data-test": "transaction_token_transfer_link"
-                      ) %>
-                 <% end %>
-              <%= link(
-                    gettext("Internal Transactions"),
-                    class: "dropdown-item",
-                    to: transaction_path(@conn, :show, @transaction)
-                  ) %>
-              <%= link(
-                    gettext("Logs"),
-                    class: "dropdown-item active",
-                    to: transaction_log_path(@conn, :index, @transaction),
-                    "data-test": "transaction_logs_link"
-                  ) %>
-            </div>
-          </li>
-        </ul>
-      </div>
-
-      <div class="card-body">
-        <h2 class="card-title"><%= gettext "Logs" %></h2>
-        <%= if Enum.count(@logs) > 0 do %>
-          <%= for log <- @logs do %>
-            <div data-test="transaction_log" class="tile tile-muted">
-              <dl class="row">
-                <dt class="col-md-1"> <%= gettext "Address" %> </dt>
-                <dd class="col-md-11">
-                  <h3 class="">
-                    <%= link(
-                        log.address,
-                        to: address_path(@conn, :show, log.address),
-                        "data-test": "log_address_link",
-                        "data-address-hash": log.address
-                      ) %>
-                  </h3>
-                </dd>
-                <dt class="col-md-1"><%= gettext "Topics" %></dt>
-                <dd class="col-md-11">
-                  <%= unless is_nil(log.first_topic) do %>
-                    <div class="text-dark">
-                      <span class="text-dark">[0]</span>
-                      <%= log.first_topic %>
-                    </div>
-                  <% end %>
-                  <%= unless is_nil(log.second_topic) do %>
-                    <div class="text-dark">
-                      <span class="">[1] </span>
-                      <%= log.second_topic %>
-                    </div>
-                  <% end %>
-                  <%= unless is_nil(log.third_topic) do %>
-                    <div class="text-dark">
-                      <span>[2]</span>
-                      <%= log.third_topic %>
-                    </div>
-                  <% end %>
-                </dd>
-                <dt class="col-md-1">
-                  <%= gettext "Data" %>
-                </dt>
-                <dd class="col-md-11">
-                  <%= unless is_nil(log.data) do %>
-                    <div class="text-dark">
-                      <%= log.data %>
-                    </div>
-                  <% end %>
-                </dd>
-              </dl>
-            </div>
-          <% end %>
-        <% else %>
-        <div class="tile tile-muted text-center">
-          <span><%= gettext "There are no logs for this transaction." %></span>
-        </div>
-        <% end %>
-        <%= if @next_page_params do %>
-          <%= link(
-            gettext("Newer"),
-            class: "button button-secondary button-sm u-float-right mt-3",
-            to: transaction_log_path(
-              @conn,
-              :index,
-              @transaction,
-              @next_page_params
-            )
-          ) %>
-        <% end %>
-      </div>
+  <div class="card">
+    <div class="card-header">
+      <%= render BlockScoutWeb.TransactionView, "_tabs.html", assigns %>
     </div>
-  </section>
+
+    <div class="card-body">
+      <h2 class="card-title"><%= gettext "Logs" %></h2>
+      <%= if Enum.count(@logs) > 0 do %>
+        <%= for log <- @logs do %>
+          <div data-test="transaction_log" class="tile tile-muted">
+            <dl class="row">
+              <dt class="col-md-1"> <%= gettext "Address" %> </dt>
+              <dd class="col-md-11">
+                <h3 class="">
+                  <%= link(
+                      log.address,
+                      to: address_path(@conn, :show, log.address),
+                      "data-test": "log_address_link",
+                      "data-address-hash": log.address
+                    ) %>
+                </h3>
+              </dd>
+              <dt class="col-md-1"><%= gettext "Topics" %></dt>
+              <dd class="col-md-11">
+                <%= unless is_nil(log.first_topic) do %>
+                  <div class="text-dark">
+                    <span class="text-dark">[0]</span>
+                    <%= log.first_topic %>
+                  </div>
+                <% end %>
+                <%= unless is_nil(log.second_topic) do %>
+                  <div class="text-dark">
+                    <span class="">[1] </span>
+                    <%= log.second_topic %>
+                  </div>
+                <% end %>
+                <%= unless is_nil(log.third_topic) do %>
+                  <div class="text-dark">
+                    <span>[2]</span>
+                    <%= log.third_topic %>
+                  </div>
+                <% end %>
+              </dd>
+              <dt class="col-md-1">
+                <%= gettext "Data" %>
+              </dt>
+              <dd class="col-md-11">
+                <%= unless is_nil(log.data) do %>
+                  <div class="text-dark">
+                    <%= log.data %>
+                  </div>
+                <% end %>
+              </dd>
+            </dl>
+          </div>
+        <% end %>
+      <% else %>
+      <div class="tile tile-muted text-center">
+        <span><%= gettext "There are no logs for this transaction." %></span>
+      </div>
+      <% end %>
+
+      <%= if @next_page_params do %>
+        <%= link(
+          gettext("Newer"),
+          class: "button button-secondary button-sm u-float-right mt-3",
+          to: transaction_log_path(
+            @conn,
+            :index,
+            @transaction,
+            @next_page_params
+          )
+        ) %>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/index.html.eex
@@ -3,55 +3,7 @@
 
   <div class="card">
     <div class="card-header">
-
-      <!-- DESKTOP TAB NAV -->
-      <ul class="nav nav-tabs card-header-tabs d-none d-lg-inline-flex">
-        <li class="nav-item">
-          <%= link(
-                gettext("Token Transfers"),
-                class: "nav-link active",
-                to: transaction_token_transfer_path(@conn, :index, @transaction)
-          ) %>
-        </li>
-        <li class="nav-item">
-          <%= link(
-                gettext("Internal Transactions"),
-                class: "nav-link",
-                to: transaction_internal_transaction_path(@conn, :index, @transaction)
-          ) %>
-        </li>
-        <li class="nav-item">
-          <%= link(
-                gettext("Logs"),
-                class: "nav-link",
-                to: transaction_log_path(@conn, :index, @transaction)
-          ) %>
-        </li>
-      </ul>
-
-      <!-- MOBILE DROPDOWN NAV -->
-      <ul class="nav nav-tabs card-header-tabs d-lg-none">
-        <li class="nav-item dropdown flex-fill text-center">
-          <a class="nav-link active dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><%= gettext("Token Transfers") %></a>
-          <div class="dropdown-menu">
-            <%= link(
-                  gettext("Token Transfers"),
-                  class: "dropdown-item active",
-                  to: transaction_token_transfer_path(@conn, :index, @transaction)
-            ) %>
-            <%= link(
-                  gettext("Internal Transactions"),
-                  class: "dropdown-item",
-                  to: transaction_internal_transaction_path(@conn, :index, @transaction)
-            ) %>
-            <%= link(
-                  gettext("Logs"),
-                  class: "dropdown-item",
-                  to: transaction_log_path(@conn, :index, @transaction)
-            ) %>
-          </div>
-        </li>
-      </ul>
+      <%= render BlockScoutWeb.TransactionView, "_tabs.html", assigns %>
     </div>
 
     <div class="card-body">

--- a/apps/block_scout_web/lib/block_scout_web/views/tab_helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tab_helpers.ex
@@ -1,0 +1,47 @@
+defmodule BlockScoutWeb.TabHelpers do
+  @moduledoc """
+  Helper functions for dealing with tabs, which are very common between pages.
+  """
+
+  @doc """
+  Get the current status of a tab by its name and the request path.
+
+  A tab is considered active if its name responds true to active?/2.
+
+  * returns the string "active" if the tab active.
+  * returns nil if the tab is not active.
+
+  ## Examples
+
+  iex> BlockScoutWeb.TabHelpers.tab_status("token", "/page/0xSom3tH1ng/token")
+  "active"
+
+  iex> BlockScoutWeb.TabHelpers.tab_status("token", "/page/0xSom3tH1ng/token_transfer")
+  nil
+  """
+  def tab_status(tab_name, request_path) do
+    if tab_active?(tab_name, request_path) do
+      "active"
+    end
+  end
+
+  @doc """
+  Check if the given tab is the current tab given the request path.
+
+  It is considered active if there is a substring that exactly matches the tab name in the path.
+
+  * returns true if the tab name is in the path.
+  * returns nil if the tab name is not in the path.
+
+  ## Examples
+
+  iex> BlockScoutWeb.TabHelpers.tab_active?("token", "/page/0xSom3tH1ng/token")
+  true
+
+  iex> BlockScoutWeb.TabHelpers.tab_active?("token", "/page/0xSom3tH1ng/token_transfer")
+  false
+  """
+  def tab_active?(tab_name, request_path) do
+    String.match?(request_path, ~r/\b#{tab_name}\b/)
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -4,9 +4,11 @@ defmodule BlockScoutWeb.TransactionView do
   alias Cldr.Number
   alias Explorer.Chain
   alias Explorer.Chain.{Address, InternalTransaction, Transaction, Wei}
-  alias BlockScoutWeb.{AddressView, BlockView}
+  alias BlockScoutWeb.{AddressView, BlockView, TabHelpers}
 
   import BlockScoutWeb.Gettext
+
+  @tabs ["token_transfers", "internal_transactions", "logs"]
 
   defguardp is_transaction_type(mod) when mod in [InternalTransaction, Transaction]
 
@@ -151,4 +153,24 @@ defmodule BlockScoutWeb.TransactionView do
     include_label? = Keyword.get(opts, :include_label, true)
     {fee_type, format_wei_value(Wei.from(fee, :wei), denomination, include_unit_label: include_label?)}
   end
+
+  @doc """
+  Get the current tab name/title from the request path and possible tab names.
+
+  The tabs on mobile are represented by a dropdown list, which has a title. This title is the currently selected tab name. This function returns that name, properly gettext'ed.
+
+  The list of possible tab names for this page is repesented by the attribute @tab.
+
+  Raises an error if there is no match, so a developer of a new tab must include it in the list.
+
+  """
+  def current_tab_name(request_path) do
+    @tabs
+    |> Enum.filter(&TabHelpers.tab_active?(&1, request_path))
+    |> tab_name()
+  end
+
+  defp tab_name(["token_transfers"]), do: gettext("Token Transfers")
+  defp tab_name(["internal_transactions"]), do: gettext("Internal Transactions")
+  defp tab_name(["logs"]), do: gettext("Logs")
 end

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -140,7 +140,7 @@ msgstr ""
 msgid "%{count} transactions in this block"
 msgstr ""
 
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:70
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:15
 #: lib/block_scout_web/views/address_view.ex:79
 msgid "Address"
 msgstr ""
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:55
+#: lib/block_scout_web/views/transaction_view.ex:57
 msgid "Success"
 msgstr ""
 
@@ -209,8 +209,8 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/index.html.eex:16
 #: lib/block_scout_web/templates/transaction/index.html.eex:35
 #: lib/block_scout_web/templates/transaction/overview.html.eex:54
-#: lib/block_scout_web/views/transaction_view.ex:53
-#: lib/block_scout_web/views/transaction_view.ex:79
+#: lib/block_scout_web/views/transaction_view.ex:55
+#: lib/block_scout_web/views/transaction_view.ex:81
 msgid "Pending"
 msgstr ""
 
@@ -222,15 +222,10 @@ msgstr ""
 msgid "Last Seen"
 msgstr ""
 
-#:
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:27
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:54
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:28
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:38
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:54
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:65
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:25
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:48
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:21
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:48
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:10
+#: lib/block_scout_web/views/transaction_view.ex:175
 msgid "Logs"
 msgstr ""
 
@@ -325,14 +320,10 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:84
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:28
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:73
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:20
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:38
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:49
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:64
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:21
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:49
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:18
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:43
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
+#: lib/block_scout_web/views/transaction_view.ex:174
 msgid "Internal Transactions"
 msgstr ""
 
@@ -473,7 +464,7 @@ msgstr ""
 msgid "Total Gas Used"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:124
+#: lib/block_scout_web/views/transaction_view.ex:126
 msgid "Transaction"
 msgstr ""
 
@@ -516,7 +507,7 @@ msgstr ""
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:78
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:86
 #: lib/block_scout_web/templates/transaction/index.html.eex:66
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:72
+#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:24
 msgid "Older"
 msgstr ""
 
@@ -568,13 +559,13 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:77
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:122
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:23
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:68
 msgid "Newer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:122
+#: lib/block_scout_web/views/transaction_view.ex:124
 msgid "Contract Creation"
 msgstr ""
 
@@ -671,7 +662,7 @@ msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:123
+#: lib/block_scout_web/views/transaction_view.ex:125
 msgid "Contract Call"
 msgstr ""
 
@@ -770,12 +761,12 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:71
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:17
 msgid "There are no internal transactions for this transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:117
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:62
 msgid "There are no logs for this transaction."
 msgstr ""
 
@@ -787,7 +778,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/_token_transfer.html.eex:4
-#: lib/block_scout_web/views/transaction_view.ex:121
+#: lib/block_scout_web/views/transaction_view.ex:123
 msgid "Token Transfer"
 msgstr ""
 
@@ -838,14 +829,10 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:46
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:49
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:70
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:12
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:42
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:13
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:42
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:11
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:35
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:38
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:58
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:6
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:36
+#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:10
+#: lib/block_scout_web/views/transaction_view.ex:173
 msgid "Token Transfers"
 msgstr ""
 
@@ -870,7 +857,7 @@ msgid "API"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:65
+#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:17
 msgid "There are no token transfers for this transaction."
 msgstr ""
 
@@ -1064,7 +1051,7 @@ msgid "Less than"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:45
+#: lib/block_scout_web/views/transaction_view.ex:47
 msgid "Max of"
 msgstr ""
 
@@ -1159,7 +1146,7 @@ msgid "Contract source code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:103
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:48
 msgid "Data"
 msgstr ""
 
@@ -1205,7 +1192,7 @@ msgid "Toggle navigation"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:81
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:26
 msgid "Topics"
 msgstr ""
 
@@ -1225,17 +1212,17 @@ msgid "Connection Lost, click to load newer blocks"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:54
+#: lib/block_scout_web/views/transaction_view.ex:56
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:58
+#: lib/block_scout_web/views/transaction_view.ex:60
 msgid "Error: %{reason}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:56
+#: lib/block_scout_web/views/transaction_view.ex:58
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -152,7 +152,7 @@ msgstr "%{confirmations} block confirmations"
 msgid "%{count} transactions in this block"
 msgstr "%{count} transactions in this block"
 
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:70
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:15
 #: lib/block_scout_web/views/address_view.ex:79
 msgid "Address"
 msgstr "Address"
@@ -169,7 +169,7 @@ msgstr "From"
 msgid "Overview"
 msgstr "Overview"
 
-#: lib/block_scout_web/views/transaction_view.ex:55
+#: lib/block_scout_web/views/transaction_view.ex:57
 msgid "Success"
 msgstr "Success"
 
@@ -221,8 +221,8 @@ msgstr "Showing %{count} Transactions"
 #: lib/block_scout_web/templates/transaction/index.html.eex:16
 #: lib/block_scout_web/templates/transaction/index.html.eex:35
 #: lib/block_scout_web/templates/transaction/overview.html.eex:54
-#: lib/block_scout_web/views/transaction_view.ex:53
-#: lib/block_scout_web/views/transaction_view.ex:79
+#: lib/block_scout_web/views/transaction_view.ex:55
+#: lib/block_scout_web/views/transaction_view.ex:81
 msgid "Pending"
 msgstr "Pending"
 
@@ -234,15 +234,10 @@ msgstr ""
 msgid "Last Seen"
 msgstr ""
 
-#:
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:27
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:54
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:28
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:38
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:54
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:65
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:25
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:48
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:21
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:48
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:10
+#: lib/block_scout_web/views/transaction_view.ex:175
 msgid "Logs"
 msgstr ""
 
@@ -337,14 +332,10 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:84
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:28
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:73
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:20
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:38
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:49
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:64
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:21
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:49
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:18
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:43
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
+#: lib/block_scout_web/views/transaction_view.ex:174
 msgid "Internal Transactions"
 msgstr ""
 
@@ -485,7 +476,7 @@ msgstr ""
 msgid "Total Gas Used"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:124
+#: lib/block_scout_web/views/transaction_view.ex:126
 msgid "Transaction"
 msgstr ""
 
@@ -528,7 +519,7 @@ msgstr ""
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:78
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:86
 #: lib/block_scout_web/templates/transaction/index.html.eex:66
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:72
+#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:24
 msgid "Older"
 msgstr ""
 
@@ -570,15 +561,23 @@ msgstr "Yes"
 msgid "Last Updated In Block"
 msgstr ""
 
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:49
+msgid "WEI"
+msgstr ""
+
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:50
+msgid "ETH"
+msgstr ""
+
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:77
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:122
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:23
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:68
 msgid "Newer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:122
+#: lib/block_scout_web/views/transaction_view.ex:124
 msgid "Contract Creation"
 msgstr ""
 
@@ -675,7 +674,7 @@ msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:123
+#: lib/block_scout_web/views/transaction_view.ex:125
 msgid "Contract Call"
 msgstr ""
 
@@ -774,12 +773,12 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:71
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:17
 msgid "There are no internal transactions for this transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:117
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:62
 msgid "There are no logs for this transaction."
 msgstr ""
 
@@ -791,7 +790,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/token/_token_transfer.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/_token_transfer.html.eex:4
-#: lib/block_scout_web/views/transaction_view.ex:121
+#: lib/block_scout_web/views/transaction_view.ex:123
 msgid "Token Transfer"
 msgstr ""
 
@@ -842,14 +841,10 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:46
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:49
 #: lib/block_scout_web/templates/tokens/token/show.html.eex:70
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:12
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:42
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:13
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:42
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:11
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:35
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:38
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:58
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:6
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:36
+#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:10
+#: lib/block_scout_web/views/transaction_view.ex:173
 msgid "Token Transfers"
 msgstr ""
 
@@ -874,7 +869,7 @@ msgid "API"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:65
+#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:17
 msgid "There are no token transfers for this transaction."
 msgstr ""
 
@@ -1068,7 +1063,7 @@ msgid "Less than"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:45
+#: lib/block_scout_web/views/transaction_view.ex:47
 msgid "Max of"
 msgstr ""
 
@@ -1163,7 +1158,7 @@ msgid "Contract source code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:103
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:48
 msgid "Data"
 msgstr ""
 
@@ -1209,7 +1204,7 @@ msgid "Toggle navigation"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:81
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:26
 msgid "Topics"
 msgstr ""
 
@@ -1229,17 +1224,17 @@ msgid "Connection Lost, click to load newer blocks"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:54
+#: lib/block_scout_web/views/transaction_view.ex:56
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:58
+#: lib/block_scout_web/views/transaction_view.ex:60
 msgid "Error: %{reason}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:56
+#: lib/block_scout_web/views/transaction_view.ex:58
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 

--- a/apps/block_scout_web/test/block_scout_web/views/tab_helpers_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tab_helpers_test.exs
@@ -1,0 +1,57 @@
+defmodule BlockScoutWeb.TabHelpersTest do
+  use ExUnit.Case
+
+  alias BlockScoutWeb.TabHelpers
+
+  doctest BlockScoutWeb.TabHelpers, import: true
+
+  describe "tab_status/2" do
+    test "returns \"active\" if the tab is active" do
+      tab_name = "token_transfers"
+      request_path = "/page/0xSom3tH1ng/token_transfers/?additional_params=blah"
+
+      assert TabHelpers.tab_status(tab_name, request_path) == "active"
+    end
+
+    test "returns nil if the tab is not active" do
+      tab_name = "internal_transactions"
+      request_path = "/page/0xSom3tH1ng/token_transfers/?additional_params=blah"
+
+      assert TabHelpers.tab_status(tab_name, request_path) == nil
+    end
+  end
+
+  describe "tab_active?/2" do
+    test "returns true if the tab name is in the path" do
+      tab_name = "token_transfers"
+      request_path = "/page/0xSom3tH1ng/token_transfers/?additional_params=blah"
+
+      assert TabHelpers.tab_active?(tab_name, request_path)
+    end
+
+    test "macthes the tab name at any path level" do
+      tab_name_1 = "token_transfers"
+      tab_name_2 = "tokens"
+      request_path = "/page/0xSom3tH1ng/tokens/0xLuc4S/token_transfers/0xd4uMl1Gu1"
+
+      assert TabHelpers.tab_active?(tab_name_1, request_path)
+      assert TabHelpers.tab_active?(tab_name_2, request_path)
+    end
+
+    test "matches only the exact tab name to avoid ambiguity" do
+      tab_name = "transactions"
+      request_path_1 = "/page/0xSom3tH1ng/transactions"
+      request_path_2 = "/page/0xSom3tH1ng/internal_transactions"
+
+      assert TabHelpers.tab_active?(tab_name, request_path_1)
+      refute TabHelpers.tab_active?(tab_name, request_path_2)
+    end
+
+    test "returns nil if the tab name is not in the path" do
+      tab_name = "internal_transactions"
+      request_path = "/page/0xSom3tH1ng/token_transfers/?additional_params=blah"
+
+      refute TabHelpers.tab_active?(tab_name, request_path)
+    end
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/views/transaction_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/transaction_view_test.exs
@@ -146,4 +146,16 @@ defmodule BlockScoutWeb.TransactionViewTest do
       assert TransactionView.to_address(transaction) == transaction.to_address
     end
   end
+
+  describe "current_tab_name/1" do
+    test "generates the correct tab name" do
+      token_transfers_path = "/page/0xSom3tH1ng/token_transfers/?additional_params=blah"
+      internal_transactions_path = "/page/0xSom3tH1ng/internal_transactions/?additional_params=blah"
+      logs_path = "/page/0xSom3tH1ng/logs/?additional_params=blah"
+
+      assert TransactionView.current_tab_name(token_transfers_path) == "Token Transfers"
+      assert TransactionView.current_tab_name(internal_transactions_path) == "Internal Transactions"
+      assert TransactionView.current_tab_name(logs_path) == "Logs"
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/778

The code that defines the card header, where the tab links are, was
being repeated in every tab. This commit moves this code to a partial
and creates a little helper function to get the currently active tab. This
function simply looks for the current tab name in the request path.