### PR TITLE
Add backoff for Ethereum JSON RPC requests

### DIFF
--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -8,11 +8,12 @@ config :logger, :ethereum_jsonrpc,
 
 config :ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator,
   rolling_window_opts: [
-    window_count: 6,
-    window_length: :timer.seconds(10),
+    window_count: 12,
+    duration: :timer.minutes(1),
     table: EthereumJSONRPC.RequestCoordinator.TimeoutCounter
   ],
-  wait_per_timeout: :timer.seconds(10)
+  wait_per_timeout: :timer.seconds(20),
+  max_jitter: :timer.seconds(2)
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -10,7 +10,7 @@ config :ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator,
   rolling_window_opts: [
     window_count: 6,
     window_length: :timer.seconds(10),
-    bucket: EthereumJSONRPC.RequestCoordinator.TimeoutCounter
+    table: EthereumJSONRPC.RequestCoordinator.TimeoutCounter
   ],
   wait_per_timeout: :timer.seconds(10)
 

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -6,6 +6,14 @@ config :logger, :ethereum_jsonrpc,
   metadata: [:application, :request_id],
   metadata_filter: [application: :ethereum_jsonrpc]
 
+config :ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator,
+  rolling_window_opts: [
+    window_count: 6,
+    window_length: :timer.seconds(10),
+    bucket: EthereumJSONRPC.RequestCoordinator.TimeoutCounter
+  ],
+  wait_per_timeout: :timer.seconds(10)
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/apps/ethereum_jsonrpc/config/test.exs
+++ b/apps/ethereum_jsonrpc/config/test.exs
@@ -7,7 +7,7 @@ config :logger, :ethereum_jsonrpc,
 config :ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator,
   rolling_window_opts: [
     window_count: 3,
-    window_length: :timer.seconds(5),
+    duration: :timer.seconds(6),
     table: EthereumJSONRPC.RequestCoordinator.TimeoutCounter
   ],
   wait_per_timeout: 2,

--- a/apps/ethereum_jsonrpc/config/test.exs
+++ b/apps/ethereum_jsonrpc/config/test.exs
@@ -3,3 +3,11 @@ use Mix.Config
 config :logger, :ethereum_jsonrpc,
   level: :warn,
   path: Path.absname("logs/test/ethereum_jsonrpc.log")
+
+config :ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator,
+  rolling_window_opts: [
+    window_count: 3,
+    window_length: :timer.seconds(5),
+    table: EthereumJSONRPC.RequestCoordinator.TimeoutCounter
+  ],
+  wait_per_timeout: 1

--- a/apps/ethereum_jsonrpc/config/test.exs
+++ b/apps/ethereum_jsonrpc/config/test.exs
@@ -10,4 +10,5 @@ config :ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator,
     window_length: :timer.seconds(5),
     table: EthereumJSONRPC.RequestCoordinator.TimeoutCounter
   ],
-  wait_per_timeout: 1
+  wait_per_timeout: 2,
+  max_jitter: 1

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -17,6 +17,7 @@ defmodule EthereumJSONRPC do
   """
 
   alias Explorer.Chain.Block
+
   alias EthereumJSONRPC.{
     Blocks,
     Receipts,
@@ -58,7 +59,10 @@ defmodule EthereumJSONRPC do
 
   """
   @type json_rpc_named_arguments :: [
-          {:transport, Transport.t()} | {:transport_options, Transport.options()} | {:variant, Variant.t()} | {:throttle_timeout, non_neg_integer()}
+          {:transport, Transport.t()}
+          | {:transport_options, Transport.options()}
+          | {:variant, Variant.t()}
+          | {:throttle_timeout, non_neg_integer()}
         ]
 
   @typedoc """

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -323,7 +323,7 @@ defmodule EthereumJSONRPC do
   def json_rpc(request, named_arguments) when (is_map(request) or is_list(request)) and is_list(named_arguments) do
     transport = Keyword.fetch!(named_arguments, :transport)
     transport_options = Keyword.fetch!(named_arguments, :transport_options)
-    throttle_timeout = Keyword.get(named_arguments, :throttle_timeout, 60_000)
+    throttle_timeout = Keyword.get(named_arguments, :throttle_timeout, :timer.minutes(2))
 
     RequestCoordinator.perform(request, transport, transport_options, throttle_timeout)
   end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -21,7 +21,7 @@ defmodule EthereumJSONRPC do
   Requests for fetching blockchain can put a lot of CPU pressure on JSON RPC
   nodes. EthereumJSONRPC will check for request timeouts as well as bad-gateway
   responses and add delay between requests until the JSON RPC nodes reach
-  stability. For finer tuning and configuratio of throttling, read the
+  stability. For finer tuning and configuration of throttling, read the
   documentation for `EthereumJSONRPC.RequestCoordinator`.
   """
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
@@ -5,7 +5,7 @@ defmodule EthereumJSONRPC.Application do
 
   use Application
 
