### PR TITLE
Log InternalTransaction.Fetcher errors as error

### DIFF
--- a/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
@@ -112,7 +112,7 @@ defmodule Indexer.InternalTransaction.Fetcher do
           })
         else
           {:error, step, reason, _changes_so_far} ->
-            Logger.debug(fn ->
+            Logger.error(fn ->
               [
                 "failed to import internal transactions for ",
                 to_string(length(transactions_params)),
@@ -128,7 +128,7 @@ defmodule Indexer.InternalTransaction.Fetcher do
         end
 
       {:error, reason} ->
-        Logger.debug(fn ->
+        Logger.error(fn ->
           "failed to fetch internal transactions for #{length(transactions_params)} transactions: #{inspect(reason)}"
         end)
 


### PR DESCRIPTION
## Motivation

* Currently errors when importing internal transactions are being logged
with 'debug' level. Making them 'error' level would make sure we notice
them quicker and that they're prioritized accordingly.

## Changelog

### Enhancements
Changed log levels from 'debug' to 'error', in `Indexer.InternalTransaction.Fetcher`.