### PR TITLE
Optimize entry memory usage for work queues

### DIFF
--- a/apps/explorer/lib/explorer/chain/hash.ex
+++ b/apps/explorer/lib/explorer/chain/hash.ex
@@ -48,6 +48,9 @@ defmodule Explorer.Chain.Hash do
       %__MODULE__{byte_count: ^byte_count, bytes: <<_::big-integer-size(byte_count)-unit(@bits_per_byte)>>} = cast ->
         {:ok, cast}
 
+      <<_::big-integer-size(byte_count)-unit(@bits_per_byte)>> ->
+        {:ok, %__MODULE__{byte_count: byte_count, bytes: term}}
+
       <<"0x", hexadecimal_digits::binary>> ->
         cast_hexadecimal_digits(hexadecimal_digits, byte_count)
 

--- a/apps/explorer/lib/explorer/exchange_rates/token.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/token.ex
@@ -28,7 +28,50 @@ defmodule Explorer.ExchangeRates.Token do
           volume_24h_usd: Decimal.t()
         }
 
+  @enforce_keys ~w(available_supply btc_value id last_updated market_cap_usd name symbol usd_value volume_24h_usd)a
   defstruct ~w(available_supply btc_value id last_updated market_cap_usd name symbol usd_value volume_24h_usd)a
 
-  def null, do: %__MODULE__{}
+  def null,
+    do: %__MODULE__{
+      symbol: nil,
+      id: nil,
+      name: nil,
+      available_supply: nil,
+      usd_value: nil,
+      volume_24h_usd: nil,
+      market_cap_usd: nil,
+      btc_value: nil,
+      last_updated: nil
+    }
+
+  def to_tuple(%__MODULE__{
+        symbol: symbol,
+        id: id,
+        name: name,
+        available_supply: available_supply,
+        usd_value: usd_value,
+        volume_24h_usd: volume_24h_usd,
+        market_cap_usd: market_cap_usd,
+        btc_value: btc_value,
+        last_updated: last_updated
+      }) do
+    # symbol is first because it is the key used for lookup in `Explorer.ExchangeRates`'s ETS table
+    {symbol, id, name, available_supply, usd_value, volume_24h_usd, market_cap_usd, btc_value, last_updated}
+  end
+
+  def from_tuple(
+        {symbol, id, name, available_supply, usd_value, volume_24h_usd, market_cap_usd, btc_value, last_updated}
+      ) do
+    %__MODULE__{
+      symbol: symbol,
+      id: id,
+      name: name,
+      available_supply: available_supply,
+      usd_value: usd_value,
+      volume_24h_usd: volume_24h_usd,
+      market_cap_usd: market_cap_usd,
+      btc_value: btc_value,
+      last_updated: last_updated
+    }
+  end
 end

--- a/apps/explorer/test/explorer/chain/hash/full_test.exs
+++ b/apps/explorer/test/explorer/chain/hash/full_test.exs
@@ -1,5 +1,17 @@
 defmodule Explorer.Chain.Hash.FullTest do
   use ExUnit.Case, async: true
 
-  doctest Explorer.Chain.Hash.Full
+  alias Explorer.Chain.Hash
+
+  doctest Hash.Full
+
+  describe "cast" do
+    test ~S|is not confused by big integer that starts with <<48, 120>> which is "0x"| do
+      assert {:ok, _} =
+               Hash.Full.cast(
+                 <<48, 120, 238, 242, 122, 170, 157, 194, 106, 180, 42, 65, 178, 64, 202, 214, 148, 99, 171, 74, 64, 18,
+                   14, 163, 47, 7, 39, 180, 235, 9, 98, 158>>
+               )
+    end
+  end
 end

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -5,7 +5,7 @@ defmodule Indexer.Block.Fetcher do
 
   require Logger
 
-  alias Explorer.Chain.{Block, Import}
+  alias Explorer.Chain.{Address, Block, Import}
   alias Indexer.{CoinBalance, AddressExtraction, Token, TokenTransfers}
   alias Indexer.Address.{CoinBalances, TokenBalances}
   alias Indexer.Block.Fetcher.Receipts
@@ -164,7 +164,7 @@ defmodule Indexer.Block.Fetcher do
         address_hash_to_fetched_balance_block_number: address_hash_to_block_number
       }) do
     addresses