-  alias EthereumJSONRPC.{RollingWindow, TimeoutCounter, RequestCoordinator}
+  alias EthereumJSONRPC.{RollingWindow, RequestCoordinator}
 
   @impl Application
   def start(_type, _args) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
@@ -9,9 +9,14 @@ defmodule EthereumJSONRPC.Application do
 
   @impl Application
   def start(_type, _args) do
+    rolling_window_opts =
+      :ethereum_jsonrpc,
+      |> Application.fetch_env!(RequestCoordinator)
+      |> Keyword.fetch!(:rolling_window_opts)
+
     children = [
       :hackney_pool.child_spec(:ethereum_jsonrpc, recv_timeout: 60_000, timeout: 60_000, max_connections: 1000),
-      {RollingWindow, [RequestCoordinator.rolling_window_opts(), [name: TimeoutCounter]]}
+      {RollingWindow, [rolling_window_opts]}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one, name: EthereumJSONRPC.Supervisor)

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
@@ -5,7 +5,7 @@ defmodule EthereumJSONRPC.Application do
 
   use Application
 
-  alias EthereumJSONRPC.{RollingWindow, RequestCoordinator}
+  alias EthereumJSONRPC.{RequestCoordinator, RollingWindow}
 
   @impl Application
   def start(_type, _args) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
@@ -10,7 +10,7 @@ defmodule EthereumJSONRPC.Application do
   @impl Application
   def start(_type, _args) do
     rolling_window_opts =
-      :ethereum_jsonrpc,
+      :ethereum_jsonrpc
       |> Application.fetch_env!(RequestCoordinator)
       |> Keyword.fetch!(:rolling_window_opts)
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
@@ -5,10 +5,19 @@ defmodule EthereumJSONRPC.Application do
 
   use Application
 
+  alias EthereumJSONRPC.{RollingWindow, TimeoutCounter, RequestCoordinator}
+
+  @rolling_window_opts [
+    bucket: :ethereum_jsonrpc_bucket,
+    window_length: :timer.seconds(10),
+    window_count: 6
+  ]
+
   @impl Application
   def start(_type, _args) do
     children = [
-      :hackney_pool.child_spec(:ethereum_jsonrpc, recv_timeout: 60_000, timeout: 60_000, max_connections: 1000)
+      :hackney_pool.child_spec(:ethereum_jsonrpc, recv_timeout: 60_000, timeout: 60_000, max_connections: 1000),
+      {RollingWindow, [RequestCoordinator.rolling_window_opts(), [name: TimeoutCounter]]}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one, name: EthereumJSONRPC.Supervisor)

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/application.ex
@@ -7,12 +7,6 @@ defmodule EthereumJSONRPC.Application do
 
   alias EthereumJSONRPC.{RollingWindow, TimeoutCounter, RequestCoordinator}
 
