### PR TITLE
Ignore burn address token balance for Tokens ERC-721

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -938,7 +938,7 @@ defmodule Explorer.Chain do
   def stream_unfetched_token_balances(initial, reducer) when is_function(reducer, 2) do
     Repo.transaction(
       fn ->
-        query = from(tb in TokenBalance, where: is_nil(tb.value_fetched_at))
+        query = TokenBalance.unfetched_token_balances()
 
         query
         |> Repo.stream(timeout: :infinity)

--- a/apps/explorer/test/explorer/chain/address/token_balance_test.ex
+++ b/apps/explorer/test/explorer/chain/address/token_balance_test.ex
@@ -1,0 +1,79 @@
+defmodule Explorer.Chain.Address.TokenBalanceTest do
+  use Explorer.DataCase
+
+  alias Explorer.Repo
+  alias Explorer.Chain.Address.TokenBalance
+
+  describe "unfetched_token_balances/0" do
+    test "returns only the token balances that have value_fetched_at nil" do
+      address = insert(:address, hash: "0xc45e4830dff873cf8b70de2b194d0ddd06ef651e")
+      token_balance = insert(:token_balance, value_fetched_at: nil, address: address)
+      insert(:token_balance)
+
+      result =
+        TokenBalance.unfetched_token_balances()
+        |> Repo.all()
+        |> List.first()
+
+      assert result.block_number == token_balance.block_number
+    end
+
+    test "does not ignore token balance when the address isn't the burn address with Token ERC-20" do
+      address = insert(:address, hash: "0xc45e4830dff873cf8b70de2b194d0ddd06ef651e")
+      token = insert(:token, type: "ERC-20")
+
+      token_balance =
+        insert(
+          :token_balance,
+          value_fetched_at: nil,
+          address: address,
+          token_contract_address_hash: token.contract_address_hash
+        )
+
+      result =
+        TokenBalance.unfetched_token_balances()
+        |> Repo.all()
+        |> List.first()
+
+      assert result.block_number == token_balance.block_number
+    end
+
+    test "ignores the burn_address when the token type is ERC-721" do
+      burn_address = insert(:address, hash: "0x0000000000000000000000000000000000000000")
+      token = insert(:token, type: "ERC-721")
+
+      insert(
+        :token_balance,
+        address: burn_address,
+        token_contract_address_hash: token.contract_address_hash,
+        value_fetched_at: nil
+      )
+
+      result =
+        TokenBalance.unfetched_token_balances()
+        |> Repo.all()
+
+      assert result == []
+    end
+
+    test "does not ignore the burn_address when the token type is ERC-20" do
+      burn_address = insert(:address, hash: "0x0000000000000000000000000000000000000000")
+      token = insert(:token, type: "ERC-20")
+
+      token_balance =
+        insert(
+          :token_balance,
+          address: burn_address,
+          token_contract_address_hash: token.contract_address_hash,
+          value_fetched_at: nil
+        )
+
+      result =
+        TokenBalance.unfetched_token_balances()
+        |> Repo.all()
+        |> List.first()
+
+      assert result.block_number == token_balance.block_number
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2326,8 +2326,9 @@ defmodule Explorer.ChainTest do
   end
 
   describe "stream_unfetched_token_balances/2" do
-    test "returns only the token balances that have value_fetched_at nil" do
-      token_balance = insert(:token_balance, value_fetched_at: nil)
+    test "executes the given reducer with the query result" do
+      address = insert(:address, hash: "0xc45e4830dff873cf8b70de2b194d0ddd06ef651e")
+      token_balance = insert(:token_balance, value_fetched_at: nil, address: address)
       insert(:token_balance)
 
       assert Chain.stream_unfetched_token_balances([], &[&1.block_number | &2]) == {:ok, [token_balance.block_number]}

--- a/apps/indexer/lib/indexer/token_transfers.ex
+++ b/apps/indexer/lib/indexer/token_transfers.ex
@@ -44,7 +44,8 @@ defmodule Indexer.TokenTransfers do
       from_address_hash: truncate_address_hash(log.second_topic),
       to_address_hash: truncate_address_hash(log.third_topic),
       token_contract_address_hash: log.address_hash,
-      transaction_hash: log.transaction_hash
+      transaction_hash: log.transaction_hash,
+      token_type: "ERC-20"
     }
 
     token = %{
@@ -67,7 +68,8 @@ defmodule Indexer.TokenTransfers do
       to_address_hash: truncate_address_hash(log.third_topic),
       token_contract_address_hash: log.address_hash,
       token_id: token_id || 0,
-      transaction_hash: log.transaction_hash
+      transaction_hash: log.transaction_hash,
+      token_type: "ERC-721"
     }
 
     token = %{
@@ -90,7 +92,8 @@ defmodule Indexer.TokenTransfers do
       to_address_hash: encode_address_hash(to_address_hash),
       token_contract_address_hash: log.address_hash,
       token_id: token_id,
-      transaction_hash: log.transaction_hash
+      transaction_hash: log.transaction_hash,
+      token_type: "ERC-721"
     }
 
     token = %{

--- a/apps/indexer/test/indexer/address/token_balances_test.exs
+++ b/apps/indexer/test/indexer/address/token_balances_test.exs
@@ -34,5 +34,43 @@ defmodule Indexer.Address.TokenBalancesTest do
       assert %{address_hash: to_address_hash, block_number: block_number}
       assert %{address_hash: token_contract_address_hash, block_number: block_number}
     end
+
+    test "does not set params when the from_address_hash is the burn address for the Token ERC-721" do
+      block_number = 1
+      from_address_hash = "0x0000000000000000000000000000000000000000"
+      to_address_hash = "0x5b8410f67eb8040bb1cd1e8a4ff9d5f6ce678a15"
+      token_contract_address_hash = "0xe18035bf8712672935fdb4e5e431b1a0183d2dfc"
+
+      token_transfer_params = %{
+        block_number: block_number,
+        from_address_hash: from_address_hash,
+        to_address_hash: to_address_hash,
+        token_contract_address_hash: token_contract_address_hash,
+        token_type: "ERC-721"
+      }
+
+      params_set = TokenBalances.params_set(%{token_transfers_params: [token_transfer_params]})
+
+      assert MapSet.size(params_set) == 0
+    end
+
+    test "does not set params when the to_address_hash is the burn address for the Token ERC-721" do
+      block_number = 1
+      from_address_hash = "0x5b8410f67eb8040bb1cd1e8a4ff9d5f6ce678a15"
+      to_address_hash = "0x0000000000000000000000000000000000000000"
+      token_contract_address_hash = "0xe18035bf8712672935fdb4e5e431b1a0183d2dfc"
+
+      token_transfer_params = %{
+        block_number: block_number,
+        from_address_hash: from_address_hash,
+        to_address_hash: to_address_hash,
+        token_contract_address_hash: token_contract_address_hash,
+        token_type: "ERC-721"
+      }
+
+      params_set = TokenBalances.params_set(%{token_transfers_params: [token_transfer_params]})
+
+      assert MapSet.size(params_set) == 0
+    end
   end
 end

--- a/apps/indexer/test/indexer/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/token_transfers_test.exs
@@ -66,7 +66,8 @@ defmodule Indexer.TokenTransfersTest do
             to_address_hash: truncated_hash(log_3.third_topic),
             token_contract_address_hash: log_3.address_hash,
             token_id: 183,
-            transaction_hash: log_3.transaction_hash
+            transaction_hash: log_3.transaction_hash,
+            token_type: "ERC-721"
           },
           %{
             amount: Decimal.new(17_000_000_000_000_000_000),
@@ -75,7 +76,8 @@ defmodule Indexer.TokenTransfersTest do
             from_address_hash: truncated_hash(log_1.second_topic),
             to_address_hash: truncated_hash(log_1.third_topic),
             token_contract_address_hash: log_1.address_hash,
-            transaction_hash: log_1.transaction_hash
+            transaction_hash: log_1.transaction_hash,
+            token_type: "ERC-20"
           }
         ]
       }
@@ -113,7 +115,8 @@ defmodule Indexer.TokenTransfersTest do
             to_address_hash: "0xbe8cdfc13ffda20c844ac3da2b53a23ac5787f1e",
             token_contract_address_hash: log.address_hash,
             token_id: 14_939,
-            transaction_hash: log.transaction_hash
+            transaction_hash: log.transaction_hash,
+            token_type: "ERC-721"
           }
         ]
       }


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/810

As we always get errors trying to fetch token balances when the address is the burn address for Tokens ERC-721, we are gonna ignore them when we are processing the token balances from the token transfer.

## Changelog
* Stop indexing token balances for the burn address when the token type is ERC-721

### Bug Fixes
* As we won't the burn address with ERC-721 indexed, we are gonna not receive this error anymore:

```
<Elixir.Indexer.TokenBalance.Fetcher> Errors while fetching TokenBalances through Contract interaction:
<address_hash: 0x0000000000000000000000000000000000000000, contract_address_hash: 0xeaa54040679ceda84af88ef5bd0895e8e841c2d5, block_number: 4609877, error: (-32015) VM execution error.>
```