### PR TITLE
Send new_block channel messages for catchup blocks

### DIFF
--- a/apps/block_scout_web/assets/js/pages/chain.js
+++ b/apps/block_scout_web/assets/js/pages/chain.js
@@ -52,7 +52,7 @@ export function reducer (state = initialState, action) {
           skippedBlockNumbers: _.without(state.skippedBlockNumbers, blockNumber)
         })
       } else if (blockNumber < _.last(state.blockNumbers)) {
-        return Object.assign({}, state, { newBlock: null })
+        return state
       } else {
         let skippedBlockNumbers = state.skippedBlockNumbers.slice(0)
         if (blockNumber > state.blockNumbers[0] + 1) {

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -16,7 +16,7 @@ defmodule BlockScoutWeb.Notifier do
     |> Enum.each(&broadcast_balance/1)
   end
 
-  def handle_event({:chain_event, :blocks, :catchup, _blocks}) do
+  def handle_event({:chain_event, :blocks, :catchup, blocks}) do
     ratio = Chain.indexed_ratio()
 
     finished? =
@@ -30,6 +30,8 @@ defmodule BlockScoutWeb.Notifier do
       ratio: ratio,
       finished: finished?
     })
+
+    if ratio == 1.0, do: Enum.each(blocks, &broadcast_block/1)
   end
 
   def handle_event({:chain_event, :blocks, :realtime, blocks}) do

--- a/apps/block_scout_web/test/block_scout_web/channels/block_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/block_channel_test.exs
@@ -20,14 +20,50 @@ defmodule BlockScoutWeb.BlockChannelTest do
     end
   end
 
-  test "subscribed user is notified of new_block event for catchup" do
+  test "miner address is notified of new_block they validated" do
+    miner = insert(:address)
+    topic = "blocks:#{to_string(miner.hash)}"
+    @endpoint.subscribe(topic)
+
+    block = insert(:block, number: 1, miner: miner)
+
+    Notifier.handle_event({:chain_event, :blocks, :realtime, [block]})
+
+    receive do
+      %Phoenix.Socket.Broadcast{topic: ^topic, event: "new_block", payload: %{block: _}} ->
+        assert true
+    after
+      5_000 ->
+        assert false, "Expected message received nothing."
+    end
+  end
+
+  test "subscribed user is notified of indexing status" do
     topic = "blocks:indexing"
     @endpoint.subscribe(topic)
 
     Notifier.handle_event({:chain_event, :blocks, :catchup, []})
 
     receive do
-      %Phoenix.Socket.Broadcast{topic: ^topic, event: "index_status", payload: %{}} ->
+      %Phoenix.Socket.Broadcast{topic: ^topic, event: "index_status", payload: payload} ->
+        assert payload.ratio == 0
+        refute payload.finished
+    after
+      5_000 ->
+        assert false, "Expected message received nothing."
+    end
+  end
+
+  test "subscribed user is notified of new_block event for catchup" do
+    topic = "blocks:new_block"
+    @endpoint.subscribe(topic)
+
+    block = insert(:block, number: 1)
+
+    Notifier.handle_event({:chain_event, :blocks, :catchup, [block]})
+
+    receive do
+      %Phoenix.Socket.Broadcast{topic: ^topic, event: "new_block", payload: %{block: _}} ->
         assert true
     after
       5_000 ->


### PR DESCRIPTION
Resolves #908 
Resolves #907 

## Motivation

Holes (placeholders) for skipped blocks from the realtime indexer are never filled with live update if they are processed by the catchup indexer.

## Changelog

### Enhancements

* Broadcast new blocks from the catchup indexer to channels to allow for live updating of the UI.