### PR TITLE
Add metatags for individual pages on BlockScout

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_metatags.html.eex
@@ -1,0 +1,15 @@
+<%= if assigns[:address] do %>
+  <title>
+    <%= gettext(
+          "%{address} - %{subnetwork} Explorer",
+          address: BlockScoutWeb.AddressView.address_page_title(@address),
+          subnetwork: LayoutView.subnetwork_title()
+        ) %>
+  </title>
+  <meta name="description" content="<%= gettext "View the account balance, transactions, and other data for %{address} on the %{network}", address: to_string(@address), network: LayoutView.network_title() %>">
+  <meta name="keywords" content="<%= BlockScoutWeb.AddressView.address_page_title(@address) <> ", " <> Explorer.coin() <> ", "<> LayoutView.network_title() %>">
+<% else %>
+  <title>
+    <%= gettext "Top Accounts - %{subnetwork} Explorer", subnetwork: LayoutView.subnetwork_title() %>
+  </title>
+<% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -23,7 +23,7 @@
             <% end %>
             <span class="mr-4 mb-2">
               <span data-selector="transaction-count">
-                <%= Cldr.Number.to_string!(@transaction_count, format: "#,###") %>    
+                <%= Cldr.Number.to_string!(@transaction_count, format: "#,###") %>
               </span> <%= gettext("Transactions") %>
               <%= if validator?(@validation_count) do %>
                 <span data-selector="validation-count">

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.AddressView, "_metatags.html", conn: @conn, address: @address %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.AddressView, "_metatags.html", conn: @conn, address: @address %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_read_contract/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_read_contract/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.AddressView, "_metatags.html", conn: @conn, address: @address %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.AddressView, "_metatags.html", conn: @conn, address: @address %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_transfer/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_transfer/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.AddressView, "_metatags.html", conn: @conn, address: @address %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.AddressView, "_metatags.html", conn: @conn, address: @address %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_validation/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_validation/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.AddressView, "_metatags.html", conn: @conn, address: @address %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/api_docs/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/api_docs/_metatags.html.eex
@@ -1,0 +1,5 @@
+<title>
+  <%= gettext "API for the %{subnetwork} - BlockScout", subnetwork: LayoutView.subnetwork_title() %>
+</title>
+<meta name="description" content="<%= gettext "API endpoints for the %{subnetwork}", subnetwork: LayoutView.subnetwork_title()%>">
+<meta name="keywords" content="API, Analytics, Balance, transactions, logs, events, internal transactions, <%= LayoutView.subnetwork_title() %>">

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/_metatags.html.eex
@@ -1,0 +1,13 @@
+<%= if assigns[:block] do %>
+  <title>
+    <%= gettext(
+          "Block %{block_number} - %{subnetwork} Explorer",
+          block_number: @block.number,
+          subnetwork: BlockScoutWeb.LayoutView.subnetwork_title()
+        ) %>
+  </title>
+  <meta name="keywords" content="<%= "#{@block.number}, #{BlockScoutWeb.LayoutView.subnetwork_title()} #{@block.number}" %>">
+  <meta name="description" content="<%= gettext "View the transactions, token transfers, and uncles for block number %{block_number}", block_number: @block.number %>">
+<% else %>
+  <%= BlockScoutWeb.LayoutView.render("_default_title.html") %>
+<% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.BlockView, "_metatags.html", conn: @conn, block: @block %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/chain/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/chain/_metatags.html.eex
@@ -1,0 +1,5 @@
+<title>
+  <%= gettext("%{subnetwork} %{network} Explorer", subnetwork: LayoutView.subnetwork_title(), network: LayoutView.network_title()) %>
+</title>
+<meta name="description" content="<%= gettext "BlockScout provides analytics data, API, and Smart Contract tools for the %{subnetwork}", subnetwork: LayoutView.subnetwork_title() %>">
+<meta name="keywords" content="BlockScout, blockchain, api, analytics, address, smart contract">

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_default_title.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_default_title.html.eex
@@ -1,0 +1,3 @@
+<title>
+  <%= gettext("%{subnetwork} Explorer - BlockScout", subnetwork: subnetwork_title()) %>
+</title>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -16,7 +16,7 @@
     <meta name="msapplication-config" content="<%= static_path(@conn, "/browserconfig.xml") %>">
     <meta name="theme-color" content="#ffffff">
 
