### PR TITLE
Consolidate transactions by address count

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
@@ -18,7 +18,7 @@ defmodule BlockScoutWeb.AddressController do
   end
 
   def transaction_count(%Address{} = address) do
-    Chain.address_to_transactions_estimated_count(address)
+    Chain.count_transactions_by_address_hash(address.hash)
   end
 
   def validation_count(%Address{} = address) do

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -171,7 +171,7 @@ defmodule BlockScoutWeb.AddressView do
   def token_title(%Token{name: name, symbol: symbol}), do: "#{name} (#{symbol})"
 
   def transaction_count(%Address{} = address) do
-    Chain.address_to_transactions_estimated_count(address)
+    Chain.count_transactions_by_address_hash(address.hash)
   end
 
   def trimmed_hash(%Hash{} = hash) do

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -23,6 +23,7 @@ config :explorer, Explorer.Repo,
   migration_timestamps: [type: :utc_datetime]
 
 config :explorer, Explorer.Counters.TokenTransferCounter, enabled: true
+config :explorer, Explorer.Counters.TransactionCounter, enabled: true
 
 config :explorer,
   solc_bin_api_url: "https://solc-bin.ethereum.org"

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -16,6 +16,7 @@ config :explorer, Explorer.Repo,
 config :explorer, Explorer.ExchangeRates, enabled: false
 
 config :explorer, Explorer.Market.History.Cataloger, enabled: false
+config :explorer, Explorer.Counters.TransactionCounter, enabled: false
 
 config :logger, :explorer,
   level: :warn,

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -16,7 +16,7 @@ config :explorer, Explorer.Repo,
 config :explorer, Explorer.ExchangeRates, enabled: false
 
 config :explorer, Explorer.Market.History.Cataloger, enabled: false
-config :explorer, Explorer.Counters.TransactionCounter, enabled: false
+config :explorer, Explorer.Counters.TransactionCounter, subscribe_events: false
 
 config :logger, :explorer,
   level: :warn,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -16,12 +16,6 @@ defmodule Explorer.Application do
       Explorer.Repo,
       Supervisor.child_spec({Task.Supervisor, name: Explorer.MarketTaskSupervisor}, id: Explorer.MarketTaskSupervisor),
       Supervisor.child_spec({Task.Supervisor, name: Explorer.TaskSupervisor}, id: Explorer.TaskSupervisor),
-      Supervisor.child_spec({Task.Supervisor, name: Explorer.CounterTokenSupervisor},
-        id: Explorer.CounterTokenSupervisor
-      ),
-      Supervisor.child_spec({Task.Supervisor, name: Explorer.CounterTransactionSupervisor},
-        id: Explorer.CounterTransactionSupervisor
-      ),
       {Registry, keys: :duplicate, name: Registry.ChainEvents, id: Registry.ChainEvents}
     ]
 

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -19,6 +19,9 @@ defmodule Explorer.Application do
       Supervisor.child_spec({Task.Supervisor, name: Explorer.CounterTokenSupervisor},
         id: Explorer.CounterTokenSupervisor
       ),
+      Supervisor.child_spec({Task.Supervisor, name: Explorer.CounterTransactionSupervisor},
+        id: Explorer.CounterTransactionSupervisor
+      ),
       {Registry, keys: :duplicate, name: Registry.ChainEvents, id: Registry.ChainEvents}
     ]
 
@@ -33,7 +36,8 @@ defmodule Explorer.Application do
     [
       configure(Explorer.ExchangeRates),
       configure(Explorer.Market.History.Cataloger),
-      configure(Explorer.Counters.TokenTransferCounter)
+      configure(Explorer.Counters.TokenTransferCounter),
+      configure(Explorer.Counters.TransactionCounter)
     ]
     |> List.flatten()
   end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -38,7 +38,7 @@ defmodule Explorer.Chain do
 
   alias Explorer.Chain.Block.Reward
   alias Explorer.{PagingOptions, Repo}
-  alias Explorer.Counters.{TokenTransferCounter, TransactionCounter}
+  alias Explorer.Counters.{TokenTransferCounter}
 
   @default_paging_options %PagingOptions{page_size: 50}
 
@@ -1901,7 +1901,13 @@ defmodule Explorer.Chain do
 
   @spec count_transactions_by_address_hash(Hash.t()) :: non_neg_integer()
   def count_transactions_by_address_hash(address_hash) do
-    TransactionCounter.fetch(address_hash)
+    counter = Repo.get_by(Explorer.Chain.Address.TransactionCounter, address_hash: address_hash)
+
+    if counter do
+      counter.transactions_number
+    else
+      0
+    end
   end
 
   @spec transaction_has_token_transfers?(Hash.t()) :: boolean()

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -38,7 +38,7 @@ defmodule Explorer.Chain do
 
   alias Explorer.Chain.Block.Reward
   alias Explorer.{PagingOptions, Repo}
