### PR TITLE
Improve Internal Transactions listing performance 

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
@@ -62,7 +62,7 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
       internal_transaction =
         insert(
           :internal_transaction_create,
-          index: 0,
+          index: 1,
           transaction: transaction,
           from_address: address,
           created_contract_address: contract
@@ -84,7 +84,7 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
 
       insert(
         :internal_transaction,
-        index: 0,
+        index: 1,
         transaction: transaction,
         from_address: lincoln,
         to_address: contract,
@@ -95,7 +95,7 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
       internal_transaction =
         insert(
           :internal_transaction_create,
-          index: 1,
+          index: 2,
           transaction: transaction,
           from_address: contract,
           created_contract_address: another_contract
@@ -196,7 +196,7 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
         |> insert(
           transaction: from_lincoln,
           from_address: lincoln,
-          index: 0
+          index: 1
         )
         |> with_contract_creation(contract_address)
 
@@ -223,9 +223,9 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
       transaction = transactions.from_lincoln
 
       internal_transaction_lincoln_to_address =
-        insert(:internal_transaction, transaction: transaction, to_address: address, index: 0)
+        insert(:internal_transaction, transaction: transaction, to_address: address, index: 1)
 
-      insert(:internal_transaction, transaction: transaction, from_address: address, index: 1)
+      insert(:internal_transaction, transaction: transaction, from_address: address, index: 2)
       {:ok, %{internal_transaction_lincoln_to_address: internal_transaction_lincoln_to_address}}
     end
 
@@ -276,7 +276,7 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
       |> assert_has(AddressPage.internal_transactions(count: 2))
 
       internal_transaction =
-        insert(:internal_transaction, transaction: transaction, index: 0, from_address: addresses.lincoln)
+        insert(:internal_transaction, transaction: transaction, index: 2, from_address: addresses.lincoln)
 
       Notifier.handle_event({:chain_event, :internal_transactions, :realtime, [internal_transaction]})
 
@@ -305,7 +305,7 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
       |> insert(
         transaction: from_lincoln,
         from_address: lincoln,
-        index: 0
+        index: 1
       )
       |> with_contract_creation(contract_address)
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -125,14 +125,13 @@ defmodule Explorer.Chain do
       [internal_transaction],
       transaction in assoc(internal_transaction, :transaction)
     )
-    |> join(:left, [internal_transaction, transaction], block in assoc(transaction, :block))
     |> InternalTransaction.where_address_fields_match(hash, direction)
-    |> where_transaction_has_multiple_internal_transactions()
+    |> InternalTransaction.where_is_different_from_parent_transaction()
     |> page_internal_transaction(paging_options)
     |> limit(^paging_options.page_size)
     |> order_by(
-      [it, transaction, block],
-      desc: block.number,
+      [it, transaction],
+      desc: transaction.block_number,
       desc: transaction.index,
       desc: it.index
     )

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -448,4 +448,12 @@ defmodule Explorer.Chain.InternalTransaction do
         it.created_contract_address_hash == ^address_hash
     )
   end
+
+  def where_is_different_from_parent_transaction(query) do
+    where(
+      query,
+      [it],
+      (it.type == ^:call and it.index > 0) or it.type != ^:call
+    )
+  end
 end

--- a/apps/explorer/priv/repo/migrations/20181017141409_add_index_to_internal_transaction_table.exs
+++ b/apps/explorer/priv/repo/migrations/20181017141409_add_index_to_internal_transaction_table.exs
@@ -1,0 +1,17 @@
+defmodule Explorer.Repo.Migrations.AddIndexToInternalTransactionTable do
+  use Ecto.Migration
+
+  def change do
+    create(index("transactions", [:hash]))
+
+    create(
+      index("internal_transactions", [
+        :to_address_hash,
+        :from_address_hash,
+        :created_contract_address_hash,
+        :type,
+        :index
+      ])
+    )
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1218,12 +1218,16 @@ defmodule Explorer.ChainTest do
       transaction = insert(:transaction)
 
       %InternalTransaction{id: first_id} =
-        insert(:internal_transaction, index: 0, transaction: transaction, to_address: address)
-
-      %InternalTransaction{id: second_id} =
         insert(:internal_transaction, index: 1, transaction: transaction, to_address: address)
 
-      result = address |> Chain.address_to_internal_transactions() |> Enum.map(& &1.id)
+      %InternalTransaction{id: second_id} =
+        insert(:internal_transaction, index: 2, transaction: transaction, to_address: address)
+
+      result =
+        address
+        |> Chain.address_to_internal_transactions()
+        |> Enum.map(& &1.id)
+
       assert Enum.member?(result, first_id)
       assert Enum.member?(result, second_id)
     end
@@ -1271,7 +1275,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: pending_transaction,
           to_address: address,
-          index: 0
+          index: 1
         )
 
       %InternalTransaction{id: second_pending} =
