### PR TITLE
Update block reward contract beneficiary balances

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -188,6 +188,13 @@ defmodule EthereumJSONRPC do
   end
 
   @doc """
+  Fetches block reward contract beneficiaries from variant API.
+  """
+  def fetch_beneficiaries(_first.._last = range, json_rpc_named_arguments) do
+    Keyword.fetch!(json_rpc_named_arguments, :variant).fetch_beneficiaries(range, json_rpc_named_arguments)
+  end
+
+  @doc """
   Fetches blocks by block hashes.
 
   Transaction data is included for each block.

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -6,6 +6,14 @@ defmodule EthereumJSONRPC.Geth do
   @behaviour EthereumJSONRPC.Variant
 
   @doc """
+  Block reward contract beneficiary fetching is not supported currently for Geth.
+
+  To signal to the caller that fetching is not supported, `:ignore` is returned.
+  """
+  @impl EthereumJSONRPC.Variant
+  def fetch_beneficiaries(_block_range, _json_rpc_named_arguments), do: :ignore
+
+  @doc """
   Internal transaction fetching is not supported currently for Geth.
 
   To signal to the caller that fetching is not supported, `:ignore` is returned.

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity.ex
@@ -10,6 +10,30 @@ defmodule EthereumJSONRPC.Parity do
 
   @behaviour EthereumJSONRPC.Variant
 
+  @impl EthereumJSONRPC.Variant
+  def fetch_beneficiaries(block_range, json_rpc_named_arguments) do
+    Enum.reduce(
+      Enum.with_index(block_range),
+      {:ok, MapSet.new()},
+      fn
+        {block_number, index}, {:ok, beneficiaries} ->
+          quantity = EthereumJSONRPC.integer_to_quantity(block_number)
+
+          case trace_block(index, quantity, json_rpc_named_arguments) do
+            {:ok, traces} when is_list(traces) ->
+              new_beneficiaries = extract_beneficiaries(traces)
+              {:ok, MapSet.union(new_beneficiaries, beneficiaries)}
+
+            _ ->
+              {:error, "Error fetching block reward contract beneficiaries"}
+          end
+
+        _, {:error, _} = error ->
+          error
+      end
+    )
+  end
+
   @doc """
   Fetches the `t:Explorer.Chain.InternalTransaction.changeset/2` params from the Parity trace URL.
   """
@@ -46,6 +70,27 @@ defmodule EthereumJSONRPC.Parity do
 
       {:ok, transactions_params}
     end
