### PR TITLE
Blocks validated tab for miner crashing

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_validation_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_validation_controller.ex
@@ -15,7 +15,13 @@ defmodule BlockScoutWeb.AddressValidationController do
          {:ok, address} <- Chain.hash_to_address(address_hash) do
       full_options =
         Keyword.merge(
-          [necessity_by_association: %{miner: :required, transactions: :optional}],
+          [
+            necessity_by_association: %{
+              miner: :required,
+              nephews: :optional,
+              transactions: :optional
+            }
+          ],
           paging_options(params)
         )
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_validation/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_validation/index.html.eex
@@ -108,7 +108,7 @@
         <h2 class="card-title"><%=gettext("Blocks Validated")%></h2>
         <span data-selector="validations-list">
           <%= for block <- @blocks do %>
-            <%= render BlockScoutWeb.BlockView, "_tile.html", block: block %>
+            <%= render BlockScoutWeb.BlockView, "_tile.html", block: block, block_type: BlockScoutWeb.BlockView.block_type(block)%>
           <% end %>
         </span>
         <div>


### PR DESCRIPTION
resolves #909 

## Changelog

### Enhancements

- make validations tab bring needed block associations to check block type

### Bug Fixes

- pass block type to the partial that was crashing so it won't anymore
