### PR TITLE
Consolidate token transfer count

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -8,7 +8,7 @@ defmodule BlockScoutWeb.Notifier do
   alias Explorer.ExchangeRates.Token
   alias BlockScoutWeb.Endpoint
 
-  def handle_event({:chain_event, :addresses, addresses}) do
+  def handle_event({:chain_event, :addresses, :realtime, addresses}) do
     Endpoint.broadcast("addresses:new_address", "count", %{count: Chain.address_estimated_count()})
 
     addresses
@@ -16,7 +16,7 @@ defmodule BlockScoutWeb.Notifier do
     |> Enum.each(&broadcast_balance/1)
   end
 
-  def handle_event({:chain_event, :blocks, blocks}) do
+  def handle_event({:chain_event, :blocks, :realtime, blocks}) do
     Enum.each(blocks, &broadcast_block/1)
   end
 
@@ -35,7 +35,7 @@ defmodule BlockScoutWeb.Notifier do
     })
   end
 
-  def handle_event({:chain_event, :internal_transactions, internal_transactions}) do
+  def handle_event({:chain_event, :internal_transactions, :realtime, internal_transactions}) do
     internal_transactions
     |> Stream.map(
       &(InternalTransaction
@@ -45,7 +45,7 @@ defmodule BlockScoutWeb.Notifier do
     |> Enum.each(&broadcast_internal_transaction/1)
   end
 
-  def handle_event({:chain_event, :transactions, transaction_hashes}) do
+  def handle_event({:chain_event, :transactions, :realtime, transaction_hashes}) do
     transaction_hashes
     |> Chain.hashes_to_transactions(
       necessity_by_association: %{
@@ -58,6 +58,8 @@ defmodule BlockScoutWeb.Notifier do
     )
     |> Enum.each(&broadcast_transaction/1)
   end
+
+  def handle_event(_), do: nil
 
   defp broadcast_balance(%Address{hash: address_hash} = address) do
     Endpoint.broadcast("addresses:#{address_hash}", "balance_update", %{

--- a/apps/block_scout_web/test/block_scout_web/channels/address_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/address_channel_test.exs
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
     address = insert(:address)
 
-    Notifier.handle_event({:chain_event, :addresses, [address]})
+    Notifier.handle_event({:chain_event, :addresses, :realtime, [address]})
 
     receive do
       %Phoenix.Socket.Broadcast{topic: ^topic, event: "count", payload: %{count: _}} ->
@@ -30,7 +30,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
     test "notified of balance_update for matching address", %{address: address, topic: topic} do
       address_with_balance = %{address | fetched_coin_balance: 1}
-      Notifier.handle_event({:chain_event, :addresses, [address_with_balance]})
+      Notifier.handle_event({:chain_event, :addresses, :realtime, [address_with_balance]})
 
       receive do
         %Phoenix.Socket.Broadcast{topic: ^topic, event: "balance_update", payload: payload} ->
@@ -42,7 +42,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
     end
 
     test "not notified of balance_update if fetched_coin_balance is nil", %{address: address} do
-      Notifier.handle_event({:chain_event, :addresses, [address]})
+      Notifier.handle_event({:chain_event, :addresses, :realtime, [address]})
 
       receive do
         _ -> assert false, "Message was broadcast for nil fetched_coin_balance."
@@ -54,7 +54,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
     test "notified of new_pending_transaction for matching from_address", %{address: address, topic: topic} do
       pending = insert(:transaction, from_address: address)
 
-      Notifier.handle_event({:chain_event, :transactions, [pending.hash]})
+      Notifier.handle_event({:chain_event, :transactions, :realtime, [pending.hash]})
 
       receive do
         %Phoenix.Socket.Broadcast{topic: ^topic, event: "pending_transaction", payload: payload} ->
@@ -72,7 +72,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
         |> insert(from_address: address)
         |> with_block()
 
-      Notifier.handle_event({:chain_event, :transactions, [transaction.hash]})
+      Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction.hash]})
 
       receive do
         %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload} ->
@@ -90,7 +90,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
         |> insert(to_address: address)
         |> with_block()
 
-      Notifier.handle_event({:chain_event, :transactions, [transaction.hash]})
+      Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction.hash]})
 
       receive do
         %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload} ->
