### PR TITLE
Uncle support

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_controller.ex
@@ -23,7 +23,7 @@ defmodule BlockScoutWeb.BlockController do
     render(conn, "index.html", blocks: blocks, next_page_params: next_page_params(next_page, blocks, params))
   end
 
-  def show(conn, %{"id" => number}) do
-    redirect(conn, to: block_transaction_path(conn, :index, number))
+  def show(conn, %{"hash_or_number" => hash_or_number}) do
+    redirect(conn, to: block_transaction_path(conn, :index, hash_or_number))
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
@@ -1,15 +1,18 @@
 defmodule BlockScoutWeb.BlockTransactionController do
   use BlockScoutWeb, :controller
 
-  import BlockScoutWeb.Chain,
-    only: [paging_options: 1, param_to_block_number: 1, next_page_params: 3, split_list_by_page: 1]
+  import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
+  import Explorer.Chain, only: [hash_to_block: 2, number_to_block: 2, string_to_block_hash: 1]
 
   alias Explorer.Chain
 
-  def index(conn, %{"block_id" => formatted_block_number} = params) do
-    with {:ok, block_number} <- param_to_block_number(formatted_block_number),
-         {:ok, block} <- Chain.number_to_block(block_number, necessity_by_association: %{miner: :required}),
-         block_transaction_count <- Chain.block_to_transaction_count(block) do
+  def index(conn, %{"block_hash_or_number" => formatted_block_hash_or_number} = params) do
+    with {:ok, block} <-
+           param_block_hash_or_number_to_block(formatted_block_hash_or_number,
+             necessity_by_association: %{miner: :required}
+           ) do
+      block_transaction_count = Chain.block_to_transaction_count(block)
+
       full_options =
         Keyword.merge(
           [
@@ -36,11 +39,30 @@ defmodule BlockScoutWeb.BlockTransactionController do
         transactions: transactions
       )
     else
-      {:error, :invalid} ->
+      {:error, {:invalid, :hash}} ->
+        not_found(conn)
+
+      {:error, {:invalid, :number}} ->
         not_found(conn)
 
       {:error, :not_found} ->
         not_found(conn)
+    end
+  end
+
+  defp param_block_hash_or_number_to_block("0x" <> _ = param, options) do
+    with {:ok, hash} <- string_to_block_hash(param) do
+      hash_to_block(hash, options)
+    else
+      :error -> {:error, {:invalid, :hash}}
+    end
+  end
+
+  defp param_block_hash_or_number_to_block(number_string, options) when is_binary(number_string) do
+    with {:ok, number} <- BlockScoutWeb.Chain.param_to_block_number(number_string) do
+      number_to_block(number, options)
+    else
+      {:error, :invalid} -> {:error, {:invalid, :number}}
     end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -40,7 +40,7 @@ defmodule BlockScoutWeb.Router do
 
     resources("/", ChainController, only: [:show], singleton: true, as: :chain)
 
-    resources "/blocks", BlockController, only: [:index, :show] do
+    resources "/blocks", BlockController, only: [:index, :show], param: "hash_or_number" do
       resources("/transactions", BlockTransactionController, only: [:index], as: :transaction)
     end
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/index.html.eex
@@ -12,7 +12,7 @@
             <%= link(
                   gettext("Transactions"),
                   class: "nav-link active",
-                  to: block_transaction_path(@conn, :index, @conn.params["block_id"])
+                  to: block_transaction_path(@conn, :index, @conn.params["block_hash_or_number"])
                 ) %>
           </li>
         </ul>
@@ -25,7 +25,7 @@
               <%= link(
                     gettext("Transactions"),
                     class: "dropdown-item active",
-                    to: block_transaction_path(@conn, :index, @conn.params["block_id"])
+                    to: block_transaction_path(@conn, :index, @conn.params["block_hash_or_number"])
                   ) %>
             </div>
           </li>

--- a/apps/block_scout_web/lib/phoenix/param.ex
+++ b/apps/block_scout_web/lib/phoenix/param.ex
@@ -7,8 +7,12 @@ defimpl Phoenix.Param, for: [Address, Transaction] do
 end
 
 defimpl Phoenix.Param, for: Block do
-  def to_param(%@for{number: number}) do
+  def to_param(%@for{consensus: true, number: number}) do
     to_string(number)
+  end
+
+  def to_param(%@for{consensus: false, hash: hash}) do
+    to_string(hash)
   end
 end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
@@ -81,6 +81,14 @@ defmodule BlockScoutWeb.ChainControllerTest do
       assert conn.status == 404
     end
 
+    test "finds non-consensus block by hash", %{conn: conn} do
+      %Block{hash: hash} = insert(:block, consensus: false)
+
+      conn = get(conn, "/search?q=#{hash}")
+
+      assert redirected_to(conn) == block_path(conn, :show, hash)
+    end
+
     test "finds a transaction by hash", %{conn: conn} do
       transaction =
         :transaction

--- a/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
@@ -3,6 +3,8 @@ defmodule BlockScoutWeb.ChainControllerTest do
 
   import BlockScoutWeb.Router.Helpers, only: [chain_path: 2, block_path: 3, transaction_path: 3, address_path: 3]
 
+  alias Explorer.Chain.Block
+
   describe "GET index/2" do
     test "returns a welcome message", %{conn: conn} do
       conn = get(conn, chain_path(BlockScoutWeb.Endpoint, :show))
@@ -64,11 +66,19 @@ defmodule BlockScoutWeb.ChainControllerTest do
   end
 
   describe "GET q/2" do
-    test "finds a block by block number", %{conn: conn} do
+    test "finds a consensus block by block number", %{conn: conn} do
       insert(:block, number: 37)
       conn = get(conn, "/search?q=37")
 
       assert redirected_to(conn) == block_path(conn, :show, "37")
+    end
+
+    test "does not find non-consensus block by number", %{conn: conn} do
+      %Block{number: number} = insert(:block, consensus: false)
+
+      conn = get(conn, "/search?q=#{number}")
+
+      assert conn.status == 404
     end
 
     test "finds a transaction by hash", %{conn: conn} do

--- a/apps/block_scout_web/test/phoenix/param/explorer/chain/block_test.exs
+++ b/apps/block_scout_web/test/phoenix/param/explorer/chain/block_test.exs
@@ -1,0 +1,17 @@
+defmodule Phoenix.Param.Explorer.Chain.BlockTest do
+  use ExUnit.Case
+
+  import Explorer.Factory
+
+  test "without consensus" do
+    block = build(:block, consensus: false)
+
+    assert Phoenix.Param.to_param(block) == to_string(block.hash)
+  end
+
+  test "with consensus" do
+    block = build(:block, consensus: true)
+
+    assert Phoenix.Param.to_param(block) == to_string(block.number)
+  end
+end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
@@ -77,7 +77,7 @@ defmodule EthereumJSONRPC.Block do
       ...>     "totalDifficulty" => 340282366920938463463374607431465668165,
       ...>     "transactions" => [],
       ...>     "transactionsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-      ...>     "uncles" => []
+      ...>     "uncles" => ["0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273311"]
       ...>   }
       ...> )
       %{
@@ -91,7 +91,8 @@ defmodule EthereumJSONRPC.Block do
         parent_hash: "0x5b28c1bfd3a15230c9a46b399cd0f9a6920d432e85381cc6a140b06e8410112f",
         size: 576,
         timestamp: Timex.parse!("2017-12-15T21:03:30Z", "{ISO:Extended:Z}"),
-        total_difficulty: 340282366920938463463374607431465668165
+        total_difficulty: 340282366920938463463374607431465668165,
+        uncles: [%{hash: "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273311"}]
       }
 
   [Geth] `elixir` can be converted to params
@@ -131,7 +132,8 @@ defmodule EthereumJSONRPC.Block do
         parent_hash: "0xcd5b5c4cecd7f18a13fe974255badffd58e737dc67596d56bc01f063dd282e9e",
         size: 542,
         timestamp: Timex.parse!("2015-07-30T15:32:07Z", "{ISO:Extended:Z}"),
-        total_difficulty: 1039309006117
+        total_difficulty: 1039309006117,
+        uncles: []
       }
 
   """
@@ -147,7 +149,8 @@ defmodule EthereumJSONRPC.Block do
           "parentHash" => parent_hash,
           "size" => size,
           "timestamp" => timestamp,
-          "totalDifficulty" => total_difficulty
+          "totalDifficulty" => total_difficulty,
+          "uncles" => uncles
         } = elixir
       ) do
     %{
@@ -160,7 +163,8 @@ defmodule EthereumJSONRPC.Block do
       parent_hash: parent_hash,
       size: size,
       timestamp: timestamp,
-      total_difficulty: total_difficulty
+      total_difficulty: total_difficulty,
+      uncles: Enum.map(uncles, &%{hash: &1})
     }
     |> Map.put(:nonce, Map.get(elixir, "nonce", 0))
   end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/blocks.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/blocks.ex
@@ -4,9 +4,10 @@ defmodule EthereumJSONRPC.Blocks do
   and [`eth_getBlockByNumber`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbynumber) from batch requests.
   """
 
-  alias EthereumJSONRPC.{Block, Transactions}
+  alias EthereumJSONRPC.{Block, Transactions, Uncles}
 
   @type elixir :: [Block.elixir()]
+  @type params :: [Block.params()]
   @type t :: [Block.t()]
 
   @doc """
@@ -37,7 +38,7 @@ defmodule EthereumJSONRPC.Blocks do
       ...>       "totalDifficulty" => 131072,
       ...>       "transactions" => [],
       ...>       "transactionsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-      ...>       "uncles" => []
+      ...>       "uncles" => ["0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273311"]
       ...>     }
       ...>   ]
       ...> )
@@ -54,12 +55,12 @@ defmodule EthereumJSONRPC.Blocks do
           size: 533,
           timestamp: Timex.parse!("1970-01-01T00:00:00Z", "{ISO:Extended:Z}"),
           total_difficulty: 131072,
-          uncles: []
+          uncles: ["0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273311"]
         }
       ]
 
   """
-  @spec elixir_to_params(elixir) :: [map]
+  @spec elixir_to_params(elixir) :: params()
   def elixir_to_params(elixir) when is_list(elixir) do
     Enum.map(elixir, &Block.elixir_to_params/1)
   end
