### PR TITLE
Consolidate validation count

### DIFF
--- a/apps/block_scout_web/assets/js/pages/address.js
+++ b/apps/block_scout_web/assets/js/pages/address.js
@@ -36,7 +36,7 @@ export function reducer (state = initialState, action) {
         beyondPageOne: action.beyondPageOne,
         filter: action.filter,
         transactionCount: numeral(action.transactionCount).value(),
-        validationCount: action.transactionCount ? numeral(action.transactionCount).value() : null
+        validationCount: action.validationCount ? numeral(action.validationCount).value() : null
       })
     }
     case 'CHANNEL_DISCONNECTED': {

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -16,6 +16,8 @@ config :explorer, Explorer.Integrations.EctoLogger, query_time_ms_threshold: 2_0
 
 config :explorer, Explorer.ExchangeRates, enabled: true
 
+config :explorer, Explorer.Counters.BlockValidationCounter, enabled: true
+
 config :explorer, Explorer.Market.History.Cataloger, enabled: true
 
 config :explorer, Explorer.Repo,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -16,9 +16,6 @@ defmodule Explorer.Application do
       Explorer.Repo,
       Supervisor.child_spec({Task.Supervisor, name: Explorer.MarketTaskSupervisor}, id: Explorer.MarketTaskSupervisor),
       Supervisor.child_spec({Task.Supervisor, name: Explorer.TaskSupervisor}, id: Explorer.TaskSupervisor),
-      Supervisor.child_spec({Task.Supervisor, name: Explorer.BlockValidationCounter},
-        id: Explorer.BlockValidationCounter
-      ),
       {Registry, keys: :duplicate, name: Registry.ChainEvents, id: Registry.ChainEvents}
     ]
 

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -16,10 +16,7 @@ defmodule Explorer.Application do
       Explorer.Repo,
       Supervisor.child_spec({Task.Supervisor, name: Explorer.MarketTaskSupervisor}, id: Explorer.MarketTaskSupervisor),
       Supervisor.child_spec({Task.Supervisor, name: Explorer.TaskSupervisor}, id: Explorer.TaskSupervisor),
-      Supervisor.child_spec({Task.Supervisor, name: Explorer.CounterTokenSupervisor},
-        id: Explorer.CounterTokenSupervisor
-      ),
-      Supervisor.child_spec({Task.Supervisor, name: Explorer.BlockValidationCounter}, 
+      Supervisor.child_spec({Task.Supervisor, name: Explorer.BlockValidationCounter},
         id: Explorer.BlockValidationCounter
       ),
       {Registry, keys: :duplicate, name: Registry.ChainEvents, id: Registry.ChainEvents}
@@ -36,11 +33,8 @@ defmodule Explorer.Application do
     [
       configure(Explorer.ExchangeRates),
       configure(Explorer.Market.History.Cataloger),
-<<<<<<< HEAD
-      configure(Explorer.Counters.TokenTransferCounter)
-=======
+      configure(Explorer.Counters.TokenTransferCounter),
       configure(Explorer.Counters.BlockValidationCounter)
->>>>>>> 8a3d34bc... Store validation counts for each address in an ets table.
     ]
     |> List.flatten()
   end

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -19,6 +19,9 @@ defmodule Explorer.Application do
       Supervisor.child_spec({Task.Supervisor, name: Explorer.CounterTokenSupervisor},
         id: Explorer.CounterTokenSupervisor
       ),
+      Supervisor.child_spec({Task.Supervisor, name: Explorer.BlockValidationCounter}, 
+        id: Explorer.BlockValidationCounter
+      ),
       {Registry, keys: :duplicate, name: Registry.ChainEvents, id: Registry.ChainEvents}
     ]
 
@@ -33,7 +36,11 @@ defmodule Explorer.Application do
     [
       configure(Explorer.ExchangeRates),
       configure(Explorer.Market.History.Cataloger),
+<<<<<<< HEAD
       configure(Explorer.Counters.TokenTransferCounter)
+=======
+      configure(Explorer.Counters.BlockValidationCounter)
+>>>>>>> 8a3d34bc... Store validation counts for each address in an ets table.
     ]
     |> List.flatten()
   end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -37,8 +37,7 @@ defmodule Explorer.Chain do
 
   alias Explorer.Chain.Block.Reward
   alias Explorer.{PagingOptions, Repo}
-  alias Explorer.Counters.TokenTransferCounter
-  alias Explorer.Counters.BlockValidationCounter
+  alias Explorer.Counters.{TokenTransferCounter, BlockValidationCounter}
 
   @default_paging_options %PagingOptions{page_size: 50}
 