@@ -108,7 +108,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
         |> insert(from_address: address, to_address: address)
         |> with_block()
 
-      Notifier.handle_event({:chain_event, :transactions, [transaction.hash]})
+      Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction.hash]})
 
       receive do
         %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload} ->
@@ -134,7 +134,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
       internal_transaction = insert(:internal_transaction, transaction: transaction, from_address: address, index: 0)
 
-      Notifier.handle_event({:chain_event, :internal_transactions, [internal_transaction]})
+      Notifier.handle_event({:chain_event, :internal_transactions, :realtime, [internal_transaction]})
 
       receive do
         %Phoenix.Socket.Broadcast{topic: ^topic, event: "internal_transaction", payload: payload} ->
@@ -154,7 +154,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
       internal_transaction = insert(:internal_transaction, transaction: transaction, to_address: address, index: 0)
 
-      Notifier.handle_event({:chain_event, :internal_transactions, [internal_transaction]})
+      Notifier.handle_event({:chain_event, :internal_transactions, :realtime, [internal_transaction]})
 
       receive do
         %Phoenix.Socket.Broadcast{topic: ^topic, event: "internal_transaction", payload: payload} ->
@@ -178,7 +178,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
       internal_transaction =
         insert(:internal_transaction, transaction: transaction, from_address: address, to_address: address, index: 0)
 
-      Notifier.handle_event({:chain_event, :internal_transactions, [internal_transaction]})
+      Notifier.handle_event({:chain_event, :internal_transactions, :realtime, [internal_transaction]})
 
       receive do
         %Phoenix.Socket.Broadcast{topic: ^topic, event: "internal_transaction", payload: payload} ->

--- a/apps/block_scout_web/test/block_scout_web/channels/block_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/block_channel_test.exs
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.BlockChannelTest do
 
     block = insert(:block, number: 1)
 
-    Notifier.handle_event({:chain_event, :blocks, [block]})
+    Notifier.handle_event({:chain_event, :blocks, :realtime, [block]})
 
     receive do
       %Phoenix.Socket.Broadcast{topic: ^topic, event: "new_block", payload: %{block: _}} ->

--- a/apps/block_scout_web/test/block_scout_web/channels/transaction_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/transaction_channel_test.exs
@@ -13,7 +13,7 @@ defmodule BlockScoutWeb.TransactionChannelTest do
       |> insert()
       |> with_block()
 
-    Notifier.handle_event({:chain_event, :transactions, [transaction.hash]})
+    Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction.hash]})
 
     receive do
       %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload} ->
@@ -30,7 +30,7 @@ defmodule BlockScoutWeb.TransactionChannelTest do
 
     pending = insert(:transaction)
 
-    Notifier.handle_event({:chain_event, :transactions, [pending.hash]})
+    Notifier.handle_event({:chain_event, :transactions, :realtime, [pending.hash]})
 
     receive do
       %Phoenix.Socket.Broadcast{topic: ^topic, event: "pending_transaction", payload: payload} ->
@@ -50,7 +50,7 @@ defmodule BlockScoutWeb.TransactionChannelTest do
     topic = "transactions:#{Hash.to_string(transaction.hash)}"
     @endpoint.subscribe(topic)
 
-    Notifier.handle_event({:chain_event, :transactions, [transaction.hash]})
+    Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction.hash]})
 
     receive do
       %Phoenix.Socket.Broadcast{topic: ^topic, event: "collated", payload: %{}} ->

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
@@ -147,7 +147,7 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
 
       new_pending = insert(:transaction, from_address: addresses.lincoln)
 