-    |> Enum.map(fn address_hash ->
+    |> Enum.map(fn %Address{hash: address_hash} ->
       block_number = Map.fetch!(address_hash_to_block_number, to_string(address_hash))
       %{address_hash: address_hash, block_number: block_number}
     end)

--- a/apps/indexer/lib/indexer/coin_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/coin_balance/fetcher.ex
@@ -97,14 +97,13 @@ defmodule Indexer.CoinBalance.Fetcher do
     end
   end
 
-  defp entry_to_params(%{address_hash_bytes: address_hash_bytes, block_number: block_number})
-       when is_integer(block_number) do
+  defp entry_to_params({address_hash_bytes, block_number}) when is_integer(block_number) do
     {:ok, address_hash} = Hash.Address.cast(address_hash_bytes)
     %{block_quantity: integer_to_quantity(block_number), hash_data: to_string(address_hash)}
   end
 
   defp entry(%{address_hash: %Hash{bytes: address_hash_bytes}, block_number: block_number}) do
-    %{address_hash_bytes: address_hash_bytes, block_number: block_number}
+    {address_hash_bytes, block_number}
   end
 
   # We want to record all historical balances for an address, but have the address itself have balance from the

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -97,20 +97,13 @@ defmodule Indexer.TokenBalance.Fetcher do
          address_hash: address_hash,
          block_number: block_number
        }) do
-    %{
-      token_contract_address_hash_bytes: token_contract_address_hash.bytes,
-      address_hash_bytes: address_hash.bytes,
-      block_number: block_number
-    }
+    {address_hash.bytes, token_contract_address_hash.bytes, block_number}
   end
 
-  defp format_params(%{
-         token_contract_address_hash_bytes: token_contract_address_hash_bytes,
-         address_hash_bytes: address_hash_bytes,
-         block_number: block_number
-       }) do
+  defp format_params({address_hash_bytes, token_contract_address_hash_bytes, block_number}) do
     {:ok, token_contract_address_hash} = Hash.Address.cast(token_contract_address_hash_bytes)
     {:ok, address_hash} = Hash.Address.cast(address_hash_bytes)
+
     %{
       token_contract_address_hash: to_string(token_contract_address_hash),
       address_hash: to_string(address_hash),

--- a/apps/indexer/test/indexer/coin_balance/fetcher_test.exs
+++ b/apps/indexer/test/indexer/coin_balance/fetcher_test.exs
@@ -251,9 +251,10 @@ defmodule Indexer.CoinBalance.FetcherTest do
         end)
       end
 
-      params_list = Enum.map(block_quantities, &%{block_quantity: &1, hash_data: hash_data})
+      {:ok, %Hash{bytes: address_hash_bytes}} = Hash.Address.cast(hash_data)
+      entries = Enum.map(block_quantities, &%{address_hash_bytes: address_hash_bytes, block_number: quantity_to_integer(&1)})
 
-      case CoinBalance.Fetcher.run(params_list, 0, json_rpc_named_arguments) do
+      case CoinBalance.Fetcher.run(entries, 0, json_rpc_named_arguments) do
         :ok ->
           balances = Repo.all(from(balance in Address.CoinBalance, where: balance.address_hash == ^hash_data))
 
@@ -283,12 +284,14 @@ defmodule Indexer.CoinBalance.FetcherTest do
         other ->
           # not all nodes behind the `https://mainnet.infura.io` pool are fully-synced.  Node that aren't fully-synced
           # won't have historical address balances.
-          assert {:retry, ^params_list} = other
+          assert {:retry, ^entries} = other
       end
     end
 
-    test "duplicate params retry unique params", %{json_rpc_named_arguments: json_rpc_named_arguments} do
-      hash_data = "0x000000000000000000000000000000000"
+    test "duplicate entries retry unique entries", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      hash_data = "0x0000000000000000000000000000000000000000"
+
+      {:ok, %Hash{bytes: bytes}} = Hash.Address.cast(hash_data)
 
       if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
         EthereumJSONRPC.Mox
@@ -298,15 +301,15 @@ defmodule Indexer.CoinBalance.FetcherTest do
       end
 
       assert CoinBalance.Fetcher.run(
-               [%{block_quantity: "0x1", hash_data: hash_data}, %{block_quantity: "0x1", hash_data: hash_data}],
+               [%{address_hash_bytes: bytes, block_number: 1}, %{address_hash_bytes: bytes, block_number: 1}],
                0,
                json_rpc_named_arguments
              ) ==
                {:retry,
                 [
                   %{
-                    block_quantity: "0x1",
-                    hash_data: "0x000000000000000000000000000000000"
+                    address_hash_bytes: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>,
+                    block_number: 1
                   }
                 ]}
     end


### PR DESCRIPTION
Related to #888

## Motivation

While adding memory manager for #888, I used `:observer` to see what the state of each of the fetchers looked like and realized that we were storing a lot of redundant parts of data structures.

## Changelog

