### PR TITLE
Add Wobserver

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -38,6 +38,11 @@ config :logger, :block_scout_web,
   metadata: [:application, :request_id],
   metadata_filter: [application: :block_scout_web]
 
+config :wobserver,
+  # return only the local node
+  discovery: :none,
+  mode: :plug
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/apps/block_scout_web/lib/block_scout_web/endpoint.ex
+++ b/apps/block_scout_web/lib/block_scout_web/endpoint.ex
@@ -6,6 +6,7 @@ defmodule BlockScoutWeb.Endpoint do
   end
 
   socket("/socket", BlockScoutWeb.UserSocket)
+  socket("/wobserver", Wobserver.Web.PhoenixSocket)
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -1,6 +1,8 @@
 defmodule BlockScoutWeb.Router do
   use BlockScoutWeb, :router
 
+  forward("/wobserver", Wobserver.Web.Router)
+
   pipeline :browser do
     plug(:accepts, ["html"])
     plug(:fetch_session)

--- a/apps/block_scout_web/mix.exs
+++ b/apps/block_scout_web/mix.exs
@@ -10,6 +10,7 @@ defmodule BlockScoutWeb.Mixfile do
       compilers: [:phoenix, :gettext | Mix.compilers()],
       deps: deps(),
       deps_path: "../../deps",
+      description: "Web interface for BlockScout.",
       dialyzer: [
         plt_add_deps: :transitive,
         ignore_warnings: "../../.dialyzer-ignore"

--- a/apps/block_scout_web/mix.exs
+++ b/apps/block_scout_web/mix.exs
@@ -61,6 +61,7 @@ defmodule BlockScoutWeb.Mixfile do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
+      {:bypass, "~> 0.8", only: :test},
       {:cowboy, "~> 1.0"},
       {:credo, "0.9.2", only: [:dev, :test], runtime: false},
       {:crontab, "~> 1.1"},
@@ -87,16 +88,15 @@ defmodule BlockScoutWeb.Mixfile do
       {:phoenix_html, "~> 2.10"},
       {:phoenix_live_reload, "~> 1.0", only: [:dev]},
       {:phoenix_pubsub, "~> 1.0"},
+      # Waiting for the Pretty Print to be implemented at the Jason lib
+      # https://github.com/michalmuskala/jason/issues/15
+      {:poison, "~> 3.1"},
       {:postgrex, ">= 0.0.0"},
+      {:qrcode, "~> 0.1.0"},
       {:sobelow, ">= 0.7.0", only: [:dev, :test], runtime: false},
       {:timex, "~> 3.1.24"},
       {:timex_ecto, "~> 3.2.1"},
-      {:wallaby, "~> 0.20", only: [:test], runtime: false},
-      {:qrcode, "~> 0.1.0"},
-      {:bypass, "~> 0.8", only: :test},
-      # Waiting for the Pretty Print to be implemented at the Jason lib
-      # https://github.com/michalmuskala/jason/issues/15
-      {:poison, "~> 3.1"}
+      {:wallaby, "~> 0.20", only: [:test], runtime: false}
     ]
   end
 

--- a/apps/block_scout_web/mix.exs
+++ b/apps/block_scout_web/mix.exs
@@ -96,7 +96,8 @@ defmodule BlockScoutWeb.Mixfile do
       {:sobelow, ">= 0.7.0", only: [:dev, :test], runtime: false},
       {:timex, "~> 3.1.24"},
       {:timex_ecto, "~> 3.2.1"},
-      {:wallaby, "~> 0.20", only: [:test], runtime: false}
+      {:wallaby, "~> 0.20", only: [:test], runtime: false},
+      {:wobserver, "~> 0.1.8"}
     ]
   end
 

--- a/apps/ethereum_jsonrpc/mix.exs
+++ b/apps/ethereum_jsonrpc/mix.exs
@@ -9,6 +9,7 @@ defmodule EthereumJsonrpc.MixProject do
       config_path: "../../config/config.exs",
       deps: deps(),
       deps_path: "../../deps",
