### PR TITLE
Remove token holders count from Token's page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
@@ -21,7 +21,6 @@ defmodule BlockScoutWeb.Tokens.HolderController do
         "index.html",
         token: token,
         token_balances: token_balances_paginated,
-        total_token_holders: Chain.count_token_holders_from_token_hash(address_hash),
         total_token_transfers: Chain.count_token_transfers_from_token_hash(address_hash),
         next_page_params: next_page_params(next_page, token_balances_paginated, params)
       )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
@@ -23,7 +23,6 @@ defmodule BlockScoutWeb.Tokens.InventoryController do
         token: token,
         unique_tokens: unique_tokens_paginated,
         total_token_transfers: Chain.count_token_transfers_from_token_hash(address_hash),
-        total_token_holders: Chain.count_token_holders_from_token_hash(address_hash),
         next_page_params: unique_tokens_next_page(next_page, unique_tokens_paginated, params)
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/read_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/read_contract_controller.ex
@@ -10,8 +10,7 @@ defmodule BlockScoutWeb.Tokens.ReadContractController do
         conn,
         "index.html",
         token: token,
-        total_token_transfers: Chain.count_token_transfers_from_token_hash(address_hash),
-        total_token_holders: Chain.count_token_holders_from_token_hash(address_hash)
+        total_token_transfers: Chain.count_token_transfers_from_token_hash(address_hash)
       )
     else
       :error ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
@@ -17,7 +17,6 @@ defmodule BlockScoutWeb.Tokens.TransferController do
         transfers: token_transfers_paginated,
         token: token,
         total_token_transfers: Chain.count_token_transfers_from_token_hash(address_hash),
-        total_token_holders: Chain.count_token_holders_from_token_hash(address_hash),
         next_page_params: next_page_params(next_page, token_transfers_paginated, params)
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
@@ -4,7 +4,6 @@
     "_details.html",
     token: @token,
     total_token_transfers: @total_token_transfers,
-    total_token_holders: @total_token_holders,
     conn: @conn
   ) %>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/index.html.eex
@@ -4,7 +4,6 @@
     "_details.html",
     token: @token,
     total_token_transfers: @total_token_transfers,
-    total_token_holders: @total_token_holders,
     conn: @conn
   ) %>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
@@ -36,7 +36,6 @@
             </span>
             <div class="d-flex flex-row justify-content-start text-muted">
               <span class="mr-4"> <%= @token.type %> </span>
-              <span class="mr-4"><%= @total_token_holders %>  <%= gettext "addresses" %></span>
               <span class="mr-4"><%= @total_token_transfers %> <%= gettext "Transfers" %></span>
               <%= if decimals?(@token) do %>
                 <span class="mr-4"><%= @token.decimals %> <%= gettext "decimals" %></span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
@@ -4,7 +4,6 @@
     "_details.html",
     token: @token,
     total_token_transfers: @total_token_transfers,
-    total_token_holders: @total_token_holders,
     conn: @conn
   ) %>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/token/show.html.eex
@@ -4,7 +4,6 @@
     "_details.html",
     token: @token,
     total_token_transfers: @total_token_transfers,
-    total_token_holders: @total_token_holders,
     conn: @conn
   ) %>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/index.html.eex
@@ -4,7 +4,6 @@
     "_details.html",
     token: @token,
     total_token_transfers: @total_token_transfers,
-    total_token_holders: @total_token_holders,
     conn: @conn
   ) %>
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -155,8 +155,8 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:73
 #: lib/block_scout_web/templates/address/overview.html.eex:81
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:82
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:90
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:81
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:89
 msgid "Close"
 msgstr ""
 
@@ -439,7 +439,7 @@ msgid "Internal Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:18
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:17
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:23
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:67
 #: lib/block_scout_web/views/tokens/overview_view.ex:38
@@ -536,8 +536,8 @@ msgid "Next"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:35
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:34
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:34
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:33
 msgid "Next Page"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block/index.html.eex:20
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:70
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:34
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:33
 #: lib/block_scout_web/templates/transaction/index.html.eex:70
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:24
 msgid "Older"
