### PR TITLE
Preload created contract address for transaction logs

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_log_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_log_controller.ex
@@ -13,6 +13,7 @@ defmodule BlockScoutWeb.TransactionLogController do
              transaction_hash,
              necessity_by_association: %{
                :block => :optional,
+               [created_contract_address: :names] => :optional,
                [from_address: :names] => :required,
                [to_address: :names] => :optional,
                :token_transfers => :optional

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_log_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_log_controller_test.exs
@@ -119,4 +119,16 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
 
     assert %Token{} = conn.assigns.exchange_rate
   end
+
+  test "loads for transcations that created a contract", %{conn: conn} do
+    contract_address = insert(:contract_address)
+
+    transaction =
+      :transaction
+      |> insert(to_address: nil)
+      |> with_contract_creation(contract_address)
+
+    conn = get(conn, transaction_log_path(conn, :index, transaction))
+    assert html_response(conn, 200)
+  end
 end


### PR DESCRIPTION
Fixes #799.

## Motivation

Transactions that create a contract address rely on the `created_contract_address` field to be preloaded when viewing the logs for respective transactions.

## Changelog

### Bug Fixes
* Preload `created_contract_address` when viewing transaction logs