### PR TITLE
Deployment fixes for the network path

### DIFF
--- a/apps/block_scout_web/assets/package-lock.json
+++ b/apps/block_scout_web/assets/package-lock.json
@@ -3789,7 +3789,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3813,13 +3814,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3836,19 +3839,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3979,7 +3985,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3993,6 +4000,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4009,6 +4017,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4017,13 +4026,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4044,6 +4055,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4132,7 +4144,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4146,6 +4159,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4241,7 +4255,8 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4283,6 +4298,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4304,6 +4320,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4352,13 +4369,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -10,12 +10,19 @@ config :block_scout_web,
   namespace: BlockScoutWeb,
   ecto_repos: [Explorer.Repo]
 
-config :block_scout_web, BlockScoutWeb.Chain, logo: "/images/poa_logo.svg"
+config :block_scout_web, BlockScoutWeb.Chain,
+  network: System.get_env("NETWORK"),
+  subnetwork: System.get_env("SUBNETWORK"),
+  network_icon: System.get_env("NETWORK_ICON"),
+  logo: System.get_env("LOGO")
 
 # Configures the endpoint
 config :block_scout_web, BlockScoutWeb.Endpoint,
   instrumenters: [BlockScoutWeb.Prometheus.Instrumenter],
-  url: [host: "localhost"],
+  url: [
+    host: "localhost",
+    path: System.get_env("NETWORK_PATH") || "/"
+  ],
   render_errors: [view: BlockScoutWeb.ErrorView, accepts: ~w(html json)],
   pubsub: [name: BlockScoutWeb.PubSub, adapter: Phoenix.PubSub.PG2]
 

--- a/apps/block_scout_web/config/prod.exs
+++ b/apps/block_scout_web/config/prod.exs
@@ -17,7 +17,7 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   force_ssl: false,
   secret_key_base: System.get_env("SECRET_KEY_BASE"),
-  check_origin: ["//*.blockscout.com", "//*.elb.amazonaws.com"],
+  check_origin: System.get_env("CHECK_ORIGIN") || false,
   http: [port: System.get_env("PORT")],
   url: [
     scheme: "http",

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -57,13 +57,13 @@
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <!-- ICON FOR MAINNET -->
             <span class="nav-link-icon">
-              <%= render BlockScoutWeb.IconsView, "_network_icon.html" %>
+              <%= render BlockScoutWeb.IconsView, Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:network_icon] %>
             </span>
             <!-- ICON FOR TESTNET -->
             <!-- <span class="nav-link-icon">
               <%= render BlockScoutWeb.IconsView, "_test_network_icon.html" %>
             </span> -->
-            <%= gettext("POA Core") %>
+            <%= Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:subnetwork] %>
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
             <a class="dropdown-item" href="https://sokol.blockscout.com/"><%= gettext("POA Sokol") %></a>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-dark navbar-expand-lg navbar-primary" data-selector="navbar">
   <div class="container">
     <%= link to: chain_path(@conn, :show), class: "navbar-brand", "data-test": "header_logo" do %>
-      <img class="navbar-logo" src="<%= Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:logo] %>" />
+      <img class="navbar-logo" src="<%= logo() %>" />
     <% end %>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="<%= gettext("Toggle navigation") %>">
       <span class="navbar-toggler-icon"></span>
@@ -57,13 +57,13 @@
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <!-- ICON FOR MAINNET -->
             <span class="nav-link-icon">
-              <%= render BlockScoutWeb.IconsView, Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:network_icon] %>
+              <%= render BlockScoutWeb.IconsView, network_icon_partial() %>
             </span>
             <!-- ICON FOR TESTNET -->
             <!-- <span class="nav-link-icon">
               <%= render BlockScoutWeb.IconsView, "_test_network_icon.html" %>
             </span> -->
-            <%= Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:subnetwork] %>
+            <%= subnetwork_title() %>
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
             <a class="dropdown-item" href="https://sokol.blockscout.com/"><%= gettext("POA Sokol") %></a>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><%= gettext "BlockScout" %></title>