-  alias Explorer.Counters.TokenTransferCounter
+  alias Explorer.Counters.{TokenTransferCounter, TransactionCounter}
 
   @default_paging_options %PagingOptions{page_size: 50}
 
@@ -1929,6 +1929,11 @@ defmodule Explorer.Chain do
   @spec count_token_transfers_from_token_hash(Hash.t()) :: non_neg_integer()
   def count_token_transfers_from_token_hash(token_address_hash) do
     TokenTransferCounter.fetch(token_address_hash)
+  end
+
+  @spec count_transactions_by_address_hash(Hash.t()) :: non_neg_integer()
+  def count_transactions_by_address_hash(address_hash) do
+    TransactionCounter.fetch(address_hash)
   end
 
   @spec transaction_has_token_transfers?(Hash.t()) :: boolean()

--- a/apps/explorer/lib/explorer/chain/address/transaction_counter.ex
+++ b/apps/explorer/lib/explorer/chain/address/transaction_counter.ex
@@ -1,0 +1,38 @@
+defmodule Explorer.Chain.Address.TransactionCounter do
+  use Explorer.Schema
+
+  alias Explorer.Repo
+  alias Explorer.Chain.{Address, Hash}
+
+  @required_fields ~w(address_hash transactions_number)a
+
+  @type t :: %__MODULE__{
+          address: %Ecto.Association.NotLoaded{} | Address.t(),
+          address_hash: Hash.Address.t(),
+          transactions_number: non_neg_integer()
+        }
+
+  @primary_key false
+  schema "address_transaction_counter" do
+    belongs_to(:address, Address, foreign_key: :address_hash, references: :hash, type: Hash.Address)
+    field(:transactions_number, :integer)
+  end
+
+  def changeset(%__MODULE__{} = transaction_counter, params) do
+    transaction_counter
+    |> cast(params, @required_fields)
+    |> validate_required(@required_fields)
+    |> foreign_key_constraint(:address_hash)
+  end
+
+  def insert_or_update_counter({address_hash, transactions_number}) do
+    %__MODULE__{}
+    |> changeset(%{address_hash: address_hash, transactions_number: transactions_number})
+    |> Repo.insert(
+      on_conflict: [
+        inc: [transactions_number: transactions_number]
+      ],
+      conflict_target: :address_hash
+    )
+  end
+end

--- a/apps/explorer/lib/explorer/counters/transaction_counter.ex
+++ b/apps/explorer/lib/explorer/counters/transaction_counter.ex
@@ -1,0 +1,97 @@
+defmodule Explorer.Counters.TransactionCounter do
+  use GenServer
+
+  @moduledoc """
+  Module responsible for fetching and consolidating the number of transactions by address.
+  """
+
+  alias Explorer.Chain
+  alias Explorer.Chain.{Hash, Transaction}
+
+  @table :transaction_counter
+
+  def table_name do
+    @table
+  end
+
+  @doc """
+  Starts a process to continually monitor the transaction counters.
+  """
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  ## Server
+  @impl true
+  def init(args) do
+    create_table()
+
+    Task.start_link(&consolidate/0)
+
+    Chain.subscribe_to_events(:transactions)
+
+    {:ok, args}
+  end
+
+  def create_table do
+    opts = [
+      :set,
+      :named_table,
+      :public,
+      read_concurrency: true
+    ]
+
+    :ets.new(table_name(), opts)
+  end
+
+  @doc """
+  Consolidates the number of transactions grouped by address.
+  """
+  def consolidate do
+    total_transactions = Transaction.consolidate_by_address()
+
+    for {address_hash, total} <- total_transactions do
+      insert_or_update_counter(address_hash, total)
+    end
+  end
+
+  @doc """
+  Fetches the number of transactions related to a address hash.
+  """
+  @spec fetch(Hash.t()) :: non_neg_integer
+  def fetch(address_hash) do
+    do_fetch(:ets.lookup(table_name(), address_hash.bytes))
+  end
+
+  defp do_fetch([{_, result}]), do: result
+  defp do_fetch([]), do: 0
+
+  @impl true
+  def handle_info({:chain_event, :transactions, _type, transaction_hashes}, state) do
+    transaction_hashes
+    |> find_transactions
+    |> Enum.flat_map(&[&1.to_address_hash, &1.from_address_hash, &1.created_contract_address_hash])
+    |> Enum.reject(&is_nil/1)
+    |> Enum.each(&insert_or_update_counter(&1, 1))
+
+    {:noreply, state}
+  end
+
+  defp find_transactions(transaction_hashes) do
+    Chain.hashes_to_transactions(transaction_hashes, [])
+  end
+
+  @doc """
+  Inserts a new item into the `:ets` table.
+
+  When the record exist, the counter will be incremented by one. When the
+  record does not exist, the counter will be inserted with a default value.
+  """
+  @spec insert_or_update_counter(Hash.t(), non_neg_integer) :: term()
+  def insert_or_update_counter(address_hash, number) do
+    default = {address_hash.bytes, 0}
+
+    :ets.update_counter(table_name(), address_hash.bytes, number, default)
+  end
+end

