### PR TITLE
Address 404 page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -5,7 +5,7 @@ defmodule BlockScoutWeb.Chain do
 
   import Explorer.Chain,
     only: [
-      hash_to_address: 1,
+      find_or_insert_address_from_hash: 1,
       hash_to_block: 1,
       hash_to_transaction: 1,
       number_to_block: 1,
@@ -153,7 +153,7 @@ defmodule BlockScoutWeb.Chain do
 
   defp address_from_param(param) do
     with {:ok, hash} <- string_to_address_hash(param) do
-      hash_to_address(hash)
+      find_or_insert_address_from_hash(hash)
     else
       :error -> {:error, :not_found}
     end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_validation_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_validation_controller.ex
@@ -12,7 +12,7 @@ defmodule BlockScoutWeb.AddressValidationController do
 
   def index(conn, %{"address_id" => address_hash_string} = params) do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
-         {:ok, address} <- Chain.hash_to_address(address_hash) do
+         {:ok, address} <- Chain.find_or_insert_address_from_hash(address_hash) do
       full_options =
         Keyword.merge(
           [

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -479,6 +479,11 @@ msgid "Hash"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:58
+msgid "Hide"
+msgstr ""
+
+#, elixir-format
 #: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:31
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:46
 msgid "IN"
@@ -774,6 +779,11 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:120
 msgid "Server Response"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:57
+msgid "Show"
 msgstr ""
 
 #, elixir-format
@@ -1183,14 +1193,4 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/views/address_contract_view.ex:15
 msgid "true"
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:58
-msgid "Hide"
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:57
-msgid "Show"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -479,6 +479,11 @@ msgid "Hash"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:58
+msgid "Hide"
+msgstr ""
+
+#, elixir-format
 #: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:31
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:46
 msgid "IN"
@@ -774,6 +779,11 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:120
 msgid "Server Response"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:57
+msgid "Show"
 msgstr ""
 
 #, elixir-format
@@ -1183,14 +1193,4 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/views/address_contract_view.ex:15
 msgid "true"
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:58
-msgid "Hide"
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:57
-msgid "Show"
 msgstr ""

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -637,6 +637,7 @@ defmodule Explorer.Chain do
 
       {:error, :not_found} ->
         Chain.create_address(%{hash: to_string(hash)})
+        Chain.hash_to_address(hash)
     end
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -628,11 +628,6 @@ defmodule Explorer.Chain do
       iex> {:ok, %Explorer.Chain.Address{hash: found_hash}} = Explorer.Chain.hash_to_address(hash)
       iex> found_hash == hash
       true
-
-  Returns `:error` if it cannot process the value passed in.
-      iex> :error = Explorer.Chain.hash_to_address(:not_a_hash)
-      :error
-
   """
   @spec find_or_insert_address_from_hash(Hash.Address.t()) :: {:ok, Address.t()}
   def find_or_insert_address_from_hash(%Hash{byte_count: unquote(Hash.Address.byte_count())} = hash) do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -18,6 +18,8 @@ defmodule Explorer.Chain do
   alias Ecto.Adapters.SQL
   alias Ecto.Multi
 
+  alias Explorer.Chain
+
   alias Explorer.Chain.{
     Address,
     Address.TokenBalance,
@@ -603,6 +605,43 @@ defmodule Explorer.Chain do
     |> case do
       nil -> {:error, :not_found}
       address -> {:ok, address}
+    end
+  end
+
+  @doc """
+  Converts `t:Explorer.Chain.Address.t/0` `hash` to the `t:Explorer.Chain.Address.t/0` with that `hash`.
+
+  Returns `{:ok, %Explorer.Chain.Address{}}` if found
+
+      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.create_address(
+      ...>   %{hash: "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"}
+      ...> )
+      iex> {:ok, %Explorer.Chain.Address{hash: found_hash}} = Explorer.Chain.hash_to_address(hash)
+      iex> found_hash == hash
+      true
+
+  Returns `{:error, address}` if not found but created an address
+
+      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.create_address(
+      ...>   %{hash: "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"}
+      ...> )
+      iex> {:ok, %Explorer.Chain.Address{hash: found_hash}} = Explorer.Chain.hash_to_address(hash)
+      iex> found_hash == hash
+      true
+
+  Returns `:error` if it cannot process the value passed in.
+      iex> :error = Explorer.Chain.hash_to_address(:not_a_hash)
+      :error
+
+  """
+  @spec find_or_insert_address_from_hash(Hash.Address.t()) :: {:ok, Address.t()}
+  def find_or_insert_address_from_hash(%Hash{byte_count: unquote(Hash.Address.byte_count())} = hash) do
+    case Chain.hash_to_address(hash) do
+      {:ok, address} ->
+        {:ok, address}
+
+      {:error, :not_found} ->
+        Chain.create_address(%{hash: to_string(hash)})
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -723,8 +723,7 @@ defmodule Explorer.ChainTest do
       hash_str = "0xcbbcd5ac86f9a50e13313633b262e16f695a90c2"
       {:ok, hash} = Chain.string_to_address_hash(hash_str)
 
-      assert {:ok, %Chain.Address{hash: hash}} = 
-        Chain.find_or_insert_address_from_hash(hash)
+      assert {:ok, %Chain.Address{hash: hash}} = Chain.find_or_insert_address_from_hash(hash)
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -697,6 +697,37 @@ defmodule Explorer.ChainTest do
     end
   end
 
+  describe "hash_to_address/1" do
+    test "returns not found if the address doesn't exist" do
+      hash_str = "0xcbbcd5ac86f9a50e13313633b262e16f695a90c2"
+      {:ok, hash} = Chain.string_to_address_hash(hash_str)
+
+      assert {:error, :not_found} = Chain.hash_to_address(hash)
+    end
+
+    test "returns the correct address if it exists" do
+      address = insert(:address)
+
+      assert {:ok, address} = Chain.hash_to_address(address.hash)
+    end
+  end
+
+  describe "find_or_insert_address_from_hash/1" do
+    test "returns an address if it already exists" do
+      address = insert(:address)
+
+      assert {:ok, address} = Chain.find_or_insert_address_from_hash(address.hash)
+    end
+
+    test "returns an address if it doesn't exist" do
+      hash_str = "0xcbbcd5ac86f9a50e13313633b262e16f695a90c2"
+      {:ok, hash} = Chain.string_to_address_hash(hash_str)
+
+      assert {:ok, %Chain.Address{hash: hash}} = 
+        Chain.find_or_insert_address_from_hash(hash)
+    end
+  end
+
   describe "hashes_to_transactions/2" do
     test "with transaction with block required without block returns nil" do
       [%Transaction{hash: hash_with_block1}, %Transaction{hash: hash_with_block2}] =


### PR DESCRIPTION
Closes #37

## Motivation
We're currently showing a 404 page if the address is not in our DB. Instead, we should be showing the address page with a 0 balance. The address exists, we either did not update the balance yet or the address has not balance.

## Changelog
* Create `Chain.find_or_insert_address_from_hash/1` which creates an address and returns it if one isn't found.
* Created tests for `Chain.find_or_insert_address_from_hash/1` and `Chain.hash_to_address/1`.
* Updated the query in `Chain.find_or_insert_address_from_hash/1` to return the loaded associations.

### Enhancements
* Created a test for `Chain.hash_to_address/1`