+    <title><%= Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:subnetwork] <> " Explorer - " <> Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:network] <> " by BlockScout" %></title>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
 
     <link rel="apple-touch-icon" sizes="180x180" href="<%= static_path(@conn, "/apple-touch-icon.png") %>">

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><%= Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:subnetwork] <> " Explorer - " <> Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:network] <> " by BlockScout" %></title>
+    <title><%= app_title() %></title>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
 
     <link rel="apple-touch-icon" sizes="180x180" href="<%= static_path(@conn, "/apple-touch-icon.png") %>">

--- a/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
@@ -3,6 +3,28 @@ defmodule BlockScoutWeb.LayoutView do
 
   alias BlockScoutWeb.SocialMedia
 
+  def network_icon_partial do
+    Keyword.get(application_config(), :network_icon) || "_network_icon.html"
+  end
+
+  def logo do
+    Keyword.get(application_config(), :logo) || "/images/poa_logo.svg"
+  end
+
+  def subnetwork_title do
+    Keyword.get(application_config(), :subnetwork) || "Sokol Testnet"
+  end
+
+  def app_title do
+    network_title = Keyword.get(application_config(), :network) || "POA"
+
+    gettext("%{subnetwork} %{network} Explorer", subnetwork: subnetwork_title(), network: network_title)
+  end
+
+  defp application_config do
+    Application.get_env(:block_scout_web, BlockScoutWeb.Chain)
+  end
+
   def configured_social_media_services do
     SocialMedia.links()
   end

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -124,11 +124,6 @@ msgid "Block Number"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:7
-msgid "BlockScout"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/block/index.html.eex:10
 #: lib/block_scout_web/templates/chain/show.html.eex:56
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:16
@@ -586,7 +581,6 @@ msgid "Owner Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:66
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:70
 msgid "POA Core"
 msgstr ""
@@ -1070,4 +1064,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:14
 msgid "More pending transactions have come in"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/layout_view.ex:21
+msgid "%{subnetwork} %{network} Explorer"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -124,11 +124,6 @@ msgid "Block Number"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:7
-msgid "BlockScout"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/block/index.html.eex:10
 #: lib/block_scout_web/templates/chain/show.html.eex:56
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:16
@@ -586,7 +581,6 @@ msgid "Owner Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:66
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:70
 msgid "POA Core"
 msgstr ""
@@ -1070,4 +1064,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:14
 msgid "More pending transactions have come in"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/layout_view.ex:21
+msgid "%{subnetwork} %{network} Explorer"
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/views/layout_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/layout_view_test.exs
@@ -1,9 +1,69 @@
 defmodule BlockScoutWeb.LayoutViewTest do
-  use BlockScoutWeb.ConnCase, async: true
+  use BlockScoutWeb.ConnCase
 
   alias BlockScoutWeb.LayoutView
 
   test "configured_social_media_services/0" do
     assert length(LayoutView.configured_social_media_services()) > 0
+  end
+
+  setup do
+    on_exit(fn ->
+      Application.put_env(:block_scout_web, BlockScoutWeb.Chain, [])
+    end)
+  end
+
+  describe "network_icon_partial/0" do
+    test "use the enviroment icon when it's configured" do
+      Application.put_env(:block_scout_web, BlockScoutWeb.Chain, network_icon: "custom_icon")
+
+      assert LayoutView.network_icon_partial() == "custom_icon"
+    end
+
+    test "use the default icon when there is no env configured for it" do
+      assert LayoutView.network_icon_partial() == "_network_icon.html"
+    end
+  end
+
+  describe "logo/0" do
+    test "use the enviroment logo when it's configured" do
+      Application.put_env(:block_scout_web, BlockScoutWeb.Chain, logo: "custom/logo.png")
+
+      assert LayoutView.logo() == "custom/logo.png"
+    end
+
+    test "use the default logo when there is no env configured for it" do
+      assert LayoutView.logo() == "/images/poa_logo.svg"
+    end
+  end
+
+  describe "subnetwork_title/0" do
+    test "use the enviroment subnetwork title when it's configured" do
+      Application.put_env(:block_scout_web, BlockScoutWeb.Chain, subnetwork: "Subnetwork Test")
+
+      assert LayoutView.subnetwork_title() == "Subnetwork Test"
+    end
+
+    test "use the default subnetwork title when there is no env configured for it" do
+      assert LayoutView.subnetwork_title() == "Sokol Testnet"
+    end
+  end
+
+  describe "app_title/0" do
+    test "use the enviroment subnetwork title when it's configured" do
+      Application.put_env(:block_scout_web, BlockScoutWeb.Chain, subnetwork: "Subnetwork Test")
+
+      assert LayoutView.app_title() == "Subnetwork Test POA Explorer"
+    end
+
+    test "use the enviroment network title when it's configured" do
+      Application.put_env(:block_scout_web, BlockScoutWeb.Chain, network: "Custom")
+
+      assert LayoutView.app_title() == "Sokol Testnet Custom Explorer"
+    end
+
+    test "use the default subnetwork title when there is no env configured for it" do
+      assert LayoutView.app_title() == "Sokol Testnet POA Explorer"
+    end
   end
 end

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -10,7 +10,7 @@ config :ecto, json_library: Jason
 # General application configuration
 config :explorer,
   ecto_repos: [Explorer.Repo],