--- a/apps/explorer/lib/explorer/counters/transaction_counter.ex
+++ b/apps/explorer/lib/explorer/counters/transaction_counter.ex
@@ -5,14 +5,8 @@ defmodule Explorer.Counters.TransactionCounter do
   Module responsible for fetching and consolidating the number of transactions by address.
   """
 
-  alias Explorer.Chain
-  alias Explorer.Chain.{Hash, Transaction}
-
-  @table :transaction_counter
-
-  def table_name do
-    @table
-  end
+  alias Explorer.{Chain}
+  alias Explorer.Chain.{Address, Transaction}
 
   @doc """
   Starts a process to continually monitor the transaction counters.
@@ -25,8 +19,6 @@ defmodule Explorer.Counters.TransactionCounter do
   ## Server
   @impl true
   def init(args) do
-    create_table()
-
     Task.start_link(&consolidate/0)
 
     subscribe_to_events()
@@ -51,17 +43,6 @@ defmodule Explorer.Counters.TransactionCounter do
     end
   end
 
-  def create_table do
-    opts = [
-      :set,
-      :named_table,
-      :public,
-      read_concurrency: true
-    ]
-
-    :ets.new(table_name(), opts)
-  end
-
   @doc """
   Consolidates the number of transactions grouped by address.
   """
@@ -69,46 +50,25 @@ defmodule Explorer.Counters.TransactionCounter do
     total_transactions = Transaction.consolidate_by_address()
 
     for {address_hash, total} <- total_transactions do
-      insert_or_update_counter(address_hash, total)
+      Address.TransactionCounter.insert_or_update_counter({address_hash, total})
     end
   end
-
-  @doc """
-  Fetches the number of transactions related to a address hash.
-  """
-  @spec fetch(Hash.t()) :: non_neg_integer
-  def fetch(address_hash) do
-    do_fetch(:ets.lookup(table_name(), address_hash.bytes))
-  end
-
-  defp do_fetch([{_, result}]), do: result
-  defp do_fetch([]), do: 0
 
   @impl true
   def handle_info({:chain_event, :transactions, _type, transaction_hashes}, state) do
     transaction_hashes
-    |> find_transactions
-    |> Enum.flat_map(&[&1.to_address_hash, &1.from_address_hash, &1.created_contract_address_hash])
-    |> Enum.reject(&is_nil/1)
-    |> Enum.each(&insert_or_update_counter(&1, 1))
+    |> Chain.hashes_to_transactions([])
+    |> prepare_transactions
+    |> Enum.each(&Address.TransactionCounter.insert_or_update_counter(&1))
 
     {:noreply, state}
   end
 
-  defp find_transactions(transaction_hashes) do
-    Chain.hashes_to_transactions(transaction_hashes, [])
-  end
-
-  @doc """
-  Inserts a new item into the `:ets` table.
-
-  When the record exist, the counter will be incremented by one. When the
-  record does not exist, the counter will be inserted with a default value.
-  """
-  @spec insert_or_update_counter(Hash.t(), non_neg_integer) :: term()
-  def insert_or_update_counter(address_hash, number) do
-    default = {address_hash.bytes, 0}
-
-    :ets.update_counter(table_name(), address_hash.bytes, number, default)
+  def prepare_transactions(transactions) do
+    transactions
+    |> Enum.flat_map(&[&1.to_address_hash, &1.from_address_hash, &1.created_contract_address_hash])
+    |> Enum.reject(&is_nil/1)
+    |> Enum.group_by(& &1)
+    |> Enum.map(fn {address_hash, hashes} -> {address_hash, Enum.count(hashes)} end)
   end
 end

--- a/apps/explorer/priv/repo/migrations/20181011180940_create_address_transactions_counter.exs
+++ b/apps/explorer/priv/repo/migrations/20181011180940_create_address_transactions_counter.exs
@@ -1,0 +1,16 @@
+defmodule Explorer.Repo.Migrations.CreateAddressTransactionsCounter do
+  use Ecto.Migration
+
+  def change do
+    create table(:address_transaction_counter, primary_key: false) do
+      add(
+        :address_hash,
+        references(:addresses, column: :hash, on_delete: :delete_all, type: :bytea),
+        null: false,
+        primary_key: true
+      )
+
+      add(:transactions_number, :bigint, default: 0)
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction_test.exs
@@ -177,4 +177,39 @@ defmodule Explorer.Chain.TransactionTest do
       assert result == [transaction_c.block_number, transaction_b.block_number, transaction_a.block_number]
     end
   end
