### PR TITLE
Don't count every sibling unnecessarily.

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1816,7 +1816,9 @@ defmodule Explorer.Chain do
           """
           (SELECT COUNT(sibling.id)
           FROM internal_transactions AS sibling
-          WHERE sibling.transaction_hash = ?)
+          WHERE sibling.transaction_hash = ?
+          LIMIT 2
+          )
           """,
           transaction.hash
         ) > 1


### PR DESCRIPTION
In `where_transaction_has_multiple_internal_transactions` it counts every sibling unncessarily: I added a `limit` to it so it only `select`s up to `2`.

Related to #872 

## Motivation
The queries take a long time and the pages don't load correctly.

### Enhancements
`Chain.where_transaction_has_multiple_internal_transactions/1` no longer counts every sibling unnecessarily, now only up to `2`.
