### PR TITLE
Handle more errors types at Smart Contract Reader

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -114,7 +114,7 @@ defmodule Explorer.SmartContract.Reader do
     |> decode_results(abi, functions)
   rescue
     error ->
-      format_error(functions, error.message)
+      format_error(functions, error)
   end
 
   defp decode_results({:ok, results}, abi, functions), do: Encoder.decode_abi_results(results, abi, functions)
@@ -123,12 +123,20 @@ defmodule Explorer.SmartContract.Reader do
     format_error(functions, "Bad Gateway")
   end
 
-  defp format_error(functions, message) do
+  defp format_error(functions, message) when is_binary(message) do
     functions
     |> Enum.map(fn {function_name, _args} ->
       %{function_name => {:error, message}}
     end)
     |> List.first()
+  end
+
+  defp format_error(functions, %{message: error_message}) do
+    format_error(functions, error_message)
+  end
+
+  defp format_error(functions, error) do
+    format_error(functions, Exception.message(error))
   end
 
   @doc """

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -82,6 +82,24 @@ defmodule Explorer.SmartContract.ReaderTest do
 
       assert %{"get" => {:error, "Bad Gateway"}} = response
     end
+
+    test "handles other types of errors" do
+      smart_contract = build(:smart_contract)
+      contract_address_hash = Hash.to_string(smart_contract.address_hash)
+      abi = smart_contract.abi
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [%{id: _, method: _, params: [%{data: _, to: _}]}], _options ->
+          raise FunctionClauseError
+        end
+      )
+
+      response = Reader.query_contract(contract_address_hash, abi, %{"get" => []})
+
+      assert %{"get" => {:error, "no function clause matches"}} = response
+    end
   end
 
   describe "query_verified_contract/2" do


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/800.

Errors may pop up that do not comply with the current expect API: they
may not include a `:message` key in its formation. When they did not, the
exception handler was throwing an exception.