### PR TITLE
[POC] dump user data

### DIFF
--- a/apps/explorer/lib/mix/tasks/dump_user_data.ex
+++ b/apps/explorer/lib/mix/tasks/dump_user_data.ex
@@ -1,0 +1,18 @@
+defmodule Mix.Tasks.DumpUserData do
+  use Mix.Task
+
+  @user_tables [Explorer.Chain.Address.Name, Explorer.Chain.SmartContract]
+
+  @shortdoc "generate dump of data from tables that require manual input"
+  def run(_) do
+    {dump, _} =
+      System.cmd(
+        "pg_dump",
+        Enum.reduce(@user_tables, [Application.get_env(:explorer, Explorer.Repo)[:database], "-a"], fn schema, acc ->
+          Enum.concat(acc, ["-t", schema.__schema__(:source)])
+        end)
+      )
+
+    File.write!("user_data_dump.sql", dump)
+  end
+end

--- a/apps/explorer/lib/mix/tasks/restore_user_data_from_dump.ex
+++ b/apps/explorer/lib/mix/tasks/restore_user_data_from_dump.ex
@@ -1,0 +1,15 @@
+defmodule Mix.Tasks.RestoreUserDataFromDump do
+  use Mix.Task
+
+  @shortdoc "restore user data from sql dump"
+  def run(_) do
+    {_, 0} =
+      System.cmd("psql", [
+        "-d",
+        Application.get_env(:explorer, Explorer.Repo)[:database],
+        "-a",
+        "-f",
+        "user_data_dump.sql"
+      ])
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20181001174638_alter_smart_contracts_table_remove_foreign_key.exs
+++ b/apps/explorer/priv/repo/migrations/20181001174638_alter_smart_contracts_table_remove_foreign_key.exs
@@ -1,0 +1,17 @@
+defmodule Explorer.Repo.Migrations.AlterSmartContractsTableRemoveForeignKey do
+  use Ecto.Migration
+
+  def up do
+    alter table("smart_contracts") do
+      modify(:address_hash, :bytea, null: false)
+    end
+
+    drop(constraint(:smart_contracts, "smart_contracts_address_hash_fkey"))
+  end
+
+  def down do
+    alter table("smart_contracts") do
+      modify(:address_hash, references(:addresses, column: :hash, on_delete: :delete_all, type: :bytea), null: false)
+    end
+  end
+end


### PR DESCRIPTION
closes #827

this POC is to explore the possibility of creating a dump of the two tables that are filled by user data instead of the indexer so this data can be restored by any other instance of blockscout if needed

## what's in this POC?

### changes

- create a dump of the address_names and smart_contracts tables

- restore from that dump

- removed foreign key constraint from smart_contracts so the dump can be restored before indexing

## What is not in this POC but will probably be needed in the real issue if we take this path

- send the dump file to a remote something(maybe an S3 bucket or something else)

- make the dump task run periodically

- add a config to make the dumping task optional

- allow to restore the dump from a remote file

## other observations

- regarding the use of IPFS, I feel it's not a good idea to store the dump in it yet since they seem to still be on alpha

## alternative solutions proposed so far

- make a second database for the user data allocated in a separate instance that won't be dropped

- change the code so all blockscout instances to communicate via sockets and trade information