@@ -143,9 +144,75 @@ defmodule EthereumJSONRPC.Blocks do
       ]
 
   """
-  @spec elixir_to_transactions(t) :: Transactions.elixir()
+  @spec elixir_to_transactions(elixir) :: Transactions.elixir()
   def elixir_to_transactions(elixir) when is_list(elixir) do
     Enum.flat_map(elixir, &Block.elixir_to_transactions/1)
+  end
+
+  @doc """
+  Extracts the `t:EthereumJSONRPC.Uncles.elixir/0` from the `t:elixir/0`.
+
+      iex> EthereumJSONRPC.Blocks.elixir_to_uncles([
+      ...>   %{
+      ...>     "author" => "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+      ...>     "difficulty" => 340282366920938463463374607431768211454,
+      ...>     "extraData" => "0xd5830108048650617269747986312e32322e31826c69",
+      ...>     "gasLimit" => 6926030,
+      ...>     "gasUsed" => 269607,
+      ...>     "hash" => "0xe52d77084cab13a4e724162bcd8c6028e5ecfaa04d091ee476e96b9958ed6b47",
+      ...>     "logsBloom" => "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      ...>     "miner" => "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+      ...>     "number" => 34,
+      ...>     "parentHash" => "0x106d528393159b93218dd410e2a778f083538098e46f1a44902aa67a164aed0b",
+      ...>     "receiptsRoot" => "0xf45ed4ab910504ffe231230879c86e32b531bb38a398a7c9e266b4a992e12dfb",
+      ...>     "sealFields" => ["0x84120a71db",
+      ...>      "0xb8417ad0ecca535f81e1807dac338a57c7ccffd05d3e7f0687944650cd005360a192205df306a68eddfe216e0674c6b113050d90eff9b627c1762d43657308f986f501"],
+      ...>     "sha3Uncles" => "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+      ...>     "signature" => "7ad0ecca535f81e1807dac338a57c7ccffd05d3e7f0687944650cd005360a192205df306a68eddfe216e0674c6b113050d90eff9b627c1762d43657308f986f501",
+      ...>     "size" => 1493,
+      ...>     "stateRoot" => "0x6eaa6281df37b9b010f4779affc25ee059088240547ce86cf7ca7b7acd952d4f",
+      ...>     "step" => "302674395",
+      ...>     "timestamp" => Timex.parse!("2017-12-15T21:06:15Z", "{ISO:Extended:Z}"),
+      ...>     "totalDifficulty" => 11569600475311907757754736652679816646147,
+      ...>     "transactions" => [
+      ...>       %{
+      ...>         "blockHash" => "0xe52d77084cab13a4e724162bcd8c6028e5ecfaa04d091ee476e96b9958ed6b47",
+      ...>         "blockNumber" => 34,
+      ...>         "chainId" => 77,
+      ...>         "condition" => nil,
+      ...>         "creates" => "0xffc87239eb0267bc3ca2cd51d12fbf278e02ccb4",
+      ...>         "from" => "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+      ...>         "gas" => 4700000,
+      ...>         "gasPrice" => 100000000000,
+      ...>         "hash" => "0x3a3eb134e6792ce9403ea4188e5e79693de9e4c94e499db132be086400da79e6",
+      ...>         "input" => "0x6060604052341561000f57600080fd5b336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506102db8061005e6000396000f300606060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100a05780638da5cb5b146100c9578063fdacd5761461011e575b600080fd5b341561007257600080fd5b61009e600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610141565b005b34156100ab57600080fd5b6100b3610224565b6040518082815260200191505060405180910390f35b34156100d457600080fd5b6100dc61022a565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561012957600080fd5b61013f600480803590602001909190505061024f565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610220578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b151561020b57600080fd5b6102c65a03f1151561021c57600080fd5b5050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102ac57806001819055505b505600a165627a7a72305820a9c628775efbfbc17477a472413c01ee9b33881f550c59d21bee9928835c854b0029",
+      ...>         "nonce" => 0,
+      ...>         "publicKey" => "0xe5d196ad4ceada719d9e592f7166d0c75700f6eab2e3c3de34ba751ea786527cb3f6eb96ad9fdfdb9989ff572df50f1c42ef800af9c5207a38b929aff969b5c9",
+      ...>         "r" => "0xad3733df250c87556335ffe46c23e34dbaffde93097ef92f52c88632a40f0c75",
+      ...>         "raw" => "0xf9038d8085174876e8008347b7608080b903396060604052341561000f57600080fd5b336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506102db8061005e6000396000f300606060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100a05780638da5cb5b146100c9578063fdacd5761461011e575b600080fd5b341561007257600080fd5b61009e600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610141565b005b34156100ab57600080fd5b6100b3610224565b6040518082815260200191505060405180910390f35b34156100d457600080fd5b6100dc61022a565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561012957600080fd5b61013f600480803590602001909190505061024f565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610220578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b151561020b57600080fd5b6102c65a03f1151561021c57600080fd5b5050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102ac57806001819055505b505600a165627a7a72305820a9c628775efbfbc17477a472413c01ee9b33881f550c59d21bee9928835c854b002981bda0ad3733df250c87556335ffe46c23e34dbaffde93097ef92f52c88632a40f0c75a072caddc0371451a58de2ca6ab64e0f586ccdb9465ff54e1c82564940e89291e3",
+      ...>         "s" => "0x72caddc0371451a58de2ca6ab64e0f586ccdb9465ff54e1c82564940e89291e3",
+      ...>         "standardV" => "0x0",
+      ...>         "to" => nil,
+      ...>         "transactionIndex" => 0,
+      ...>         "v" => "0xbd",
+      ...>         "value" => 0
+      ...>       }
+      ...>     ],
+      ...>     "transactionsRoot" => "0x2c2e243e9735f6d0081ffe60356c0e4ec4c6a9064c68d10bf8091ff896f33087",
+      ...>     "uncles" => ["0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273311"]
+      ...>   }
+      ...> ])
+      [
+        %{
+          "hash" => "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273311",
+          "nephewHash" => "0xe52d77084cab13a4e724162bcd8c6028e5ecfaa04d091ee476e96b9958ed6b47"
+        }
+      ]
+
+  """
+  @spec elixir_to_uncles(elixir) :: Uncles.elixir()
+  def elixir_to_uncles(elixir) do
+    Enum.flat_map(elixir, &Block.elixir_to_uncles/1)
   end
 
   @doc """

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/blocks.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/blocks.ex
@@ -53,7 +53,8 @@ defmodule EthereumJSONRPC.Blocks do
           parent_hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
           size: 533,
           timestamp: Timex.parse!("1970-01-01T00:00:00Z", "{ISO:Extended:Z}"),
-          total_difficulty: 131072
+          total_difficulty: 131072,
+          uncles: []
         }
       ]
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transactions.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transactions.ex
@@ -8,6 +8,7 @@ defmodule EthereumJSONRPC.Transactions do
   alias EthereumJSONRPC.Transaction
 
   @type elixir :: [Transaction.elixir()]
