### PR TITLE
Add Internal Transaction type to the tile

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-md-2 d-flex flex-row flex-md-column align-items-left justify-content-start justify-content-lg-center mb-1 mb-md-0 pl-md-4">
       <%= gettext("Internal Transaction") %>
+      <span>(<%= type(@internal_transaction) %>)</span>
     </div>
     <div class="col-md-7 col-lg-8 d-flex flex-column text-nowrap pr-2 pr-sm-2 pr-md-0">
       <%= render BlockScoutWeb.TransactionView, "_link.html", transaction_hash: @internal_transaction.transaction_hash %>

--- a/apps/block_scout_web/lib/block_scout_web/views/internal_transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/internal_transaction_view.ex
@@ -1,3 +1,34 @@
 defmodule BlockScoutWeb.InternalTransactionView do
   use BlockScoutWeb, :view
+
+  alias Explorer.Chain.InternalTransaction
+
+  import BlockScoutWeb.Gettext
+
+  @doc """
+  Returns the formatted string for the type of the internal transaction.
+
+  When the type is `call`, we return the formatted string for the call type.
+
+  Examples:
+
+  iex> BlockScoutWeb.InternalTransactionView.type(%Explorer.Chain.InternalTransaction{type: :reward})
+  "Reward"
+
+  iex> BlockScoutWeb.InternalTransactionView.type(%Explorer.Chain.InternalTransaction{type: :call, call_type: :delegatecall})
+  "Delegate Call"
+  """
+  def type(%InternalTransaction{type: :call, call_type: call_type}) do
+    formatted_type(call_type)
+  end
+
+  def type(%InternalTransaction{type: type}) do
+    formatted_type(type)
+  end
+
+  defp formatted_type(:call), do: gettext("Call")
+  defp formatted_type(:delegatecall), do: gettext("Delegate Call")
+  defp formatted_type(:create), do: gettext("Create")
+  defp formatted_type(:suicide), do: gettext("Suicide")
+  defp formatted_type(:reward), do: gettext("Reward")
 end

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -144,7 +144,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_link.html.eex:2
-#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:21
+#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:22
 #: lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex:44
 msgid "Block #%{number}"
 msgstr ""
@@ -404,7 +404,7 @@ msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:15
+#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:16
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:26
 #: lib/block_scout_web/templates/transaction/overview.html.eex:98
@@ -484,7 +484,7 @@ msgid "Hide"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:31
+#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:32
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:46
 msgid "IN"
 msgstr ""
@@ -631,7 +631,7 @@ msgid "Nonce"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:29
+#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:30
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:42
 msgid "OUT"
 msgstr ""
@@ -1185,4 +1185,29 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/views/address_contract_view.ex:15
 msgid "true"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/internal_transaction_view.ex:29
+msgid "Call"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/internal_transaction_view.ex:31
+msgid "Create"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/internal_transaction_view.ex:30
+msgid "Delegate Call"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/internal_transaction_view.ex:33
+msgid "Reward"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/internal_transaction_view.ex:32
+msgid "Suicide"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -144,7 +144,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_link.html.eex:2
-#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:21
+#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:22
 #: lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex:44
 msgid "Block #%{number}"
 msgstr ""
@@ -404,7 +404,7 @@ msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:15
+#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:16
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:26
 #: lib/block_scout_web/templates/transaction/overview.html.eex:98
@@ -484,7 +484,7 @@ msgid "Hide"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:31
+#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:32
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:46
 msgid "IN"
 msgstr ""
@@ -631,7 +631,7 @@ msgid "Nonce"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:29
+#: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:30
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:42
 msgid "OUT"
 msgstr ""
@@ -1185,4 +1185,29 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/views/address_contract_view.ex:15
 msgid "true"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/internal_transaction_view.ex:29
+msgid "Call"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/internal_transaction_view.ex:31
+msgid "Create"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/internal_transaction_view.ex:30
+msgid "Delegate Call"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/internal_transaction_view.ex:33
+msgid "Reward"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/internal_transaction_view.ex:32
+msgid "Suicide"
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/views/internal_transaction_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/internal_transaction_view_test.exs
@@ -1,0 +1,40 @@
+defmodule BlockScoutWeb.InternalTransactionViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.InternalTransactionView
+  alias Explorer.Chain.InternalTransaction
+
+  doctest BlockScoutWeb.InternalTransactionView
+
+  describe "type/1" do
+    test "returns the correct string when the type is :call and call type is :call" do
+      internal_transaction = %InternalTransaction{type: :call, call_type: :call}
+
+      assert InternalTransactionView.type(internal_transaction) == "Call"
+    end
+
+    test "returns the correct string when the type is :call and call type is :delegate_call" do
+      internal_transaction = %InternalTransaction{type: :call, call_type: :delegatecall}
+
+      assert InternalTransactionView.type(internal_transaction) == "Delegate Call"
+    end
+
+    test "returns the correct string when the type is :create" do
+      internal_transaction = %InternalTransaction{type: :create}
+
+      assert InternalTransactionView.type(internal_transaction) == "Create"
+    end
+
+    test "returns the correct string when the type is :suicide" do
+      internal_transaction = %InternalTransaction{type: :suicide}
+
+      assert InternalTransactionView.type(internal_transaction) == "Suicide"
+    end
+
+    test "returns the correct string when the type is :reward" do
+      internal_transaction = %InternalTransaction{type: :reward}
+
+      assert InternalTransactionView.type(internal_transaction) == "Reward"
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/938

## Changelog

### Enhancements

- Add a helper function to Internal Transaction view to get the type to be
displayed. When it is an Internal Transaction of type `:call`, show the
`:call_type` instead.

### Screenshot

<details>
<summary><b>Internal Transaction tile with type</b></summary>

![image](https://user-images.githubusercontent.com/10884247/47268247-ddb58580-d524-11e8-99c8-4eb8f6693051.png)

</details>