### PR TITLE
Display shortened addresses in named address links

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
@@ -1,7 +1,6 @@
 <span class="<%= if @contract do %>contract-address<% end %>" data-address-hash="<%= @address.hash %>">
   <%= if name = primary_name(@address) do %>
-    <span class="d-none d-md-none d-lg-inline" data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= short_hash(@address) %>...)</span>
-    <span class="d-md-inline-block d-lg-none " data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= short_hash(@address) %>...)</span>
+    <span data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= short_hash(@address) %>...)</span>
   <% else %>
     <%= if assigns[:truncate] do %>
       <%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
@@ -1,7 +1,7 @@
 <span class="<%= if @contract do %>contract-address<% end %>" data-address-hash="<%= @address.hash %>">
   <%= if name = primary_name(@address) do %>
-    <span class="d-none d-md-none d-lg-inline" data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %></span>
-    <span class="d-md-inline-block d-lg-none " data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %></span>
+    <span class="d-none d-md-none d-lg-inline" data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= short_hash(@address) %>...)</span>
+    <span class="d-md-inline-block d-lg-none " data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= short_hash(@address) %>...)</span>
   <% else %>
     <%= if assigns[:truncate] do %>
       <%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -219,4 +219,14 @@ defmodule BlockScoutWeb.AddressView do
   defp tab_name(["internal_transactions"]), do: gettext("Internal Transactions")
   defp tab_name(["contracts"]), do: gettext("Code")
   defp tab_name(["read_contract"]), do: gettext("Read Contract")
+
+  def short_hash(%Address{hash: hash}) do
+    <<
+      "0x",
+      short_address::binary-size(6),
+      _rest::binary
+    >> = to_string(hash)
+
+    "0x" <> short_address
+  end
 end

--- a/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
@@ -321,4 +321,12 @@ defmodule BlockScoutWeb.AddressViewTest do
       assert AddressView.current_tab_name(path) == "Read Contract"
     end
   end
+
+  describe "short_hash/1" do
+    test "returns a shortened hash of 6 hex characters" do
+      address = insert(:address)
+      assert "0x" <> short_hash = AddressView.short_hash(address)
+      assert String.length(short_hash) == 6
+    end
+  end
 end


### PR DESCRIPTION
Resolves #793 

## Motivation

Due to the nature of named addresses being non-unique, multiple addresses may share the same name and be confused with another without the address's hash visible in context. This PR display 6 digits of the address's hash along with the name when used in links.

![image](https://user-images.githubusercontent.com/911605/46301820-0de4b680-c56d-11e8-8e82-2300c6fba63c.png)

## Changelog

### Enhancements
* Add function to shorten an address's hash to 6 hex digits
* Display shortened address hash next to address primary name in links
