### PR TITLE
Set endpoint to load favicon-related assets

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/endpoint.ex
+++ b/apps/block_scout_web/lib/block_scout_web/endpoint.ex
@@ -16,8 +16,24 @@ defmodule BlockScoutWeb.Endpoint do
     Plug.Static,
     at: "/",
     from: :block_scout_web,
-    gzip: false,
-    only: ~w(css fonts images js favicon.ico robots.txt)
+    gzip: true,
+    only: ~w(
+      css
+      fonts
+      images
+      js
+      android-chrome-192x192.png
+      android-chrome-512x512.png
+      apple-touch-icon.png
+      browserconfig.xml
+      favicon.ico
+      favicon-16x16.png
+      favicon-32x32.png
+      mstile-150x150.png
+      safari-pinned-tab.svg
+      site.manifest
+      robots.txt
+    )
   )
 
   # Code reloading can be explicitly enabled under the


### PR DESCRIPTION
Resolves #879

## Motivation

This PR makes `BlockScoutWeb.Endpoint` aware of favicon-related assets for `Plug.Static` and allows them to be loaded. This also enables gzip of static assets to lower file-transfer bandwidth.

## Changelog

### Bug Fixes
* Favicon-related assets are now loaded with `Plug.Static`