+
+  describe "consolidate_by_address/1" do
+    test "counts transactions and group by addresses" do
+      address_a = insert(:address, hash: "0x0000000000000000000000000000000000000b09")
+      address_b = insert(:address, hash: "0x0000000000000000000000000000000000000b08")
+
+      insert(:transaction, to_address: address_a, from_address: address_b)
+
+      expected = [
+        {address_a.hash, 1},
+        {address_b.hash, 1}
+      ]
+
+      assert Transaction.consolidate_by_address() == expected
+    end
+
+    test "considers the created_contract_address when the to_address is nil" do
+      address_a = insert(:address, hash: "0x0000000000000000000000000000000000000b02")
+      address_b = insert(:contract_address, hash: "0x0000000000000000000000000000000000000b03")
+
+      insert(
+        :transaction,
+        from_address: address_a,
+        to_address: nil,
+        created_contract_address: address_b
+      )
+
+      expected = [
+        {address_a.hash, 1},
+        {address_b.hash, 1}
+      ]
+
+      assert Transaction.consolidate_by_address() == expected
+    end
+  end
 end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -344,12 +344,6 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "address_to_transactions_estimated_count/1" do
-    test "returns integer" do
-      assert is_integer(Chain.address_to_transactions_estimated_count(build(:address)))
-    end
-  end
-
   describe "average_block_time/0" do
     test "without blocks duration is 0" do
       assert Chain.average_block_time() == Timex.Duration.parse!("PT0S")

--- a/apps/explorer/test/explorer/counters/transaction_counter_test.exs
+++ b/apps/explorer/test/explorer/counters/transaction_counter_test.exs
@@ -1,0 +1,38 @@
+defmodule Explorer.Counters.TransactionCounterTest do
+  use Explorer.DataCase
+
+  alias Explorer.Counters.TransactionCounter
+
+  setup do
+    TransactionCounter.create_table()
+    :ok
+  end
+
+  describe "consolidate/0" do
+    test "loads transactions consolidate info" do
+      address_a = insert(:address)
+      address_b = insert(:address)
+
+      :transaction
+      |> insert(to_address: address_a, from_address: address_b)
+      |> with_block()
+
+      TransactionCounter.consolidate()
+
+      assert TransactionCounter.fetch(address_a.hash) == 1
+      assert TransactionCounter.fetch(address_b.hash) == 1
+    end
+  end
+
+  describe "fetch/1" do
+    test "fetchs the total transactions by address hash" do
+      address = insert(:address)
+
+      assert TransactionCounter.fetch(address.hash) == 0
+
+      TransactionCounter.insert_or_update_counter(address.hash, 15)
+
+      assert TransactionCounter.fetch(address.hash) == 15
+    end
+  end
+end

--- a/apps/explorer/test/explorer/counters/transaction_counter_test.exs
+++ b/apps/explorer/test/explorer/counters/transaction_counter_test.exs
@@ -30,4 +30,31 @@ defmodule Explorer.Counters.TransactionCounterTest do
       assert TransactionCounter.fetch(address.hash) == 15
     end
   end
+
+  describe "prepare_transactions/0" do
+    test "returns an array so that each item is a tuple with the address and the transactions number" do
+      address_a = insert(:address)
+      address_b = insert(:address)
+      address_c = insert(:contract_address)
+      transaction_a = insert(:transaction, from_address: address_a, to_address: address_b)
+      transaction_b = insert(:transaction, from_address: address_b, to_address: address_a)
+
+      transaction_c =
+        insert(:transaction, from_address: address_a, created_contract_address: address_c, to_address: nil)
+
+      transactions = [
+        transaction_a,
+        transaction_b,
+        transaction_c
+      ]
+
+      expected = [
+        {address_a.hash, 3},
+        {address_b.hash, 2},
+        {address_c.hash, 1}
+      ]
+
+      assert TransactionCounter.prepare_transactions(transactions) == expected
+    end
+  end
 end

--- a/apps/explorer/test/explorer/counters/transaction_counter_test.exs
+++ b/apps/explorer/test/explorer/counters/transaction_counter_test.exs
@@ -3,11 +3,6 @@ defmodule Explorer.Counters.TransactionCounterTest do
 
   alias Explorer.Counters.TransactionCounter
 
-  setup do
-    TransactionCounter.create_table()
-    :ok
-  end
-
   describe "consolidate/0" do
     test "loads transactions consolidate info" do
       address_a = insert(:address)


### PR DESCRIPTION
Relates to #820

## Motivation

The Address' pages have a performance problem due to the amount of data and the MVCC implementation in PostgreSQL.

This PR consolidates the transactions by address count info.

## Changelog

### Enhancements
* Consolidate the transactions by address when the server is started
* Increment transactions count (ETS table) by address as new transactions are indexed.
