### PR TITLE
Fix channel event name for chain transactions.

### DIFF
--- a/apps/block_scout_web/assets/js/pages/chain.js
+++ b/apps/block_scout_web/assets/js/pages/chain.js
@@ -127,7 +127,7 @@ if ($chainDetailsPage.length) {
 
       const transactionsChannel = socket.channel(`transactions:new_transaction`)
       transactionsChannel.join()
-      transactionsChannel.on('new_transaction', batchChannel((msgs) =>
+      transactionsChannel.on('transaction', batchChannel((msgs) =>
         store.dispatch({ type: 'RECEIVED_NEW_TRANSACTION_BATCH', msgs: humps.camelizeKeys(msgs) }))
       )
 


### PR DESCRIPTION
Resolves #851 

## Motivation

Transactions were not live updating on home page.

## Changelog

### Bug Fixes
* Restored live updating of transactions by fixing the event name that the transaction updates were subscribed to.