-    <%= render_existing(@view_module, "_metatags.html") %>
+    <%= render_existing(@view_module, "_metatags.html", assigns) || render("_default_title.html") %>
   </head>
 
   <body>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><%= app_title() %></title>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
 
     <link rel="apple-touch-icon" sizes="180x180" href="<%= static_path(@conn, "/apple-touch-icon.png") %>">
@@ -16,6 +15,8 @@
     <meta name="msapplication-TileColor" content="#7dd79f">
     <meta name="msapplication-config" content="<%= static_path(@conn, "/browserconfig.xml") %>">
     <meta name="theme-color" content="#ffffff">
+
+    <%= render_existing(@view_module, "_metatags.html") %>
   </head>
 
   <body>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= BlockScoutWeb.Tokens.OverviewView.render "_metatags.html", conn: @conn, token: @token %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= BlockScoutWeb.Tokens.OverviewView.render "_metatags.html", conn: @conn, token: @token %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_metatags.html.eex
@@ -1,0 +1,5 @@
+<title>
+  <%= "#{token_name(@token)} (#{token_symbol(@token)}) - #{LayoutView.subnetwork_title()} - BlockScout" %>
+</title>
+<meta name="description" content="<%= token_name(@token) %>, balances, and analytics on the <%= LayoutView.network_title() %>">
+<meta name="keywords" content="<%= "#{token_name(@token)}, #{token_symbol(@token)}, #{to_string(@token.contract_address_hash)}, #{LayoutView.network_title()}, #{Explorer.coin()}" %>">

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= BlockScoutWeb.Tokens.OverviewView.render "_metatags.html", conn: @conn, token: @token %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= BlockScoutWeb.Tokens.OverviewView.render "_metatags.html", conn: @conn, token: @token %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_metatags.html.eex
@@ -1,0 +1,14 @@
+<%= if assigns[:transaction] do %>
+  <title>
+    <%= gettext(
+          "Transaction %{transaction} - %{subnetwork} Explorer",
+          transaction: to_string(@transaction.hash),
+          subnetwork: BlockScoutWeb.LayoutView.subnetwork_title()
+        ) %>
+  </title>
+
+  <meta name="description" content="<%= gettext "View transaction %{transaction} on %{subnetwork}", transaction: to_string(@transaction.hash), subnetwork: BlockScoutWeb.LayoutView.subnetwork_title() %>">
+  <meta name="keywords" content="<%= gettext "Transaction %{transaction}, %{subnetwork} %{transaction}", transaction: to_string(@transaction.hash), subnetwork: BlockScoutWeb.LayoutView.subnetwork_title() %>">
+<% else %>
+  <%= BlockScoutWeb.LayoutView.render("_default_title.html") %>
+<% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.TransactionView, "_metatags.html", conn: @conn, transaction: @transaction %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.TransactionView, "_metatags.html", conn: @conn, transaction: @transaction %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.TransactionView, "_metatags.html", conn: @conn, transaction: @transaction %>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.AddressView do
 
   alias Explorer.Chain
   alias Explorer.Chain.{Address, Hash, InternalTransaction, SmartContract, Token, TokenTransfer, Transaction, Wei}
+  alias BlockScoutWeb.LayoutView
 
   @dialyzer :no_match
 
@@ -230,5 +231,13 @@ defmodule BlockScoutWeb.AddressView do
     >> = to_string(hash)
 
     "0x" <> short_address
+  end
+
+  def address_page_title(address) do
+    cond do
+      smart_contract_verified?(address) -> "#{address.smart_contract.name} (#{to_string(address)})"
+      contract?(address) -> "Contract #{to_string(address)}"
+      true -> "#{to_string(address)}"
+    end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
@@ -1,6 +1,8 @@
 defmodule BlockScoutWeb.APIDocsView do
   use BlockScoutWeb, :view
 
+  alias BlockScoutWeb.LayoutView
+
   def action_tile_id(module, action) do
     "#{module}-#{action}"
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/chain_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/chain_view.ex
@@ -1,6 +1,8 @@
 defmodule BlockScoutWeb.ChainView do
   use BlockScoutWeb, :view
 
+  alias BlockScoutWeb.LayoutView
+
   def encode_market_history_data(market_history_data) do
     market_history_data
     |> Enum.map(fn day -> Map.take(day, [:closing_price, :date]) end)

--- a/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
@@ -15,10 +15,8 @@ defmodule BlockScoutWeb.LayoutView do
     Keyword.get(application_config(), :subnetwork) || "Sokol Testnet"
   end
 