-  @rolling_window_opts [
-    bucket: :ethereum_jsonrpc_bucket,
-    window_length: :timer.seconds(10),
-    window_count: 6
-  ]
-
   @impl Application
   def start(_type, _args) do
     children = [

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
@@ -1,0 +1,68 @@
+defmodule EthereumJSONRPC.RequestCoordinator do
+  @failure_rate_limit_interval :timer.minutes(3)
+  @failure_rate_limit 30
+
+  def perform(request, named_arguments) do
+    transport = Keyword.fetch!(named_arguments, :transport)
+    transport_options = Keyword.fetch!(named_arguments, :transport_options)
+    retry_options = Keyword.get(named_arguments, :retry_options)
+
+    if retry_options do
+      retry_timeout = Keyword.get(retry_options, :retry_timeout, 5_000)
+
+      fn ->
+        request_with_retry(transport, request, transport_options)
+      end
+      |> Task.async()
+      |> Task.await()
+    else
+      request(transport, request, transport_options)
+    end
+  end
+
+  defp request_with_retry(transport, request, transport_options) do
+    key = something_that_uniquely_identifies_this_transport(transport, transport_options)
+
+    sleep_if_too_many_recent_timeouts(key)
+
+    case request(transport, request, transport_options) do
+      {:error, :timeout} ->
+        increment_recent_timeouts(key)
+
+        request_with_retry(transport, request, transport_options)
+
+      response ->
+        response
+    end
+  end
+
+  defp request(transport, request, transport_options), do: transport.json_rpc(request, transport_options)
+
+  @spec increment_recent_timeouts(String.t()) :: :ok
+  defp increment_recent_timeouts(key) do
+    # TODO: Call into rolling window rate limiter
+    # ExRated.check_rate(key, @failure_rate_limit_interval, @failure_rate_limit)
+
+    :ok
+  end
+
+  defp sleep_if_too_many_recent_timeouts(key) do
+    wait_coefficient = count_of_recent_timeouts(key)
+
+    # TODO: Math TBD
+    :timer.sleep(:timer.seconds(wait_coefficient))
+  end
+
+  defp something_that_uniquely_identifies_this_transport(transport, transport_options) do
+    to_string(transport) <> "." <> transport_options[:url]
+  end
+
+  defp count_of_recent_timeouts(key) do
+    # if we are using ex_rated it looks like this:
+    # TODO: Call into rolling window rate limiter
+    # {count, _count_remaining, _ms_to_next_bucket, _created_at, _updated_at} =
+    #   ExRated.inspect_bucket(key, @failure_rate_limit_interval, @failure_rate_limit)
+
+    count
+  end
+end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
@@ -12,19 +12,32 @@ defmodule EthereumJSONRPC.RequestCoordinator do
 
   * `:rolling_window_opts` - Options for the process tracking timeouts
     * `:window_count` - Number of windows
-    * `:window_length` - Length of each window in milliseconds
+    * `:duration` - Total amount of time to count timeout events in milliseconds
     * `:table` - name of the ets table to store the data in
-  * `:wait_per_timeout` - Milliseconds to wait for each recent timeout within the tracked window
+  * `:wait_per_timeout` - Milliseconds to wait for each recent timeout within
+    the tracked window
+  * `:max_jitter` - Maximimum amount of time in milliseconds to be added to each
+    wait before multiplied by timeout count
+
+  See the docs for `EthereumJSONRPC.RollingWindow` for more documentation for
+  `:rolling_window_opts`.
+
+  This is how the wait time for each request is calculated:
+
+      (wait_per_timeout + jitter) * recent_timeouts
+
+  where jitter is some random number between 0 and max_jitter.
 
   ### Example Configuration
 
       config :ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator,
         rolling_window_opts: [
           window_count: 6,
-          window_length: :timer.seconds(10),
+          duration: :timer.seconds(10),
           table: EthereumJSONRPC.RequestCoordinator.TimeoutCounter
         ],
-        wait_per_timeout: :timer.seconds(10)
+        wait_per_timeout: :timer.seconds(10),
+        max_jitter: :timer.seconds(1)
 
   With this configuration, timeouts are tracked for 6 windows of 10 seconds for a total of 1 minute.
   """
@@ -43,7 +56,7 @@ defmodule EthereumJSONRPC.RequestCoordinator do
   @spec perform(Transport.request(), Transport.t(), Transport.options(), non_neg_integer()) ::
           {:ok, Transport.result()} | {:error, term()}
   @spec perform(Transport.batch_request(), Transport.t(), Transport.options(), non_neg_integer()) ::
-          {:ok, Transport.batch_result()} | {:error, term()}
+          {:ok, Transport.batch_response()} | {:error, term()}
   def perform(request, transport, transport_options, throttle_timeout) do
     sleep_time = sleep_time()
 
@@ -59,7 +72,7 @@ defmodule EthereumJSONRPC.RequestCoordinator do
   end
 
   defp handle_transport_response({:error, :timeout} = error) do
-    increment_recent_timeouts()
+    RollingWindow.inc(table(), @timeout_key)
     error
   end
 
@@ -67,22 +80,21 @@ defmodule EthereumJSONRPC.RequestCoordinator do
 
   defp sleep_time do
     wait_coefficient = RollingWindow.count(table(), @timeout_key)
+    jitter = :rand.uniform(config(:max_jitter))
+    wait_per_timeout = config(:wait_per_timeout)
 
-    wait_per_timeout =
-      :ethereum_jsonrpc
-      |> Application.get_env(__MODULE__)
-      |> Keyword.fetch!(:wait_per_timeout)
-
-    wait_coefficient * wait_per_timeout
-  end
-
-  defp increment_recent_timeouts do
-    RollingWindow.inc(table(), @timeout_key)
-
-    :ok
+    wait_coefficient * (wait_per_timeout + jitter)
   end
 
   defp table do
-    Application.get_env(:ethereum_jsonrpc, __MODULE__)[:rolling_window_opts][:table]
+    :rolling_window_opts
+    |> config()
+    |> Keyword.fetch!(:table)
+  end
+
+  defp config(key) do
+    :ethereum_jsonrpc
+    |> Application.get_env(__MODULE__)
+    |> Keyword.fetch!(key)
   end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
@@ -1,7 +1,35 @@
 defmodule EthereumJSONRPC.RequestCoordinator do
-  @failure_rate_limit_interval :timer.minutes(3)
-  @failure_rate_limit 30
+  @moduledoc """
+  Retries JSONRPC requests according to the provided retry_options
 
+  Leverages `EthereumJSONRPC.RollingWindow` to keep track of the count
+  of recent timeouts, and waits a small amount of time per timeout.
+
+  To see the rolling window options, see `EthereumJSONRPC.Application`
+  """
+  alias EthereumJSONRPC.{RollingWindow, TimeoutCounter}
+
+  @wait_per_timeout :timer.seconds(5)
+  @rolling_window_opts [
+    bucket: :ethereum_jsonrpc_bucket,
+    window_length: :timer.seconds(10),
+    window_count: 6
+  ]
+
+  @doc "Options used when initializing the RollingWindow used by this module."
+  @spec rolling_window_opts() :: Keyword.t()
+  def rolling_window_opts do
+    @rolling_window_opts
+  end
+
+  @doc """
+  Retries the request according to the provided retry_options
+
+  If none were provided, the request is not retried. In all cases, the request
+  waits an amount of time before proceeding based on the count of recent
+  failures.
+  """
+  @spec perform(term(), )
   def perform(request, named_arguments) do
     transport = Keyword.fetch!(named_arguments, :transport)
     transport_options = Keyword.fetch!(named_arguments, :transport_options)
@@ -11,37 +39,37 @@ defmodule EthereumJSONRPC.RequestCoordinator do
       retry_timeout = Keyword.get(retry_options, :retry_timeout, 5_000)
 
       fn ->
-        request_with_retry(transport, request, transport_options)
+        request(transport, request, transport_options, true)
       end
       |> Task.async()
-      |> Task.await()
+      |> Task.await(retry_timeout)
     else
-      request(transport, request, transport_options)
+      request(transport, request, transport_options, false)
     end
   end
 
-  defp request_with_retry(transport, request, transport_options) do
+  defp request(transport, request, transport_options, retry?) do
     key = something_that_uniquely_identifies_this_transport(transport, transport_options)
 
     sleep_if_too_many_recent_timeouts(key)
 
     case request(transport, request, transport_options) do
-      {:error, :timeout} ->
+      {:error, :timeout} = error ->
         increment_recent_timeouts(key)
 
-        request_with_retry(transport, request, transport_options)
+        if retry? do
+          request_with_retry(transport, request, transport_options)
+        else
+          error
+        end
 
       response ->
         response
     end
   end
 
-  defp request(transport, request, transport_options), do: transport.json_rpc(request, transport_options)
-
-  @spec increment_recent_timeouts(String.t()) :: :ok
   defp increment_recent_timeouts(key) do
-    # TODO: Call into rolling window rate limiter
-    # ExRated.check_rate(key, @failure_rate_limit_interval, @failure_rate_limit)
+    RollingWindow.inc(TimeoutCounter, key)
 
     :ok
   end
@@ -49,8 +77,7 @@ defmodule EthereumJSONRPC.RequestCoordinator do
   defp sleep_if_too_many_recent_timeouts(key) do
     wait_coefficient = count_of_recent_timeouts(key)
 
-    # TODO: Math TBD
-    :timer.sleep(:timer.seconds(wait_coefficient))
+    :timer.sleep(wait_coefficient * @wait_per_timeout)
   end
 
   defp something_that_uniquely_identifies_this_transport(transport, transport_options) do
@@ -58,11 +85,6 @@ defmodule EthereumJSONRPC.RequestCoordinator do
   end
 
   defp count_of_recent_timeouts(key) do
-    # if we are using ex_rated it looks like this:
-    # TODO: Call into rolling window rate limiter
-    # {count, _count_remaining, _ms_to_next_bucket, _created_at, _updated_at} =
-    #   ExRated.inspect_bucket(key, @failure_rate_limit_interval, @failure_rate_limit)
-
-    count
+    RollingWindow.count(TimeoutCounter, key)
   end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
@@ -73,7 +73,7 @@ defmodule EthereumJSONRPC.RequestCoordinator do
       |> Application.get_env(__MODULE__)
       |> Keyword.fetch!(:wait_per_timeout)
 
-    wait_coefficient * @wait_per_timeout
+    wait_coefficient * wait_per_timeout
   end
 
   defp increment_recent_timeouts do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
@@ -71,6 +71,11 @@ defmodule EthereumJSONRPC.RequestCoordinator do
     end
   end
 
+  defp handle_transport_response({:error, {:bad_gateway, _}} = error) do
+    RollingWindow.inc(table(), @timeout_key)
+    error
+  end
+
   defp handle_transport_response({:error, :timeout} = error) do
     RollingWindow.inc(table(), @timeout_key)
     error

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
@@ -29,7 +29,6 @@ defmodule EthereumJSONRPC.RequestCoordinator do
   waits an amount of time before proceeding based on the count of recent
   failures.
   """
-  @spec perform(term(), )
   def perform(request, named_arguments) do
     transport = Keyword.fetch!(named_arguments, :transport)
     transport_options = Keyword.fetch!(named_arguments, :transport_options)
@@ -53,12 +52,12 @@ defmodule EthereumJSONRPC.RequestCoordinator do
 
     sleep_if_too_many_recent_timeouts(key)
 
-    case request(transport, request, transport_options) do
+    case transport.json_rpc(request, transport_options) do
       {:error, :timeout} = error ->
         increment_recent_timeouts(key)
 
         if retry? do
-          request_with_retry(transport, request, transport_options)
+          request(transport, request, transport_options, true)
         else
           error
         end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/rolling_window.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/rolling_window.ex
@@ -1,0 +1,49 @@
+defmodule EthereumJSONRPC.RollingWindow do
+  use GenServer
+  require Logger
+
+  @sweep_after :timer.seconds(10)
+  @interval :timer.seconds(60)
+  @tab :rate_limiter_requests
+
+  ## Client
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def log_timeout(key) do
+    :ets.update_counter(@tab, key, {2, 1}, {key, 0, 0, 0, 0, 0, 0})
+  end
+
+  def count_timeouts(key) do
+    case :ets.lookup(@tab, key) do
+      [{_, a, b, c, d, e, f}] -> a + b + c + d + e + f
+      _ -> 0
+    end
+  end
+
+  ## Server
+  def init(_) do
+    :ets.new(@tab, [:set, :named_table, :public, read_concurrency: true, write_concurrency: true])
+    schedule_sweep()
+    {:ok, %{}}
+  end
+
+  def handle_info(:sweep, state) do
+    Logger.debug("Sweeping requests")
+
+    match_spec = [
+      {{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7"}, [], [{{:"$1", 0, :"$2", :"$3", :"$4", :"$5", :"$6"}}]}
+    ]
+
+    :ets.select_replace(@tab, match_spec)
+
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  defp schedule_sweep do
+    Process.send_after(self(), :sweep, @sweep_after)
+  end
+end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/rolling_window.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/rolling_window.ex
@@ -1,49 +1,104 @@
 defmodule EthereumJSONRPC.RollingWindow do
+  @moduledoc """
+  TODO
+  """
+
   use GenServer
-  require Logger
 
   @sweep_after :timer.seconds(10)
-  @interval :timer.seconds(60)
-  @tab :rate_limiter_requests
 
-  ## Client
+  def child_spec([init_arguments]) do
+    child_spec([init_arguments, []])
+  end
 
-  def start_link do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def child_spec([_init_arguments, _gen_server_options] = start_link_arguments) do
+    spec = %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, start_link_arguments},
+      restart: :permanent,
+      type: :worker
+    }
+
+    Supervisor.child_spec(spec, [])
+  end
+
+  def start_link(init_arguments, gen_server_options \\ []) do
+    GenServer.start_link(__MODULE__, init_arguments, gen_server_options)
+  end
+
+  def init(opts) do
+    table_name = Keyword.fetch!(opts, :bucket)
+    window_length = Keyword.fetch!(opts, :window_length)
+    window_count = Keyword.fetch(otps, :window_count)
+
+    table = :ets.new(bucket, [:named_table, :set, :public, read_concurrency: true, write_concurrency: true])
+
+    state = %{
+      table: table,
+      window_length: window_length,
+      window_count: window_count
+    }
+
+    schedule_sweep(window_length)
+
+    {:ok, state}
+  end
+
+  def handle_info(:sweep, %{window_count: window_count, table: table, window_length: window_length} = state) do
+    Logger.debug(fn -> "Sweeping windows" end)
+
+    match_spec = match_spec(window_count)
+
+    :ets.select_replace(table, match_spec)
+
+    schedule_sweep(window_length)
+
+    {:noreply, state}
+  end
+
+  defp match_spec(window_count) do
+    [{
+      match_spec_matcher(window_count),
+      [],
+      match_spec_mapper(window_count)
+    }]
+  end
+
+  defp match_spec_matcher(window_count) do
+    range = Range.new(1, window_count + 1)
+
+    range
+    |> Enum.map(& :"$#{&1}")
+    |> to_tuple()
+  end
+
+  defp match_spec_mapper(1) do
+    [{{:"$1", 0}}]
+  end
+
+  defp match_spec_mapper(window_count) do
+    inner_tuple =
+      1..window_count
+      |> Enum.map(& :"$#{&1}")
+      |> to_tuple()
+      |> Tuple.insert_at(1, 0)
+    [{inner_tuple}]
+  end
+
+  defp schedule_sweep(window_length) do
+    Process.send_after(self(), :sweep, window_length)
   end
 
   def log_timeout(key) do
+    # TODO account for tables of different window counts
     :ets.update_counter(@tab, key, {2, 1}, {key, 0, 0, 0, 0, 0, 0})
   end
 
   def count_timeouts(key) do
+    # TODO account for tables of different window counts
     case :ets.lookup(@tab, key) do
       [{_, a, b, c, d, e, f}] -> a + b + c + d + e + f
       _ -> 0
     end
-  end
-
-  ## Server
-  def init(_) do
-    :ets.new(@tab, [:set, :named_table, :public, read_concurrency: true, write_concurrency: true])
-    schedule_sweep()
-    {:ok, %{}}
-  end
-
-  def handle_info(:sweep, state) do
-    Logger.debug("Sweeping requests")
-
-    match_spec = [
-      {{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6", :"$7"}, [], [{{:"$1", 0, :"$2", :"$3", :"$4", :"$5", :"$6"}}]}
-    ]
-
-    :ets.select_replace(@tab, match_spec)
-
-    schedule_sweep()
-    {:noreply, state}
-  end
-
-  defp schedule_sweep do
-    Process.send_after(self(), :sweep, @sweep_after)
   end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/rolling_window.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/rolling_window.ex
@@ -71,6 +71,7 @@ defmodule EthereumJSONRPC.RollingWindow do
     default = List.to_tuple([key | windows])
 
     :ets.update_counter(table, key, {2, 1}, default)
+    # TODO consider broadcasting to indexers than some threshold has been met with result of updating the counter
 
     {:noreply, state}
   end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/request_coordinator_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/request_coordinator_test.exs
@@ -1,0 +1,65 @@
+defmodule EthereumJSONRPC.RequestCoordinatorTest do
+  use ExUnit.Case
+  use EthereumJSONRPC.Case
+
+  alias EthereumJSONRPC.RollingWindow
+  alias EthereumJSONRPC.RequestCoordinator
+
+  import Mox
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  defp sleep_time(timeouts) do
+    wait_per_timeout =
+      :ethereum_jsonrpc
+      |> Application.get_env(RequestCoordinator)
+      |> Keyword.fetch!(:wait_per_timeout)
+
+    timeouts * wait_per_timeout
+  end
+
+  setup do
+    table = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator)[:rolling_window_opts][:table]
+
+    :ets.delete_all_objects(table)
+
+    %{table: table}
+  end
+
+  test "rolling window increments on timeout", %{table: table} do
+    expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ -> {:error, :timeout} end)
+
+    RequestCoordinator.perform(%{}, EthereumJSONRPC.Mox, [], :timer.minutes(60))
+
+    assert RollingWindow.count(table, :timeout) == 1
+  end
+
+  test "waits the configured amount of time per failure", %{table: table} do
+    RollingWindow.inc(table, :timeout)
+    RollingWindow.inc(table, :timeout)
+    RollingWindow.inc(table, :timeout)
+    RollingWindow.inc(table, :timeout)
+    RollingWindow.inc(table, :timeout)
+    RollingWindow.inc(table, :timeout)
+
+    test_process = self()
+
+    expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+      send(test_process, :called_json_rpc)
+    end)
+
+    # Calculate expected sleep time as if there were one less failure, allowing
+    # a margin of error between the refute_receive, assert_receive, and actual
+    # call.
+    wait_time = sleep_time(5)
+
+    Task.async(fn ->
+      RequestCoordinator.perform(%{}, EthereumJSONRPC.Mox, [], :timer.minutes(60))
+    end)
+
+    refute_receive(:called_json_rpc, wait_time)
+
+    assert_receive(:called_json_rpc, wait_time)
+  end
+end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/rolling_window_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/rolling_window_test.exs
@@ -1,6 +1,5 @@
 defmodule EthereumJSONRPC.RollingWindowTest do
   use ExUnit.Case, async: true
