### PR TITLE
Fix where_forked selecting all transactions when there are no blocks being imported

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -1047,7 +1047,7 @@ defmodule Explorer.Chain.Import do
         ]
       )
 
-    {sql, parameters} = SQL.to_sql(:all, Repo, query)
+    {sql, parameters} = SQL.to_sql(:all, Repo, query) |> IO.inspect()
 
     {:ok, %Postgrex.Result{columns: ["uncle_hash", "hash"], command: :insert, rows: rows}} =
       SQL.query(

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -1019,7 +1019,9 @@ defmodule Explorer.Chain.Import do
   end
 
   defp where_forked(blocks_changes) when is_list(blocks_changes) do
-    Enum.reduce(blocks_changes, Transaction, fn %{consensus: consensus, hash: hash, number: number}, acc ->
+    initial = from(t in Transaction, where: false)
+
+    Enum.reduce(blocks_changes, initial, fn %{consensus: consensus, hash: hash, number: number}, acc ->
       case consensus do
         false ->
           from(transaction in acc, or_where: transaction.block_hash == ^hash and transaction.block_number == ^number)

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -1629,5 +1629,17 @@ defmodule Explorer.Chain.ImportTest do
 
       assert DateTime.compare(timestamp, timestamp_before) == :eq
     end
+
+    # https://github.com/poanetwork/blockscout/issues/850 regression test
+    test "derive_transaction_forks returns errors" do
+      _pending_transaction = insert(:transaction)
+
+      {:error, :derive_transaction_forks, %Postgrex.Error{postgres: %{code: :not_null_violation, column: "index"}}, _} =
+        Import.all(%{
+          blocks: %{
+            params: []
+          }
+        })
+    end
   end
 end

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -1461,52 +1461,124 @@ defmodule Explorer.Chain.ImportTest do
     end
 
     test "timeouts can be overridden" do
-      assert {:ok, _} =
+      miner_hash = address_hash()
+      uncle_miner_hash = address_hash()
+      block_number = 0
+      block_hash = block_hash()
+      uncle_hash = block_hash()
+      from_address_hash = address_hash()
+      to_address_hash = address_hash()
+      transaction_hash = transaction_hash()
+      token_contract_address_hash = address_hash()
+
+      assert {:ok,
+              %{
+                addresses: _,
+                balances: _,
+                blocks: _,
+                block_second_degree_relations: _,
+                internal_transactions: _,
+                logs: _,
+                token_transfers: _,
+                tokens: _,
+                transactions: _,
+                transaction_forks: _,
+                token_balances: _
+              }} =
                Import.all(%{
                  addresses: %{
-                   params: [],
+                   params: [
+                     %{hash: miner_hash},
+                     %{hash: uncle_miner_hash},
+                     %{hash: to_address_hash},
+                     %{hash: from_address_hash},
+                     %{hash: token_contract_address_hash}
+                   ],
                    timeout: 1
                  },
                  balances: %{
-                   params: [],
+                   params: [
+                     %{address_hash: miner_hash, block_number: block_number, value: nil},
+                     %{address_hash: uncle_miner_hash, block_number: block_number, value: nil}
+                   ],
                    timeout: 1
                  },
                  blocks: %{
-                   params: [],
+                   params: [
+                     params_for(:block, hash: block_hash, consensus: true, miner_hash: miner_hash, number: block_number),
+                     params_for(:block,
+                       hash: uncle_hash,
+                       consensus: false,
+                       miner_hash: uncle_miner_hash,
+                       number: block_number
+                     )
+                   ],
                    timeout: 1
                  },
                  block_second_degree_relations: %{
-                   params: [],
+                   params: [%{nephew_hash: block_hash, uncle_hash: uncle_hash}],
                    timeout: 1
                  },
                  internal_transactions: %{
-                   params: [],
+                   params: [
+                     params_for(:internal_transaction,
+                       transaction_hash: transaction_hash,
+                       index: 0,
+                       from_address_hash: from_address_hash,
+                       to_address_hash: to_address_hash
+                     )
+                   ],
                    timeout: 1
                  },
                  logs: %{
-                   params: [],
+                   params: [params_for(:log, transaction_hash: transaction_hash, address_hash: miner_hash)],
                    timeout: 1
                  },
                  token_transfers: %{
-                   params: [],
+                   params: [
+                     params_for(:token_transfer,
+                       from_address_hash: from_address_hash,
+                       to_address_hash: to_address_hash,
+                       token_contract_address_hash: token_contract_address_hash,
+                       transaction_hash: transaction_hash
+                     )
+                   ],
                    timeout: 1
                  },
                  tokens: %{
-                   params: [],
+                   params: [params_for(:token, contract_address_hash: token_contract_address_hash)],
                    on_conflict: :replace_all,
                    timeout: 1
                  },
                  transactions: %{
-                   params: [],
+                   params: [
+                     params_for(:transaction,
+                       hash: transaction_hash,
+                       block_hash: block_hash,
+                       block_number: block_number,
+                       index: 0,
+                       from_address_hash: from_address_hash,
+                       to_address_hash: to_address_hash,
+                       gas_used: 0,
+                       cumulative_gas_used: 0
+                     )
+                   ],
                    on_conflict: :replace_all,
                    timeout: 1
                  },
                  transaction_forks: %{
-                   params: [],
+                   params: [%{uncle_hash: uncle_hash, hash: transaction_hash, index: 0}],
                    timeout: 1
                  },
                  token_balances: %{
-                   params: [],
+                   params: [
+                     params_for(
+                       :token_balance,
+                       address_hash: to_address_hash,
+                       token_contract_address_hash: token_contract_address_hash,
+                       block_number: block_number
+                     )
+                   ],
                    timeout: 1
                  }
                })
@@ -1631,15 +1703,14 @@ defmodule Explorer.Chain.ImportTest do
     end
 
     # https://github.com/poanetwork/blockscout/issues/850 regression test
-    test "derive_transaction_forks does not try to fork pending transactions when there are no blocks" do
+    test "derive_transaction_forks does not run when there are no blocks" do
       _pending_transaction = insert(:transaction)
 
-      {:ok, %{derive_transaction_forks: []}} =
-        Import.all(%{
-          blocks: %{
-            params: []
-          }
-        })
+      assert Import.all(%{
+               blocks: %{
+                 params: []
+               }
+             }) == {:ok, %{}}
     end
   end
 end

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -1631,10 +1631,10 @@ defmodule Explorer.Chain.ImportTest do
     end
 
     # https://github.com/poanetwork/blockscout/issues/850 regression test
-    test "derive_transaction_forks returns errors" do
+    test "derive_transaction_forks does not try to fork pending transactions when there are no blocks" do
       _pending_transaction = insert(:transaction)
 
-      {:error, :derive_transaction_forks, %Postgrex.Error{postgres: %{code: :not_null_violation, column: "index"}}, _} =
+      {:ok, %{derive_transaction_forks: []}} =
         Import.all(%{
           blocks: %{
             params: []

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -5,18 +5,11 @@ defmodule Indexer.Block.Catchup.Fetcher do
 
   require Logger
 
-  import Indexer.Block.Fetcher, only: [fetch_and_import_range: 2]
+  import Indexer.Block.Fetcher,
+    only: [async_import_coin_balances: 2, async_import_tokens: 1, async_import_uncles: 1, fetch_and_import_range: 2]
 
   alias Explorer.Chain
-
-  alias Indexer.{
-    Block,
-    CoinBalance,
-    InternalTransaction,
-    Sequence,
-    Token,
-    TokenBalance
-  }
+  alias Indexer.{Block, InternalTransaction, Sequence, TokenBalance}
 
   @behaviour Block.Fetcher
 
@@ -121,43 +114,32 @@ defmodule Indexer.Block.Catchup.Fetcher do
     end
   end
 
-  defp async_import_remaining_block_data(
-         imported,
-         %{
-           address_hash_to_fetched_balance_block_number: address_hash_to_block_number,
-           transaction_hash_to_block_number: transaction_hash_to_block_number
-         }
-       ) do
-    imported
-    |> Map.get(:addresses, [])
-    |> Enum.map(fn address_hash ->
-      block_number = Map.fetch!(address_hash_to_block_number, to_string(address_hash))
-      %{address_hash: address_hash, block_number: block_number}
-    end)
-    |> CoinBalance.Fetcher.async_fetch_balances()
+  defp async_import_remaining_block_data(imported, options) do
+    async_import_coin_balances(imported, options)
+    async_import_internal_transactions(imported, options)
+    async_import_tokens(imported)
+    async_import_token_balances(imported)
+    async_import_uncles(imported)
+  end
 
-    imported
-    |> Map.get(:transactions, [])
+  defp async_import_internal_transactions(%{transactions: transactions}, %{
+         transaction_hash_to_block_number: transaction_hash_to_block_number
+       }) do
+    transactions
     |> Enum.map(fn transaction_hash ->
       block_number = Map.fetch!(transaction_hash_to_block_number, to_string(transaction_hash))
       %{block_number: block_number, hash: transaction_hash}
     end)
     |> InternalTransaction.Fetcher.async_fetch(10_000)
-
-    imported
-    |> Map.get(:tokens, [])
-    |> Enum.map(& &1.contract_address_hash)
-    |> Token.Fetcher.async_fetch()
-
-    imported
-    |> Map.get(:token_balances, [])
-    |> TokenBalance.Fetcher.async_fetch()
-
-    imported
-    |> Map.get(:block_second_degree_relations, [])
-    |> Enum.map(& &1.uncle_hash)
-    |> Block.Uncle.Fetcher.async_fetch_blocks()
   end
+
+  defp async_import_internal_transactions(_, _), do: :ok
+
+  defp async_import_token_balances(%{token_balances: token_balances}) do
+    TokenBalance.Fetcher.async_fetch(token_balances)
+  end
+
+  defp async_import_token_balances(_), do: :ok
 
   defp stream_fetch_and_import(%__MODULE__{blocks_concurrency: blocks_concurrency} = state, sequence)
        when is_pid(sequence) do

--- a/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
@@ -99,13 +99,14 @@ defmodule Indexer.InternalTransaction.Fetcher do
             {hash, block_number}
           end)
 
-        with {:ok, %{addresses: address_hashes}} <-
+        with {:ok, imported} <-
                Chain.import(%{
                  addresses: %{params: addresses_params},
                  internal_transactions: %{params: internal_transactions_params},
                  timeout: :infinity
                }) do
-          address_hashes
+          imported
+          |> Map.get(:addresses, [])
           |> Enum.map(fn address_hash ->
             block_number = Map.fetch!(address_hash_to_block_number, to_string(address_hash))
             %{address_hash: address_hash, block_number: block_number}

--- a/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
@@ -7,8 +7,10 @@ defmodule Indexer.InternalTransaction.Fetcher do
 
   require Logger
 
+  import Indexer.Block.Fetcher, only: [async_import_coin_balances: 2]
+
   alias Explorer.Chain
-  alias Indexer.{AddressExtraction, BufferedTask, CoinBalance}
+  alias Indexer.{AddressExtraction, BufferedTask}
   alias Explorer.Chain.{Block, Hash}
 
   @behaviour BufferedTask
@@ -105,13 +107,9 @@ defmodule Indexer.InternalTransaction.Fetcher do
                  internal_transactions: %{params: internal_transactions_params},
                  timeout: :infinity
                }) do
-          imported
-          |> Map.get(:addresses, [])
-          |> Enum.map(fn address_hash ->
-            block_number = Map.fetch!(address_hash_to_block_number, to_string(address_hash))
-            %{address_hash: address_hash, block_number: block_number}
-          end)
-          |> CoinBalance.Fetcher.async_fetch_balances()
+          async_import_coin_balances(imported, %{
+            address_hash_to_fetched_balance_block_number: address_hash_to_block_number
+          })
         else
           {:error, step, reason, _changes_so_far} ->
             Logger.debug(fn ->

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -213,9 +213,7 @@ defmodule Indexer.Block.FetcherTest do
           assert {:ok,
                   {%{
                      addresses: [%Address{hash: ^address_hash}],
-                     blocks: [%Chain.Block{hash: ^block_hash}],
-                     logs: [],
-                     transactions: []
+                     blocks: [%Chain.Block{hash: ^block_hash}]
                    }, :more}} = result
 
           wait_for_tasks(InternalTransaction.Fetcher)

--- a/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
@@ -402,7 +402,6 @@ defmodule Indexer.Block.Realtime.FetcherTest do
                    %{index: 4, transaction_hash: transaction_hash},
                    %{index: 5, transaction_hash: transaction_hash}
                  ],
-                 logs: [],
                  transactions: [transaction_hash]
                }, :more}} = Indexer.Block.Fetcher.fetch_and_import_range(block_fetcher, 3_946_079..3_946_080)
     end


### PR DESCRIPTION
Fixes #850

## Changelog

### Enhancements
* Regression test for #850
* Don't run imports for empty params
* Don't do async imports with empty lists

### Bug Fixes
* Return `:error` tuples from `dervie_transaction_forks` instead of raising `MatchError`s.
* There was a bug with `where_forked`, where if there are no blocks it will select **ALL** transactions because no `WHERE` conditions are added to the `SELECT ... FROM transactions`. Instead of starting the initial query that way, start with `WHERE false`, so it will select nothing until the `OR`s for the block hashes and numbers are added.   This means that if there was ever no block, and no pending transactions in the database, all pre-existing transaction would have had a `transaction_forks` row created and their receipt fields blanked.