-  def app_title do
-    network_title = Keyword.get(application_config(), :network) || "POA"
-
-    gettext("%{subnetwork} %{network} Explorer", subnetwork: subnetwork_title(), network: network_title)
+  def network_title do
+    Keyword.get(application_config(), :network) || "POA"
   end
 
   defp application_config do

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/overview_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/overview_view.ex
@@ -3,6 +3,8 @@ defmodule BlockScoutWeb.Tokens.OverviewView do
 
   alias Explorer.Chain.{Address, SmartContract, Token}
 
+  alias BlockScoutWeb.LayoutView
+
   @tabs ["token_transfers", "token_holders", "read_contract", "inventory"]
 
   def decimals?(%Token{decimals: nil}), do: false

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -65,7 +65,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:15
-#: lib/block_scout_web/views/address_view.ex:81
+#: lib/block_scout_web/views/address_view.ex:82
 msgid "Address"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:90
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:122
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
-#: lib/block_scout_web/views/address_view.ex:222
+#: lib/block_scout_web/views/address_view.ex:223
 msgid "Code"
 msgstr ""
 
@@ -210,14 +210,14 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:12
-#: lib/block_scout_web/views/address_view.ex:79
+#: lib/block_scout_web/views/address_view.ex:80
 msgid "Contract Address"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:15
-#: lib/block_scout_web/views/address_view.ex:23
-#: lib/block_scout_web/views/address_view.ex:57
+#: lib/block_scout_web/views/address_view.ex:24
+#: lib/block_scout_web/views/address_view.ex:58
 msgid "Contract Address Pending"
 msgstr ""
 
@@ -433,7 +433,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:221
+#: lib/block_scout_web/views/address_view.ex:222
 #: lib/block_scout_web/views/transaction_view.ex:176
 msgid "Internal Transactions"
 msgstr ""
@@ -442,12 +442,12 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/inventory/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:23
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:67
-#: lib/block_scout_web/views/tokens/overview_view.ex:36
+#: lib/block_scout_web/views/tokens/overview_view.ex:38
 msgid "Inventory"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:34
+#: lib/block_scout_web/templates/layout/app.html.eex:35
 msgid "Less than"
 msgstr ""
 
@@ -466,8 +466,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:17
-#: lib/block_scout_web/templates/layout/app.html.eex:35
-#: lib/block_scout_web/views/address_view.ex:101
+#: lib/block_scout_web/templates/layout/app.html.eex:36
+#: lib/block_scout_web/views/address_view.ex:102
 msgid "Market Cap"
 msgstr ""
 
@@ -625,7 +625,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:10
-#: lib/block_scout_web/templates/layout/app.html.eex:36
+#: lib/block_scout_web/templates/layout/app.html.eex:37
 msgid "Price"
 msgstr ""
 
@@ -649,8 +649,8 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:53
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
-#: lib/block_scout_web/views/address_view.ex:223
-#: lib/block_scout_web/views/tokens/overview_view.ex:35
+#: lib/block_scout_web/views/address_view.ex:224
+#: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/holder/index.html.eex:19
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:13
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:60
-#: lib/block_scout_web/views/tokens/overview_view.ex:34
+#: lib/block_scout_web/views/tokens/overview_view.ex:36
 msgid "Token Holders"
 msgstr ""
 
@@ -837,7 +837,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:6
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:36
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:10
-#: lib/block_scout_web/views/tokens/overview_view.ex:33
+#: lib/block_scout_web/views/tokens/overview_view.ex:35
 #: lib/block_scout_web/views/transaction_view.ex:175
 msgid "Token Transfers"
 msgstr ""
@@ -850,7 +850,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:18
 #: lib/block_scout_web/templates/address_validation/index.html.eex:62
 #: lib/block_scout_web/templates/address_validation/index.html.eex:70
-#: lib/block_scout_web/views/address_view.ex:219
+#: lib/block_scout_web/views/address_view.ex:220
 msgid "Tokens"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:24
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:56
 #: lib/block_scout_web/templates/transaction/index.html.eex:56
-#: lib/block_scout_web/views/address_view.ex:220
+#: lib/block_scout_web/views/address_view.ex:221
 msgid "Transactions"
 msgstr ""
 
@@ -1068,11 +1068,71 @@ msgid "More pending transactions have come in"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/layout_view.ex:21
+#: lib/block_scout_web/templates/chain/_metatags.html.eex:2
 msgid "%{subnetwork} %{network} Explorer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:33
