### PR TITLE
Fill-in skipped blocks on page render for blocks list

### DIFF
--- a/apps/block_scout_web/assets/__tests__/pages/block.js
+++ b/apps/block_scout_web/assets/__tests__/pages/block.js
@@ -1,6 +1,5 @@
 import { reducer, initialState } from '../../js/pages/block'
 
-
 test('CHANNEL_DISCONNECTED', () => {
   const state = initialState
   const action = {
@@ -9,6 +8,61 @@ test('CHANNEL_DISCONNECTED', () => {
   const output = reducer(state, action)
 
   expect(output.channelDisconnected).toBe(true)
+})
+
+describe('PAGE_LOAD', () => {
+  test('page 1 loads block numbers', () => {
+    const state = initialState
+    const action = {
+      type: 'PAGE_LOAD',
+      beyondPageOne: false,
+      blockNumbers: [2, 1]
+    }
+    const output = reducer(state, action)
+
+    expect(output.beyondPageOne).toBe(false)
+    expect(output.blockNumbers).toEqual([2, 1])
+    expect(output.skippedBlockNumbers).toEqual([])
+  })
+  test('page 2 loads block numbers', () => {
+    const state = initialState
+    const action = {
+      type: 'PAGE_LOAD',
+      beyondPageOne: true,
+      blockNumbers: [2, 1]
+    }
+    const output = reducer(state, action)
+
+    expect(output.beyondPageOne).toBe(true)
+    expect(output.blockNumbers).toEqual([2, 1])
+    expect(output.skippedBlockNumbers).toEqual([])
+  })
+  test('page 1 with skipped blocks', () => {
+    const state = initialState
+    const action = {
+      type: 'PAGE_LOAD',
+      beyondPageOne: false,
+      blockNumbers: [4, 1]
+    }
+    const output = reducer(state, action)
+
+    expect(output.beyondPageOne).toBe(false)
+    expect(output.blockNumbers).toEqual([4, 3, 2, 1])
+    expect(output.skippedBlockNumbers).toEqual([3, 2])
+  })
+  test('page 2 with skipped blocks', () => {
+    const state = initialState
+    const action = {
+      type: 'PAGE_LOAD',
+      beyondPageOne: true,
+      blockNumbers: [4, 1]
+    }
+    const output = reducer(state, action)
+
+    expect(output.beyondPageOne).toBe(true)
+    expect(output.blockNumbers).toEqual([4, 3, 2, 1])
+    expect(output.skippedBlockNumbers).toEqual([3, 2])
+  })
 })
 
 describe('RECEIVED_NEW_BLOCK', () => {
@@ -56,12 +110,12 @@ describe('RECEIVED_NEW_BLOCK', () => {
 
     expect(output.newBlock).toBe('test5')
     expect(output.blockNumbers).toEqual([5, 4, 3, 2])
-    expect(output.skippedBlockNumbers).toEqual([3, 4])
+    expect(output.skippedBlockNumbers).toEqual([4, 3])
   })
   test('replaces skipped block', () => {
     const state = Object.assign({}, initialState, {
       blockNumbers: [5, 4, 3, 2, 1],
-      skippedBlockNumbers: [1, 3, 4]
+      skippedBlockNumbers: [4, 3, 1]
     })
     const action = {
       type: 'RECEIVED_NEW_BLOCK',
@@ -74,7 +128,7 @@ describe('RECEIVED_NEW_BLOCK', () => {
 
     expect(output.newBlock).toBe('test3')
     expect(output.blockNumbers).toEqual([5, 4, 3, 2, 1])
-    expect(output.skippedBlockNumbers).toEqual([1, 4])
+    expect(output.skippedBlockNumbers).toEqual([4, 1])
   })
   test('replaces duplicated block', () => {
     const state = Object.assign({}, initialState, {

--- a/apps/block_scout_web/assets/__tests__/pages/chain.js
+++ b/apps/block_scout_web/assets/__tests__/pages/chain.js
@@ -1,5 +1,30 @@
 import { reducer, initialState } from '../../js/pages/chain'
 
+describe('PAGE_LOAD', () => {
+  test('loads block numbers', () => {
+    const state = initialState
+    const action = {
+      type: 'PAGE_LOAD',
+      blockNumbers: [2, 1]
+    }
+    const output = reducer(state, action)
+
+    expect(output.blockNumbers).toEqual([2, 1])
+    expect(output.skippedBlockNumbers).toEqual([])
+  })
+  test('loads with skipped blocks', () => {
+    const state = initialState
+    const action = {
+      type: 'PAGE_LOAD',
+      blockNumbers: [4, 1]
+    }
+    const output = reducer(state, action)
+
+    expect(output.blockNumbers).toEqual([4, 3, 2, 1])
+    expect(output.skippedBlockNumbers).toEqual([3, 2])
+  })
+})
+
 test('RECEIVED_NEW_ADDRESS_COUNT', () => {
   const state = Object.assign({}, initialState, {
     addressCount: '1,000'
@@ -54,12 +79,12 @@ describe('RECEIVED_NEW_BLOCK', () => {
     expect(output.averageBlockTime).toEqual('5 seconds')
     expect(output.newBlock).toBe('test5')
     expect(output.blockNumbers).toEqual([5, 4, 3, 2])
-    expect(output.skippedBlockNumbers).toEqual([3, 4])
+    expect(output.skippedBlockNumbers).toEqual([4, 3])
   })
   test('replaces skipped block', () => {
     const state = Object.assign({}, initialState, {
       blockNumbers: [4, 3, 2, 1],
-      skippedBlockNumbers: [1, 2, 3]
+      skippedBlockNumbers: [3, 2, 1]
     })
     const action = {
       type: 'RECEIVED_NEW_BLOCK',
@@ -74,7 +99,7 @@ describe('RECEIVED_NEW_BLOCK', () => {
     expect(output.averageBlockTime).toEqual('5 seconds')
     expect(output.newBlock).toBe('test2')
     expect(output.blockNumbers).toEqual([4, 3, 2, 1])
-    expect(output.skippedBlockNumbers).toEqual([1, 3])
+    expect(output.skippedBlockNumbers).toEqual([3, 1])
   })
   test('replaces duplicated block', () => {
     const state = Object.assign({}, initialState, {
@@ -116,7 +141,7 @@ describe('RECEIVED_NEW_BLOCK', () => {
   test('only tracks 4 blocks based on page display limit', () => {
     const state = Object.assign({}, initialState, {
       blockNumbers: [5, 4, 3, 2],
-      skippedBlockNumbers: [2, 3, 4]
+      skippedBlockNumbers: [4, 3, 2]
     })
     const action = {
       type: 'RECEIVED_NEW_BLOCK',
@@ -129,12 +154,12 @@ describe('RECEIVED_NEW_BLOCK', () => {
 
     expect(output.newBlock).toBe('test6')
     expect(output.blockNumbers).toEqual([6, 5, 4, 3])
-    expect(output.skippedBlockNumbers).toEqual([3, 4])
+    expect(output.skippedBlockNumbers).toEqual([4, 3])
   })
   test('skipped blocks list replaced when another block comes in with +3 blockheight', () => {
     const state = Object.assign({}, initialState, {
       blockNumbers: [5, 4, 3, 2],
-      skippedBlockNumbers: [2, 3, 4]
+      skippedBlockNumbers: [4, 3, 2]
     })
     const action = {
       type: 'RECEIVED_NEW_BLOCK',
@@ -147,7 +172,7 @@ describe('RECEIVED_NEW_BLOCK', () => {
 
     expect(output.newBlock).toBe('test10')
     expect(output.blockNumbers).toEqual([10, 9, 8, 7])
-    expect(output.skippedBlockNumbers).toEqual([7, 8, 9])
+    expect(output.skippedBlockNumbers).toEqual([9, 8, 7])
   })
 })
 

--- a/apps/block_scout_web/assets/css/components/_tile.scss
+++ b/apps/block_scout_web/assets/css/components/_tile.scss
@@ -17,7 +17,7 @@
 
   &-type {
 
-    &-Block {
+    &-block {
       border-left: 4px solid $indigo;
 
       .tile-label {
@@ -25,7 +25,7 @@
       }
     }
 
-    &-Uncle {
+    &-uncle {
       border-left: 4px solid $cyan;
 
       .tile-label {
@@ -33,7 +33,7 @@
       }
     }
 
-    &-Reorg {
+    &-reorg {
       border-left: 4px solid $purple;
 
       .tile-label {

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -31,7 +31,7 @@
     </div>
     <script>
       window.localized = {
-        'Block Processing': '<%= gettext("Block Mined, awaiting processing...") %>',
+        'Block Processing': '<%= gettext("Block Mined, awaiting import...") %>',
         'Less than': '<%= gettext("Less than") %>',
         'Market Cap': '<%= gettext("Market Cap") %>',
         'Price': '<%= gettext("Price") %>',

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -141,17 +141,6 @@ defmodule BlockScoutWeb.AddressView do
     |> Base.encode64()
   end
 
-  def render_partial(%{partial: partial, address: address, contract: contract?, truncate: truncate}) do
-    render(
-      partial,
-      address: address,
-      contract: contract?,
-      truncate: truncate
-    )
-  end
-
-  def render_partial(text), do: text
-
   def smart_contract_verified?(%Address{smart_contract: %SmartContract{}}), do: true
 
   def smart_contract_verified?(%Address{smart_contract: nil}), do: false

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1057,11 +1057,6 @@ msgid "%{subnetwork} %{network} Explorer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:34
-msgid "Block Mined, awaiting processing..."
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/address/_metatags.html.eex:3
 msgid "%{address} - %{subnetwork} Explorer"
 msgstr ""
@@ -1160,4 +1155,9 @@ msgstr ""
 #: lib/block_scout_web/templates/block/overview.html.eex:76
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:23
 msgid "Uncles"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/app.html.eex:34
+msgid "Block Mined, awaiting import..."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -157,7 +157,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:90
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:122
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
-#: lib/block_scout_web/views/address_view.ex:223
+#: lib/block_scout_web/views/address_view.ex:212
 msgid "Code"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:222
+#: lib/block_scout_web/views/address_view.ex:211
 #: lib/block_scout_web/views/transaction_view.ex:176
 msgid "Internal Transactions"
 msgstr ""
@@ -639,7 +639,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:53
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
-#: lib/block_scout_web/views/address_view.ex:224
+#: lib/block_scout_web/views/address_view.ex:213
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -839,7 +839,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:18
 #: lib/block_scout_web/templates/address_validation/index.html.eex:62
 #: lib/block_scout_web/templates/address_validation/index.html.eex:70
-#: lib/block_scout_web/views/address_view.ex:220
+#: lib/block_scout_web/views/address_view.ex:209
 msgid "Tokens"
 msgstr ""
 
@@ -889,7 +889,7 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:35
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:56
 #: lib/block_scout_web/templates/transaction/index.html.eex:56
-#: lib/block_scout_web/views/address_view.ex:221
+#: lib/block_scout_web/views/address_view.ex:210
 msgid "Transactions"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1057,11 +1057,6 @@ msgid "%{subnetwork} %{network} Explorer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:34
-msgid "Block Mined, awaiting processing..."
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/address/_metatags.html.eex:3
 msgid "%{address} - %{subnetwork} Explorer"
 msgstr ""
@@ -1136,7 +1131,7 @@ msgstr ""
 msgid "%{block_type}s"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/block_scout_web/templates/block/overview.html.eex:13
 msgid "Block Height: %{height}"
 msgstr ""
@@ -1160,4 +1155,9 @@ msgstr ""
 #: lib/block_scout_web/templates/block/overview.html.eex:76
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:23
 msgid "Uncles"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/block_scout_web/templates/layout/app.html.eex:34
+msgid "Block Mined, awaiting import..."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -157,7 +157,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:90
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:122
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
-#: lib/block_scout_web/views/address_view.ex:223
+#: lib/block_scout_web/views/address_view.ex:212
 msgid "Code"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:222
+#: lib/block_scout_web/views/address_view.ex:211
 #: lib/block_scout_web/views/transaction_view.ex:176
 msgid "Internal Transactions"
 msgstr ""
@@ -639,7 +639,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:53
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
-#: lib/block_scout_web/views/address_view.ex:224
+#: lib/block_scout_web/views/address_view.ex:213
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -839,7 +839,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:18
 #: lib/block_scout_web/templates/address_validation/index.html.eex:62
 #: lib/block_scout_web/templates/address_validation/index.html.eex:70
-#: lib/block_scout_web/views/address_view.ex:220
+#: lib/block_scout_web/views/address_view.ex:209
 msgid "Tokens"
 msgstr ""
 
@@ -889,7 +889,7 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:35
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:56
 #: lib/block_scout_web/templates/transaction/index.html.eex:56
-#: lib/block_scout_web/views/address_view.ex:221
+#: lib/block_scout_web/views/address_view.ex:210
 msgid "Transactions"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 msgid "Uncles"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/block_scout_web/templates/layout/app.html.eex:34
 msgid "Block Mined, awaiting import..."
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
@@ -113,10 +113,6 @@ defmodule BlockScoutWeb.AddressPage do
     css("[data-transaction-hash='#{hash}'] [data-test='address_hash_link'] [data-address-hash='#{address_hash}']")
   end
 
-  def transaction_count do
-    css("[data-selector='transaction-count']")
-  end
-
   def transaction_status(%Transaction{hash: transaction_hash}) do
     css("[data-transaction-hash='#{transaction_hash}'] [data-test='transaction_status']")
   end

--- a/apps/block_scout_web/test/block_scout_web/features/pages/block_list_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/block_list_page.ex
@@ -20,7 +20,7 @@ defmodule BlockScoutWeb.BlockListPage do
   end
 
   def block(%Block{number: block_number}) do
-    css("[data-selector='block-tile'][data-block-number='#{block_number}']")
+    css("[data-block-number='#{block_number}']")
   end
 
   def place_holder_blocks(count) do

--- a/apps/block_scout_web/test/block_scout_web/features/pages/chain_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/chain_page.ex
@@ -5,7 +5,11 @@ defmodule BlockScoutWeb.ChainPage do
 
   import Wallaby.Query, only: [css: 1, css: 2]
 
-  alias Explorer.Chain.Transaction
+  alias Explorer.Chain.{Block, Transaction}
+
+  def block(%Block{number: block_number}) do
+    css("[data-block-number='#{block_number}']")
+  end
 
   def blocks(count: count) do
     css("[data-selector='chain-block']", count: count)
@@ -13,6 +17,10 @@ defmodule BlockScoutWeb.ChainPage do
 
   def contract_creation(%Transaction{created_contract_address_hash: hash}) do
     css("[data-test='contract-creation'] [data-address-hash='#{hash}']")
+  end
+
+  def place_holder_blocks(count) do
+    css("[data-selector='place-holder']", count: count)
   end
 
   def search(session, text) do

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_blocks_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_blocks_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.ViewingBlocksTest do
   use BlockScoutWeb.FeatureCase, async: true
 
-  alias BlockScoutWeb.{BlockListPage, BlockPage, Notifier}
+  alias BlockScoutWeb.{BlockListPage, BlockPage}
   alias Explorer.Chain.Block
 
   setup do
@@ -130,35 +130,6 @@ defmodule BlockScoutWeb.ViewingBlocksTest do
       session
       |> BlockListPage.visit_page()
       |> assert_has(BlockListPage.block(block))
-    end
-
-    test "inserts place holder blocks if out of order block received", %{session: session} do
-      BlockListPage.visit_page(session)
-
-      block = insert(:block, number: 315)
-      Notifier.handle_event({:chain_event, :blocks, :realtime, [block]})
-
-      session
-      |> assert_has(BlockListPage.block(block))
-      |> assert_has(BlockListPage.place_holder_blocks(3))
-    end
-
-    test "replaces place holder block if skipped block received", %{session: session} do
-      BlockListPage.visit_page(session)
-
-      block = insert(:block, number: 315)
-      Notifier.handle_event({:chain_event, :blocks, :realtime, [block]})
-
-      session
-      |> assert_has(BlockListPage.block(block))
-      |> assert_has(BlockListPage.place_holder_blocks(3))
-
-      skipped_block = insert(:block, number: 314)
-      Notifier.handle_event({:chain_event, :blocks, :realtime, [skipped_block]})
-
-      session
-      |> assert_has(BlockListPage.block(skipped_block))
-      |> assert_has(BlockListPage.place_holder_blocks(2))
     end
 
     test "inserts place holder blocks on render for out of order blocks", %{session: session} do

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_blocks_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_blocks_test.exs
@@ -169,19 +169,6 @@ defmodule BlockScoutWeb.ViewingBlocksTest do
       |> assert_has(BlockListPage.block(%Block{number: 314}))
       |> assert_has(BlockListPage.place_holder_blocks(3))
     end
-
-    test "replaces rendered place holder block if skipped block received", %{session: session} do
-      insert(:block, number: 315)
-
-      BlockListPage.visit_page(session)
-
-      block = insert(:block, number: 314)
-      Notifier.handle_event({:chain_event, :blocks, [block]})
-
-      session
-      |> assert_has(BlockListPage.block(block))
-      |> assert_has(BlockListPage.place_holder_blocks(2))
-    end
   end
 
   describe "viewing uncle blocks list" do

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_chain_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_chain_test.exs
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.ViewingChainTest do
 
   use BlockScoutWeb.FeatureCase, async: true
 
-  alias BlockScoutWeb.{AddressPage, BlockPage, ChainPage, Notifier, TransactionPage}
+  alias BlockScoutWeb.{AddressPage, BlockPage, ChainPage, TransactionPage}
   alias Explorer.Chain.Block
 
   setup do
@@ -50,35 +50,6 @@ defmodule BlockScoutWeb.ViewingChainTest do
       session
       |> ChainPage.visit_page()
       |> assert_has(ChainPage.blocks(count: 4))
-    end
-
-    test "inserts place holder blocks if out of order block received", %{session: session} do
-      ChainPage.visit_page(session)
-
-      block = insert(:block, number: 409)
-      Notifier.handle_event({:chain_event, :blocks, :realtime, [block]})
-
-      session
-      |> assert_has(ChainPage.block(block))
-      |> assert_has(ChainPage.place_holder_blocks(3))
-    end
-
-    test "replaces place holder block if skipped block received", %{session: session} do
-      ChainPage.visit_page(session)
-
-      block = insert(:block, number: 409)
-      Notifier.handle_event({:chain_event, :blocks, :realtime, [block]})
-
-      session
-      |> assert_has(ChainPage.block(block))
-      |> assert_has(ChainPage.place_holder_blocks(3))
-
-      skipped_block = insert(:block, number: 408)
-      Notifier.handle_event({:chain_event, :blocks, :realtime, [skipped_block]})
-
-      session
-      |> assert_has(ChainPage.block(skipped_block))
-      |> assert_has(ChainPage.place_holder_blocks(2))
     end
 
     test "inserts place holder blocks on render for out of order blocks", %{session: session} do

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_chain_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_chain_test.exs
@@ -89,19 +89,6 @@ defmodule BlockScoutWeb.ViewingChainTest do
       |> assert_has(ChainPage.block(%Block{number: 408}))
       |> assert_has(ChainPage.place_holder_blocks(3))
     end
-
-    test "replaces rendered place holder block if skipped block received", %{session: session} do
-      insert(:block, number: 409)
-
-      ChainPage.visit_page(session)
-
-      block = insert(:block, number: 408)
-      Notifier.handle_event({:chain_event, :blocks, [block]})
-
-      session
-      |> assert_has(ChainPage.block(block))
-      |> assert_has(ChainPage.place_holder_blocks(2))
-    end
   end
 
   describe "viewing transactions" do


### PR DESCRIPTION
Resolves #865 

## Motivation

Placeholders are put in for skipped blocks with live reload, but they aren't when the page is initially rendered (or refreshed).

## Changelog

### Enhancements
* Add placeholders for skipped blocks on page render (for blocks list and homepage)