### PR TITLE
Fix ping/pong from ganache ws implementation

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/web_socket/web_socket_client.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/web_socket/web_socket_client.ex
@@ -145,6 +145,9 @@ defmodule EthereumJSONRPC.WebSocket.WebSocketClient do
   end
 
   @impl :websocket_client
+  def websocket_handle({:ping, ""}, _request, %__MODULE__{} = state), do: {:reply, {:pong, ""}, state}
+
+  @impl :websocket_client
   def websocket_info({:"$gen_call", from, request}, _, %__MODULE__{} = state) do
     case handle_call(request, from, state) do
       {:reply, _, %__MODULE__{}} = reply -> reply


### PR DESCRIPTION
## Motivation

Fixes ganache ping/pong ws implementation. 
Ganache send `ping` message every N seconds and if it's not getting `pong` message it terminates ws connection.

## Changelog

### Enhancements
Added `{:ping, ""}` ws message handler.