+#: lib/block_scout_web/templates/layout/app.html.eex:34
 msgid "Block Mined, awaiting processing..."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/_metatags.html.eex:3
+msgid "%{address} - %{subnetwork} Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_default_title.html.eex:2
+msgid "%{subnetwork} Explorer - BlockScout"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/api_docs/_metatags.html.eex:4
+msgid "API endpoints for the %{subnetwork}"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/api_docs/_metatags.html.eex:2
+msgid "API for the %{subnetwork} - BlockScout"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block/_metatags.html.eex:3
+msgid "Block %{block_number} - %{subnetwork} Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/chain/_metatags.html.eex:4
+msgid "BlockScout provides analytics data, API, and Smart Contract tools for the %{subnetwork}"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/_metatags.html.eex:13
+msgid "Top Accounts - %{subnetwork} Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_metatags.html.eex:3
+msgid "Transaction %{transaction} - %{subnetwork} Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_metatags.html.eex:11
+msgid "Transaction %{transaction}, %{subnetwork} %{transaction}"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/_metatags.html.eex:9
+msgid "View the account balance, transactions, and other data for %{address} on the %{network}"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block/_metatags.html.eex:10
+msgid "View the transactions, token transfers, and uncles for block number %{block_number}"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_metatags.html.eex:10
+msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -65,7 +65,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:15
-#: lib/block_scout_web/views/address_view.ex:81
+#: lib/block_scout_web/views/address_view.ex:82
 msgid "Address"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:90
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:122
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
-#: lib/block_scout_web/views/address_view.ex:222
+#: lib/block_scout_web/views/address_view.ex:223
 msgid "Code"
 msgstr ""
 
@@ -210,14 +210,14 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:12
-#: lib/block_scout_web/views/address_view.ex:79
+#: lib/block_scout_web/views/address_view.ex:80
 msgid "Contract Address"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:15
-#: lib/block_scout_web/views/address_view.ex:23
-#: lib/block_scout_web/views/address_view.ex:57
+#: lib/block_scout_web/views/address_view.ex:24
+#: lib/block_scout_web/views/address_view.ex:58
 msgid "Contract Address Pending"
 msgstr ""
 
@@ -433,7 +433,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:221
+#: lib/block_scout_web/views/address_view.ex:222
 #: lib/block_scout_web/views/transaction_view.ex:176
 msgid "Internal Transactions"
 msgstr ""
@@ -442,12 +442,12 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/inventory/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:23
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:67
-#: lib/block_scout_web/views/tokens/overview_view.ex:36
+#: lib/block_scout_web/views/tokens/overview_view.ex:38
 msgid "Inventory"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:34
+#: lib/block_scout_web/templates/layout/app.html.eex:35
 msgid "Less than"
 msgstr ""
 
@@ -466,8 +466,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:17
-#: lib/block_scout_web/templates/layout/app.html.eex:35
-#: lib/block_scout_web/views/address_view.ex:101
+#: lib/block_scout_web/templates/layout/app.html.eex:36
+#: lib/block_scout_web/views/address_view.ex:102
 msgid "Market Cap"
 msgstr ""
 
@@ -625,7 +625,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:10
-#: lib/block_scout_web/templates/layout/app.html.eex:36
+#: lib/block_scout_web/templates/layout/app.html.eex:37
 msgid "Price"
 msgstr ""
 
@@ -649,8 +649,8 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:53
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
-#: lib/block_scout_web/views/address_view.ex:223
-#: lib/block_scout_web/views/tokens/overview_view.ex:35
+#: lib/block_scout_web/views/address_view.ex:224
+#: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/holder/index.html.eex:19
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:13
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:60
-#: lib/block_scout_web/views/tokens/overview_view.ex:34
+#: lib/block_scout_web/views/tokens/overview_view.ex:36
 msgid "Token Holders"
 msgstr ""
 
@@ -837,7 +837,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:6
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:36
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:10
-#: lib/block_scout_web/views/tokens/overview_view.ex:33
+#: lib/block_scout_web/views/tokens/overview_view.ex:35
 #: lib/block_scout_web/views/transaction_view.ex:175
 msgid "Token Transfers"
 msgstr ""
@@ -850,7 +850,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:18
 #: lib/block_scout_web/templates/address_validation/index.html.eex:62
 #: lib/block_scout_web/templates/address_validation/index.html.eex:70