-  use EthereumJSONRPC.Case
 
   alias EthereumJSONRPC.RollingWindow
 
@@ -9,13 +8,30 @@ defmodule EthereumJSONRPC.RollingWindowTest do
   setup do
     # We set `window_length` to a large time frame so that we can sweep manually to simulate
     # time passing
-    RollingWindow.start_link([table: @table, window_length: :timer.minutes(120), window_count: 3], name: RollingWindow)
+    RollingWindow.start_link([table: @table, duration: :timer.minutes(120), window_count: 3], name: RollingWindow)
 
     :ok
   end
 
   defp sweep do
     GenServer.call(RollingWindow, :sweep)
+  end
+
+  test "start_link/2" do
+    assert {:ok, _} = RollingWindow.start_link(table: :test_table, duration: 5, window_count: 1)
+  end
+
+  describe "init/1" do
+    test "raises when duration isn't evenly divisble by window_count" do
+      assert_raise ArgumentError, ~r"evenly divisible", fn ->
+        RollingWindow.init(table: @table, duration: :timer.seconds(2), window_count: 3)
+      end
+    end
+
+    test "schedules a sweep" do
+      assert {:ok, _} = RollingWindow.init(table: :test_table, duration: 5, window_count: 1)
+      assert_receive :sweep, 10
+    end
   end
 
   test "when no increments have happened, inspect returns an empty list" do