@@ -634,7 +634,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:72
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:13
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:13
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:81
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:80
 msgid "QR Code"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgid "Telegram"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:28
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:27
 msgid "There are no holders for this Token."
 msgstr ""
 
@@ -767,7 +767,7 @@ msgid "There are no tokens for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:27
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:26
 msgid "There are no tokens."
 msgstr ""
 
@@ -778,7 +778,7 @@ msgid "There are no transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:27
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:26
 msgid "There are no transfers for this Token."
 msgstr ""
 
@@ -811,7 +811,7 @@ msgid "Token Details"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:19
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:13
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:60
 #: lib/block_scout_web/views/tokens/overview_view.ex:36
@@ -833,7 +833,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:5
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:54
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:18
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:17
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:6
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:36
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:10
@@ -865,7 +865,7 @@ msgid "Total Difficulty"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:54
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:53
 msgid "Total Supply"
 msgstr ""
 
@@ -905,7 +905,7 @@ msgid "Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:40
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:39
 msgid "Transfers"
 msgstr ""
 
@@ -1004,23 +1004,18 @@ msgid "Yes"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:39
-msgid "addresses"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:48
 msgid "at"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:42
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:41
 msgid "decimals"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:12
-#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:19
+#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:18
 msgid "loading..."
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -155,8 +155,8 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:73
 #: lib/block_scout_web/templates/address/overview.html.eex:81
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:82
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:90
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:81
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:89
 msgid "Close"
 msgstr ""
 
@@ -439,7 +439,7 @@ msgid "Internal Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:18
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:17
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:23
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:67
 #: lib/block_scout_web/views/tokens/overview_view.ex:38
@@ -536,8 +536,8 @@ msgid "Next"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:35
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:34
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:34
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:33
 msgid "Next Page"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block/index.html.eex:20
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:70
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:34
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:33
 #: lib/block_scout_web/templates/transaction/index.html.eex:70
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:24
 msgid "Older"
@@ -634,7 +634,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:72
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:13
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:13
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:81
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:80
 msgid "QR Code"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgid "Telegram"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:28
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:27
 msgid "There are no holders for this Token."
 msgstr ""
 
@@ -767,7 +767,7 @@ msgid "There are no tokens for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:27
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:26
 msgid "There are no tokens."
 msgstr ""
 
@@ -778,7 +778,7 @@ msgid "There are no transactions for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:27
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:26
 msgid "There are no transfers for this Token."
 msgstr ""
 
@@ -811,7 +811,7 @@ msgid "Token Details"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:19
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:13
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:60
 #: lib/block_scout_web/views/tokens/overview_view.ex:36
@@ -833,7 +833,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:5
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:54
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:18
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:17
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:6
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:36
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:10
@@ -865,7 +865,7 @@ msgid "Total Difficulty"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:54
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:53
 msgid "Total Supply"
 msgstr ""
 
@@ -905,7 +905,7 @@ msgid "Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:40
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:39
 msgid "Transfers"
 msgstr ""
 
@@ -1004,23 +1004,18 @@ msgid "Yes"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:39
-msgid "addresses"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:48
 msgid "at"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:42
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:41
 msgid "decimals"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:12
-#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:19
+#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:18
 msgid "loading..."
 msgstr ""
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/tokens/read_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/tokens/read_contract_controller_test.exs
@@ -31,7 +31,6 @@ defmodule BlockScoutWeb.Tokens.ReadContractControllerTest do
       assert html_response(conn, 200)
       assert token.contract_address_hash == conn.assigns.token.contract_address_hash
       assert conn.assigns.total_token_transfers
-      assert conn.assigns.total_token_holders
     end
   end
 end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1987,6 +1987,9 @@ defmodule Explorer.Chain do
     |> Repo.all()
   end
 
+  # This function is deprecated.
+  #
+  # The code is being treated at https://github.com/poanetwork/blockscout/issues/880
   @spec count_token_holders_from_token_hash(Hash.Address.t()) :: non_neg_integer()
   def count_token_holders_from_token_hash(contract_address_hash) do
     contract_address_hash


### PR DESCRIPTION
Resolves #884 

## Motivation

The `token holders` counter is being improved in the #880 issue, but the page is still slow with this information.

## Changelog

Removes the `token holders` count info from the token's page.



