### PR TITLE
Ensure order is preserved for account multibalance

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -563,7 +563,9 @@ defmodule Explorer.Chain do
     query =
       from(
         address in Address,
-        where: address.hash in ^hashes
+        where: address.hash in ^hashes,
+        # https://stackoverflow.com/a/29598910/470451
+        order_by: fragment("array_position(?, ?)", type(^hashes, {:array, Hash.Address}), address.hash)
       )
 
     Repo.all(query)

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -536,10 +536,20 @@ defmodule Explorer.ChainTest do
 
   describe "hashes_to_addresses/1" do
     test "with existing addresses" do
-      address1_attrs = %{hash: "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"}
-      address2_attrs = %{hash: "0x6aaeb6053f3e94c9b9a09f33669435e7ef1beaed"}
-      address1 = insert(:address, address1_attrs)
-      address2 = insert(:address, address2_attrs)
+      address1 = insert(:address, hash: "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed")
+      address2 = insert(:address, hash: "0x6aaeb6053f3e94c9b9a09f33669435e7ef1beaed")
+      # in opposite of insertion order, to check that ordering matches ordering of arguments
+      # regression test for https://github.com/poanetwork/blockscout/issues/843
+      hashes = [address2.hash, address1.hash]
+
+      [found_address1, found_address2] = Explorer.Chain.hashes_to_addresses(hashes)
+
+      %Explorer.Chain.Address{hash: found_hash1} = found_address1
+      %Explorer.Chain.Address{hash: found_hash2} = found_address2
+
+      assert found_hash1 == address2.hash
+      assert found_hash2 == address1.hash
+
       hashes = [address1.hash, address2.hash]
 
       [found_address1, found_address2] = Explorer.Chain.hashes_to_addresses(hashes)


### PR DESCRIPTION
Fixes #843

## Changelog

### Enhancements
* Regression test for #843.

### Bug Fixes
* Use order of hashes passed to `Chain.hashes_to_addresses` to order returned `Address`es.