@@ -95,7 +111,7 @@ defmodule EthereumJSONRPC.RollingWindowTest do
   end
 
   test "sweeping schedules another sweep" do
-    {:ok, state} = RollingWindow.init(table: :anything, window_length: 1, window_count: 1)
+    {:ok, state} = RollingWindow.init(table: :anything, duration: 1, window_count: 1)
     RollingWindow.handle_info(:sweep, state)
     assert_receive(:sweep)
   end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/rolling_window_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/rolling_window_test.exs
@@ -38,7 +38,7 @@ defmodule EthereumJSONRPC.RollingWindowTest do
     assert RollingWindow.inspect(@table, :foobar) == []
   end
 
-  test "when no increments hafve happened, count returns 0" do
+  test "when no increments have happened, count returns 0" do
     assert RollingWindow.count(@table, :foobar) == 0
   end
 

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/rolling_window_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/rolling_window_test.exs
@@ -1,0 +1,102 @@
+defmodule EthereumJSONRPC.RollingWindowTest do
+  use ExUnit.Case, async: true
+  use EthereumJSONRPC.Case
+
+  alias EthereumJSONRPC.RollingWindow
+
+  @table :table
+
+  setup do
+    # We set `window_length` to a large time frame so that we can sweep manually to simulate
+    # time passing
+    RollingWindow.start_link([table: @table, window_length: :timer.minutes(120), window_count: 3], name: RollingWindow)
+
+    :ok
+  end
+
+  defp sweep do
+    GenServer.call(RollingWindow, :sweep)
+  end
+
+  test "when no increments have happened, inspect returns an empty list" do
+    assert RollingWindow.inspect(@table, :foobar) == []
+  end
+
+  test "when no increments hafve happened, count returns 0" do
+    assert RollingWindow.count(@table, :foobar) == 0
+  end
+
+  test "when an increment has happened, inspect returns the count for that window" do
+    RollingWindow.inc(@table, :foobar)
+
+    assert RollingWindow.inspect(@table, :foobar) == [1]
+  end
+
+  test "when an increment has happened, count returns the count for that window" do
+    RollingWindow.inc(@table, :foobar)
+
+    assert RollingWindow.count(@table, :foobar) == 1
+  end
+
+  test "when an increment has happened in multiple windows, inspect returns the count for both windows" do
+    RollingWindow.inc(@table, :foobar)
+    sweep()
+    RollingWindow.inc(@table, :foobar)
+
+    assert RollingWindow.inspect(@table, :foobar) == [1, 1]
+  end
+
+  test "when an increment has happened in multiple windows, count returns the sum of both windows" do
+    RollingWindow.inc(@table, :foobar)
+    sweep()
+    RollingWindow.inc(@table, :foobar)
+
+    assert RollingWindow.count(@table, :foobar) == 2
+  end
+
+  test "when an increment has happened in multiple windows, with an empty window in between, inspect shows that empty window" do
+    RollingWindow.inc(@table, :foobar)
+    sweep()
+    sweep()
+    RollingWindow.inc(@table, :foobar)
+
+    assert RollingWindow.inspect(@table, :foobar) == [1, 0, 1]
+  end
+
+  test "when an increment has happened in multiple windows, with an empty window in between, count still sums all windows" do
+    RollingWindow.inc(@table, :foobar)
+    sweep()
+    sweep()
+    RollingWindow.inc(@table, :foobar)
+
+    assert RollingWindow.count(@table, :foobar) == 2
+  end
+
+  test "when an increment has happened, but has been swept <window_count> times, it no longer appears in inspect" do
+    RollingWindow.inc(@table, :foobar)
+    sweep()
+    sweep()
+    RollingWindow.inc(@table, :foobar)
+    sweep()
+    RollingWindow.inc(@table, :foobar)
+
+    assert RollingWindow.inspect(@table, :foobar) == [1, 1, 0]
+  end
+
+  test "when an increment has happened, but has been swept <window_count> times, it no longer is included in count" do
+    RollingWindow.inc(@table, :foobar)
+    sweep()
+    sweep()
+    RollingWindow.inc(@table, :foobar)
+    sweep()
+    RollingWindow.inc(@table, :foobar)
+
+    assert RollingWindow.count(@table, :foobar) == 2
+  end
+
+  test "sweeping schedules another sweep" do
+    {:ok, state} = RollingWindow.init(table: :anything, window_length: 1, window_count: 1)
+    RollingWindow.handle_info(:sweep, state)
+    assert_receive(:sweep)
+  end
+end


### PR DESCRIPTION
## Motivation

Whenever our requests for fetching chain data start hammering nodes, we do not do any sort of backing off to slow down our rate of requests to allow the node to reach a stable state. This PR adds a mechanism to keep track of the number of recent request timeouts from the last minute and adds a wait time to any outgoing JSON RPC request based on that number.

For each recent timeout, a delay is added to the request with some additional randomized jitter. The delay is calculated as `timeouts * (base_delay + jitter)` where the base delay is 20 seconds. This can be configured as we find values that work best in production. If a requests delay time were to exceed some threshold, the request won't be performed and `{:error, :timeout}` will be returned immediately.

As a whole, this PR is a first step to responding to downstream bottlenecks and slowing down the explorer as a whole.

## Changelog

### Enhancements
* Add backoff mechanism based on a recent count of timeouts for all outgoing requests for Ethereum JSON RPC