-#: lib/block_scout_web/views/address_view.ex:219
+#: lib/block_scout_web/views/address_view.ex:220
 msgid "Tokens"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:24
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:56
 #: lib/block_scout_web/templates/transaction/index.html.eex:56
-#: lib/block_scout_web/views/address_view.ex:220
+#: lib/block_scout_web/views/address_view.ex:221
 msgid "Transactions"
 msgstr ""
 
@@ -1068,11 +1068,71 @@ msgid "More pending transactions have come in"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/layout_view.ex:21
+#: lib/block_scout_web/templates/chain/_metatags.html.eex:2
 msgid "%{subnetwork} %{network} Explorer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:33
+#: lib/block_scout_web/templates/layout/app.html.eex:34
 msgid "Block Mined, awaiting processing..."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/_metatags.html.eex:3
+msgid "%{address} - %{subnetwork} Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_default_title.html.eex:2
+msgid "%{subnetwork} Explorer - BlockScout"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/api_docs/_metatags.html.eex:4
+msgid "API endpoints for the %{subnetwork}"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/api_docs/_metatags.html.eex:2
+msgid "API for the %{subnetwork} - BlockScout"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block/_metatags.html.eex:3
+msgid "Block %{block_number} - %{subnetwork} Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/chain/_metatags.html.eex:4
+msgid "BlockScout provides analytics data, API, and Smart Contract tools for the %{subnetwork}"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/_metatags.html.eex:13
+msgid "Top Accounts - %{subnetwork} Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_metatags.html.eex:3
+msgid "Transaction %{transaction} - %{subnetwork} Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_metatags.html.eex:11
+msgid "Transaction %{transaction}, %{subnetwork} %{transaction}"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/_metatags.html.eex:9
+msgid "View the account balance, transactions, and other data for %{address} on the %{network}"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block/_metatags.html.eex:10
+msgid "View the transactions, token transfers, and uncles for block number %{block_number}"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_metatags.html.eex:10
+msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
@@ -316,4 +316,25 @@ defmodule BlockScoutWeb.AddressViewTest do
       assert String.length(short_hash) == 6
     end
   end
+
+  describe "address_page_title/1" do
+    test "uses the Smart Contract name when the contract is verified" do
+      smart_contract = build(:smart_contract, name: "POA")
+      address = build(:address, smart_contract: smart_contract)
+
+      assert AddressView.address_page_title(address) == "POA (#{address.hash})"
+    end
+
+    test "uses the string 'Contract' when it's a contract" do
+      address = build(:contract_address, smart_contract: nil)
+
+      assert AddressView.address_page_title(address) == "Contract #{address.hash}"
+    end
+
+    test "uses the address hash when it is not a contract" do
+      address = build(:address, smart_contract: nil)
+
+      assert AddressView.address_page_title(address) == "#{address.hash}"
+    end
+  end
 end

--- a/apps/block_scout_web/test/block_scout_web/views/layout_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/layout_view_test.exs
@@ -49,21 +49,15 @@ defmodule BlockScoutWeb.LayoutViewTest do
     end
   end
 
-  describe "app_title/0" do
-    test "use the enviroment subnetwork title when it's configured" do
-      Application.put_env(:block_scout_web, BlockScoutWeb.Chain, subnetwork: "Subnetwork Test")
-
-      assert LayoutView.app_title() == "Subnetwork Test POA Explorer"
-    end
-
+  describe "network_title/0" do
     test "use the enviroment network title when it's configured" do
-      Application.put_env(:block_scout_web, BlockScoutWeb.Chain, network: "Custom")
+      Application.put_env(:block_scout_web, BlockScoutWeb.Chain, network: "Custom Network")
 
-      assert LayoutView.app_title() == "Sokol Testnet Custom Explorer"
+      assert LayoutView.network_title() == "Custom Network"
     end
 
-    test "use the default subnetwork title when there is no env configured for it" do
-      assert LayoutView.app_title() == "Sokol Testnet POA Explorer"
+    test "use the default network title when there is no env configured for it" do
+      assert LayoutView.network_title() == "POA"
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/568

## Changelog

### Enhancements
Add meta tags for the following pages:
* Home page
* Address's page
* Token's page
* API page
* Accounts' page
* Block's page
* Transactions' page

We are using `render_existing/3` in the `app.html.eex` that will try to render the template `metatags.html.eex` if there is one inside the requested view. If this `partial` doesn't exist, it will render the partial `_default_title.html.eex`.
