### PR TITLE
Highlight transaction status

### DIFF
--- a/apps/block_scout_web/assets/css/_typography.scss
+++ b/apps/block_scout_web/assets/css/_typography.scss
@@ -94,3 +94,11 @@ label, textarea.form-control {
       color: $teal;
     }
 }
+
+[data-transaction-status="Success"] {
+  color: $success;
+}
+
+[data-transaction-status^="Error"] {
+  color: $danger;
+}

--- a/apps/block_scout_web/assets/css/components/_tile.scss
+++ b/apps/block_scout_web/assets/css/components/_tile.scss
@@ -109,18 +109,18 @@
 
   &-status {
     &--error--reason {
-      border-top: 1px solid lighten($danger, 10%);
-      border-right: 1px solid lighten($danger, 10%);
-      border-bottom: 1px solid lighten($danger, 10%);
+      border-top: 2px solid lighten($danger, 10%);
+      border-right: 2px solid lighten($danger, 10%);
+      border-bottom: 2px solid lighten($danger, 10%);
 
       .tile-status-label {
         color: $danger;
       }
     }
     &--awaiting-internal-transactions {
-      border-top: 1px solid lighten($warning, 10%);
-      border-right: 1px solid lighten($warning, 10%);
-      border-bottom: 1px solid lighten($warning, 10%);
+      border-top: 2px solid lighten($warning, 10%);
+      border-right: 2px solid lighten($warning, 10%);
+      border-bottom: 2px solid lighten($warning, 10%);
 
       .tile-status-label {
         color: $warning;

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -32,7 +32,7 @@
           </span>
           <div class="d-flex flex-row justify-content-start text-muted">
             <span class="mr-4 text-<%= BlockScoutWeb.TransactionView.type_suffix(@transaction) %>"><%= BlockScoutWeb.TransactionView.transaction_display_type(@transaction) %></span>
-            <span class="mr-4"><%= BlockScoutWeb.TransactionView.formatted_status(@transaction) %></span>
+            <span class="mr-4" data-transaction-status="<%= BlockScoutWeb.TransactionView.formatted_status(@transaction) %>"><%= BlockScoutWeb.TransactionView.formatted_status(@transaction) %></span>
             <span class="mr-4">
               <%= if block do %>
                 <span data-from-now="<%= @transaction.block.timestamp %>"></span>


### PR DESCRIPTION
Resolves: #755 

## Motivation

Highlight the transaction status on the transaction details page to more clearly communicate the transaction's status at a glance. 

## Changelog

### Enhancements
* Add color to the transaction status label to visually represent its status.
* Make the transaction tile error state more prominent by increasing the colored border width

### Screenshots
<img width="770" alt="screen shot 2018-10-03 at 9 56 25 am" src="https://user-images.githubusercontent.com/1641169/46415450-4e6e3c80-c6f3-11e8-9b19-b132784fcce7.png">
<img width="768" alt="screen shot 2018-10-03 at 9 55 20 am" src="https://user-images.githubusercontent.com/1641169/46415452-4e6e3c80-c6f3-11e8-9f70-326914612f95.png">


### Bug Fixes
n/a

### Incompatible Changes
n/a

## Upgrading
n/a