@@ -923,7 +922,7 @@ defmodule Explorer.Chain do
   Counts all of the block validations and groups by the `miner_hash`.
   """
   def group_block_validations_by_address do
-    query = 
+    query =
       from(
         b in Block,
         join: addr in Address,

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -12,8 +12,7 @@ defmodule Explorer.Chain do
       order_by: 3,
       preload: 2,
       where: 2,
-      where: 3,
-      select: 3
+      where: 3
     ]
 
   alias Ecto.Adapters.SQL
@@ -39,6 +38,7 @@ defmodule Explorer.Chain do
   alias Explorer.Chain.Block.Reward
   alias Explorer.{PagingOptions, Repo}
   alias Explorer.Counters.TokenTransferCounter
+  alias Explorer.Counters.BlockValidationCounter
 
   @default_paging_options %PagingOptions{page_size: 50}
 
@@ -920,14 +920,27 @@ defmodule Explorer.Chain do
   end
 
   @doc """
+  Counts all of the block validations and groups by the `miner_hash`.
+  """
+  def group_block_validations_by_address do
+    query = 
+      from(
+        b in Block,
+        join: addr in Address,
+        where: b.miner_hash == addr.hash,
+        select: {b.miner_hash, count(b.miner_hash)},
+        group_by: b.miner_hash
+      )
+
+    Repo.all(query)
+  end
+
+  @doc """
   Counts the number of `t:Explorer.Chain.Block.t/0` validated by the `address`.
   """
   @spec address_to_validation_count(Address.t()) :: non_neg_integer()
   def address_to_validation_count(%Address{hash: hash}) do
-    Block
-    |> where(miner_hash: ^hash)
-    |> select([b], count(b.hash))
-    |> Repo.one()
+    BlockValidationCounter.fetch(hash)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/counters/block_validation_counter.ex
+++ b/apps/explorer/lib/explorer/counters/block_validation_counter.ex
@@ -63,8 +63,7 @@ defmodule Explorer.Counters.BlockValidationCounter do
   """
   @spec fetch(Hash.Address.t()) :: non_neg_integer
   def fetch(addr_hash) do
-    :ets.lookup(table_name(), to_string(addr_hash))
-    |> do_fetch()
+    do_fetch(:ets.lookup(table_name(), to_string(addr_hash)))
   end
 
   defp do_fetch([{_, result} | _]), do: result

--- a/apps/explorer/lib/explorer/counters/block_validation_counter.ex
+++ b/apps/explorer/lib/explorer/counters/block_validation_counter.ex
@@ -1,0 +1,95 @@
+defmodule Explorer.Counters.BlockValidationCounter do
+  use GenServer
+
+  @moduledoc """
+  Module responsible for fetching and consolidating the number of 
+  validations from an address.
+  """
+
+  alias Explorer.Chain
+  alias Explorer.Chain.Hash
+
+  @table :block_validation_counter
+
+  def table_name do
+    @table
+  end
+
+  @doc """
+  Creates a process to continually monitor the validation counts.
+  """
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  ## Server
+  @impl true
+  def init(args) do
+    create_table()
+
+    Task.start_link(&consolidate_blocks/0)
+
+    Chain.subscribe_to_events(:blocks)
+
+    {:ok, args}
+  end
+
+  def create_table do
+    opts = [
+      :set,
+      :named_table,
+      :public,
+      read_concurrency: true,
+      write_concurrency: true
+    ]
+
+    :ets.new(table_name(), opts)
+  end
+
+  @doc """
+  Consolidates the number of block validations grouped by `address_hash`.
+  """
+  def consolidate_blocks do
+    total_block_validations = Chain.group_block_validations_by_address()
+
+    for {address_hash, total} <- total_block_validations do
+      insert_or_update_counter(address_hash, total)
+    end
+  end
+
+  @doc """
+  Fetches the number of validations related to an `address_hash`. 
+  """
+  @spec fetch(Hash.Address.t()) :: non_neg_integer
+  def fetch(addr_hash) do
+    :ets.lookup(table_name(), to_string(addr_hash))
+    |> do_fetch()
+  end
+
+  defp do_fetch([{_, result} | _]), do: result
+  defp do_fetch([]), do: 0
+
+  @impl true
+  def handle_info({:chain_event, :blocks, _type, blocks}, state) do
+    blocks
+    |> Enum.map(& &1.miner_hash)
+    |> Enum.each(&insert_or_update_counter(&1, 1))
+
+    {:noreply, state}
+  end
+
+  @doc """
+  Inserts a new item into the `:ets` table.
+
+  When the record exist, the counter will be incremented by one. When the
+  record does not exist, the counter will be inserted with a default value.
+  """
+  @spec insert_or_update_counter(Hash.Address.t(), non_neg_integer) :: term()
+  def insert_or_update_counter(addr_hash, number) do
+    string_addr = to_string(addr_hash)
+    default = {string_addr, 0}
+
+    :ets.update_counter(table_name(), string_addr, number, default)
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1127,23 +1127,16 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "address_to_validation_count/1" do
-    test "returns 0 when there aren't any blocks" do
+  describe "group_block_validations_by_address/0" do
+    test "returns block validations grouped by the address that validated them (`address_hash`)" do
       address = insert(:address)