@@ -1279,7 +1283,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: pending_transaction,
           to_address: address,
-          index: 1
+          index: 2
         )
 
       a_block = insert(:block, number: 2000)
@@ -1294,7 +1298,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: first_a_transaction,
           to_address: address,
-          index: 0
+          index: 1
         )
 
       %InternalTransaction{id: second} =
@@ -1302,7 +1306,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: first_a_transaction,
           to_address: address,
-          index: 1
+          index: 2
         )
 
       second_a_transaction =
@@ -1315,7 +1319,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: second_a_transaction,
           to_address: address,
-          index: 0
+          index: 1
         )
 
       %InternalTransaction{id: fourth} =
@@ -1323,7 +1327,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: second_a_transaction,
           to_address: address,
-          index: 1
+          index: 2
         )
 
       b_block = insert(:block, number: 6000)
@@ -1338,7 +1342,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: first_b_transaction,
           to_address: address,
-          index: 0
+          index: 1
         )
 
       %InternalTransaction{id: sixth} =
@@ -1346,7 +1350,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: first_b_transaction,
           to_address: address,
-          index: 1
+          index: 2
         )
 
       result =
@@ -1366,14 +1370,14 @@ defmodule Explorer.ChainTest do
         :internal_transaction,
         transaction: pending_transaction,
         to_address: address,
-        index: 0
+        index: 1
       )
 
       insert(
         :internal_transaction,
         transaction: pending_transaction,
         to_address: address,
-        index: 1
+        index: 2
       )
 
       a_block = insert(:block, number: 2000)
@@ -1388,7 +1392,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: first_a_transaction,
           to_address: address,
-          index: 0
+          index: 1
         )
 
       %InternalTransaction{id: second} =
@@ -1396,7 +1400,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: first_a_transaction,
           to_address: address,
-          index: 1
+          index: 2
         )
 
       second_a_transaction =
@@ -1409,7 +1413,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: second_a_transaction,
           to_address: address,
-          index: 0
+          index: 1
         )
 
       %InternalTransaction{id: fourth} =
@@ -1417,7 +1421,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: second_a_transaction,
           to_address: address,
-          index: 1
+          index: 2
         )
 
       b_block = insert(:block, number: 6000)
@@ -1432,7 +1436,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: first_b_transaction,
           to_address: address,
-          index: 0
+          index: 1
         )
 
       %InternalTransaction{id: sixth} =
@@ -1440,7 +1444,7 @@ defmodule Explorer.ChainTest do
           :internal_transaction,
           transaction: first_b_transaction,
           to_address: address,
-          index: 1
+          index: 2
         )
 
       # When paged, internal transactions need an associated block number, so `second_pending` and `first_pending` are
@@ -1453,7 +1457,7 @@ defmodule Explorer.ChainTest do
                |> Enum.map(& &1.id)
 
       # block number ==, transaction index ==, internal transaction index <
-      assert [fifth, fourth, third, second, first] ==
+      assert [fourth, third, second, first] ==
                address
                |> Chain.address_to_internal_transactions(
                  paging_options: %PagingOptions{key: {6000, 0, 1}, page_size: 8}


### PR DESCRIPTION
Resolves #872

## Motivation

Listing Internal Transactions for some specific Addresses with lots of Txs is very slow.

## Changelog

The query performance dropped from `15s` to `1.5s`, the stats can be followed here
https://explain.depesz.com/s/XQcj

### Enhancements
* The query was taking too long and one of the reasons was because it was performing a sub-query in the internal_transactions table to identify if the transaction had siblings.
This was made because for every parent transactions there is one equal internal_transaction, so this check was made to only show internal transactions that are different from the parent transaction.

* There is another way to check this that removes the need to perform a sub-query in the internal transactions table. We need to check the indexes >`0` for `type`=`call`.

* Also created two new indexes to improve the 'join' operation and the 'where' match.