-      Notifier.handle_event({:chain_event, :transactions, [new_pending.hash]})
+      Notifier.handle_event({:chain_event, :transactions, :realtime, [new_pending.hash]})
 
       assert_has(session, AddressPage.pending_transaction(new_pending))
     end
@@ -278,7 +278,7 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
       internal_transaction =
         insert(:internal_transaction, transaction: transaction, index: 0, from_address: addresses.lincoln)
 
-      Notifier.handle_event({:chain_event, :internal_transactions, [internal_transaction]})
+      Notifier.handle_event({:chain_event, :internal_transactions, :realtime, [internal_transaction]})
 
       session
       |> assert_has(AddressPage.internal_transactions(count: 3))

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_blocks_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_blocks_test.exs
@@ -39,7 +39,7 @@ defmodule BlockScoutWeb.ViewingBlocksTest do
       BlockListPage.visit_page(session)
 
       block = insert(:block, number: 315)
-      Notifier.handle_event({:chain_event, :blocks, [block]})
+      Notifier.handle_event({:chain_event, :blocks, :realtime, [block]})
 
       session
       |> assert_has(BlockListPage.block(block))
@@ -50,14 +50,14 @@ defmodule BlockScoutWeb.ViewingBlocksTest do
       BlockListPage.visit_page(session)
 
       block = insert(:block, number: 315)
-      Notifier.handle_event({:chain_event, :blocks, [block]})
+      Notifier.handle_event({:chain_event, :blocks, :realtime, [block]})
 
       session
       |> assert_has(BlockListPage.block(block))
       |> assert_has(BlockListPage.place_holder_blocks(3))
 
       skipped_block = insert(:block, number: 314)
-      Notifier.handle_event({:chain_event, :blocks, [skipped_block]})
+      Notifier.handle_event({:chain_event, :blocks, :realtime, [skipped_block]})
 
       session
       |> assert_has(BlockListPage.block(skipped_block))

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -22,6 +22,8 @@ config :explorer, Explorer.Repo,
   loggers: [Explorer.Repo.PrometheusLogger, Ecto.LogEntry],
   migration_timestamps: [type: :utc_datetime]
 
+config :explorer, Explorer.Counters.TokenTransferCounter, enabled: true
+
 config :explorer,
   solc_bin_api_url: "https://solc-bin.ethereum.org"
 

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -16,6 +16,9 @@ defmodule Explorer.Application do
       Explorer.Repo,
       Supervisor.child_spec({Task.Supervisor, name: Explorer.MarketTaskSupervisor}, id: Explorer.MarketTaskSupervisor),
       Supervisor.child_spec({Task.Supervisor, name: Explorer.TaskSupervisor}, id: Explorer.TaskSupervisor),
+      Supervisor.child_spec({Task.Supervisor, name: Explorer.CounterTokenSupervisor},
+        id: Explorer.CounterTokenSupervisor
+      ),
       {Registry, keys: :duplicate, name: Registry.ChainEvents, id: Registry.ChainEvents}
     ]
 
@@ -29,7 +32,8 @@ defmodule Explorer.Application do
   defp configurable_children do
     [
       configure(Explorer.ExchangeRates),
-      configure(Explorer.Market.History.Cataloger)
+      configure(Explorer.Market.History.Cataloger),
+      configure(Explorer.Counters.TokenTransferCounter)
     ]
     |> List.flatten()
   end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -38,6 +38,7 @@ defmodule Explorer.Chain do
 
   alias Explorer.Chain.Block.Reward
   alias Explorer.{PagingOptions, Repo}
+  alias Explorer.Counters.TokenTransferCounter
 
   @default_paging_options %PagingOptions{page_size: 50}
 
@@ -1922,7 +1923,7 @@ defmodule Explorer.Chain do
 
   @spec count_token_transfers_from_token_hash(Hash.t()) :: non_neg_integer()
   def count_token_transfers_from_token_hash(token_address_hash) do
