### PR TITLE
Provide default 2nd arg for executing contract functions on Geth

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
@@ -147,11 +147,11 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
     end
   end
 
-  defp blockchain_get_function_mock() do
+  defp blockchain_get_function_mock do
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,
-      fn [%{id: id, method: _, params: [%{data: _, to: _}]}], _options ->
+      fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
         {:ok, [%{id: id, jsonrpc: "2.0", result: "0x0000000000000000000000000000000000000000000000000000000000000000"}]}
       end
     )

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -147,7 +147,7 @@ defmodule EthereumJSONRPC do
          %{contract_address: address, data: data, id: id},
          nil = _block_number
        ) do
-    params = [%{to: address, data: data}]
+    params = [%{to: address, data: data}, "latest"]
     request(%{id: id, method: "eth_call", params: params})
   end
 

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
@@ -792,7 +792,7 @@ defmodule EthereumJSONRPCTest do
       expect(
         EthereumJSONRPC.Mox,
         :json_rpc,
-        fn [%{id: id, method: _, params: [%{data: _, to: _}]}], _options ->
+        fn [%{id: id, method: _, params: [%{data: _, to: _}, "latest"]}], _options ->
           {:ok,
            [
              %{

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -2,12 +2,12 @@ defmodule Explorer.SmartContract.ReaderTest do
   use EthereumJSONRPC.Case
   use Explorer.DataCase
 
-  doctest Explorer.SmartContract.Reader
+  import Mox
 
   alias Explorer.SmartContract.Reader
   alias Explorer.Chain.Hash
 
-  import Mox
+  doctest Explorer.SmartContract.Reader
 
   setup :verify_on_exit!
 
@@ -55,7 +55,7 @@ defmodule Explorer.SmartContract.ReaderTest do
       expect(
         EthereumJSONRPC.Mox,
         :json_rpc,
-        fn [%{id: id, method: _, params: [%{data: _, to: _}]}], _options ->
+        fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
           {:ok, [%{id: id, jsonrpc: "2.0", error: %{code: "12345", message: "Error message"}}]}
         end
       )
@@ -73,7 +73,7 @@ defmodule Explorer.SmartContract.ReaderTest do
       expect(
         EthereumJSONRPC.Mox,
         :json_rpc,
-        fn [%{id: _, method: _, params: [%{data: _, to: _}]}], _options ->
+        fn [%{id: _, method: _, params: [%{data: _, to: _}, _]}], _options ->
           {:error, {:bad_gateway, "request_url"}}
         end
       )
@@ -91,7 +91,7 @@ defmodule Explorer.SmartContract.ReaderTest do
       expect(
         EthereumJSONRPC.Mox,
         :json_rpc,
-        fn [%{id: _, method: _, params: [%{data: _, to: _}]}], _options ->
+        fn [%{id: _, method: _, params: [%{data: _, to: _}, _]}], _options ->
           raise FunctionClauseError
         end
       )
@@ -137,7 +137,7 @@ defmodule Explorer.SmartContract.ReaderTest do
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,
-      fn [%{id: id, method: _, params: [%{data: _, to: _}]}], _options ->
+      fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
         {:ok, [%{id: id, jsonrpc: "2.0", result: "0x0000000000000000000000000000000000000000000000000000000000000012"}]}
       end
     )
@@ -319,11 +319,11 @@ defmodule Explorer.SmartContract.ReaderTest do
     end
   end
 
-  defp blockchain_get_function_mock() do
+  defp blockchain_get_function_mock do
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,
-      fn [%{id: id, method: _, params: [%{data: _, to: _}]}], _options ->
+      fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
         {:ok, [%{id: id, jsonrpc: "2.0", result: "0x0000000000000000000000000000000000000000000000000000000000000000"}]}
       end
     )


### PR DESCRIPTION
Resolves #964

## Motivation

Geth requires a 2nd argument to be explicitly provided when running `eth_call` to execute contract functions. This PR sets `"latest"` as the default 2nd argument. This doesn't affect the values for Parity since it defaults to latest.

## Changelog

### Bug Fixes
* Provide block argument for executing contract functions on Geth