-
-      assert 0 = Chain.address_to_validation_count(address)
-    end
-
-    test "returns the number of blocks mined by addres" do
-      address = insert(:address)
-      another_address = insert(:address)
 
       insert(:block, miner: address, miner_hash: address.hash)
-      insert(:block, miner: another_address, miner_hash: another_address.hash)
-      insert(:block, miner: another_address, miner_hash: another_address.hash)
 
-      assert 1 = Chain.address_to_validation_count(address)
-      assert 2 = Chain.address_to_validation_count(another_address)
+      results = Chain.group_block_validations_by_address()
+
+      assert length(results) == 1
+      assert results == [{address.hash, 1}]
     end
   end
 

--- a/apps/explorer/test/explorer/counters/block_validation_counter_test.exs
+++ b/apps/explorer/test/explorer/counters/block_validation_counter_test.exs
@@ -5,8 +5,6 @@ defmodule Explorer.Counters.BlockValidationCounterTest do
 
   describe "consolidate/0" do
     test "loads the address' validations consolidated info" do
-      BlockValidationCounter.start_link([])
-
       address = insert(:address)
 
       insert(:block, miner: address, miner_hash: address.hash)
@@ -25,8 +23,6 @@ defmodule Explorer.Counters.BlockValidationCounterTest do
 
   describe "fetch/1" do
     test "fetches the total block validations by a given address" do
-      BlockValidationCounter.start_link([])
-
       address = insert(:address)
       another_address = insert(:address)
 

--- a/apps/explorer/test/explorer/counters/block_validation_counter_test.exs
+++ b/apps/explorer/test/explorer/counters/block_validation_counter_test.exs
@@ -1,0 +1,44 @@
+defmodule Explorer.Counters.BlockValidationCounterTest do
+  use Explorer.DataCase
+
+  alias Explorer.Counters.BlockValidationCounter
+
+  describe "consolidate/0" do
+    test "loads the address' validations consolidated info" do
+      BlockValidationCounter.start_link([])
+
+      address = insert(:address)
+
+      insert(:block, miner: address, miner_hash: address.hash)
+      insert(:block, miner: address, miner_hash: address.hash)
+
+      another_address = insert(:address)
+
+      insert(:block, miner: another_address, miner_hash: another_address.hash)
+
+      BlockValidationCounter.consolidate_blocks()
+
+      assert BlockValidationCounter.fetch(address.hash) == 2
+      assert BlockValidationCounter.fetch(another_address.hash) == 1 
+    end
+  end
+
+  describe "fetch/1" do
+    test "fetches the total block validations by a given address" do
+      BlockValidationCounter.start_link([])
+      
+      address = insert(:address)
+      another_address = insert(:address)
+
+      assert BlockValidationCounter.fetch(address.hash) == 0
+      assert BlockValidationCounter.fetch(another_address.hash) == 0
+
+      BlockValidationCounter.insert_or_update_counter(address.hash, 1)
+      BlockValidationCounter.insert_or_update_counter(another_address.hash, 10)
+
+      assert BlockValidationCounter.fetch(address.hash) == 1
+      assert BlockValidationCounter.fetch(another_address.hash) == 10
+    end
+  end
+
+end

--- a/apps/explorer/test/explorer/counters/block_validation_counter_test.exs
+++ b/apps/explorer/test/explorer/counters/block_validation_counter_test.exs
@@ -19,14 +19,14 @@ defmodule Explorer.Counters.BlockValidationCounterTest do
       BlockValidationCounter.consolidate_blocks()
 
       assert BlockValidationCounter.fetch(address.hash) == 2
-      assert BlockValidationCounter.fetch(another_address.hash) == 1 
+      assert BlockValidationCounter.fetch(another_address.hash) == 1
     end
   end
 
   describe "fetch/1" do
     test "fetches the total block validations by a given address" do
       BlockValidationCounter.start_link([])
-      
+
       address = insert(:address)
       another_address = insert(:address)
 
@@ -40,5 +40,4 @@ defmodule Explorer.Counters.BlockValidationCounterTest do
       assert BlockValidationCounter.fetch(another_address.hash) == 10
     end
   end
-
 end


### PR DESCRIPTION
Resolves #875, related to #768.

## Motivation
As a user, I want to navigate to the `address` page and be able to see the number of `validations` the address has performed.

## Changelog

### Enhancements
* I copied @amandasposito's changes to events by differentiating between `:realtime` and `:catchup` by using `atoms` instead of `booleans`.

### Bug Fixes
* I noticed that the number of `validations` when viewing an `address` was being set to the number of `transactions`. Fixed this by setting `state.validationCount` to the number of validations passed in, not the number of transactions in [`address.js`](https://github.com/poanetwork/blockscout/compare/master...Lokraan:consolidate-validation-count?expand=1#diff-9ea2062dff8b90dd854d1db13438ede6)