-    TokenTransfer.count_token_transfers_from_token_hash(token_address_hash)
+    TokenTransferCounter.fetch(token_address_hash)
   end
 
   @spec transaction_has_token_transfers?(Hash.t()) :: boolean()

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -57,6 +57,7 @@ defmodule Explorer.Chain do
           | :internal_transactions
           | :logs
           | :transactions
+          | :token_transfers
 
   @type direction :: :from | :to
 
@@ -1449,7 +1450,7 @@ defmodule Explorer.Chain do
   """
   @spec subscribe_to_events(chain_event()) :: :ok
   def subscribe_to_events(event_type)
-      when event_type in ~w(addresses address_coin_balances blocks exchange_rate internal_transactions logs transactions)a do
+      when event_type in ~w(addresses address_coin_balances blocks exchange_rate internal_transactions logs token_transfers transactions)a do
     Registry.register(Registry.ChainEvents, event_type, [])
     :ok
   end

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -38,7 +38,7 @@ defmodule Explorer.Chain.Import do
     end
 
   @type all_options :: %{
-          optional(:broadcast) => boolean,
+          optional(:broadcast) => atom,
           optional(:timeout) => timeout,
           unquote_splicing(quoted_runner_options)
         }

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -127,18 +127,6 @@ defmodule Explorer.Chain.TokenTransfer do
     |> Repo.all()
   end
 
-  @spec count_token_transfers_from_token_hash(Hash.t()) :: non_neg_integer()
-  def count_token_transfers_from_token_hash(token_address_hash) do
-    query =
-      from(
-        tt in TokenTransfer,
-        where: tt.token_contract_address_hash == ^token_address_hash,
-        select: count(tt.id)
-      )
-
-    Repo.one(query)
-  end
-
   def page_token_transfer(query, %PagingOptions{key: nil}), do: query
 
   def page_token_transfer(query, %PagingOptions{key: {token_id}}) do

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -197,4 +197,20 @@ defmodule Explorer.Chain.TokenTransfer do
       select: tt
     )
   end
+
+  @doc """
+  Counts all the token transfers and groups by token contract address hash.
+  """
+  def count_token_transfers do
+    query =
+      from(
+        tt in TokenTransfer,
+        join: t in Token,
+        on: tt.token_contract_address_hash == t.contract_address_hash,
+        select: {tt.token_contract_address_hash, count(tt.id)},
+        group_by: tt.token_contract_address_hash
+      )
+
+    Repo.all(query)
+  end
 end

--- a/apps/explorer/lib/explorer/counters/token_transfer_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_transfer_counter.ex
@@ -1,0 +1,93 @@
+defmodule Explorer.Counters.TokenTransferCounter do
+  use GenServer
+
+  @moduledoc """
+  Module responsible for fetching and consolidating the number of transfers
+  from a token.
+  """
+
+  alias Explorer.Chain
+  alias Explorer.Chain.{Hash, TokenTransfer}
+
+  @table :token_transfer_counter
+
+  def table_name do
+    @table
+  end
+
+  @doc """
+  Starts a process to continually monitor the token counters.
+  """
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  ## Server
+  @impl true
+  def init(args) do
+    create_table()
+
+    Task.start_link(&consolidate/0)
+
+    Chain.subscribe_to_events(:token_transfers)
+
+    {:ok, args}
+  end
+
+  def create_table do
+    opts = [
+      :set,
+      :named_table,
+      :public,
+      read_concurrency: true,
+      write_concurrency: true
+    ]
+
+    :ets.new(table_name(), opts)
+  end
+
+  @doc """
+  Consolidates the number of token transfers grouped by token.
+  """
+  def consolidate do
+    total_token_transfers = TokenTransfer.count_token_transfers()
+
+    for {token_hash, total} <- total_token_transfers do
+      insert_or_update_counter(token_hash, total)
+    end
+  end
+
+  @doc """
+  Fetches the number of transfers related to a token hash.
+  """
+  @spec fetch(Hash.t()) :: non_neg_integer
+  def fetch(token_hash) do
+    do_fetch(:ets.lookup(table_name(), to_string(token_hash)))
+  end
+
+  defp do_fetch([{_, result} | _]), do: result
+  defp do_fetch([]), do: 0
+
+  @impl true
+  def handle_info({:chain_event, :token_transfers, _type, token_transfers}, state) do
+    token_transfers
+    |> Enum.map(& &1.token_contract_address_hash)
+    |> Enum.each(&insert_or_update_counter(&1, 1))
+
+    {:noreply, state}
+  end
+
+  @doc """
+  Inserts a new item into the `:ets` table.
+
+  When the record exist, the counter will be incremented by one. When the
+  record does not exist, the counter will be inserted with a default value.
+  """
+  @spec insert_or_update_counter(Hash.t(), non_neg_integer) :: term()
+  def insert_or_update_counter(token_hash, number) do
+    default = {to_string(token_hash), 0}
+
+    :ets.update_counter(table_name(), to_string(token_hash), number, default)
+  end
+end

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -42,7 +42,7 @@ defmodule Explorer.Chain.ImportTest do
         ],
         timeout: 5
       },
-      broadcast: true,
+      broadcast: :realtime,
       internal_transactions: %{
         params: [
           %{
@@ -399,7 +399,7 @@ defmodule Explorer.Chain.ImportTest do
     test "publishes data to subscribers on insert" do
       Chain.subscribe_to_events(:logs)
       Import.all(@import_data)
-      assert_received {:chain_event, :logs, [%Log{}]}
+      assert_received {:chain_event, :logs, :realtime, [%Log{}]}
     end
 
     test "with invalid data" do
@@ -413,31 +413,39 @@ defmodule Explorer.Chain.ImportTest do
     test "publishes addresses with updated fetched_coin_balance data to subscribers on insert" do
       Chain.subscribe_to_events(:addresses)
       Import.all(@import_data)
-      assert_received {:chain_event, :addresses, [%Address{}, %Address{}, %Address{}]}
+      assert_received {:chain_event, :addresses, :realtime, [%Address{}, %Address{}, %Address{}]}
     end
 
     test "publishes block data to subscribers on insert" do
       Chain.subscribe_to_events(:blocks)
       Import.all(@import_data)
-      assert_received {:chain_event, :blocks, [%Block{}]}
+      assert_received {:chain_event, :blocks, :realtime, [%Block{}]}
     end
 
     test "publishes internal_transaction data to subscribers on insert" do
       Chain.subscribe_to_events(:internal_transactions)
       Import.all(@import_data)
-      assert_received {:chain_event, :internal_transactions, [%{id: _}, %{id: _}]}
+      assert_received {:chain_event, :internal_transactions, :realtime, [%{id: _}, %{id: _}]}
     end
 
     test "publishes log data to subscribers on insert" do
       Chain.subscribe_to_events(:logs)
       Import.all(@import_data)
-      assert_received {:chain_event, :logs, [%Log{}]}
+      assert_received {:chain_event, :logs, :realtime, [%Log{}]}
     end
 
     test "publishes transaction hashes data to subscribers on insert" do
       Chain.subscribe_to_events(:transactions)
       Import.all(@import_data)
-      assert_received {:chain_event, :transactions, [%Hash{}]}
+      assert_received {:chain_event, :transactions, :realtime, [%Hash{}]}
+    end
+
+    test "publishes token_transfers data to subscribers on insert" do
+      Chain.subscribe_to_events(:token_transfers)
+
+      Import.all(@import_data)
+
+      assert_received {:chain_event, :token_transfers, :realtime, [%TokenTransfer{}]}
     end
 
     test "does not broadcast if broadcast option is false" do
@@ -445,7 +453,7 @@ defmodule Explorer.Chain.ImportTest do
 
       Chain.subscribe_to_events(:logs)
       Import.all(non_broadcast_data)
-      refute_received {:chain_event, :logs, [%Log{}]}
+      refute_received {:chain_event, :logs, :realtime, [%Log{}]}
     end
 
     test "updates address with contract code" do

--- a/apps/explorer/test/explorer/chain/token_transfer_test.exs
+++ b/apps/explorer/test/explorer/chain/token_transfer_test.exs
@@ -112,17 +112,16 @@ defmodule Explorer.Chain.TokenTransferTest do
     end
   end
 
-  describe "count_token_transfers/1" do
-    test "counts how many token transfers a token has" do
+  describe "count_token_transfers/0" do
+    test "returns token transfers grouped by tokens" do
       token_contract_address = insert(:contract_address)
+      token = insert(:token, contract_address: token_contract_address)
 
       transaction =
         :transaction
         |> insert()
         |> with_block()
 
-      token = insert(:token)
-
       insert(
         :token_transfer,
         to_address: build(:address),
@@ -139,7 +138,10 @@ defmodule Explorer.Chain.TokenTransferTest do
         token: token
       )
 
-      assert TokenTransfer.count_token_transfers_from_token_hash(token_contract_address.hash) == 2
+      results = TokenTransfer.count_token_transfers()
+
+      assert length(results) == 1
+      assert List.first(results) == {token.contract_address_hash, 2}
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -558,28 +558,6 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "count_token_transfers_from_token_hash/1" do
-    test "without token transfers" do
-      %Token{contract_address_hash: contract_address_hash} = insert(:token)
-
-      assert Chain.count_token_transfers_from_token_hash(contract_address_hash) == 0
-    end
-
-    test "with token transfers" do
-      address = insert(:address)
-
-      transaction =
-        :transaction
-        |> insert()
-        |> with_block()
-
-      %TokenTransfer{token_contract_address_hash: token_contract_address_hash} =
-        insert(:token_transfer, to_address: address, transaction: transaction)
-
-      assert Chain.count_token_transfers_from_token_hash(token_contract_address_hash) == 1
-    end
-  end
-
   describe "gas_price/2" do
     test ":wei unit" do
       assert Chain.gas_price(%Transaction{gas_price: %Wei{value: Decimal.new(1)}}, :wei) == Decimal.new(1)

--- a/apps/explorer/test/explorer/counters/token_transfer_counter_test.exs
+++ b/apps/explorer/test/explorer/counters/token_transfer_counter_test.exs
@@ -1,0 +1,50 @@
+defmodule Explorer.Counters.TokenTransferCounterTest do
+  use Explorer.DataCase
+
+  alias Explorer.Counters.TokenTransferCounter
+
+  describe "consolidate/0" do
+    test "loads the token's transfers consolidate info" do
+      token_contract_address = insert(:contract_address)
+      token = insert(:token, contract_address: token_contract_address)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(
+        :token_transfer,
+        to_address: build(:address),
+        transaction: transaction,
+        token_contract_address: token_contract_address,
+        token: token
+      )
+
+      insert(
+        :token_transfer,
+        to_address: build(:address),
+        transaction: transaction,
+        token_contract_address: token_contract_address,
+        token: token
+      )
+
+      TokenTransferCounter.consolidate()
+
+      assert TokenTransferCounter.fetch(token.contract_address_hash) == 2
+    end
+  end
+
+  describe "fetch/1" do
+    test "fetchs the total token transfers by token contract address hash" do
+      token_contract_address = insert(:contract_address)
+      token = insert(:token, contract_address: token_contract_address)
+
+      assert TokenTransferCounter.fetch(token.contract_address_hash) == 0
+
+      TokenTransferCounter.insert_or_update_counter(token.contract_address_hash, 15)
+
+      assert TokenTransferCounter.fetch(token.contract_address_hash) == 15
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -56,7 +56,7 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
   end
 
   defp new(%{block_fetcher: common_block_fetcher} = named_arguments) do
-    block_fetcher = %Block.Fetcher{common_block_fetcher | broadcast: false, callback_module: Catchup.Fetcher}
+    block_fetcher = %Block.Fetcher{common_block_fetcher | broadcast: :catchup, callback_module: Catchup.Fetcher}
 
     block_interval = Map.get(named_arguments, :block_interval, @block_interval)
     minimum_interval = div(block_interval, 2)

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -28,7 +28,7 @@ defmodule Indexer.Block.Fetcher do
                 address_token_balances: Import.Runner.options(),
                 blocks: Import.Runner.options(),
                 block_second_degree_relations: Import.Runner.options(),
-                broadcast: boolean,
+                broadcast: term(),
                 logs: Import.Runner.options(),
                 token_transfers: Import.Runner.options(),
                 tokens: Import.Runner.options(),
@@ -82,13 +82,13 @@ defmodule Indexer.Block.Fetcher do
              | {step :: atom(), failed_value :: term(), changes_so_far :: term()}}
   def fetch_and_import_range(
         %__MODULE__{
-          broadcast: broadcast,
+          broadcast: _broadcast,
           callback_module: callback_module,
           json_rpc_named_arguments: json_rpc_named_arguments
         } = state,
         _.._ = range
       )
-      when broadcast in ~w(true false)a and callback_module != nil do
+      when callback_module != nil do
     with {:blocks, {:ok, next, result}} <-
            {:blocks, EthereumJSONRPC.fetch_blocks_by_range(range, json_rpc_named_arguments)},
          %{

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -22,7 +22,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
 
   @type t :: %__MODULE__{
           block_fetcher: %Block.Fetcher{
-            broadcast: true,
+            broadcast: term(),
             callback_module: __MODULE__,
             json_rpc_named_arguments: EthereumJSONRPC.json_rpc_named_arguments(),
             receipts_batch_size: pos_integer(),
@@ -39,7 +39,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
   @impl GenServer
   def init(%{block_fetcher: %Block.Fetcher{} = block_fetcher, subscribe_named_arguments: subscribe_named_arguments})
       when is_list(subscribe_named_arguments) do
-    {:ok, %__MODULE__{block_fetcher: %Block.Fetcher{block_fetcher | broadcast: true, callback_module: __MODULE__}},
+    {:ok, %__MODULE__{block_fetcher: %Block.Fetcher{block_fetcher | broadcast: :realtime, callback_module: __MODULE__}},
      {:continue, {:init, subscribe_named_arguments}}}
   end
 

--- a/apps/indexer/lib/indexer/block/uncle/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/uncle/fetcher.ex
@@ -48,7 +48,7 @@ defmodule Indexer.Block.Uncle.Fetcher do
     merged_init_options =
       @defaults
       |> Keyword.merge(mergeable_init_options)
-      |> Keyword.put(:state, %Block.Fetcher{state | broadcast: false, callback_module: __MODULE__})
+      |> Keyword.put(:state, %Block.Fetcher{state | broadcast: :uncle, callback_module: __MODULE__})
 
     Supervisor.child_spec({BufferedTask, [{__MODULE__, merged_init_options}, gen_server_options]}, id: __MODULE__)
   end

--- a/apps/indexer/lib/indexer/pending_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/pending_transaction/fetcher.ex
@@ -110,7 +110,7 @@ defmodule Indexer.PendingTransaction.Fetcher do
         {:ok, _} =
           Chain.import(%{
             addresses: %{params: addresses_params},
-            broadcast: true,
+            broadcast: :realtime,
             transactions: %{params: transactions_params, on_conflict: :nothing}
           })
 


### PR DESCRIPTION
Relates to #820

## Motivation

The `Tokens` pages have a performance problem due to the amount of data and the MVCC implementation in PostgreSQL.

This PR consolidate the token transfers count info.

## Changelog

### Enhancements

This PR adds a `GenServer` that is responsible to consolidate the total of token transfers per contract hash and store it in a `ets` table.

The `Live Update` feature at the front-end already use events to constantly show new items, but for the `Live Update`, only the `realtime` events are important. For the token counter, both `realtime` and `catchup` are important, that's the reason why now instead of a boolean for the `broadcast` option, now we pass from where the event came (`realtime`, `catchup` and `uncle`)


