### PR TITLE
Allow insecure WebSocket connections

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/web_socket/web_socket_client.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/web_socket/web_socket_client.ex
@@ -55,6 +55,22 @@ defmodule EthereumJSONRPC.WebSocket.WebSocketClient do
     )
   end
 
+  def start_link(["ws://" <> _ = url, gen_fsm_options]) when is_list(gen_fsm_options) do
+    fsm_name =
+      case Keyword.fetch(gen_fsm_options, :name) do
+        {:ok, name} when is_atom(name) -> {:local, name}
+        :error -> :undefined
+      end
+
+    :websocket_client.start_link(
+      fsm_name,
+      url,
+      __MODULE__,
+      url,
+      []
+    )
+  end
+
   # Client interface
 
   @impl WebSocket

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -15,6 +15,6 @@ config :indexer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: "wss://mainnet.infura.io/ws/8lTvJTKmHPCHazkneJsY"
+      url: System.get_env("ETHEREUM_JSONRPC_WEB_SOCKET_URL") || "wss://mainnet.infura.io/ws/8lTvJTKmHPCHazkneJsY"
     ]
   ]


### PR DESCRIPTION
Related to #624

## Motivation

Some setup like ours will have the WebSocket connection in a private network to a local node and thus do not require a secure connection.

## Changelog

### Enhancements
- Allow inscure websocket connections with `ws://` scheme instead of `wss://`.
- Read from `ETHEREUM_JSONRPC_WEB_SOCKET_URL` in `apps/indexer/config/geth.exs`.