+  end
+
+  defp extract_beneficiaries(traces) when is_list(traces) do
+    Enum.reduce(traces, MapSet.new(), fn
+      %{"action" => %{"rewardType" => "block", "author" => author}, "blockNumber" => block_number}, beneficiaries ->
+        beneficiary = %{
+          block_number: block_number,
+          address_hash: author
+        }
+
+        MapSet.put(beneficiaries, beneficiary)
+
+      _, beneficiaries ->
+        beneficiaries
+    end)
+  end
+
+  defp trace_block(index, quantity, json_rpc_named_arguments) do
+    %{id: index, method: "trace_block", params: [quantity]}
+    |> request()
+    |> json_rpc(json_rpc_named_arguments)
   end
 
   defp trace_replay_transaction_responses_to_internal_transactions_params(responses, id_to_params)

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/variant.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/variant.ex
@@ -14,6 +14,22 @@ defmodule EthereumJSONRPC.Variant do
   @type internal_transaction_params :: map()
 
   @doc """
+  Fetch the block reward contract beneficiaries for a given block
+  range, from the variant of the Ethereum JSONRPC API.
+
+  For more information on block reward contracts see:
+  https://wiki.parity.io/Block-Reward-Contract.html
+
+  ## Returns
+
+   * `{:ok, #MapSet<[%{...}]>}` - beneficiaries were successfully fetched
+   * `{:error, reason}` - there was one or more errors with `reason` in fetching the beneficiaries
+   * `:ignore` - the variant does not support fetching beneficiaries
+  """
+  @callback fetch_beneficiaries(Range.t(), EthereumJSONRPC.json_rpc_named_arguments()) ::
+              {:ok, MapSet.t()} | {:error, reason :: term} | :ignore
+
+  @doc """
   Fetches the `t:Explorer.Chain.InternalTransaction.changeset/2` params from the variant of the Ethereum JSONRPC API.
 
   ## Returns

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
@@ -165,6 +165,19 @@ defmodule EthereumJSONRPCTest do
     end
   end
 
+  describe "fetch_beneficiaries/2" do
+    @tag :no_geth
+    test "fetches benefeciaries from variant API", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
+        expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+          {:ok, []}
+        end)
+
+        assert EthereumJSONRPC.fetch_beneficiaries(1..1, json_rpc_named_arguments) == {:ok, MapSet.new()}
+      end
+    end
+  end
+
   describe "fetch_block_by_hash/2" do
     test "can fetch blocks", %{json_rpc_named_arguments: json_rpc_named_arguments} do
       %{block_hash: block_hash, transaction_hash: transaction_hash} =

--- a/apps/indexer/config/dev/parity.exs
+++ b/apps/indexer/config/dev/parity.exs
@@ -9,6 +9,7 @@ config :indexer,
       url: "https://sokol.poa.network",
       method_to_url: [
         eth_getBalance: "https://sokol-trace.poa.network",
+        trace_block: "https://sokol-trace.poa.network",
         trace_replayTransaction: "https://sokol-trace.poa.network"
       ],
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]

--- a/apps/indexer/config/prod/parity.exs
+++ b/apps/indexer/config/prod/parity.exs
@@ -9,6 +9,7 @@ config :indexer,
       url: System.get_env("ETHEREUM_URL") || "https://sokol.poa.network",
       method_to_url: [
         eth_getBalance: System.get_env("TRACE_URL") || "https://sokol-trace.poa.network",
+        trace_block: System.get_env("TRACE_URL") || "https://sokol-trace.poa.network",
         trace_replayTransaction: System.get_env("TRACE_URL") || "https://sokol-trace.poa.network"
       ],
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]

--- a/apps/indexer/lib/indexer/address_extraction.ex
+++ b/apps/indexer/lib/indexer/address_extraction.ex
@@ -116,6 +116,12 @@ defmodule Indexer.AddressExtraction do
         %{from: :block_number, to: :fetched_coin_balance_block_number},
         %{from: :to_address_hash, to: :hash}
       ]
+    ],
+    block_reward_contract_beneficiaries: [
+      [
+        %{from: :block_number, to: :fetched_coin_balance_block_number},
+        %{from: :address_hash, to: :hash}
+      ]
     ]
   }
 
@@ -377,6 +383,12 @@ defmodule Indexer.AddressExtraction do
             %{
               required(:from_address_hash) => String.t(),
               required(:to_address_hash) => String.t(),
+              required(:block_number) => non_neg_integer()
+            }
+          ],
+          optional(:block_reward_contract_beneficiaries) => [
+            %{
+              required(:address_hash) => String.t(),
               required(:block_number) => non_neg_integer()
             }
           ]

--- a/apps/indexer/test/indexer/address_extraction_test.exs
+++ b/apps/indexer/test/indexer/address_extraction_test.exs
@@ -107,12 +107,18 @@ defmodule Indexer.AddressExtractionTest do
         token_contract_address_hash: gen_hash()
       }
 
+      beneficiary = %{
+        block_number: 6,
+        address_hash: gen_hash()
+      }
+
       blockchain_data = %{
         blocks: [block],
         internal_transactions: [internal_transaction],
         transactions: [transaction],
         logs: [log],
-        token_transfers: [token_transfer]
+        token_transfers: [token_transfer],
+        block_reward_contract_beneficiaries: [beneficiary]
       }
 
       assert AddressExtraction.extract_addresses(blockchain_data) == [
@@ -144,6 +150,10 @@ defmodule Indexer.AddressExtractionTest do
                %{
                  hash: token_transfer.token_contract_address_hash,
                  fetched_coin_balance_block_number: token_transfer.block_number
+               },
+               %{
+                 hash: beneficiary.address_hash,
+                 fetched_coin_balance_block_number: beneficiary.block_number
                }
              ]
     end

--- a/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
@@ -63,6 +63,9 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisorTest do
                    "uncles" => []
                  }}
 
+              %{method: "trace_block"}, _options ->
+                {:ok, []}
+
               [%{method: "eth_getBlockByNumber", params: [_, true]} | _] = requests, _options ->
                 {:ok,
                  Enum.map(requests, fn %{id: id, params: [block_quantity, true]} ->
@@ -464,6 +467,17 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisorTest do
            }
          ]}
       end)
+      |> (fn mock ->
+            case Keyword.fetch!(json_rpc_named_arguments, :variant) do
+              EthereumJSONRPC.Parity ->
+                expect(mock, :json_rpc, fn %{method: "trace_block"}, _options ->
+                  {:ok, []}
+                end)
+
+              _ ->
+                mock
+            end
+          end).()
       |> stub(:json_rpc, fn [
                               %{
                                 id: id,

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -109,6 +109,9 @@ defmodule Indexer.Block.FetcherTest do
                  }
                ]}
             end)
+            |> expect(:json_rpc, fn %{id: _id, method: "trace_block", params: [^block_quantity]}, _options ->
+              {:ok, []}
+            end)
             |> expect(:json_rpc, fn [
                                       %{
                                         id: id,
@@ -355,6 +358,10 @@ defmodule Indexer.Block.FetcherTest do
                    }
                  }
                ]}
+            end)
+            |> expect(:json_rpc, fn json, _options ->
+              assert %{id: _id, method: "trace_block", params: [^block_quantity]} = json
+              {:ok, []}
             end)
             # async requests need to be grouped in one expect because the order is non-deterministic while multiple expect
             # calls on the same name/arity are used in order

--- a/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
@@ -24,7 +24,8 @@ defmodule Indexer.Block.Realtime.FetcherTest do
       |> put_in(
         [:transport_options, :method_to_url],
         eth_getBalance: "https://core-trace.poa.network",
-        trace_replayTransaction: "https://core-trace.poa.network"
+        trace_replayTransaction: "https://core-trace.poa.network",
+        trace_block: "https://core-trace.poa.network"
       )
 
     block_fetcher = %Indexer.Block.Fetcher{
@@ -194,6 +195,9 @@ defmodule Indexer.Block.Realtime.FetcherTest do
                }
              }
            ]}
+        end)
+        |> expect(:json_rpc, 2, fn %{method: "trace_block"}, _options ->
+          {:ok, []}
         end)
         |> expect(:json_rpc, fn [
                                   %{


### PR DESCRIPTION
Resolves: https://github.com/poanetwork/blockscout/issues/767

## Motivation

* "Parity’s consensus engine allows using a smart contract for block
reward calculation." - see https://wiki.parity.io/Block-Reward-Contract
for details. This means that we need to use `trace_block`
(https://wiki.parity.io/JSONRPC-trace-module#trace_block) to fetch the
block reward contract beneficiaries and update their balances. Currently
this doesn't happen so there are addresses (block contract reward
beneficiaries) with inaccurate balances and missing rows in the
`address_coin_balances` table.

## Changelog

### Enhancements
* Adding `EthereumJSONRPC.fetch_beneficiaries/2` to help us fetch the
block reward contract beneficiaries of a given block range. This only
works with Parity.
* Editing Indexer's dev and prod config by adding `trace_block` config to
`:method_to_url`.
* Adding `block_reward_contract_beneficiaries` to
`Indexer.AddressExtraction` for it to know how to get addresses in this
scenario.
* Editing `Indexer.Block.Fetcher.fetch_and_import_range/2` to get block
reward contract beneficiaries, create their addresses if they don't yet
exist, and update their coin balances.

### Bug Fixes
* Coin balances for block reward contract beneficiaries are updated with every block that affects them.

### Incompatible Changes
* Re-index

## Upgrading

* Database reset and re-index required