+  @type params :: [Transaction.params()]
   @type t :: [Transaction.t()]
 
   @doc """

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/uncle.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/uncle.ex
@@ -1,0 +1,39 @@
+defmodule EthereumJSONRPC.Uncle do
+  @moduledoc """
+  [Uncle](https://github.com/ethereum/wiki/wiki/Glossary#ethereum-blockchain).
+
+  An uncle is a block that didn't make the main chain due to them being validated slightly behind what became the main
+  chain.
+  """
+
+  @type elixir :: %{String.t() => EthereumJSONRPC.hash()}
+
+  @typedoc """
+  * `"hash"` - the hash of the uncle block.
+  * `"nephewHash"` - the hash of the nephew block that included `"hash` as an uncle.
+  """
+  @type t :: %{String.t() => EthereumJSONRPC.hash()}
+
+  @type params :: %{nephew_hash: EthereumJSONRPC.hash(), uncle_hash: EthereumJSONRPC.hash()}
+
+  @doc """
+  Converts each entry in `t:elixir/0` to `t:params/0` used in `Explorer.Chain.Uncle.changeset/2`.
+
+      iex> EthereumJSONRPC.Uncle.elixir_to_params(
+      ...>   %{
+      ...>     "hash" => "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273311",
+      ...>     "nephewHash" => "0xe52d77084cab13a4e724162bcd8c6028e5ecfaa04d091ee476e96b9958ed6b47"
+      ...>   }
+      ...> )
+      %{
+        nephew_hash: "0xe52d77084cab13a4e724162bcd8c6028e5ecfaa04d091ee476e96b9958ed6b47",
+        uncle_hash: "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273311"
+      }
+
+  """
+  @spec elixir_to_params(elixir) :: params
+  def elixir_to_params(%{"hash" => uncle_hash, "nephewHash" => nephew_hash})
+      when is_binary(uncle_hash) and is_binary(nephew_hash) do
+    %{nephew_hash: nephew_hash, uncle_hash: uncle_hash}
+  end
+end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/uncles.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/uncles.ex
@@ -1,0 +1,35 @@
+defmodule EthereumJSONRPC.Uncles do
+  @moduledoc """
+  List of [uncles](https://github.com/ethereum/wiki/wiki/Glossary#ethereum-blockchain).  Uncles are blocks that didn't
+  make the main chain due to them being validated slightly behind what became the main chain.
+  """
+
+  alias EthereumJSONRPC.Uncle
+
+  @type elixir :: [Uncle.elixir()]
+  @type params :: [Uncle.params()]
+
+  @doc """
+  Converts each entry in `elixir` to params used in `Explorer.Chain.Uncle.changeset/2`.
+
+      iex> EthereumJSONRPC.Uncles.elixir_to_params(
+      ...>   [
+      ...>     %{
+      ...>       "hash" => "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273311",
+      ...>       "nephewHash" => "0xe52d77084cab13a4e724162bcd8c6028e5ecfaa04d091ee476e96b9958ed6b47"
+      ...>     }
+      ...>    ]
+      ...> )
+      [
+        %{
+          uncle_hash: "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273311",
+          nephew_hash: "0xe52d77084cab13a4e724162bcd8c6028e5ecfaa04d091ee476e96b9958ed6b47"
+        }
+      ]
+
+  """
+  @spec elixir_to_params(elixir) :: params
+  def elixir_to_params(elixir) when is_list(elixir) do
+    Enum.map(elixir, &Uncle.elixir_to_params/1)
+  end
+end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/uncle_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/uncle_test.exs
@@ -1,0 +1,5 @@
+defmodule EthereumJSONRPC.UncleTest do
+  use ExUnit.Case, async: true
+
+  doctest EthereumJSONRPC.Uncle
+end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/uncles_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/uncles_test.exs
@@ -1,0 +1,5 @@
+defmodule EthereumJSONRPC.UnclesTest do
+  use ExUnit.Case, async: true
+
+  doctest EthereumJSONRPC.Uncles
+end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
@@ -216,7 +216,8 @@ defmodule EthereumJSONRPCTest do
                      "v" => "0x0",
                      "value" => "0x0"
                    }
-                 ]
+                 ],
+                 "uncles" => []
                }
              }
            ]}
@@ -358,7 +359,8 @@ defmodule EthereumJSONRPCTest do
                "size" => "0x0",
                "timestamp" => "0x0",
                "totalDifficulty" => "0x0",
-               "transactions" => []
+               "transactions" => [],
+               "uncles" => []
              },
              jsonrpc: "2.0"
            },

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -605,11 +605,20 @@ defmodule Explorer.Chain do
       iex> Explorer.Chain.hash_to_block(hash)
       {:error, :not_found}
 
+  ## Options
+
+    * `:necessity_by_association` - use to load `t:association/0` as `:required` or `:optional`.  If an association is
+      `:required`, and the `t:Explorer.Chain.Block.t/0` has no associated record for that association, then the
+      `t:Explorer.Chain.Block.t/0` will not be included in the page `entries`.
+
   """
-  @spec hash_to_block(Hash.Full.t()) :: {:ok, Block.t()} | {:error, :not_found}
-  def hash_to_block(%Hash{byte_count: unquote(Hash.Full.byte_count())} = hash) do
+  @spec hash_to_block(Hash.Full.t(), [necessity_by_association_option]) :: {:ok, Block.t()} | {:error, :not_found}
+  def hash_to_block(%Hash{byte_count: unquote(Hash.Full.byte_count())} = hash, options \\ []) when is_list(options) do
+    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+
     Block
     |> where(hash: ^hash)
+    |> join_associations(necessity_by_association)
     |> Repo.one()
     |> case do
       nil ->

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1062,7 +1062,7 @@ defmodule Explorer.Chain do
   end
 
   @doc """
-  Finds `t:Explorer.Chain.Block.t/0` with `number`
+  Finds consensus `t:Explorer.Chain.Block.t/0` with `number`.
 
   ## Options
 
@@ -1077,7 +1077,7 @@ defmodule Explorer.Chain do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
 
     Block
-    |> where(number: ^number)
+    |> where(consensus: true, number: ^number)
     |> join_associations(necessity_by_association)
     |> Repo.one()
     |> case do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -586,6 +586,41 @@ defmodule Explorer.Chain do
   end
 
   @doc """
+  Converts `t:Explorer.Chain.Block.t/0` `hash` to the `t:Explorer.Chain.Block.t/0` with that `hash`.
+
+  Unlike `number_to_block/1`, both consensus and non-consensus blocks can be returned when looked up by `hash`.
+
+  Returns `{:ok, %Explorer.Chain.Block{}}` if found
+
+      iex> %Block{hash: hash} = insert(:block, consensus: false)
+      iex> {:ok, %Explorer.Chain.Block{hash: found_hash}} = Explorer.Chain.hash_to_block(hash)
+      iex> found_hash == hash
+      true
+
+  Returns `{:error, :not_found}` if not found
+
+      iex> {:ok, hash} = Explorer.Chain.string_to_block_hash(
+      ...>   "0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b"
+      ...> )
+      iex> Explorer.Chain.hash_to_block(hash)
+      {:error, :not_found}
+
+  """
+  @spec hash_to_block(Hash.Full.t()) :: {:ok, Block.t()} | {:error, :not_found}
+  def hash_to_block(%Hash{byte_count: unquote(Hash.Full.byte_count())} = hash) do
+    Block
+    |> where(hash: ^hash)
+    |> Repo.one()
+    |> case do
+      nil ->
+        {:error, :not_found}
+
+      block ->
+        {:ok, block}
+    end
+  end
+
+  @doc """
   Converts the `Explorer.Chain.Hash.t:t/0` to `iodata` representation that can be written efficiently to users.
 
       iex> %Explorer.Chain.Hash{

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -9,7 +9,7 @@ defmodule Explorer.Chain.Block do
 
   alias Explorer.Chain.{Address, Block.SecondDegreeRelation, Gas, Hash, Transaction}
 
-  @required_attrs ~w(difficulty gas_limit gas_used hash miner_hash nonce number parent_hash size timestamp
+  @required_attrs ~w(consensus difficulty gas_limit gas_used hash miner_hash nonce number parent_hash size timestamp
                      total_difficulty)a
 
   @typedoc """
@@ -25,6 +25,9 @@ defmodule Explorer.Chain.Block do
   @type block_number :: non_neg_integer()
 
   @typedoc """
+   * `consensus`
+     * `true` - this is a block on the longest consensus agreed upon chain.
+     * `false` - this is an uncle block from a fork.
    * `difficulty` - how hard the block was to mine.
    * `gas_limit` - If the total number of gas used by the computation spawned by the transaction, including the
      original message and any sub-messages that may be triggered, is less than or equal to the gas limit, then the
@@ -43,6 +46,7 @@ defmodule Explorer.Chain.Block do
    * `transactions` - the `t:Explorer.Chain.Transaction.t/0` in this block.
   """
   @type t :: %__MODULE__{
+          consensus: boolean(),
           difficulty: difficulty(),
           gas_limit: Gas.t(),
           gas_used: Gas.t(),
@@ -60,6 +64,7 @@ defmodule Explorer.Chain.Block do
 
   @primary_key {:hash, Hash.Full, autogenerate: false}
   schema "blocks" do
+    field(:consensus, :boolean)
     field(:difficulty, :decimal)
     field(:gas_limit, :decimal)
     field(:gas_used, :decimal)

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -7,7 +7,7 @@ defmodule Explorer.Chain.Block do
 
   use Explorer.Schema
 
-  alias Explorer.Chain.{Address, Gas, Hash, Transaction}
+  alias Explorer.Chain.{Address, Block.SecondDegreeRelation, Gas, Hash, Transaction}
 
   @required_attrs ~w(difficulty gas_limit gas_used hash miner_hash nonce number parent_hash size timestamp
                      total_difficulty)a
@@ -72,7 +72,15 @@ defmodule Explorer.Chain.Block do
     timestamps()
 
     belongs_to(:miner, Address, foreign_key: :miner_hash, references: :hash, type: Hash.Address)
+
+    has_many(:nephew_relations, SecondDegreeRelation, foreign_key: :uncle_hash)
+    has_many(:nephews, through: [:nephew_relations, :nephew])
+
     belongs_to(:parent, __MODULE__, foreign_key: :parent_hash, references: :hash, type: Hash.Full)
+
+    has_many(:uncle_relations, SecondDegreeRelation, foreign_key: :nephew_hash)
+    has_many(:uncles, through: [:uncle_relations, :uncle])
+
     has_many(:transactions, Transaction)
   end
 

--- a/apps/explorer/lib/explorer/chain/block/second_degree_relation.ex
+++ b/apps/explorer/lib/explorer/chain/block/second_degree_relation.ex
@@ -1,0 +1,64 @@
+defmodule Explorer.Chain.Block.SecondDegreeRelation do
+  @moduledoc """
+  A [second-degree relative](https://en.wikipedia.org/wiki/Second-degree_relative) is a relative where the share
+  point is the parent's parent block in the chain.
+
+  For Ethereum, nephews are rewarded for included their uncles.
+
+  Uncles occur when a Proof-of-Work proof is completed slightly late, but before the next block is completes, so the
+  network knows about the late proof and can credit as an uncle in the next block.
+
+  This schema is the join schema between the `nephew` and the `uncle` it is is including the `uncle`.  The actual
+  `uncle` block is still a normal `t:Explorer.Chain.Block.t/0`.
+  """
+
+  use Explorer.Schema
+
+  alias Explorer.Chain.{Block, Hash}
+
+  @optional_fields ~w(uncle_fetched_at)a
+  @required_fields ~w(nephew_hash uncle_hash)a
+  @allowed_fields @optional_fields ++ @required_fields
+
+  @typedoc """
+   * `nephew` - `t:Explorer.Chain.Block.t/0` that included `hash` as an uncle.
+   * `nephew_hash` - foreign key for `nephew_block`.
+   * `uncle` - the uncle block.  Maybe `nil` when `uncle_fetched_at` is `nil`.  It could not be `nil` if the
+     `uncle_hash` was fetched for some other reason already.
+   * `uncle_fetched_at` - when `t:Explorer.Chain.Block.t/0` for `uncle_hash` was confirmed as fetched.
+   * `uncle_hash` - foreign key for `uncle`.
+  """
+  @type t ::
+          %__MODULE__{
+            nephew: %Ecto.Association.NotLoaded{} | Block.t(),
+            nephew_hash: Hash.Full.t(),
+            uncle: %Ecto.Association.NotLoaded{} | Block.t() | nil,
+            uncle_fetched_at: nil,
+            uncle_hash: Hash.Full.t()
+          }
+          | %__MODULE__{
+              nephew: %Ecto.Association.NotLoaded{} | Block.t(),
+              nephew_hash: Hash.Full.t(),
+              uncle: %Ecto.Association.NotLoaded{} | Block.t(),
+              uncle_fetched_at: DateTime.t(),
+              uncle_hash: Hash.Full.t()
+            }
+
+  @primary_key false
+  schema "block_second_degree_relations" do
+    field(:uncle_fetched_at, :utc_datetime)
+
+    belongs_to(:nephew, Block, foreign_key: :nephew_hash, references: :hash, type: Hash.Full)
+    belongs_to(:uncle, Block, foreign_key: :uncle_hash, references: :hash, type: Hash.Full)
+  end
+
+  def changeset(%__MODULE__{} = uncle, params) do
+    uncle
+    |> cast(params, @allowed_fields)
+    |> validate_required(@required_fields)
+    |> foreign_key_constraint(:nephew_hash)
+    |> unique_constraint(:nephew_hash, name: :uncle_hash_to_nephew_hash)
+    |> unique_constraint(:nephew_hash, name: :unfetched_uncles)
+    |> unique_constraint(:uncle_hash, name: :nephew_hash_to_uncle_hash)
+  end
+end

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -39,6 +39,10 @@ defmodule Explorer.Chain.Import do
           required(:params) => params,
           optional(:timeout) => timeout
         }
+  @type block_second_degree_relations_options :: %{
+          required(:params) => params,
+          optional(:timeout) => timeout
+        }
   @type internal_transactions_options :: %{
           required(:params) => params,
           optional(:timeout) => timeout
@@ -74,6 +78,7 @@ defmodule Explorer.Chain.Import do
           optional(:addresses) => addresses_options,
           optional(:balances) => balances_options,
           optional(:blocks) => blocks_options,
+          optional(:block_second_degree_relations) => block_second_degree_relations_options,
           optional(:broadcast) => boolean,
           optional(:internal_transactions) => internal_transactions_options,
           optional(:logs) => logs_options,
@@ -92,6 +97,9 @@ defmodule Explorer.Chain.Import do
                %{required(:address_hash) => Hash.Address.t(), required(:block_number) => Block.block_number()}
              ],
              optional(:blocks) => [Block.t()],
+             optional(:block_second_degree_relations) => [
+               %{required(:nephew_hash) => Hash.Full.t(), required(:uncle_hash) => Hash.Full.t()}
+             ],
              optional(:internal_transactions) => [
                %{required(:index) => non_neg_integer(), required(:transaction_hash) => Hash.Full.t()}
              ],
@@ -115,6 +123,7 @@ defmodule Explorer.Chain.Import do
   @insert_addresses_timeout 60_000
   @insert_balances_timeout 60_000
   @insert_blocks_timeout 60_000
+  @insert_block_second_degree_relations_timeout 60_000
   @insert_internal_transactions_timeout 60_000
   @insert_logs_timeout 60_000
   @insert_token_transfers_timeout 60_000
@@ -127,16 +136,17 @@ defmodule Explorer.Chain.Import do
 
   The import returns the unique key(s) for each type of record inserted.
 
-  | Key                      | Value Type                                                                                      | Value Description                                                                             |
-  |--------------------------|-------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
-  | `:addresses`             | `[Explorer.Chain.Address.t()]`                                                                  | List of `t:Explorer.Chain.Address.t/0`s                                                       |
-  | `:balances`              | `[%{address_hash: Explorer.Chain.Hash.t(), block_number: Explorer.Chain.Block.block_number()}]` | List of `t:Explorer.Chain.Address.t/0`s                                                       |
-  | `:blocks`                | `[Explorer.Chain.Block.t()]`                                                                    | List of `t:Explorer.Chain.Block.t/0`s                                                         |
-  | `:internal_transactions` | `[%{index: non_neg_integer(), transaction_hash: Explorer.Chain.Hash.t()}]`                      | List of maps of the `t:Explorer.Chain.InternalTransaction.t/0` `index` and `transaction_hash` |
-  | `:logs`                  | `[Explorer.Chain.Log.t()]`                                                                      | List of `t:Explorer.Chain.Log.t/0`s                                                           |
-  | `:token_transfers`       | `[Explorer.Chain.TokenTransfer.t()]`                                                            | List of `t:Explor.Chain.TokenTransfer.t/0`s                                                   |
-  | `:tokens`                | `[Explorer.Chain.Token.t()]`                                                                    | List of `t:Explorer.Chain.token.t/0`s                                                         |
-  | `:transactions`          | `[Explorer.Chain.Hash.t()]`                                                                     | List of `t:Explorer.Chain.Transaction.t/0` `hash`                                             |
+  | Key                              | Value Type                                                                                      | Value Description                                                                             |
+  |----------------------------------|-------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+  | `:addresses`                     | `[Explorer.Chain.Address.t()]`                                                                  | List of `t:Explorer.Chain.Address.t/0`s                                                       |
+  | `:balances`                      | `[%{address_hash: Explorer.Chain.Hash.t(), block_number: Explorer.Chain.Block.block_number()}]` | List of `t:Explorer.Chain.Address.t/0`s                                                       |
+  | `:blocks`                        | `[Explorer.Chain.Block.t()]`                                                                    | List of `t:Explorer.Chain.Block.t/0`s                                                         |
+  | `:internal_transactions`         | `[%{index: non_neg_integer(), transaction_hash: Explorer.Chain.Hash.t()}]`                      | List of maps of the `t:Explorer.Chain.InternalTransaction.t/0` `index` and `transaction_hash` |
+  | `:logs`                          | `[Explorer.Chain.Log.t()]`                                                                      | List of `t:Explorer.Chain.Log.t/0`s                                                           |
+  | `:token_transfers`               | `[Explorer.Chain.TokenTransfer.t()]`                                                            | List of `t:Explor.Chain.TokenTransfer.t/0`s                                                   |
+  | `:tokens`                        | `[Explorer.Chain.Token.t()]`                                                                    | List of `t:Explorer.Chain.token.t/0`s                                                         |
+  | `:transactions`                  | `[Explorer.Chain.Hash.t()]`                                                                     | List of `t:Explorer.Chain.Transaction.t/0` `hash`                                             |
+  | `:block_second_degree_relations` | `[%{uncle_hash: Explorer.Chain.Hash.t(), nephew_hash: Explorer.Chain.Hash.t()]`                 | List of maps `t:Explorer.Chain.Block.SecondDegreeRelation.t/0` `uncle_hash` and `nephew_hash` |
 
   The params for each key are validated using the corresponding `Ecto.Schema` module's `changeset/2` function.  If there
   are errors, they are returned in `Ecto.Changeset.t`s, so that the original, invalid value can be reconstructed for any
@@ -165,6 +175,9 @@ defmodule Explorer.Chain.Import do
     * `:blocks`
       * `:params` - `list` of params for `Explorer.Chain.Block.changeset/2`.
       * `:timeout` - the timeout for inserting all blocks. Defaults to `#{@insert_blocks_timeout}` milliseconds.
+    * `:block_second_degree_relations`
+      * `:params` - `list` of params `for `Explorer.Chain.Block.SecondDegreeRelation.changeset/2`.
+      * `:timeout` - the timeout for inserting all uncles found in the params list.
     * `:broadcast` - Boolean flag indicating whether or not to broadcast the event.
     * `:internal_transactions`
       * `:params` - `list` of params for `Explorer.Chain.InternalTransaction.changeset/2`.
@@ -198,6 +211,7 @@ defmodule Explorer.Chain.Import do
     * `:token_balances`
       * `:params` - `list` of params for `Explorer.Chain.TokenBalance.changeset/2`
     * `:timeout` - the timeout for `Repo.transaction`. Defaults to `#{@transaction_timeout}` milliseconds.
+
   """
   @spec all(all_options()) :: all_result()
   def all(options) when is_map(options) do
@@ -277,6 +291,7 @@ defmodule Explorer.Chain.Import do
     addresses: Address,
     balances: CoinBalance,
     blocks: Block,
+    block_second_degree_relations: Block.SecondDegreeRelation,
     internal_transactions: InternalTransaction,
     logs: Log,
     token_transfers: TokenTransfer,
@@ -294,6 +309,7 @@ defmodule Explorer.Chain.Import do
     |> run_addresses(ecto_schema_module_to_changes_list_map, full_options)
     |> run_balances(ecto_schema_module_to_changes_list_map, full_options)
     |> run_blocks(ecto_schema_module_to_changes_list_map, full_options)
+    |> run_block_second_degree_relations(ecto_schema_module_to_changes_list_map, full_options)
     |> run_transactions(ecto_schema_module_to_changes_list_map, full_options)
     |> run_internal_transactions(ecto_schema_module_to_changes_list_map, full_options)
     |> run_logs(ecto_schema_module_to_changes_list_map, full_options)
@@ -507,6 +523,25 @@ defmodule Explorer.Chain.Import do
     end
   end
 
+  defp run_block_second_degree_relations(multi, ecto_schema_module_to_changes_list, options)
+       when is_map(ecto_schema_module_to_changes_list) and is_map(options) do
+    case ecto_schema_module_to_changes_list do
+      %{Block.SecondDegreeRelation => block_second_degree_relations_changes} ->
+        Multi.run(multi, :block_second_degree_relations, fn _ ->
+          insert_block_second_degree_relations(
+            block_second_degree_relations_changes,
+            %{
+              timeout:
+                options[:block_second_degree_relations][:timeout] || @insert_block_second_degree_relations_timeout
+            }
+          )
+        end)
+
+      _ ->
+        multi
+    end
+  end
+
   @spec insert_addresses([%{hash: Hash.Address.t()}], %{
           required(:timeout) => timeout,
           required(:timestamps) => timestamps
@@ -654,6 +689,32 @@ defmodule Explorer.Chain.Import do
       )
 
     {:ok, blocks}
+  end
+
+  @spec insert_block_second_degree_relations([map()], %{required(:timeout) => timeout}) ::
+          {:ok, %{nephew_hash: Hash.Full.t(), uncle_hash: Hash.Full.t()}} | {:error, [Changeset.t()]}
+  defp insert_block_second_degree_relations(changes_list, %{timeout: timeout}) when is_list(changes_list) do
+    # order so that row ShareLocks are grabbed in a consistent order
+    ordered_changes_list = Enum.sort_by(changes_list, &{&1.nephew_hash, &1.uncle_hash})
+
+    insert_changes_list(ordered_changes_list,
+      conflict_target: [:nephew_hash, :uncle_hash],
+      on_conflict:
+        from(
+          block_second_degree_relation in Block.SecondDegreeRelation,
+          update: [
+            set: [
+              uncle_fetched_at:
+                fragment("LEAST(?, EXCLUDED.uncle_fetched_at)", block_second_degree_relation.uncle_fetched_at)
+            ]
+          ]
+        ),
+      for: Block.SecondDegreeRelation,
+      returning: [:nephew_hash, :uncle_hash],
+      timeout: timeout,
+      # block_second_degree_relations doesn't have timestamps
+      timestamps: %{}
+    )
   end
 
   @spec insert_internal_transactions([map], %{required(:timeout) => timeout, required(:timestamps) => timestamps}) ::

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -724,7 +724,7 @@ defmodule Explorer.Chain.Import do
     {:ok, blocks} =
       insert_changes_list(
         ordered_changes_list,
-        conflict_target: :number,
+        conflict_target: :hash,
         on_conflict: :replace_all,
         for: Block,
         returning: true,

--- a/apps/explorer/lib/explorer/chain/transaction/fork.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/fork.ex
@@ -1,0 +1,63 @@
+defmodule Explorer.Chain.Transaction.Fork do
+  @moduledoc """
+  A transaction fork has the same `hash` as a `t:Explorer.Chain.Transaction.t/0`, but associates that `hash` with a
+  non-consensus uncle `t:Explorer.Chain.Block.t/0` instead of the consensus block linked in the
+  `t:Explorer.Chain.Transaction.t/0` `block_hash`.
+  """
+
+  use Explorer.Schema
+
+  alias Explorer.Chain.{Block, Hash, Transaction}
+
+  @optional_attrs ~w()a
+  @required_attrs ~w(hash index uncle_hash)a
+  @allowed_attrs @optional_attrs ++ @required_attrs
+
+  @typedoc """
+   * `hash` - hash of contents of this transaction
+   * `index` - index of this transaction in `uncle`.
+   * `transaction` - the data shared between all forks and the consensus transaction.
+   * `uncle` - the block in which this transaction was mined/validated.
+   * `uncle_hash` - `uncle` foreign key.
+  """
+  @type t :: %__MODULE__{
+          hash: Hash.t(),
+          index: Transaction.transaction_index(),
+          transaction: %Ecto.Association.NotLoaded{} | Transaction.t(),
+          uncle: %Ecto.Association.NotLoaded{} | Block.t(),
+          uncle_hash: Hash.t()
+        }
+
+  @primary_key false
+  schema "transaction_forks" do
+    field(:index, :integer)
+
+    timestamps()
+
+    belongs_to(:transaction, Transaction, foreign_key: :hash, references: :hash, type: Hash.Full)
+    belongs_to(:uncle, Block, foreign_key: :uncle_hash, references: :hash, type: Hash.Full)
+  end
+
+  @doc """
+  All fields are required for transaction fork
+
+      iex> changeset = Fork.changeset(
+      ...>   %Fork{},
+      ...>   %{
+      ...>     hash: "0x3a3eb134e6792ce9403ea4188e5e79693de9e4c94e499db132be086400da79e6",
+      ...>     index: 1,
+      ...>     uncle_hash: "0xe52d77084cab13a4e724162bcd8c6028e5ecfaa04d091ee476e96b9958ed6b48"
+      ...>   }
+      ...> )
+      iex> changeset.valid?
+      true
+
+  """
+  def changeset(%__MODULE__{} = fork, attrs \\ %{}) do
+    fork
+    |> cast(attrs, @allowed_attrs)
+    |> validate_required(@required_attrs)
+    |> assoc_constraint(:transaction)
+    |> assoc_constraint(:uncle)
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20180117221922_create_blocks.exs
+++ b/apps/explorer/priv/repo/migrations/20180117221922_create_blocks.exs
@@ -3,6 +3,7 @@ defmodule Explorer.Repo.Migrations.CreateBlocks do
 
   def change do
     create table(:blocks, primary_key: false) do
+      add(:consensus, :boolean, null: false)
       add(:difficulty, :numeric, precision: 50)
       add(:gas_limit, :numeric, precision: 100, null: false)
       add(:gas_used, :numeric, precision: 100, null: false)
@@ -22,7 +23,7 @@ defmodule Explorer.Repo.Migrations.CreateBlocks do
     end
 
     create(index(:blocks, [:timestamp]))
-    create(unique_index(:blocks, [:parent_hash]))
-    create(unique_index(:blocks, [:number]))
+    create(index(:blocks, [:parent_hash], unique: true, where: ~s(consensus), name: :one_consensus_child_per_parent))
+    create(index(:blocks, [:number], unique: true, where: ~s(consensus), name: :one_consensus_block_at_height))
   end
 end

--- a/apps/explorer/priv/repo/migrations/20180917182319_create_block_second_degree_relations.exs
+++ b/apps/explorer/priv/repo/migrations/20180917182319_create_block_second_degree_relations.exs
@@ -1,0 +1,22 @@
+defmodule Explorer.Repo.Migrations.CreateBlockSecondDegreeRelations do
+  use Ecto.Migration
+
+  def change do
+    create table(:block_second_degree_relations, primary_key: false) do
+      add(:nephew_hash, references(:blocks, column: :hash, type: :bytea), null: false)
+      add(:uncle_hash, :bytea, null: false)
+      add(:uncle_fetched_at, :utc_datetime, default: fragment("NULL"), null: true)
+    end
+
+    create(unique_index(:block_second_degree_relations, [:nephew_hash, :uncle_hash], name: :nephew_hash_to_uncle_hash))
+
+    create(
+      unique_index(:block_second_degree_relations, [:nephew_hash, :uncle_hash],
+        name: :unfetched_uncles,
+        where: "uncle_fetched_at IS NULL"
+      )
+    )
+
+    create(unique_index(:block_second_degree_relations, [:uncle_hash, :nephew_hash], name: :uncle_hash_to_nephew_hash))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20180918200001_create_transaction_fork.exs
+++ b/apps/explorer/priv/repo/migrations/20180918200001_create_transaction_fork.exs
@@ -1,0 +1,16 @@
+defmodule Explorer.Repo.Migrations.CreateTransactionBlockUncles do
+  use Ecto.Migration
+
+  def change do
+    create table(:transaction_forks, primary_key: false) do
+      add(:hash, references(:transactions, column: :hash, on_delete: :delete_all, type: :bytea), null: false)
+      add(:index, :integer, null: false)
+      add(:uncle_hash, references(:blocks, column: :hash, on_delete: :delete_all, type: :bytea), null: false)
+
+      timestamps()
+    end
+
+    create(index(:transaction_forks, :uncle_hash))
+    create(unique_index(:transaction_forks, [:uncle_hash, :index]))
+  end
+end

--- a/apps/explorer/test/explorer/chain/block/second_degree_relation_test.exs
+++ b/apps/explorer/test/explorer/chain/block/second_degree_relation_test.exs
@@ -1,0 +1,50 @@
+defmodule Explorer.Chain.Block.SecondDegreeRelationTest do
+  use Explorer.DataCase, async: true
+
+  alias Ecto.Changeset
+  alias Explorer.Chain.Block
+
+  describe "changeset/2" do
+    test "requires hash and nephew_hash" do
+      assert %Changeset{valid?: false} =
+               changeset = Block.SecondDegreeRelation.changeset(%Block.SecondDegreeRelation{}, %{})
+
+      assert changeset_errors(changeset) == %{nephew_hash: ["can't be blank"], uncle_hash: ["can't be blank"]}
+
+      assert %Changeset{valid?: true} =
+               Block.SecondDegreeRelation.changeset(%Block.SecondDegreeRelation{}, %{
+                 nephew_hash: block_hash(),
+                 uncle_hash: block_hash()
+               })
+    end
+
+    test "allows uncle_fetched_at" do
+      assert %Changeset{changes: %{uncle_fetched_at: _}, valid?: true} =
+               Block.SecondDegreeRelation.changeset(%Block.SecondDegreeRelation{}, %{
+                 nephew_hash: block_hash(),
+                 uncle_hash: block_hash(),
+                 uncle_fetched_at: DateTime.utc_now()
+               })
+    end
+
+    test "enforces foreign key constraint on nephew_hash" do
+      assert {:error, %Changeset{valid?: false} = changeset} =
+               %Block.SecondDegreeRelation{}
+               |> Block.SecondDegreeRelation.changeset(%{nephew_hash: block_hash(), uncle_hash: block_hash()})
+               |> Repo.insert()
+
+      assert changeset_errors(changeset) == %{nephew_hash: ["does not exist"]}
+    end
+
+    test "enforces unique constraints on {nephew_hash, uncle_hash}" do
+      %Block.SecondDegreeRelation{nephew_hash: nephew_hash, uncle_hash: hash} = insert(:block_second_degree_relation)
+
+      assert {:error, %Changeset{valid?: false} = changeset} =
+               %Block.SecondDegreeRelation{}
+               |> Block.SecondDegreeRelation.changeset(%{nephew_hash: nephew_hash, uncle_hash: hash})
+               |> Repo.insert()
+
+      assert changeset_errors(changeset) == %{uncle_hash: ["has already been taken"]}
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -24,6 +24,7 @@ defmodule Explorer.Chain.ImportTest do
       blocks: %{
         params: [
           %{
+            consensus: true,
             difficulty: 340_282_366_920_938_463_463_374_607_431_768_211_454,
             gas_limit: 6_946_336,
             gas_used: 50450,
@@ -516,6 +517,7 @@ defmodule Explorer.Chain.ImportTest do
         blocks: %{
           params: [
             %{
+              consensus: true,
               difficulty: 340_282_366_920_938_463_463_374_607_431_768_211_454,
               gas_limit: 6_926_030,
               gas_used: 269_607,
@@ -605,6 +607,7 @@ defmodule Explorer.Chain.ImportTest do
         blocks: %{
           params: [
             %{
+              consensus: true,
               difficulty: 340_282_366_920_938_463_463_374_607_431_768_211_454,
               gas_limit: 6_926_030,
               gas_used: 269_607,
@@ -698,6 +701,7 @@ defmodule Explorer.Chain.ImportTest do
         blocks: %{
           params: [
             %{
+              consensus: true,
               difficulty: 340_282_366_920_938_463_463_374_607_431_768_211_454,
               gas_limit: 6_926_030,
               gas_used: 269_607,
@@ -788,6 +792,7 @@ defmodule Explorer.Chain.ImportTest do
                  blocks: %{
                    params: [
                      %{
+                       consensus: true,
                        difficulty: 340_282_366_920_938_463_463_374_607_431_768_211_454,
                        gas_limit: 6_946_336,
                        gas_used: 50450,
@@ -911,6 +916,7 @@ defmodule Explorer.Chain.ImportTest do
                  blocks: %{
                    params: [
                      %{
+                       consensus: true,
                        difficulty: 242_354_495_292_210,
                        gas_limit: 4_703_218,
                        gas_used: 1_009_480,
@@ -924,6 +930,7 @@ defmodule Explorer.Chain.ImportTest do
                        total_difficulty: 415_641_295_487_918_824_165
                      },
                      %{
+                       consensus: true,
                        difficulty: 247_148_243_947_046,
                        gas_limit: 4_704_624,
                        gas_used: 363_000,

--- a/apps/explorer/test/explorer/chain/transaction/fork_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction/fork_test.exs
@@ -1,0 +1,23 @@
+defmodule Explorer.Chain.Transaction.ForkTest do
+  use Explorer.DataCase
+
+  alias Ecto.Changeset
+  alias Explorer.Chain.Transaction.Fork
+
+  doctest Fork
+
+  test "a transaction fork cannot be inserted if the corresponding transaction does not exist" do
+    assert %Changeset{valid?: true} = changeset = Fork.changeset(%Fork{}, params_for(:transaction_fork))
+
+    assert {:error, %Changeset{errors: [transaction: {"does not exist", []}]}} = Repo.insert(changeset)
+  end
+
+  test "a transaction fork cannot be inserted if the corresponding uncle does not exist" do
+    transaction = insert(:transaction)
+
+    assert %Changeset{valid?: true} =
+             changeset = Fork.changeset(%Fork{}, %{hash: transaction.hash, index: 0, uncle_hash: block_hash()})
+
+    assert {:error, %Changeset{errors: [uncle: {"does not exist", []}]}} = Repo.insert(changeset)
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -684,6 +684,14 @@ defmodule Explorer.ChainTest do
           }
         ]
       },
+      block_second_degree_relations: %{
+        params: [
+          %{
+            nephew_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
+            uncle_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471be"
+          }
+        ]
+      },
       broadcast: true,
       internal_transactions: %{
         params: [

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1,6 +1,9 @@
 defmodule Explorer.ChainTest do
   use Explorer.DataCase
 
+  require Ecto.Query
+
+  import Ecto.Query
   import Explorer.Factory
 
   alias Explorer.{Chain, Factory, PagingOptions, Repo}
@@ -670,6 +673,7 @@ defmodule Explorer.ChainTest do
       blocks: %{
         params: [
           %{
+            consensus: true,
             difficulty: 340_282_366_920_938_463_463_374_607_431_768_211_454,
             gas_limit: 6_946_336,
             gas_used: 50450,
@@ -825,6 +829,7 @@ defmodule Explorer.ChainTest do
                 ],
                 blocks: [
                   %Block{
+                    consensus: true,
                     difficulty: ^difficulty,
                     gas_limit: ^gas_limit,
                     gas_used: ^gas_used,

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -132,6 +132,13 @@ defmodule Explorer.Factory do
     sequence("block_number", & &1)
   end
 
+  def block_second_degree_relation_factory do
+    %Block.SecondDegreeRelation{
+      uncle_hash: block_hash(),
+      nephew: build(:block)
+    }
+  end
+
   def with_block(%Transaction{index: nil} = transaction) do
     with_block(transaction, insert(:block))
   end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -105,6 +105,7 @@ defmodule Explorer.Factory do
 
   def block_factory do
     %Block{
+      consensus: true,
       number: block_number(),
       hash: block_hash(),
       parent_hash: block_hash(),

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -428,6 +428,14 @@ defmodule Explorer.Factory do
     data(:transaction_input)
   end
 
+  def transaction_fork_factory do
+    %Transaction.Fork{
+      hash: transaction_hash(),
+      index: 0,
+      uncle_hash: block_hash()
+    }
+  end
+
   def smart_contract_factory() do
     %SmartContract{
       address_hash: insert(:address).hash,

--- a/apps/indexer/lib/indexer/address/coin_balances.ex
+++ b/apps/indexer/lib/indexer/address/coin_balances.ex
@@ -32,6 +32,10 @@ defmodule Indexer.Address.CoinBalances do
     Enum.reduce(transactions_params, initial, &transactions_params_reducer/2)
   end
 
+  defp reducer({:block_second_degree_relations_params, block_second_degree_relations_params}, initial)
+       when is_list(block_second_degree_relations_params),
+       do: initial
+
   defp internal_transactions_params_reducer(%{block_number: block_number} = internal_transaction_params, acc)
        when is_integer(block_number) do
     case internal_transaction_params do

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -120,6 +120,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
 
   defp async_import_remaining_block_data(
          %{
+           block_second_degree_relations: block_second_degree_relations,
            transactions: transaction_hashes,
            addresses: address_hashes,
            tokens: tokens,
@@ -149,6 +150,10 @@ defmodule Indexer.Block.Catchup.Fetcher do
     |> Token.Fetcher.async_fetch()
 
     TokenBalance.Fetcher.async_fetch(token_balances)
+
+    block_second_degree_relations
+    |> Enum.map(& &1.uncle_hash)
+    |> Block.Uncle.Fetcher.async_fetch_blocks()
   end
 
   defp stream_fetch_and_import(%__MODULE__{blocks_concurrency: blocks_concurrency} = state, sequence)

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -105,7 +105,10 @@ defmodule Indexer.Block.Catchup.Fetcher do
     {async_import_remaning_block_data_options, chain_import_options} =
       Map.split(options, @async_import_remaning_block_data_options)
 
-    with {:ok, results} = ok <- Chain.import(chain_import_options) do
+    with {:ok, results} = ok <-
+           chain_import_options
+           |> put_in([:blocks, :params, Access.all(), :consensus], true)
+           |> Chain.import() do
       async_import_remaining_block_data(
         results,
         async_import_remaning_block_data_options

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -92,7 +92,11 @@ defmodule Indexer.Block.Fetcher do
       when broadcast in ~w(true false)a and callback_module != nil do
     with {:blocks, {:ok, next, result}} <-
            {:blocks, EthereumJSONRPC.fetch_blocks_by_range(range, json_rpc_named_arguments)},
-         %{blocks: blocks, transactions: transactions_without_receipts, block_second_degree_relations: block_second_degree_relations} = result,
+         %{
+           blocks: blocks,
+           transactions: transactions_without_receipts,
+           block_second_degree_relations: block_second_degree_relations
+         } = result,
          {:receipts, {:ok, receipt_params}} <- {:receipts, Receipts.fetch(state, transactions_without_receipts)},
          %{logs: logs, receipts: receipts} = receipt_params,
          transactions_with_receipts = Receipts.put(transactions_without_receipts, receipts),
@@ -112,10 +116,9 @@ defmodule Indexer.Block.Fetcher do
            }),
          token_balances = TokenBalances.params_set(%{token_transfers_params: token_transfers}),
          {:ok, inserted} <-
-           import_range(
+           __MODULE__.import(
              state,
              %{
-               range: range,
                addresses: %{params: addresses},
                balances: %{params: coin_balances_params_set},
                token_balances: %{params: token_balances},
@@ -136,11 +139,11 @@ defmodule Indexer.Block.Fetcher do
     end
   end
 
-  defp import_range(
-         %__MODULE__{broadcast: broadcast, callback_module: callback_module} = state,
-         options
-       )
-       when is_map(options) do
+  def import(
+        %__MODULE__{broadcast: broadcast, callback_module: callback_module} = state,
+        options
+      )
+      when is_map(options) do
     {address_hash_to_fetched_balance_block_number, import_options} =
       pop_address_hash_to_fetched_balance_block_number(options)
 

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -26,6 +26,7 @@ defmodule Indexer.Block.Fetcher do
                 addresses: Import.addresses_options(),
                 balances: Import.balances_options(),
                 blocks: Import.blocks_options(),
+                block_second_degree_relations: Import.block_second_degree_relations_options(),
                 broadcast: boolean,
                 logs: Import.logs_options(),
                 receipts: Import.receipts_options(),
@@ -91,7 +92,7 @@ defmodule Indexer.Block.Fetcher do
       when broadcast in ~w(true false)a and callback_module != nil do
     with {:blocks, {:ok, next, result}} <-
            {:blocks, EthereumJSONRPC.fetch_blocks_by_range(range, json_rpc_named_arguments)},
-         %{blocks: blocks, transactions: transactions_without_receipts} = result,
+         %{blocks: blocks, transactions: transactions_without_receipts, block_second_degree_relations: block_second_degree_relations} = result,
          {:receipts, {:ok, receipt_params}} <- {:receipts, Receipts.fetch(state, transactions_without_receipts)},
          %{logs: logs, receipts: receipts} = receipt_params,
          transactions_with_receipts = Receipts.put(transactions_without_receipts, receipts),
@@ -119,6 +120,7 @@ defmodule Indexer.Block.Fetcher do
                balances: %{params: coin_balances_params_set},
                token_balances: %{params: token_balances},
                blocks: %{params: blocks},
+               block_second_degree_relations: %{params: block_second_degree_relations},
                logs: %{params: logs},
                receipts: %{params: receipts},
                token_transfers: %{params: token_transfers},

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -104,6 +104,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
            options
            |> Map.drop(@import_options)
            |> put_in([:addresses, :params], balances_addresses_params)
+           |> put_in([:blocks, :params, Access.all(), :consensus], true)
            |> put_in([Access.key(:balances, %{}), :params], balances_params)
            |> put_in([Access.key(:internal_transactions, %{}), :params], internal_transactions_params)
            |> put_in([Access.key(:token_balances), :params], token_balances),

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -173,10 +173,14 @@ defmodule Indexer.Block.Realtime.Fetcher do
     end
   end
 
-  defp async_import_remaining_block_data(%{tokens: tokens}) do
+  defp async_import_remaining_block_data(%{block_second_degree_relations: block_second_degree_relations, tokens: tokens}) do
     tokens
     |> Enum.map(& &1.contract_address_hash)
     |> Token.Fetcher.async_fetch()
+
+    block_second_degree_relations
+    |> Enum.map(& &1.uncle_hash)
+    |> Block.Uncle.Fetcher.async_fetch_blocks()
   end
 
   defp internal_transactions(

--- a/apps/indexer/lib/indexer/block/supervisor.ex
+++ b/apps/indexer/lib/indexer/block/supervisor.ex
@@ -4,7 +4,7 @@ defmodule Indexer.Block.Supervisor do
   """
 
   alias Indexer.Block
-  alias Indexer.Block.{Catchup, Realtime}
+  alias Indexer.Block.{Catchup, Realtime, Uncle}
 
   use Supervisor
 
@@ -27,7 +27,8 @@ defmodule Indexer.Block.Supervisor do
          [
            %{block_fetcher: block_fetcher, subscribe_named_arguments: subscribe_named_arguments},
            [name: Realtime.Supervisor]
-         ]}
+         ]},
+        {Uncle.Supervisor, [[block_fetcher: block_fetcher], [name: Uncle.Supervisor]]}
       ],
       strategy: :one_for_one
     )

--- a/apps/indexer/lib/indexer/block/uncle/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/uncle/fetcher.ex
@@ -1,0 +1,154 @@
+defmodule Indexer.Block.Uncle.Fetcher do
+  @moduledoc """
+  Fetches `t:Explorer.Chain.Block.t/0` by `hash` and updates `t:Explorer.Chain.Block.SecondDegreeRelation.t/0`
+  `uncle_fetched_at` where the `uncle_hash` matches `hash`.
+  """
+
+  require Logger
+
+  alias Explorer.Chain
+  alias Explorer.Chain.Hash
+  alias Indexer.{AddressExtraction, Block, BufferedTask}
+
+  @behaviour Block.Fetcher
+  @behaviour BufferedTask
+
+  @defaults [
+    flush_interval: :timer.seconds(3),
+    max_batch_size: 10,
+    max_concurrency: 10,
+    init_chunk_size: 1000,
+    task_supervisor: Indexer.Block.Uncle.TaskSupervisor
+  ]
+
+  @doc """
+  Asynchronously fetches `t:Explorer.Chain.Block.t/0` for the given `hashes` and updates
+  `t:Explorer.Chain.Block.SecondDegreeRelation.t/0` `block_fetched_at`.
+  """
+  @spec async_fetch_blocks([Hash.Full.t()]) :: :ok
+  def async_fetch_blocks(block_hashes) when is_list(block_hashes) do
+    BufferedTask.buffer(
+      __MODULE__,
+      block_hashes
+      |> Enum.map(&to_string/1)
+      |> Enum.uniq()
+    )
+  end
+
+  @doc false
+  def child_spec([init_options, gen_server_options]) when is_list(init_options) do
+    {state, mergeable_init_options} = Keyword.pop(init_options, :block_fetcher)
+
+    unless state do
+      raise ArgumentError,
+            ":json_rpc_named_arguments must be provided to `#{__MODULE__}.child_spec " <>
+              "to allow for json_rpc calls when running."
+    end
+
+    merged_init_options =
+      @defaults
+      |> Keyword.merge(mergeable_init_options)
+      |> Keyword.put(:state, %Block.Fetcher{state | broadcast: false, callback_module: __MODULE__})
+
+    Supervisor.child_spec({BufferedTask, [{__MODULE__, merged_init_options}, gen_server_options]}, id: __MODULE__)
+  end
+
+  @impl BufferedTask
+  def init(initial, reducer, _) do
+    {:ok, final} =
+      Chain.stream_unfetched_uncle_hashes(initial, fn uncle_hash, acc ->
+        uncle_hash
+        |> to_string()
+        |> reducer.(acc)
+      end)
+
+    final
+  end
+
+  @impl BufferedTask
+  def run(hashes, _retries, %Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments} = block_fetcher) do
+    # the same block could be included as an uncle on multiple blocks, but we only want to fetch it once
+    unique_hashes = Enum.uniq(hashes)
+
+    Logger.debug(fn -> "fetching #{length(unique_hashes)} uncle blocks" end)
+
+    case EthereumJSONRPC.fetch_blocks_by_hash(unique_hashes, json_rpc_named_arguments) do
+      {:ok,
+       %{
+         blocks: blocks_params,
+         transactions: transactions_params,
+         block_second_degree_relations: block_second_degree_relations_params
+       }} ->
+        addresses_params =
+          AddressExtraction.extract_addresses(%{blocks: blocks_params, transactions: transactions_params})
+
+        {:ok, _} =
+          Block.Fetcher.import(block_fetcher, %{
+            addresses: %{params: addresses_params},
+            blocks: %{params: blocks_params},
+            block_second_degree_relations: %{params: block_second_degree_relations_params},
+            transactions: %{params: transactions_params, on_conflict: :nothing}
+          })
+
+        :ok
+
+      {:error, reason} ->
+        Logger.debug(fn -> "failed to fetch #{length(unique_hashes)} uncle blocks, #{inspect(reason)}" end)
+        {:retry, unique_hashes}
+    end
+  end
+
+  @impl Block.Fetcher
+  def import(_, options) when is_map(options) do
+    with {:ok, %{block_second_degree_relations: block_second_degree_relations}} = ok <-
+           options
+           |> uncle_blocks()
+           |> fork_transactions()
+           |> Chain.import() do
+      # * CoinBalance.Fetcher.async_fetch_balances is not called because uncles don't affect balances
+      # * InternalTransaction.Fetcher.async_fetch is not called because internal transactions are based on transaction
+      #   hash, which is shared with transaction on consensus blocks.
+      # * Token.Fetcher.async_fetch is not called because the tokens only matter on consensus blocks
+      # * TokenBalance.Fetcher.async_fetch is not called because it uses block numbers from consensus, not uncles
+
+      block_second_degree_relations
+      |> Enum.map(& &1.uncle_hash)
+      |> Block.Uncle.Fetcher.async_fetch_blocks()
+
+      ok
+    end
+  end
+
+  defp uncle_blocks(chain_import_options) do
+    put_in(chain_import_options, [:blocks, :params, Access.all(), :consensus], false)
+  end
+
+  defp fork_transactions(chain_import_options) do
+    transactions_params = chain_import_options[:transactions][:params] || []
+
+    chain_import_options
+    |> put_in([:transactions, :params], forked_transactions_params(transactions_params))
+    |> put_in([Access.key(:transaction_forks, %{}), :params], transaction_forks_params(transactions_params))
+  end
+
+  defp forked_transactions_params(transactions_params) do
+    # With no block_hash, there will be a collision for the same hash when a transaction is used in more than 1 uncle,
+    # so use MapSet to prevent duplicate row errors.
+    MapSet.new(transactions_params, fn transaction_params ->
+      Map.merge(transaction_params, %{
+        block_hash: nil,
+        block_number: nil,
+        index: nil,
+        gas_used: nil,
+        cumulative_gas_used: nil,
+        status: nil
+      })
+    end)
+  end
+
+  defp transaction_forks_params(transactions_params) do
+    Enum.map(transactions_params, fn %{block_hash: uncle_hash, index: index, hash: hash} ->
+      %{uncle_hash: uncle_hash, index: index, hash: hash}
+    end)
+  end
+end

--- a/apps/indexer/lib/indexer/block/uncle/supervisor.ex
+++ b/apps/indexer/lib/indexer/block/uncle/supervisor.ex
@@ -1,0 +1,38 @@
+defmodule Indexer.Block.Uncle.Supervisor do
+  @moduledoc """
+  Supervises `Indexer.Block.Uncle.Fetcher`.
+  """
+
+  use Supervisor
+
+  alias Indexer.Block.Uncle.Fetcher
+
+  def child_spec([init_arguments]) do
+    child_spec([init_arguments, []])
+  end
+
+  def child_spec([_init_arguments, _gen_server_options] = start_link_arguments) do
+    default = %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, start_link_arguments},
+      type: :supervisor
+    }
+
+    Supervisor.child_spec(default, [])
+  end
+
+  def start_link(arguments, gen_server_options \\ []) do
+    Supervisor.start_link(__MODULE__, arguments, gen_server_options)
+  end
+
+  @impl Supervisor
+  def init(fetcher_arguments) do
+    Supervisor.init(
+      [
+        {Task.Supervisor, name: Indexer.Block.Uncle.TaskSupervisor},
+        {Fetcher, [fetcher_arguments, [name: Fetcher]]}
+      ],
+      strategy: :rest_for_one
+    )
+  end
+end

--- a/apps/indexer/test/indexer/address/coin_balances_test.exs
+++ b/apps/indexer/test/indexer/address/coin_balances_test.exs
@@ -11,10 +11,20 @@ defmodule Indexer.Address.CoinBalancesTest do
         |> to_string()
 
       block_number = 1
+
       params_set = CoinBalances.params_set(%{blocks_params: [%{miner_hash: miner_hash, number: block_number}]})
 
       assert MapSet.size(params_set) == 1
       assert %{address_hash: miner_hash, block_number: block_number}
+    end
+
+    test "with block second degree relations extracts nothing" do
+      params_set =
+        CoinBalances.params_set(%{
+          block_second_degree_relations_params: [%{nephew_hash: Factory.block_hash(), uncle_hash: Factory.block_hash()}]
+        })
+
+      assert MapSet.size(params_set) == 0
     end
 
     test "with call internal transaction extracts nothing" do

--- a/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
@@ -8,7 +8,7 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisorTest do
 
   alias Explorer.Chain.Block
   alias Indexer.{BoundInterval, CoinBalance, InternalTransaction, Token, TokenBalance}
-  alias Indexer.Block.Catchup
+  alias Indexer.Block.{Catchup, Uncle}
 
   @moduletag capture_log: true
 
@@ -202,6 +202,10 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisorTest do
       Token.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       TokenBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
 
+      Uncle.Supervisor.Case.start_supervised!(
+        block_fetcher: %Indexer.Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments}
+      )
+
       Catchup.Supervisor.Case.start_supervised!(%{
         block_fetcher: %Indexer.Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments}
       })
@@ -323,6 +327,10 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisorTest do
       InternalTransaction.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       Token.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       TokenBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+      Uncle.Supervisor.Case.start_supervised!(
+        block_fetcher: %Indexer.Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments}
+      )
 
       # from `setup :state`
       assert_received :catchup_index

--- a/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
@@ -301,7 +301,8 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisorTest do
                "size" => "0x0",
                "timestamp" => "0x0",
                "totalDifficulty" => "0x0",
-               "transactions" => []
+               "transactions" => [],
+               "uncles" => []
              }
            }
          ]}

--- a/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
@@ -1,0 +1,115 @@
+defmodule Indexer.Block.Catchup.FetcherTest do
+  use EthereumJSONRPC.Case, async: false
+  use Explorer.DataCase
+
+  import Mox
+
+  alias Indexer.{Block, CoinBalance, InternalTransaction, Token, TokenBalance}
+  alias Indexer.Block.Catchup.Fetcher
+
+  @moduletag capture_log: true
+
+  # MUST use global mode because we aren't guaranteed to get `start_supervised`'s pid back fast enough to `allow` it to
+  # use expectations and stubs from test's pid.
+  setup :set_mox_global
+
+  setup :verify_on_exit!
+
+  setup do
+    # Uncle don't occur on POA chains, so there's no way to test this using the public addresses, so mox-only testing
+    %{
+      json_rpc_named_arguments: [
+        transport: EthereumJSONRPC.Mox,
+        transport_options: [],
+        # Which one does not matter, so pick one
+        variant: EthereumJSONRPC.Parity
+      ]
+    }
+  end
+
+  describe "import/1" do
+    test "fetches uncles asynchronously", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      CoinBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+      InternalTransaction.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+      Token.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+      TokenBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+      parent = self()
+
+      pid =
+        spawn_link(fn ->
+          receive do
+            {:"$gen_call", from, {:buffer, uncles}} ->
+              GenServer.reply(from, :ok)
+              send(parent, {:uncles, uncles})
+          end
+        end)
+
+      Process.register(pid, Block.Uncle.Fetcher)
+
+      nephew_hash = block_hash() |> to_string()
+      uncle_hash = block_hash() |> to_string()
+      miner_hash = address_hash() |> to_string()
+      block_number = 0
+
+      assert {:ok, _} =
+               Fetcher.import(%Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments}, %{
+                 addresses: %{
+                   params: [
+                     %{hash: miner_hash}
+                   ]
+                 },
+                 address_hash_to_fetched_balance_block_number: %{miner_hash => block_number},
+                 balances: %{
+                   params: [
+                     %{
+                       address_hash: miner_hash,
+                       block_number: block_number
+                     }
+                   ]
+                 },
+                 blocks: %{
+                   params: [
+                     %{
+                       difficulty: 0,
+                       gas_limit: 21000,
+                       gas_used: 21000,
+                       miner_hash: miner_hash,
+                       nonce: 0,
+                       number: block_number,
+                       parent_hash:
+                         block_hash()
+                         |> to_string(),
+                       size: 0,
+                       timestamp: DateTime.utc_now(),
+                       total_difficulty: 0,
+                       hash: nephew_hash
+                     }
+                   ]
+                 },
+                 block_second_degree_relations: %{
+                   params: [
+                     %{
+                       nephew_hash: nephew_hash,
+                       uncle_hash: uncle_hash
+                     }
+                   ]
+                 },
+                 tokens: %{
+                   params: [],
+                   on_conflict: :nothing
+                 },
+                 token_balances: %{
+                   params: []
+                 },
+                 transactions: %{
+                   params: [],
+                   on_conflict: :nothing
+                 },
+                 transaction_hash_to_block_number: %{}
+               })
+
+      assert_receive {:uncles, [^uncle_hash]}
+    end
+  end
+end

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -10,7 +10,7 @@ defmodule Indexer.Block.FetcherTest do
   alias Explorer.Chain
   alias Explorer.Chain.{Address, Log, Transaction, Wei}
   alias Indexer.{CoinBalance, BufferedTask, InternalTransaction, Token, TokenBalance}
-  alias Indexer.Block.Fetcher
+  alias Indexer.Block.{Fetcher, Uncle}
 
   @moduletag capture_log: true
 
@@ -44,6 +44,10 @@ defmodule Indexer.Block.FetcherTest do
       InternalTransaction.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       Token.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       TokenBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+      Uncle.Supervisor.Case.start_supervised!(
+        block_fetcher: %Fetcher{json_rpc_named_arguments: json_rpc_named_arguments}
+      )
 
       %{
         block_fetcher: %Fetcher{

--- a/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
@@ -1,4 +1,4 @@
-defmodule Indexer.BlockFetcher.RealtimeTest do
+defmodule Indexer.Block.Realtime.FetcherTest do
   use EthereumJSONRPC.Case, async: false
   use Explorer.DataCase
 
@@ -7,7 +7,7 @@ defmodule Indexer.BlockFetcher.RealtimeTest do
   alias Explorer.Chain
   alias Explorer.Chain.Address
   alias Indexer.{Sequence, Token}
-  alias Indexer.Block.Realtime
+  alias Indexer.Block.{Realtime, Uncle}
 
   @moduletag capture_log: true
 
@@ -36,7 +36,7 @@ defmodule Indexer.BlockFetcher.RealtimeTest do
     %{block_fetcher: block_fetcher, json_rpc_named_arguments: core_json_rpc_named_arguments}
   end
 
-  describe "Indexer.BlockFetcher.stream_import/1" do
+  describe "Indexer.Block.Fetcher.fetch_and_import_range/1" do
     @tag :no_geth
     test "in range with internal transactions", %{
       block_fetcher: %Indexer.Block.Fetcher{} = block_fetcher,
@@ -46,6 +46,10 @@ defmodule Indexer.BlockFetcher.RealtimeTest do
       Sequence.cap(sequence)
 
       Token.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+      Uncle.Supervisor.Case.start_supervised!(
+        block_fetcher: %Indexer.Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments}
+      )
 
       if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
         EthereumJSONRPC.Mox
@@ -122,7 +126,7 @@ defmodule Indexer.BlockFetcher.RealtimeTest do
                    }
                  ],
                  "transactionsRoot" => "0xd7c39a93eafe0bdcbd1324c13dcd674bed8c9fa8adbf8f95bf6a59788985da6f",
-                 "uncles" => []
+                 "uncles" => ["0xa4ec735cabe1510b5ae081b30f17222580b4588dbec52830529753a688b046cd"]
                }
              },
              %{

--- a/apps/indexer/test/indexer/block/uncle/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/uncle/fetcher_test.exs
@@ -1,0 +1,126 @@
+defmodule Indexer.Block.Uncle.FetcherTest do
+  # MUST be `async: false` so that {:shared, pid} is set for connection to allow CoinBalanceFetcher's self-send to have
+  # connection allowed immediately.
+  use EthereumJSONRPC.Case, async: false
+  use Explorer.DataCase
+
+  alias Explorer.Chain
+  alias Indexer.Block
+
+  import Mox
+
+  @moduletag :capture_log
+
+  # MUST use global mode because we aren't guaranteed to get `start_supervised`'s pid back fast enough to `allow` it to
+  # use expectations and stubs from test's pid.
+  setup :set_mox_global
+
+  setup :verify_on_exit!
+
+  setup do
+    # Uncle don't occur on POA chains, so there's no way to test this using the public addresses, so mox-only testing
+    %{
+      json_rpc_named_arguments: [
+        transport: EthereumJSONRPC.Mox,
+        transport_options: [],
+        # Which one does not matter, so pick one
+        variant: EthereumJSONRPC.Parity
+      ]
+    }
+  end
+
+  describe "child_spec/1" do
+    test "raises ArgumentError is `json_rpc_named_arguments is not provided" do
+      assert_raise ArgumentError,
+                   ":json_rpc_named_arguments must be provided to `Elixir.Indexer.Block.Uncle.Fetcher.child_spec " <>
+                     "to allow for json_rpc calls when running.",
+                   fn ->
+                     start_supervised({Block.Uncle.Fetcher, [[], []]})
+                   end
+    end
+  end
+
+  describe "init/1" do
+    test "fetched unfetched uncle hashes", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      assert %Chain.Block.SecondDegreeRelation{nephew_hash: nephew_hash, uncle_hash: uncle_hash, uncle: nil} =
+               :block_second_degree_relation
+               |> insert()
+               |> Repo.preload([:nephew, :uncle])
+
+      uncle_hash_data = to_string(uncle_hash)
+      uncle_uncle_hash_data = to_string(block_hash())
+
+      EthereumJSONRPC.Mox
+      |> expect(:json_rpc, fn [%{method: "eth_getBlockByHash", params: [^uncle_hash_data, true]}], _ ->
+        number_quantity = "0x0"
+
+        {:ok,
+         [
+           %{
+             result: %{
+               "author" => "0xe2ac1c6843a33f81ae4935e5ef1277a392990381",
+               "difficulty" => "0xfffffffffffffffffffffffffffffffe",
+               "extraData" => "0xd583010a068650617269747986312e32362e32826c69",
+               "gasLimit" => "0x7a1200",
+               "gasUsed" => "0x0",
+               "hash" => uncle_hash_data,
+               "logsBloom" => "0x",
+               "miner" => "0xe2ac1c6843a33f81ae4935e5ef1277a392990381",
+               "number" => number_quantity,
+               "parentHash" => "0x006edcaa1e6fde822908783bc4ef1ad3675532d542fce53537557391cfe34c3c",
+               "size" => "0x243",
+               "timestamp" => "0x5b437f41",
+               "totalDifficulty" => "0x342337ffffffffffffffffffffffffed8d29bb",
+               "transactions" => [
+                 %{
+                   "blockHash" => uncle_hash_data,
+                   "blockNumber" => number_quantity,
+                   "chainId" => "0x4d",
+                   "condition" => nil,
+                   "creates" => "0xffc87239eb0267bc3ca2cd51d12fbf278e02ccb4",
+                   "from" => "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+                   "gas" => "0x47b760",
+                   "gasPrice" => "0x174876e800",
+                   "hash" => "0x3a3eb134e6792ce9403ea4188e5e79693de9e4c94e499db132be086400da79e6",
+                   "input" => "0x",
+                   "nonce" => "0x0",
+                   "r" => "0xad3733df250c87556335ffe46c23e34dbaffde93097ef92f52c88632a40f0c75",
+                   "s" => "0x72caddc0371451a58de2ca6ab64e0f586ccdb9465ff54e1c82564940e89291e3",
+                   "standardV" => "0x0",
+                   "to" => nil,
+                   "transactionIndex" => "0x0",
+                   "v" => "0xbd",
+                   "value" => "0x0"
+                 }
+               ],
+               "uncles" => [uncle_uncle_hash_data]
+             }
+           }
+         ]}
+      end)
+
+      Block.Uncle.Supervisor.Case.start_supervised!(
+        block_fetcher: %Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments}
+      )
+
+      wait(fn ->
+        Repo.one!(
+          from(bsdr in Chain.Block.SecondDegreeRelation,
+            where: bsdr.nephew_hash == ^nephew_hash and not is_nil(bsdr.uncle_fetched_at)
+          )
+        )
+      end)
+
+      refute is_nil(Repo.get(Chain.Block, uncle_hash))
+      assert Repo.aggregate(Chain.Transaction.Fork, :count, :hash) == 1
+    end
+  end
+
+  defp wait(producer) do
+    producer.()
+  rescue
+    Ecto.NoResultsError ->
+      Process.sleep(100)
+      wait(producer)
+  end
+end

--- a/apps/indexer/test/support/indexer/block/uncle/supervisor/case.ex
+++ b/apps/indexer/test/support/indexer/block/uncle/supervisor/case.ex
@@ -1,0 +1,18 @@
+defmodule Indexer.Block.Uncle.Supervisor.Case do
+  alias Indexer.Block
+
+  def start_supervised!(fetcher_arguments \\ []) when is_list(fetcher_arguments) do
+    merged_fetcher_arguments =
+      Keyword.merge(
+        fetcher_arguments,
+        flush_interval: 50,
+        init_chunk_size: 1,
+        max_batch_size: 1,
+        max_concurrency: 1
+      )
+
+    [merged_fetcher_arguments]
+    |> Block.Uncle.Supervisor.child_spec()
+    |> ExUnit.Callbacks.start_supervised!()
+  end
+end


### PR DESCRIPTION
Resolves #643

## Test Plan

1. Get ETC URLs from @acravenho or Slack pin
2. `mix do ecto.drop, ecto.create, ecto.migrate
3. `rm -rf logs
4.  In separate terminal `watch ls -la logs/dev`
5. `iex -S mix`
6. Let indexer run for a few minutes
7. Setup
    ```
    require Ecto.Query
    import Ecto.Query
    ```
8. Count number of consensus blocks: `Explorer.Repo.aggregate(from(block in Explorer.Chain.Block, where: not block.consensus), :count, :hash)`
9. Count number of non-consensus blocks:  `Explorer.Repo.aggregate(from(block in Explorer.Chain.Block, where: block.consensus), :count, :hash)`
10. Count number of unfetched non-consensus blocks: `Explorer.Chain.stream_unfetched_uncle_hashes([], &[&1 | &2]) |> elem(1) |> length()`
11. Count number of transaction forks: `Explorer.Repo.aggregate(Explorer.Chain.Transaction.Fork, :count, :hash)`

## Test Report

Tested against ETC locally.  `iex` was used to count the number of consensus, non-consensus, and unfetched uncle blocks.

8. `878`
9. `26908`
10. `9`
11. `7910`

## Changelog

### Enhancements
* `EthereumJSONRPC.Block.elixir_to_params` now returns the uncles as `[%{hash: hash}]`.
* The nephews and uncles are [second-degree relatives](https://en.wikipedia.org/wiki/Second-degree_relative), so their link is a second-degree relation.  As such, `Explorer.Chain.Block.SecondDegreeRelation` is a join schema between the `nephew_hash` of the block that included an uncle and the `uncle_hash` that was included.  `uncle_fetched_at` is used to track which uncles have been fetched as is done with other asynchronous fetches, such as coin balances.
* Blocks in the consensus (longest) chain are marked `consensus: true` in a new field and column.  Uncle blocks and their uncles, etc are not on the consensus chain and so marked `consensus: false`.
* `Explorer.Chain.Transaction.Fork` is used to record information about an `Explorer.Chain.Transaction` when it is collated into a non-consensus `Explorer.Chain.Block`.  This is done as the consensus block information is in fields (`block`, `block_hash`, `cumulative_gas_used`, and `status`) directly on the transaction.  Because these receipt fields were denormalized onto the transaction for query efficiency it was determined that it was non-ideal to move them back out of the table when uncles were added.
  * The forks of a transaction are available in the `forks` association and the `uncles` blocks as a `has_many` `:through`.
* The unique uncle hashes that have not been fetched in `Explorer.Chain.Block.SecondDegreeRelation` can be streamed with `Explorer.Chain.stream_unfetched_uncle_hashes`.
* Uncles are fetched using `Indexer.Block.Uncle.Fetcher`.
  * Use `Explorer.Chain.stream_unfetched_uncle_hashes` to initialize queue.
  * Have `Indexer.Block.Catchup.Fetcher` and `Indexer.Block.Realtime.Fetcher` queue uncles to fetch by calling `Indexer.Block.Uncle.Fetcher.async_fetch_blocks`.
* `/blocks/*` and `/block/*/transactions` work with either `number`, as before, or `hash`.  `number` will only work for consensus blocks, but `hash` will work for both consensus and non-consensus blocks.
* `/search?q=` when given a full hash (64 hexadecimal digits) will check if it is a transaction or a block now as a way to search for non-consensus blocks by hash.

### Incompatible Changes
* As uncles use the same numbers as consensus blocks, `number` is no longer a unique column for blocks.  Instead, `hash` should be relied upon.  There is still a guarantee that only 1 block with a given number also is consensus `true`, but there may be no block.
* Entries in `Explorer.Chain.Transaction` that do not have a `block_hash` can be either pending or only exist in non-consensus blocks.  The following fields being `nil` should no longer be thought of as indicating "pending", but instead non-consensus as they can be `nil` either for pending blocks or uncles.
  * `block`
  * `block_hash`
  * `cumulative_gas_used`
  * `gas_used`
  * `status`

## Upgrading

Database reset and re-index required:
1. `mix do ecto.drop, ecto.create, ecto.migrate`
2. `rm -rf logs`
3. `MIX_ENV=test mix do ecto.drop, ecto.create, ecto.migrate`

If you need to differentiate between pending transactions and those collated into non-consensus blocks, you need to load `forks` or `uncles` on the transaction.  If a transaction has appeared in an fork on an uncle, there's no way to tell if it is actively pending for consensus, but as pending blocks are local to whatever node the indexer connects to, you should not depend on being able to see pending blocks before they are collated into the consensus.
