### PR TITLE
Adds log rotation

### DIFF
--- a/apps/block_scout_web/config/prod.exs
+++ b/apps/block_scout_web/config/prod.exs
@@ -26,4 +26,5 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
 
 config :logger, :block_scout_web,
   level: :info,
-  path: Path.absname("logs/prod/block_scout_web.log")
+  path: Path.absname("logs/prod/block_scout_web.log"),
+  rotate: %{max_bytes: 52_428_800, keep: 19}

--- a/apps/ethereum_jsonrpc/config/prod.exs
+++ b/apps/ethereum_jsonrpc/config/prod.exs
@@ -2,4 +2,5 @@ use Mix.Config
 
 config :logger, :ethereum_jsonrpc,
   level: :info,
-  path: Path.absname("logs/prod/ethereum_jsonrpc.log")
+  path: Path.absname("logs/prod/ethereum_jsonrpc.log"),
+  rotate: %{max_bytes: 52_428_800, keep: 19}

--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -11,7 +11,8 @@ config :explorer, Explorer.Repo,
 
 config :logger, :explorer,
   level: :info,
-  path: Path.absname("logs/prod/explorer.log")
+  path: Path.absname("logs/prod/explorer.log"),
+  rotate: %{max_bytes: 52_428_800, keep: 19}
 
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do

--- a/apps/indexer/config/prod.exs
+++ b/apps/indexer/config/prod.exs
@@ -2,12 +2,14 @@ use Mix.Config
 
 config :logger, :indexer,
   level: :info,
-  path: Path.absname("logs/prod/indexer.log")
+  path: Path.absname("logs/prod/indexer.log"),
+  rotate: %{max_bytes: 52_428_800, keep: 19}
 
 config :logger, :indexer_token_balances,
   level: :debug,
   path: Path.absname("logs/prod/indexer/token_balances/error.log"),
-  metadata_filter: [fetcher: :token_balances]
+  metadata_filter: [fetcher: :token_balances],
+  rotate: %{max_bytes: 52_428_800, keep: 19}
 
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -6,6 +6,9 @@ config :logger, :console, level: :info
 
 config :logger, :ecto,
   level: :info,
-  path: Path.absname("logs/prod/ecto.log")
+  path: Path.absname("logs/prod/ecto.log"),
+  rotate: %{max_bytes: 52_428_800, keep: 19}
 
-config :logger, :error, path: Path.absname("logs/prod/error.log")
+config :logger, :error,
+  path: Path.absname("logs/prod/error.log"),
+  rotate: %{max_bytes: 52_428_800, keep: 19}


### PR DESCRIPTION
## Motivation

* To limit the total size of the logs retained while still allowing
analysis of recent events.

## Changelog

### Enhancements
* Editing the logger backends to do file rotation every 50mb and keep
the last 19 log files per logger backend. 50mb * 20 = ~1gb

(☝️ edited this comment to reflect latest updates to branch/PR)