+      description: "Ethereum JSONRPC client.",
       dialyzer: [
         plt_add_deps: :transitive,
         plt_add_apps: [:mix],

--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -9,6 +9,7 @@ defmodule Explorer.Mixfile do
       config_path: "../../config/config.exs",
       deps: deps(),
       deps_path: "../../deps",
+      description: "Read-access to indexed block chain data.",
       dialyzer: [
         plt_add_deps: :transitive,
         plt_add_apps: ~w(ex_unit mix)a,

--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -70,9 +70,12 @@ defmodule Explorer.Mixfile do
       {:comeonin, "~> 4.0"},
       {:credo, "0.9.2", only: [:dev, :test], runtime: false},
       {:crontab, "~> 1.1"},
+      {:decimal, "~> 1.0"},
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
       # Casting Ethereum-native types to Elixir-native types
       {:ecto, "~> 2.2"},
+      # JSONRPC access to query smart contracts
+      {:ethereum_jsonrpc, in_umbrella: true},
       # Data factory for testing
       {:ex_machina, "~> 2.1", only: [:test]},
       # Code coverage
@@ -89,10 +92,7 @@ defmodule Explorer.Mixfile do
       {:postgrex, ">= 0.0.0"},
       {:sobelow, ">= 0.7.0", only: [:dev, :test], runtime: false},
       {:timex, "~> 3.1.24"},
-      {:timex_ecto, "~> 3.2.1"},
-      # JSONRPC access to query smart contracts
-      {:ethereum_jsonrpc, in_umbrella: true},
-      {:decimal, "~> 1.0"}
+      {:timex_ecto, "~> 3.2.1"}
     ]
   end
 

--- a/apps/indexer/mix.exs
+++ b/apps/indexer/mix.exs
@@ -9,6 +9,7 @@ defmodule Indexer.MixProject do
       config_path: "../../config/config.exs",
       deps: deps(),
       deps_path: "../../deps",
+      description: "Fetches block chain data from on-chain node for later reading with Explorer.",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       lockfile: "../../mix.lock",

--- a/mix.lock
+++ b/mix.lock
@@ -79,4 +79,5 @@
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], []},
   "wallaby": {:hex, :wallaby, "0.20.0", "cc6663555ff7b05afbebb2a8b461d18a5b321658b9017f7bc77d494b7063266a", [:mix], [{:httpoison, "~> 0.12", [hex: :httpoison, optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}]},
   "websocket_client": {:hex, :websocket_client, "1.3.0", "2275d7daaa1cdacebf2068891c9844b15f4fdc3de3ec2602420c2fb486db59b6", [:rebar3], [], "hexpm"},
+  "wobserver": {:hex, :wobserver, "0.1.8", "3ed5ea55478627f0593800ab83919b71f41fd426ec344e71cf1d975e6d2065b8", [:mix], [{:cowboy, "~> 1.1", [hex: :cowboy, repo: "hexpm", optional: false]}, {:httpoison, "~> 0.11 or ~> 0.12", [hex: :httpoison, repo: "hexpm", optional: false]}, {:plug, "~> 1.3 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 2.0 or ~> 3.1", [hex: :poison, repo: "hexpm", optional: false]}, {:websocket_client, "~> 1.2", [hex: :websocket_client, repo: "hexpm", optional: false]}], "hexpm"},
 }


### PR DESCRIPTION
Resolves #591

## Test Plan

1. `iex -S mix phx.server`
2. In a separate terminal: `open http://localhost:4000/wobserver`
   1. Click the Applications tab
      1. Check `block_scout_web`
         1. Ensure that "block_scout_web" has a description
         2. Check `iex` terminal.  Ensure no errors raised showing process tree.
      2. Switch to `ethereum_jsonrpc` in the dropdown
         1. Ensure there is a description
         2. Check `iex` terminal.  Ensure no errors raised showing process tree.
      3. Switch to `explorer` in the dropdown
         1. Ensure there is a description
         2. Check `iex` terminal.  Ensure no errors raised showing process tree.
      4. Switch to `indexer` in the dropdown
         1. Ensure there is a description
         2. Check `iex` terminal.  Ensure no errors raised showing process tree.
   2. Click the Processes tab (there will be a slight delay as there are so many processes to draw.   It is client-side, not server-side)
      1. Click on the Memory column twice.  The column should have the most memory at the top.
      2. Click on the MsgQ column twice.  The column should have the most messages at the top.

## Test Report

All tests passed.

## Changelog

### Enhancements
* Sort deps
* Wobserver (a web version of `:observer`) can be viewed at `/wobserver`.