### PR TITLE
Trim address and token names of whitespace

### DIFF
--- a/apps/explorer/lib/explorer/chain/address/name.ex
+++ b/apps/explorer/lib/explorer/chain/address/name.ex
@@ -3,8 +3,11 @@ defmodule Explorer.Chain.Address.Name do
   Represents a name for an Address.
   """
 
-  use Explorer.Schema
+  use Ecto.Schema
 
+  import Ecto.Changeset
+
+  alias Ecto.Changeset
   alias Explorer.Chain.{Address, Hash}
 
   @typedoc """
@@ -37,6 +40,17 @@ defmodule Explorer.Chain.Address.Name do
     struct
     |> cast(params, @allowed_fields)
     |> validate_required(@required_fields)
+    |> trim_name()
     |> foreign_key_constraint(:address_hash)
+  end
+
+  defp trim_name(%Changeset{valid?: false} = changeset), do: changeset
+
+  defp trim_name(%Changeset{valid?: true} = changeset) do
+    if name = get_change(changeset, :name) do
+      put_change(changeset, :name, String.trim(name))
+    else
+      changeset
+    end
   end
 end

--- a/apps/explorer/lib/explorer/chain/address/name.ex
+++ b/apps/explorer/lib/explorer/chain/address/name.ex
@@ -47,10 +47,9 @@ defmodule Explorer.Chain.Address.Name do
   defp trim_name(%Changeset{valid?: false} = changeset), do: changeset
 
   defp trim_name(%Changeset{valid?: true} = changeset) do
-    if name = get_change(changeset, :name) do
-      put_change(changeset, :name, String.trim(name))
-    else
-      changeset
+    case get_change(changeset, :name) do
+      nil -> changeset
+      name -> put_change(changeset, :name, String.trim(name))
     end
   end
 end

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -20,6 +20,8 @@ defmodule Explorer.Chain.Token do
   use Ecto.Schema
 
   import Ecto.{Changeset, Query}
+
+  alias Ecto.Changeset
   alias Explorer.Chain.{Address, Hash, Token, TokenTransfer}
 
   @typedoc """
@@ -72,7 +74,18 @@ defmodule Explorer.Chain.Token do
     |> cast(params, @required_attrs ++ @optional_attrs)
     |> validate_required(@required_attrs)
     |> foreign_key_constraint(:contract_address)
+    |> trim_name()
     |> unique_constraint(:contract_address_hash)
+  end
+
+  defp trim_name(%Changeset{valid?: false} = changeset), do: changeset
+
+  defp trim_name(%Changeset{valid?: true} = changeset) do
+    if name = get_change(changeset, :name) do
+      put_change(changeset, :name, String.trim(name))
+    else
+      changeset
+    end
   end
 
   def join_with_transfers(queryable \\ Token) do

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -81,10 +81,9 @@ defmodule Explorer.Chain.Token do
   defp trim_name(%Changeset{valid?: false} = changeset), do: changeset
 
   defp trim_name(%Changeset{valid?: true} = changeset) do
-    if name = get_change(changeset, :name) do
-      put_change(changeset, :name, String.trim(name))
-    else
-      changeset
+    case get_change(changeset, :name) do
+      nil -> changeset
+      name -> put_change(changeset, :name, String.trim(name))
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1957,6 +1957,12 @@ defmodule Explorer.ChainTest do
                primary: true
              )
     end
+
+    test "trims whitespace from address name", %{valid_attrs: valid_attrs} do
+      attrs = %{valid_attrs | name: "     SimpleStorage     "}
+      assert {:ok, _} = Chain.create_smart_contract(attrs)
+      assert Repo.get_by(Address.Name, name: "SimpleStorage")
+    end
   end
 
   describe "stream_unfetched_balances/2" do
@@ -2437,6 +2443,22 @@ defmodule Explorer.ChainTest do
       assert updated_token.total_supply == Decimal.new(update_params.total_supply)
       assert updated_token.decimals == update_params.decimals
       assert updated_token.cataloged
+    end
+
+    test "trims names of whitespace" do
+      token = insert(:token, name: nil, symbol: nil, total_supply: nil, decimals: nil, cataloged: false)
+
+      update_params = %{
+        name: "      Hodl Token     ",
+        symbol: "HT",
+        total_supply: 10,
+        decimals: 1,
+        cataloged: true
+      }
+
+      assert {:ok, updated_token} = Chain.update_token(token, update_params)
+      assert updated_token.name == "Hodl Token"
+      assert Repo.get_by(Address.Name, name: "Hodl Token")
     end
 
     test "inserts an address name record when token has a name in params" do


### PR DESCRIPTION
Resolves #772

## Motivation

This PR trims whitespace from token names and address names whenever the respective structs are inserted or updated via changesets.

## Changelog

### Enhancements
* Token and address names are trimmed of whitespace