### Enhancements
* Optimize memory usage for entries in the work queues for the various fetchers
  * `Indexer.Sequence` stores `%Range{first: first, last: last}` as `{first, last}` internally in its `:queue for a 45%-30% memory savings.

    | max_block_number | Garbage Collection | Ranges (bytes) | Tuples (bytes) | Tuples / Ranges (%) |
    |------------------|--------------------|----------------|----------------|---------------------|
    | 5,000,000        | Before             | 41,050,964     | 22,445,660     | 54.68               |
    | 5,000,000        | After              | 34,386,756     | 23,879,996     | 69.45               |
    | 10,000,000       | Before             | 80,889,772     | 47,928,116     | 59.24               |
    | 10,000,000       | After              | 71,303,316     | 49,516,492     | 69.44               |
  * `Indexer.TokenBalance.Fetcher` stores maps instead of structs for a 87%-90% memory savings

     | Token Balances | Garbage Collection | `%TokenBalance{}`s (bytes) | `%{token_contract_address_hash: Hash.to_string(token_contract_address_hash),    address_hash: Hash.to_string(address_hash),    block_number: block_number}` (bytes) | Map / Struct (%) |
     |----------------|--------------------|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
     | 1,000          | Before             | 2,549,476                  | 233,500      | 9.16             |
     | 1,000          | After              | 2,546,468                  | 233,500  | 9.17             |
     | 10,000         | Before             | 19,903,172                 | 2,549,476  | 12.81            |
     | 10,000         | After              | 19,900,260                 | 2,546,468   | 12.80            |
  * `Indexer.TokenBalance.Fetcher` stores Hash bytes instead of Hashes for an additional 39% memory savings
     
     | Token Balances | Garbage Collection | Hash Strings (bytes) | Hash Bytes (bytes) | Bytes / String (%) |
     |----------------|--------------------|----------------------|--------------------|--------------------|
     | 1,000          | Before             | 233,500              | 233,500            | 100.00             |
     | 1,000          | After              | 233,500              | 230,492            | 98.71              |
     | 10,000         | Before             | 2,549,476            | 1,577,180          | 61.86              |
     | 10,000         | After              | 2,546,468            | 1,574,172          | 61.82              |
  * `Indexer.TokenBalance.Fetcher` stores tuples instead of maps for an additional 17%-38% memory savings

     | Token Balances | Garbage Collection | Map (bytes) | Tuple (bytes) | Tuple / Map (%) |
     |----------------|--------------------|-------------|---------------|-----------------|
     | 1,000          | Before             | 233,500     | 145,828       | 62.45           |
     | 1,000          | After              | 230,492     | 142,820       | 61.96           |
     | 50,000         | Before             | 8,001,028   | 6,668,188     | 83.34           |
     | 50,000         | After              | 7,998,020   | 6,665,180     | 83.35             |
  * Store exchange rates as tuples in ETS: 2177 kB for {symbol, Token} vs 1864 kB for {symbol, ...} with each Token field in a separate element of the tuple.
  * `Indexer.CoinBalance.Fetcher` hash bytes and block integers instead of strings in buffer for 30%-38% memory savings

     | Balances | Garbage Collection | String (bytes) | Bytes and Integer (bytes) | Bytes / String (%) |
     |----------|--------------------|----------------|---------------------------|--------------------|
     | 100      | Before             | 55,244         | 34,548                    | 62.54              |
     | 100      | After              | 21,764         | 13,860                    | 63.68              |
     | 1,000    | Before             | 601,972        | 372,444                   | 61.87              |
     | 1,000    | After              | 230,596        | 142,924                   | 61.98              |
     | 10,000   | Before             | 4,119,668      | 2,546,460                 | 61.81              |
     | 10,000   | After              | 1,574,172      | 973,260                   | 61.83              |
     | 100,000  | Before             | 16,586,644     | 11,519,724                | 69.45              |
     | 100,000  | After              | 16,583,636     | 11,516,716                | 69.45              |  
  * `Indexer.CoinBalance.Fetcher` tuples instead of maps for an additional 17%-38% memory savings

     | Balances | Garbage Collection | Map (bytes) | Tuple (bytes) | Tuple / Map (%) |
     |----------|--------------------|-------------|---------------|-----------------|
     | 1,000    | Before             | 372,444     | 230,484       | 61.88           |
     | 1,000    | After              | 142,924     | 88,636        | 62.02           |
     | 100,000  | Before             | 11,519,724  | 9,600,436     | 83.34           |
     | 100,000  | After              | 11,516,716  | 9,597,428     | 83.33           |
  * `Indexer.InternalTransaction.Fetcher` tuples instead of maps for 17-38% memory savings

     | Balances | Garbage Collection | Map (bytes) | Tuple (bytes) | Tuple / Map (%) |
     |----------|--------------------|-------------|---------------|-----------------|
     | 10,000   | Before             | 4,119,668   | 2,546,460     | 61.81           |
     | 10,000   | After              | 1,574,172   | 973,260       | 61.82           |
     | 100,000  | Before             | 11,519,724  | 9,600,436     | 83.34           |
     | 100,000  | After              | 11,516,716  | 9,597,428     | 83.33           |