### PR TITLE
Realtime indexer waits half a second before fetch

### DIFF
--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -124,6 +124,9 @@ defmodule Indexer.Block.Realtime.Fetcher do
   end
 
   def fetch_and_import_block(block_number_to_fetch, block_fetcher) do
+    # Wait half a second to give Parity/Geth time to sync.
+    :timer.sleep(500)
+
     case fetch_and_import_range(block_fetcher, block_number_to_fetch..block_number_to_fetch) do
       {:ok, {_inserted, _next}} ->
         Logger.debug(fn ->


### PR DESCRIPTION
Resolves: https://github.com/poanetwork/blockscout/issues/808 (should be tested first to know if it really stops the "Unknown block number" errors from happening)

## Motivation

* For Sokol, on staging, we noticed many errors like this one:
  ```
  00:45:05.627 application=indexer [error] realtime indexer failed to
  validate for block 4668478: [%{code: -32602, data: %{"blockNumber" =>
  "0x473C3E", "hash" => "0x532e069e200be3e372da9680872826bb08caef91"},
  message: "Unknown block number"}, %{code: -32602, data: %{"blockNumber"
  => "0x473C3E", "hash" => "0x95426f2bc716022fcf1def006dbc4bb81f5b5164"},
  message: "Unknown block number"}, %{code: -32602, data: %{"blockNumber"
  => "0x473C3E", "hash" => "0xe797a1da01eb0f951e0e400f9343de9d17a06bac"},
  message: "Unknown block number"}].  Block will be retried by catchup
  indexer.
  ```

## Changelog

### Enhancements
* Editing `Indexer.Block.Realtime.Fetcher.fetch_and_import_block/2` for
it to wait half a second before starting to fetch and import. The
rationale here is that we're hoping that half a second will be enough
for Parity to sync and not return an "Unknown block number" error.