-  coin: "POA"
+  coin: System.get_env("COIN") || "POA"
 
 config :explorer, Explorer.Integrations.EctoLogger, query_time_ms_threshold: 2_000
 

--- a/apps/explorer/config/prod/parity.exs
+++ b/apps/explorer/config/prod/parity.exs
@@ -5,11 +5,11 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: "https://sokol.poa.network",
+      url: System.get_env("ETHEREUM_URL") || "https://sokol.poa.network",
       method_to_url: [
-        eth_call: "https://sokol-trace.poa.network",
-        eth_getBalance: "https://sokol-trace.poa.network",
-        trace_replayTransaction: "https://sokol-trace.poa.network"
+        eth_call: System.get_env("TRACE_URL") || "https://sokol-trace.poa.network",
+        eth_getBalance: System.get_env("TRACE_URL") || "https://sokol-trace.poa.network",
+        trace_replayTransaction: System.get_env("TRACE_URL") || "https://sokol-trace.poa.network"
       ],
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
@@ -19,7 +19,7 @@ config :explorer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: "wss://sokol-ws.poa.network/ws"
+      url: System.get_env("WS_URL") || "wss://sokol-ws.poa.network/ws"
     ],
     variant: EthereumJSONRPC.Parity
   ]

--- a/apps/indexer/config/prod/parity.exs
+++ b/apps/indexer/config/prod/parity.exs
@@ -6,10 +6,10 @@ config :indexer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: "https://sokol.poa.network",
+      url: System.get_env("ETHEREUM_URL") || "https://sokol.poa.network",
       method_to_url: [
-        eth_getBalance: "https://sokol-trace.poa.network",
-        trace_replayTransaction: "https://sokol-trace.poa.network"
+        eth_getBalance: System.get_env("TRACE_URL") || "https://sokol-trace.poa.network",
+        trace_replayTransaction: System.get_env("TRACE_URL") || "https://sokol-trace.poa.network"
       ],
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
@@ -19,6 +19,6 @@ config :indexer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: "wss://sokol-ws.poa.network/ws"
+      url: System.get_env("WS_URL") || "wss://sokol-ws.poa.network/ws"
     ]
   ]

--- a/bin/deployment/health_check
+++ b/bin/deployment/health_check
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-
 # Timeout after 2 min if we still haven't gotten a response
 timeout 120s bash <<EOT
 # Wait until an HTTP request succeeds against localhost:PORT


### PR DESCRIPTION
Fixes #790 

## Motivation

The deployed URL schema should route from subfolders similar to `/poa/sokol` and `/poa/core`. So we are configuring Phoenix to generate links using this `custom/path` that will be configured in the environment.

Notice that, after this configuration, it just generates the link with the `/custom/path` prefixed. But Phoeniex doesn't have a route for that. So, it will be necessary a proxy configuration to strip this `/custom/path` for the URL once the envs are configured, otherwise, the routes never will reach the Phoenix application.

## Changelog

- Adds environment variables for `network`, `subnetwork`, `logo`, `network path`, and `check_origin`.
- Adds the ability to change the `title`, `network path`, `network icon`, and `check_origin` for deployment purposes.
- Refactor the view to use the above variables when they are provided.

### Enhancements
Fixes contract verification in deployment.


