### PR TITLE
Monitor and shrink memory usage of Sequence and BufferedTasks when soft-limit exceeded

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -76,7 +76,7 @@
         #
         {Credo.Check.Design.AliasUsage,
          excluded_namespaces: ~w(Import Socket Task),
-         excluded_lastnames: ~w(Address DateTime Exporter Fetcher Full Instrumenter Name Number Repo Time Unit),
+         excluded_lastnames: ~w(Address DateTime Exporter Fetcher Full Instrumenter Monitor Name Number Repo Time Unit),
          priority: :low},
 
         # For some checks, you can also set other parameters

--- a/README.md
+++ b/README.md
@@ -261,6 +261,18 @@ BlockScout is setup to export [Prometheus](https://prometheus.io/) metrics at `/
    3. Click "Load"
 6. View the dashboards.  (You will need to click-around and use BlockScout for the web-related metrics to show up.)
 
+## Memory Usage
+
+The work queues for building the index of all blocks, balances (coin and token), and internal transactions can grow quite large.   By default, the soft-limit is 1 GiB, which can be changed in `apps/indexer/config/config.exs`:
+
+```
+config :indexer, memory_limit: 1 <<< 30
+```
+
+Memory usage is checked once per minute.  If the soft-limit is reached, the shrinkable work queues will shed half their load.  The shed load will be restored from the database, the same as when a restart of the server occurs, so rebuilding the work queue will be slower, but use less memory.
+
+If all queues are at their minimum size, then no more memory can be reclaimed and an error will be logged.
+
 ## Acknowledgements
 
 We would like to thank the [EthPrize foundation](http://ethprize.io/) for their funding support.

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -19,6 +19,18 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/indexer](https://hexdocs.pm/indexer).
 
+## Memory Usage
+
+The work queues for building the index of all blocks, balances (coin and token), and internal transactions can grow quite large.   By default, the soft-limit is 1 GiB, which can be changed in `config/config.exs`:
+
+```
+config :indexer, memory_limit: 1 <<< 30
+```
+
+Memory usage is checked once per minute.  If the soft-limit is reached, the shrinkable work queues will shed half their load.  The shed load will be restored from the database, the same as when a restart of the server occurs, so rebuilding the work queue will be slower, but use less memory.
+
+If all queues are at their minimum size, then no more memory can be reclaimed and an error will be logged.
+
 ## Testing
 
 ### Parity

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -2,7 +2,11 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+import Bitwise
+
 config :indexer,
+  # bytes
+  memory_limit: 1 <<< 30,
   ecto_repos: [Explorer.Repo]
 
 config :logger, :indexer,

--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -12,9 +12,17 @@ defmodule Indexer.Application do
 
   @impl Application
   def start(_type, _args) do
+    memory_monitor_options =
+      case Application.get_env(:indexer, :memory_limit) do
+        nil -> %{}
+        integer when is_integer(integer) -> %{limit: integer}
+      end
+
+    memory_monitor_name = Memory.Monitor
+
     children = [
-      Memory.Monitor,
-      Shrinkable.Supervisor
+      {Memory.Monitor, [memory_monitor_options, [name: memory_monitor_name]]},
+      {Shrinkable.Supervisor, [%{memory_monitor: memory_monitor_name}]}
     ]
 
     opts = [

--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -6,42 +6,22 @@ defmodule Indexer.Application do
   use Application
 
   alias Indexer.{
-    Block,
-    CoinBalance,
-    InternalTransaction,
-    PendingTransaction,
-    Token,
-    TokenBalance,
-    TokenTransfer
+    Memory,
+    Shrinkable
   }
 
   @impl Application
   def start(_type, _args) do
-    json_rpc_named_arguments = Application.fetch_env!(:indexer, :json_rpc_named_arguments)
-
-    block_fetcher_supervisor_named_arguments =
-      :indexer
-      |> Application.get_all_env()
-      |> Keyword.take(
-        ~w(blocks_batch_size blocks_concurrency block_interval json_rpc_named_arguments receipts_batch_size
-           receipts_concurrency subscribe_named_arguments)a
-      )
-      |> Enum.into(%{})
-
     children = [
-      {CoinBalance.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments], [name: CoinBalance.Supervisor]]},
-      {PendingTransaction.Supervisor,
-       [[json_rpc_named_arguments: json_rpc_named_arguments], [name: PendingTransactionFetcher]]},
-      {InternalTransaction.Supervisor,
-       [[json_rpc_named_arguments: json_rpc_named_arguments], [name: InternalTransaction.Supervisor]]},
-      {Token.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments], [name: Token.Supervisor]]},
-      {TokenBalance.Supervisor,
-       [[json_rpc_named_arguments: json_rpc_named_arguments], [name: TokenBalance.Supervisor]]},
-      {Block.Supervisor, [block_fetcher_supervisor_named_arguments, [name: Block.Supervisor]]},
-      {TokenTransfer.Uncataloged.Supervisor, [[], [name: TokenTransfer.Uncataloged.Supervisor]]}
+      Memory.Monitor,
+      Shrinkable.Supervisor
     ]
 
-    opts = [strategy: :one_for_one, name: Indexer.Supervisor]
+    opts = [
+      # If the `Memory.Monitor` dies, it needs all the `Shrinkable`s to re-register, so restart them.
+      strategy: :rest_for_one,
+      name: Indexer.Supervisor
+    ]
 
     Supervisor.start_link(children, opts)
   end

--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -11,7 +11,11 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
   alias Indexer.{Block, BoundInterval}
   alias Indexer.Block.Catchup
 
-  @type named_arguments :: %{required(:block_fetcher) => Block.Fetcher.t(), optional(:block_interval) => pos_integer}
+  @type named_arguments :: %{
+          required(:block_fetcher) => Block.Fetcher.t(),
+          optional(:block_interval) => pos_integer,
+          optional(:memory_monitor) => GenServer.server()
+        }
 
   # milliseconds
   @block_interval 5_000
@@ -19,6 +23,7 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
   @enforce_keys ~w(bound_interval fetcher)a
   defstruct bound_interval: nil,
             fetcher: %Catchup.Fetcher{},
+            memory_monitor: nil,
             task: nil
 
   @spec child_spec([named_arguments | GenServer.options(), ...]) :: Supervisor.child_spec()
@@ -63,7 +68,7 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
     bound_interval = BoundInterval.within(minimum_interval..(minimum_interval * 10))
 
     %__MODULE__{
-      fetcher: %Catchup.Fetcher{block_fetcher: block_fetcher},
+      fetcher: %Catchup.Fetcher{block_fetcher: block_fetcher, memory_monitor: Map.get(named_arguments, :memory_monitor)},
       bound_interval: bound_interval
     }
   end
@@ -177,7 +182,7 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
   end
 
   def handle_info(
-        {ref, %{first_block_number: first_block_number, missing_block_count: missing_block_count}},
+        {ref, %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: false}},
         %__MODULE__{
           bound_interval: bound_interval,
           task: %Task{ref: ref}
@@ -187,12 +192,20 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
     new_bound_interval =
       case missing_block_count do
         0 ->
-          Logger.info("Index already caught up in #{first_block_number}-0")
+          Logger.info(fn -> ["Index already caught up in ", to_string(first_block_number), "-0."] end)
 
           BoundInterval.increase(bound_interval)
 
         _ ->
-          Logger.info("Index had to catch up #{missing_block_count} blocks in #{first_block_number}-0")
+          Logger.info(fn ->
+            [
+              "Index had to catch up ",
+              to_string(missing_block_count),
+              " blocks in ",
+              to_string(first_block_number),
+              "-0."
+            ]
+          end)
 
           BoundInterval.decrease(bound_interval)
       end
@@ -202,12 +215,36 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
     interval = new_bound_interval.current
 
     Logger.info(fn ->
-      "Checking if index needs to catch up in #{interval}ms"
+      ["Checking if index needs to catch up in ", to_string(interval), "ms."]
     end)
 
     Process.send_after(self(), :catchup_index, interval)
 
     {:noreply, %__MODULE__{state | bound_interval: new_bound_interval, task: nil}}
+  end
+
+  def handle_info(
+        {ref, %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: true}},
+        %__MODULE__{
+          task: %Task{ref: ref}
+        } = state
+      )
+      when is_integer(missing_block_count) do
+    Process.demonitor(ref, [:flush])
+
+    Logger.info(fn ->
+      [
+        "Index had to catch up ",
+        to_string(missing_block_count),
+        " blocks in ",
+        to_string(first_block_number),
+        "-0, but the sequence was shrunk to save memory, so retrying immediately."
+      ]
+    end)
+
+    send(self(), :catchup_index)
+
+    {:noreply, %__MODULE__{state | task: nil}}
   end
 
   def handle_info(

--- a/apps/indexer/lib/indexer/block/supervisor.ex
+++ b/apps/indexer/lib/indexer/block/supervisor.ex
@@ -33,7 +33,7 @@ defmodule Indexer.Block.Supervisor do
            %{block_fetcher: block_fetcher, subscribe_named_arguments: subscribe_named_arguments},
            [name: Realtime.Supervisor]
          ]},
-        {Uncle.Supervisor, [[block_fetcher: block_fetcher], [name: Uncle.Supervisor]]}
+        {Uncle.Supervisor, [[block_fetcher: block_fetcher, memory_monitor: memory_monitor], [name: Uncle.Supervisor]]}
       ],
       strategy: :one_for_one
     )

--- a/apps/indexer/lib/indexer/block/supervisor.ex
+++ b/apps/indexer/lib/indexer/block/supervisor.ex
@@ -16,13 +16,18 @@ defmodule Indexer.Block.Supervisor do
   def init(%{block_interval: block_interval, subscribe_named_arguments: subscribe_named_arguments} = named_arguments) do
     block_fetcher =
       named_arguments
-      |> Map.drop(~w(block_interval subscribe_named_arguments)a)
+      |> Map.drop(~w(block_interval memory_monitor subscribe_named_arguments)a)
       |> Block.Fetcher.new()
+
+    memory_monitor = Map.get(named_arguments, :memory_monitor)
 
     Supervisor.init(
       [
         {Catchup.Supervisor,
-         [%{block_fetcher: block_fetcher, block_interval: block_interval}, [name: Catchup.Supervisor]]},
+         [
+           %{block_fetcher: block_fetcher, block_interval: block_interval, memory_monitor: memory_monitor},
+           [name: Catchup.Supervisor]
+         ]},
         {Realtime.Supervisor,
          [
            %{block_fetcher: block_fetcher, subscribe_named_arguments: subscribe_named_arguments},

--- a/apps/indexer/lib/indexer/block/uncle/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/uncle/fetcher.ex
@@ -66,7 +66,7 @@ defmodule Indexer.Block.Uncle.Fetcher do
   end
 
   @impl BufferedTask
-  def run(hashes, _retries, %Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments} = block_fetcher) do
+  def run(hashes, %Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments} = block_fetcher) do
     # the same block could be included as an uncle on multiple blocks, but we only want to fetch it once
     unique_hashes = Enum.uniq(hashes)
 

--- a/apps/indexer/lib/indexer/block/uncle/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/uncle/fetcher.ex
@@ -17,7 +17,6 @@ defmodule Indexer.Block.Uncle.Fetcher do
     flush_interval: :timer.seconds(3),
     max_batch_size: 10,
     max_concurrency: 10,
-    init_chunk_size: 1000,
     task_supervisor: Indexer.Block.Uncle.TaskSupervisor
   ]
 

--- a/apps/indexer/lib/indexer/bound_queue.ex
+++ b/apps/indexer/lib/indexer/bound_queue.ex
@@ -86,6 +86,24 @@ defmodule Indexer.BoundQueue do
   end
 
   @doc """
+  `push_back/2` items from `items` into `bound_queue` until it is full.
+  """
+  def push_back_until_maximum_size(
+        %__MODULE__{size: maximum_size, maximum_size: maximum_size} = bound_queue,
+        remaining
+      ),
+      do: {bound_queue, remaining}
+
+  def push_back_until_maximum_size(%__MODULE__{} = bound_queue, [] = remaining), do: {bound_queue, remaining}
+
+  def push_back_until_maximum_size(%__MODULE__{} = bound_queue, [head | tail] = remaining) do
+    case push_back(bound_queue, head) do
+      {:ok, new_bound_queue} -> push_back_until_maximum_size(new_bound_queue, tail)
+      {:error, :maximum_size} -> {bound_queue, remaining}
+    end
+  end
+
+  @doc """
   Shrinks the queue to half its current `size` and sets that as its new `max_size`.
   """
   def shrink(%__MODULE__{size: size}) when size <= 1, do: {:error, :minimum_size}

--- a/apps/indexer/lib/indexer/bound_queue.ex
+++ b/apps/indexer/lib/indexer/bound_queue.ex
@@ -1,0 +1,111 @@
+defmodule Indexer.BoundQueue do
+  @moduledoc """
+  A queue that tracks its size and can have its size bound to a maximum.
+  """
+
+  defstruct queue: :queue.new(),
+            size: 0,
+            maximum_size: nil
+
+  @typedoc """
+   * `queue` - underlying Erlang `:queue`.
+   * `size` - the size of `queue`.
+   * `max_size` - the maximum `size.  May be `nil` when there is no bound on the `queue`.
+  """
+  @type t(item) :: %__MODULE__{
+          queue: :queue.queue(item),
+          size: non_neg_integer(),
+          maximum_size: non_neg_integer() | nil
+        }
+
+  @doc """
+  Removes the first element from the back of the queue.
+
+  Returns the updated queue.
+  """
+
+  @spec drop_back(%__MODULE__{size: 0}) :: {:error, :empty}
+  def drop_back(%__MODULE__{size: 0}), do: {:error, :empty}
+
+  @spec drop_back(%__MODULE__{size: pos_integer()}) :: {:ok, t(item)} when item: term()
+  def drop_back(%__MODULE__{queue: queue, size: size} = bound_queue) do
+    updated_queue = :queue.drop_r(queue)
+    {:ok, %__MODULE__{bound_queue | queue: updated_queue, size: size - 1}}
+  end
+
+  @doc """
+  Removes the first element from the front of the queue.
+
+  Returns the first element and the updated queue.
+  """
+
+  @spec pop_front(%__MODULE__{size: 0}) :: {:error, :empty}
+  def pop_front(%__MODULE__{size: 0}), do: {:error, :empty}
+
+  @spec pop_front(%__MODULE__{size: pos_integer()}) :: {:ok, {item, t(item)}} when item: term()
+  def pop_front(%__MODULE__{queue: queue, size: size} = bound_queue) do
+    {{:value, item}, updated_queue} = :queue.out(queue)
+    {:ok, {item, %__MODULE__{bound_queue | queue: updated_queue, size: size - 1}}}
+  end
+
+  @doc """
+  Removes the last element from the back of queue.
+
+  Returns the last element and the updated queue.
+  """
+
+  @spec pop_back(%__MODULE__{size: 0}) :: {:error, :empty}
+  def pop_back(%__MODULE__{size: 0}), do: {:error, :empty}
+
+  @spec pop_back(%__MODULE__{size: pos_integer()}) :: {:ok, {item, t(item)}} when item: term()
+  def pop_back(%__MODULE__{queue: queue, size: size} = bound_queue) do
+    {{:value, item}, updated_queue} = :queue.out_r(queue)
+    {:ok, {item, %__MODULE__{bound_queue | queue: updated_queue, size: size - 1}}}
+  end
+
+  @doc """
+  Adds `element` as the first element at the front of the queue.
+  """
+  @spec push_front(t(item), item) :: {:ok, t(item)} | {:error, :maximum_size} when item: term()
+  def push_front(%__MODULE__{size: maximum_size, maximum_size: maximum_size}, _), do: {:error, :maximum_size}
+
+  def push_front(%__MODULE__{queue: queue, size: size} = bound_queue, item) do
+    updated_queue = :queue.in_r(item, queue)
+    {:ok, %__MODULE__{bound_queue | queue: updated_queue, size: size + 1}}
+  end
+
+  @doc """
+  Adds `element` as last element at the back of the queue.
+  """
+  @spec push_back(t(item), item) :: {:ok, t(item)} | {:error, :maximum_size} when item: term()
+  def push_back(%__MODULE__{size: maximum_size, maximum_size: maximum_size}, _), do: {:error, :maximum_size}
+
+  def push_back(%__MODULE__{queue: queue, size: size} = bound_queue, item) do
+    updated_queue = :queue.in(item, queue)
+    {:ok, %__MODULE__{bound_queue | queue: updated_queue, size: size + 1}}
+  end
+
+  @doc """
+  Shrinks the queue to half its current `size` and sets that as its new `max_size`.
+  """
+  def shrink(%__MODULE__{size: size}) when size <= 1, do: {:error, :minimum_size}
+
+  def shrink(%__MODULE__{size: size} = bound_queue) do
+    shrink(bound_queue, div(size, 2))
+  end
+
+  @doc """
+  Whether the queue was shrunk.
+  """
+  def shrunk?(%__MODULE__{maximum_size: nil}), do: false
+  def shrunk?(%__MODULE__{}), do: true
+
+  defp shrink(%__MODULE__{size: goal_size} = bound_queue, goal_size) do
+    {:ok, %__MODULE__{bound_queue | maximum_size: goal_size}}
+  end
+
+  defp shrink(%__MODULE__{} = bound_queue, goal_size) do
+    {:ok, shrunk_bound_queue} = drop_back(bound_queue)
+    shrink(shrunk_bound_queue, goal_size)
+  end
+end

--- a/apps/indexer/lib/indexer/coin_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/coin_balance/fetcher.ex
@@ -65,7 +65,7 @@ defmodule Indexer.CoinBalance.Fetcher do
   end
 
   @impl BufferedTask
-  def run(entries, _retries, json_rpc_named_arguments) do
+  def run(entries, json_rpc_named_arguments) do
     # the same address may be used more than once in the same block, but we only want one `Balance` for a given
     # `{address, block}`, so take unique params only
     unique_entries = Enum.uniq(entries)

--- a/apps/indexer/lib/indexer/coin_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/coin_balance/fetcher.ex
@@ -18,7 +18,6 @@ defmodule Indexer.CoinBalance.Fetcher do
     flush_interval: :timer.seconds(3),
     max_batch_size: 500,
     max_concurrency: 4,
-    init_chunk_size: 1000,
     task_supervisor: Indexer.CoinBalance.TaskSupervisor
   ]
 

--- a/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
@@ -21,7 +21,6 @@ defmodule Indexer.InternalTransaction.Fetcher do
     flush_interval: :timer.seconds(3),
     max_concurrency: @max_concurrency,
     max_batch_size: @max_batch_size,
-    init_chunk_size: 5000,
     task_supervisor: Indexer.InternalTransaction.TaskSupervisor
   ]
 

--- a/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
@@ -92,7 +92,7 @@ defmodule Indexer.InternalTransaction.Fetcher do
   end
 
   @impl BufferedTask
-  def run(entries, _retries, json_rpc_named_arguments) do
+  def run(entries, json_rpc_named_arguments) do
     unique_entries = unique_entries(entries)
 
     Logger.debug(fn -> "fetching internal transactions for #{length(unique_entries)} transactions" end)

--- a/apps/indexer/lib/indexer/logger.ex
+++ b/apps/indexer/lib/indexer/logger.ex
@@ -1,0 +1,19 @@
+defmodule Indexer.Logger do
+  @moduledoc """
+  Helpers for formatting `Logger` data as `t:iodata/0`.
+  """
+
+  @doc """
+  The PID and its registered name (if it has one) as `t:iodata/0`.
+  """
+  def process(pid) when is_pid(pid) do
+    prefix = [inspect(pid)]
+
+    {:registered_name, registered_name} = Process.info(pid, :registered_name)
+
+    case registered_name do
+      [] -> prefix
+      _ -> [prefix, " (", inspect(registered_name), ")"]
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/memory/monitor.ex
+++ b/apps/indexer/lib/indexer/memory/monitor.ex
@@ -1,0 +1,148 @@
+defmodule Indexer.Memory.Monitor do
+  @moduledoc """
+  Monitors memory usage of Erlang VM.
+
+  If memory usage (as reported by `:erlang.memory(:total)` exceeds the configured limit, then the `Process` with the
+  worst memory usage (as reported by `Process.info(pid, :memory)`) in `shrinkable_set` is asked to
+  `c:Indexer.Memory.Shrinkable.shrink/0`.
+  """
+
+  require Bitwise
+  require Logger
+
+  import Bitwise
+
+  alias Indexer.Memory.Shrinkable
+
+  defstruct limit: 1 <<< 30,
+            timer_interval: :timer.minutes(1),
+            timer_reference: nil,
+            shrinkable_set: MapSet.new()
+
+  use GenServer
+
+  @doc """
+  Registers caller as `Indexer.Memory.Shrinkable`.
+  """
+  def shrinkable(server \\ __MODULE__) do
+    GenServer.call(server, :shrinkable)
+  end
+
+  def child_spec([]) do
+    child_spec([%{}, []])
+  end
+
+  def child_spec([init_options, gen_server_options] = start_link_arguments)
+      when is_map(init_options) and is_list(gen_server_options) do
+    Supervisor.child_spec(%{id: __MODULE__, start: {__MODULE__, :start_link, start_link_arguments}}, [])
+  end
+
+  def start_link(init_options, gen_server_options \\ []) when is_map(init_options) and is_list(gen_server_options) do
+    GenServer.start_link(__MODULE__, init_options, Keyword.put_new(gen_server_options, :name, __MODULE__))
+  end
+
+  @impl GenServer
+  def init(options) when is_map(options) do
+    state = struct!(__MODULE__, options)
+    {:ok, timer_reference} = :timer.send_interval(state.timer_interval, :check)
+
+    {:ok, %__MODULE__{state | timer_reference: timer_reference}}
+  end
+
+  @impl GenServer
+  def handle_call(:shinkable, {pid, _}, %__MODULE__{shrinkable_set: shrinkable_set} = state) do
+    Process.monitor(pid)
+
+    {:reply, :ok, %__MODULE__{state | shrinkable_set: MapSet.put(shrinkable_set, pid)}}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _, :process, pid, _}, %__MODULE__{shrinkable_set: shrinkable_set}) do
+    {:noreply, %__MODULE__{shrinkable_set: MapSet.delete(shrinkable_set, pid)}}
+  end
+
+  @impl GenServer
+  def handle_info(:check, %__MODULE__{limit: limit} = state) do
+    total = :erlang.memory(:total)
+
+    if limit < total do
+      case shrinkable_with_most_memory(state) do
+        {:error, :not_found} ->
+          Logger.error(fn ->
+            [
+              prefix(%{total: total, limit: limit}),
+              "  No processes are registered as shrinkable.  Limit will remain surpassed."
+            ]
+          end)
+
+        {:ok, {pid, memory}} ->
+          Logger.warn(fn ->
+            prefix = [
+              prefix(%{total: total, limit: limit}),
+              "  Worst memory usage (",
+              to_string(memory),
+              " bytes) among shrinkable processes is ",
+              inspect(pid)
+            ]
+
+            {:registered_name, registered_name} = Process.info(pid, :registered_name)
+
+            prefix =
+              case registered_name do
+                [] -> [prefix, "."]
+                _ -> [prefix, " (", inspect(registered_name), ")."]
+              end
+
+            [prefix, "  Asking ", inspect(pid), " to shrinkable to drop below limit."]
+          end)
+
+          :ok = Shrinkable.shrink(pid)
+      end
+    end
+
+    flush(:check)
+
+    {:noreply, state}
+  end
+
+  defp flush(message) do
+    receive do
+      ^message -> flush(message)
+    after
+      0 ->
+        :ok
+    end
+  end
+
+  defp memory(pid) when is_pid(pid) do
+    case Process.info(pid, :memory) do
+      {:memory, memory} -> memory
+      # process died
+      nil -> 0
+    end
+  end
+
+  defp prefix(%{total: total, limit: limit}) do
+    [
+      to_string(total),
+      " / ",
+      to_string(limit),
+      " bytes (",
+      to_string(div(100 * total, limit)),
+      "%) of memory limit used."
+    ]
+  end
+
+  defp shrinkable_with_most_memory(%__MODULE__{shrinkable_set: shrinkable_set}) do
+    if Enum.empty?(shrinkable_set) do
+      {:error, :not_found}
+    else
+      pid_memory =
+        shrinkable_set
+        |> Enum.map(fn pid -> {pid, memory(pid)} end)
+        |> Enum.max_by(&elem(&1, 1))
+
+      {:ok, pid_memory}
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/memory/shrinkable.ex
+++ b/apps/indexer/lib/indexer/memory/shrinkable.ex
@@ -8,8 +8,18 @@ defmodule Indexer.Memory.Shrinkable do
   @doc """
   Asks `pid` to shrink its memory usage.
   """
-  @spec shrink(pid()) :: :ok
+  @spec shrink(pid()) :: :ok | {:error, :minimum_size}
   def shrink(pid) when is_pid(pid) do
     GenServer.call(pid, :shrink)
+  end
+
+  @doc """
+  Asks `pid` if it was shrunk in the past.
+
+  `pid` will only return `true` if it returned `:ok` from `shrink/1`.
+  """
+  @spec shrunk?(pid()) :: boolean()
+  def shrunk?(pid) when is_pid(pid) do
+    GenServer.call(pid, :shrunk?)
   end
 end

--- a/apps/indexer/lib/indexer/memory/shrinkable.ex
+++ b/apps/indexer/lib/indexer/memory/shrinkable.ex
@@ -1,0 +1,15 @@
+defmodule Indexer.Memory.Shrinkable do
+  @moduledoc """
+  A process that can shrink its memory usage when asked by `Indexer.Memory.Monitor`.
+
+  Processes need to `handle_call(:shrink, from, state)`.
+  """
+
+  @doc """
+  Asks `pid` to shrink its memory usage.
+  """
+  @spec shrink(pid()) :: :ok
+  def shrink(pid) when is_pid(pid) do
+    GenServer.call(pid, :shrink)
+  end
+end

--- a/apps/indexer/lib/indexer/shrinkable/supervisor.ex
+++ b/apps/indexer/lib/indexer/shrinkable/supervisor.ex
@@ -54,14 +54,27 @@ defmodule Indexer.Shrinkable.Supervisor do
     Supervisor.init(
       [
         {CoinBalance.Supervisor,
-         [[json_rpc_named_arguments: json_rpc_named_arguments], [name: CoinBalance.Supervisor]]},
+         [
+           [json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor],
+           [name: CoinBalance.Supervisor]
+         ]},
         {PendingTransaction.Supervisor,
          [[json_rpc_named_arguments: json_rpc_named_arguments], [name: PendingTransactionFetcher]]},
         {InternalTransaction.Supervisor,
-         [[json_rpc_named_arguments: json_rpc_named_arguments], [name: InternalTransaction.Supervisor]]},
-        {Token.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments], [name: Token.Supervisor]]},
+         [
+           [json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor],
+           [name: InternalTransaction.Supervisor]
+         ]},
+        {Token.Supervisor,
+         [
+           [json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor],
+           [name: Token.Supervisor]
+         ]},
         {TokenBalance.Supervisor,
-         [[json_rpc_named_arguments: json_rpc_named_arguments], [name: TokenBalance.Supervisor]]},
+         [
+           [json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor],
+           [name: TokenBalance.Supervisor]
+         ]},
         {Block.Supervisor, [block_fetcher_supervisor_named_arguments, [name: Block.Supervisor]]},
         {TokenTransfer.Uncataloged.Supervisor, [[], [name: TokenTransfer.Uncataloged.Supervisor]]}
       ],

--- a/apps/indexer/lib/indexer/shrinkable/supervisor.ex
+++ b/apps/indexer/lib/indexer/shrinkable/supervisor.ex
@@ -38,7 +38,7 @@ defmodule Indexer.Shrinkable.Supervisor do
   end
 
   @impl Supervisor
-  def init([]) do
+  def init(%{memory_monitor: memory_monitor}) do
     json_rpc_named_arguments = Application.fetch_env!(:indexer, :json_rpc_named_arguments)
 
     block_fetcher_supervisor_named_arguments =
@@ -49,6 +49,7 @@ defmodule Indexer.Shrinkable.Supervisor do
            receipts_concurrency subscribe_named_arguments)a
       )
       |> Enum.into(%{})
+      |> Map.put(:memory_monitor, memory_monitor)
 
     Supervisor.init(
       [

--- a/apps/indexer/lib/indexer/shrinkable/supervisor.ex
+++ b/apps/indexer/lib/indexer/shrinkable/supervisor.ex
@@ -1,0 +1,70 @@
+defmodule Indexer.Shrinkable.Supervisor do
+  @moduledoc """
+  Supervisor of all supervision trees that depend on `Indexer.Alarm.Supervisor`.
+  """
+
+  use Supervisor
+
+  alias Indexer.{
+    Block,
+    CoinBalance,
+    InternalTransaction,
+    PendingTransaction,
+    Token,
+    TokenBalance,
+    TokenTransfer
+  }
+
+  def child_spec([]) do
+    child_spec([[]])
+  end
+
+  def child_spec([init_arguments]) do
+    child_spec([init_arguments, []])
+  end
+
+  def child_spec([_init_arguments, _gen_server_options] = start_link_arguments) do
+    default = %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, start_link_arguments},
+      type: :supervisor
+    }
+
+    Supervisor.child_spec(default, [])
+  end
+
+  def start_link(arguments, gen_server_options \\ []) do
+    Supervisor.start_link(__MODULE__, arguments, Keyword.put_new(gen_server_options, :name, __MODULE__))
+  end
+
+  @impl Supervisor
+  def init([]) do
+    json_rpc_named_arguments = Application.fetch_env!(:indexer, :json_rpc_named_arguments)
+
+    block_fetcher_supervisor_named_arguments =
+      :indexer
+      |> Application.get_all_env()
+      |> Keyword.take(
+        ~w(blocks_batch_size blocks_concurrency block_interval json_rpc_named_arguments receipts_batch_size
+           receipts_concurrency subscribe_named_arguments)a
+      )
+      |> Enum.into(%{})
+
+    Supervisor.init(
+      [
+        {CoinBalance.Supervisor,
+         [[json_rpc_named_arguments: json_rpc_named_arguments], [name: CoinBalance.Supervisor]]},
+        {PendingTransaction.Supervisor,
+         [[json_rpc_named_arguments: json_rpc_named_arguments], [name: PendingTransactionFetcher]]},
+        {InternalTransaction.Supervisor,
+         [[json_rpc_named_arguments: json_rpc_named_arguments], [name: InternalTransaction.Supervisor]]},
+        {Token.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments], [name: Token.Supervisor]]},
+        {TokenBalance.Supervisor,
+         [[json_rpc_named_arguments: json_rpc_named_arguments], [name: TokenBalance.Supervisor]]},
+        {Block.Supervisor, [block_fetcher_supervisor_named_arguments, [name: Block.Supervisor]]},
+        {TokenTransfer.Uncataloged.Supervisor, [[], [name: TokenTransfer.Uncataloged.Supervisor]]}
+      ],
+      strategy: :one_for_one
+    )
+  end
+end

--- a/apps/indexer/lib/indexer/token/fetcher.ex
+++ b/apps/indexer/lib/indexer/token/fetcher.ex
@@ -103,7 +103,7 @@ defmodule Indexer.Token.Fetcher do
   end
 
   @impl BufferedTask
-  def run([token_contract_address], _, json_rpc_named_arguments) do
+  def run([token_contract_address], json_rpc_named_arguments) do
     case Chain.token_from_address_hash(token_contract_address) do
       {:ok, %Token{cataloged: false} = token} ->
         catalog_token(token, json_rpc_named_arguments)

--- a/apps/indexer/lib/indexer/token/fetcher.ex
+++ b/apps/indexer/lib/indexer/token/fetcher.ex
@@ -15,7 +15,6 @@ defmodule Indexer.Token.Fetcher do
     flush_interval: 300,
     max_batch_size: 1,
     max_concurrency: 10,
-    init_chunk_size: 1,
     task_supervisor: Indexer.Token.TaskSupervisor
   ]
 

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -56,7 +56,7 @@ defmodule Indexer.TokenBalance.Fetcher do
   end
 
   @impl BufferedTask
-  def run(entries, _retries, _json_rpc_named_arguments) do
+  def run(entries, _json_rpc_named_arguments) do
     Logger.debug(fn -> "fetching #{length(entries)} token balances" end)
 
     result =

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -15,7 +15,6 @@ defmodule Indexer.TokenBalance.Fetcher do
     flush_interval: 300,
     max_batch_size: 1,
     max_concurrency: 10,
-    init_chunk_size: 1,
     task_supervisor: Indexer.TokenBalance.TaskSupervisor
   ]
 

--- a/apps/indexer/test/indexer/buffered_task_test.exs
+++ b/apps/indexer/test/indexer/buffered_task_test.exs
@@ -27,8 +27,7 @@ defmodule Indexer.BufferedTaskTest do
           task_supervisor: BufferedTaskSup,
           flush_interval: 50,
           max_batch_size: max_batch_size,
-          max_concurrency: 2,
-          init_chunk_size: max_batch_size * 2}
+          max_concurrency: 2}
        ]}
     )
   end

--- a/apps/indexer/test/indexer/buffered_task_test.exs
+++ b/apps/indexer/test/indexer/buffered_task_test.exs
@@ -16,7 +16,7 @@ defmodule Indexer.BufferedTaskTest do
 
   setup :verify_on_exit!
 
-  defp start_buffer(callback_module) do
+  defp start_buffer(callback_module, max_batch_size \\ @max_batch_size) do
     start_supervised!({Task.Supervisor, name: BufferedTaskSup})
 
     start_supervised(
@@ -26,9 +26,9 @@ defmodule Indexer.BufferedTaskTest do
           state: nil,
           task_supervisor: BufferedTaskSup,
           flush_interval: 50,
-          max_batch_size: @max_batch_size,
+          max_batch_size: max_batch_size,
           max_concurrency: 2,
-          init_chunk_size: @max_batch_size * 2}
+          init_chunk_size: max_batch_size * 2}
        ]}
     )
   end
@@ -167,7 +167,7 @@ defmodule Indexer.BufferedTaskTest do
       :ok
     end)
 
-    {:ok, buffer} = start_buffer(RetryableTask)
+    {:ok, buffer} = start_buffer(RetryableTask, 1)
 
     assert %{buffer: 0, tasks: 0} = BufferedTask.debug_count(buffer)
 

--- a/apps/indexer/test/indexer/coin_balance/fetcher_test.exs
+++ b/apps/indexer/test/indexer/coin_balance/fetcher_test.exs
@@ -254,7 +254,7 @@ defmodule Indexer.CoinBalance.FetcherTest do
       {:ok, %Hash{bytes: address_hash_bytes}} = Hash.Address.cast(hash_data)
       entries = Enum.map(block_quantities, &{address_hash_bytes, quantity_to_integer(&1)})
 
-      case CoinBalance.Fetcher.run(entries, 0, json_rpc_named_arguments) do
+      case CoinBalance.Fetcher.run(entries, json_rpc_named_arguments) do
         :ok ->
           balances = Repo.all(from(balance in Address.CoinBalance, where: balance.address_hash == ^hash_data))
 

--- a/apps/indexer/test/indexer/internal_transaction/fetcher_test.exs
+++ b/apps/indexer/test/indexer/internal_transaction/fetcher_test.exs
@@ -73,7 +73,7 @@ defmodule Indexer.InternalTransaction.FetcherTest do
     hash_strings =
       InternalTransaction.Fetcher.init([], fn hash_string, acc -> [hash_string | acc] end, json_rpc_named_arguments)
 
-    assert :ok = InternalTransaction.Fetcher.run(hash_strings, 0, json_rpc_named_arguments)
+    assert :ok = InternalTransaction.Fetcher.run(hash_strings, json_rpc_named_arguments)
   end
 
   describe "init/2" do
@@ -139,7 +139,6 @@ defmodule Indexer.InternalTransaction.FetcherTest do
               {1, bytes, 0},
               {1, bytes, 0}
             ],
-            0,
             json_rpc_named_arguments
           )
         end)
@@ -170,7 +169,6 @@ defmodule Indexer.InternalTransaction.FetcherTest do
                  {1, bytes, 0},
                  {1, bytes, 0}
                ],
-               0,
                json_rpc_named_arguments
              ) == {:retry, [{1, bytes, 0}]}
     end

--- a/apps/indexer/test/indexer/sequence_test.exs
+++ b/apps/indexer/test/indexer/sequence_test.exs
@@ -1,14 +1,15 @@
 defmodule Indexer.SequenceTest do
   use ExUnit.Case
 
+  alias Indexer.Memory.Shrinkable
   alias Indexer.Sequence
 
   describe "start_link/1" do
     test "without :ranges with :first with positive step pops infinitely" do
       {:ok, ascending} = Sequence.start_link(first: 5, step: 1)
 
-      assert Sequence.pop(ascending) == 5..5
-      assert Sequence.pop(ascending) == 6..6
+      assert Sequence.pop_front(ascending) == 5..5
+      assert Sequence.pop_front(ascending) == 6..6
     end
 
     test "without :ranges with :first with negative :step is error" do
@@ -35,11 +36,11 @@ defmodule Indexer.SequenceTest do
     test "with ranges without :first" do
       {:ok, pid} = Sequence.start_link(ranges: [1..4], step: 1)
 
-      assert Sequence.pop(pid) == 1..1
-      assert Sequence.pop(pid) == 2..2
-      assert Sequence.pop(pid) == 3..3
-      assert Sequence.pop(pid) == 4..4
-      assert Sequence.pop(pid) == :halt
+      assert Sequence.pop_front(pid) == 1..1
+      assert Sequence.pop_front(pid) == 2..2
+      assert Sequence.pop_front(pid) == 3..3
+      assert Sequence.pop_front(pid) == 4..4
+      assert Sequence.pop_front(pid) == :halt
     end
 
     test "with :ranges with :first returns error" do
@@ -57,9 +58,9 @@ defmodule Indexer.SequenceTest do
     test "with 0 first with negative step does not return 0 twice" do
       {:ok, pid} = Sequence.start_link(ranges: [1..0], step: -1)
 
-      assert Sequence.pop(pid) == 1..1
-      assert Sequence.pop(pid) == 0..0
-      assert Sequence.pop(pid) == :halt
+      assert Sequence.pop_front(pid) == 1..1
+      assert Sequence.pop_front(pid) == 0..0
+      assert Sequence.pop_front(pid) == :halt
     end
 
     # Regression test for https://github.com/poanetwork/blockscout/issues/387
@@ -78,80 +79,119 @@ defmodule Indexer.SequenceTest do
     end
   end
 
-  describe "queue/2" do
+  describe "push_back/2" do
     test "with finite mode range is chunked" do
       {:ok, pid} = Sequence.start_link(ranges: [1..0], step: -1)
 
-      assert Sequence.pop(pid) == 1..1
-      assert Sequence.pop(pid) == 0..0
+      assert Sequence.pop_front(pid) == 1..1
+      assert Sequence.pop_front(pid) == 0..0
 
-      assert Sequence.queue(pid, 1..0) == :ok
+      assert Sequence.push_back(pid, 1..0) == :ok
 
-      assert Sequence.pop(pid) == 1..1
-      assert Sequence.pop(pid) == 0..0
-      assert Sequence.pop(pid) == :halt
-      assert Sequence.pop(pid) == :halt
+      assert Sequence.pop_front(pid) == 1..1
+      assert Sequence.pop_front(pid) == 0..0
+      assert Sequence.pop_front(pid) == :halt
+      assert Sequence.pop_front(pid) == :halt
     end
 
     test "with finite mode with range in wrong direction returns error" do
       {:ok, ascending} = Sequence.start_link(first: 0, step: 1)
 
-      assert Sequence.queue(ascending, 1..0) == {:error, "Range (1..0) direction is opposite step (1) direction"}
+      assert Sequence.push_back(ascending, 1..0) == {:error, "Range (1..0) direction is opposite step (1) direction"}
 
       {:ok, descending} = Sequence.start_link(ranges: [1..0], step: -1)
 
-      assert Sequence.queue(descending, 0..1) == {:error, "Range (0..1) direction is opposite step (-1) direction"}
+      assert Sequence.push_back(descending, 0..1) == {:error, "Range (0..1) direction is opposite step (-1) direction"}
     end
 
     test "with infinite mode range is chunked and is returned prior to calculated ranges" do
       {:ok, pid} = Sequence.start_link(first: 5, step: 1)
 
-      assert :ok = Sequence.queue(pid, 3..4)
+      assert :ok = Sequence.push_back(pid, 3..4)
 
-      assert Sequence.pop(pid) == 3..3
-      assert Sequence.pop(pid) == 4..4
+      assert Sequence.pop_front(pid) == 3..3
+      assert Sequence.pop_front(pid) == 4..4
       # infinite sequence takes over
-      assert Sequence.pop(pid) == 5..5
-      assert Sequence.pop(pid) == 6..6
+      assert Sequence.pop_front(pid) == 5..5
+      assert Sequence.pop_front(pid) == 6..6
+    end
+
+    test "with size == maximum_size, returns error" do
+      {:ok, pid} = Sequence.start_link(ranges: [1..0], step: -1)
+
+      :ok = Shrinkable.shrink(pid)
+
+      # error if currently size == maximumm_size
+      assert {:error, :maximum_size} = Sequence.push_back(pid, 2..2)
+
+      assert Sequence.pop_front(pid) == 1..1
+
+      # error if range would make sequence exceed maximum size
+      assert {:error, :maximum_size} = Sequence.push_back(pid, 3..2)
+
+      # no error if range makes it under maximum size
+      assert :ok = Sequence.push_back(pid, 2..2)
+
+      assert Sequence.pop_front(pid) == 2..2
+      assert Sequence.pop_front(pid) == :halt
     end
   end
 
-  describe "queue_front/2" do
+  describe "push_front/2" do
     test "with finite mode range is chunked" do
       {:ok, pid} = Sequence.start_link(ranges: [1..0], step: -1)
 
-      assert Sequence.pop(pid) == 1..1
-      assert Sequence.pop(pid) == 0..0
+      assert Sequence.pop_front(pid) == 1..1
+      assert Sequence.pop_front(pid) == 0..0
 
-      assert Sequence.queue_front(pid, 1..0) == :ok
+      assert Sequence.push_front(pid, 1..0) == :ok
 
-      assert Sequence.pop(pid) == 0..0
-      assert Sequence.pop(pid) == 1..1
-      assert Sequence.pop(pid) == :halt
-      assert Sequence.pop(pid) == :halt
+      assert Sequence.pop_front(pid) == 0..0
+      assert Sequence.pop_front(pid) == 1..1
+      assert Sequence.pop_front(pid) == :halt
+      assert Sequence.pop_front(pid) == :halt
     end
 
     test "with finite mode with range in wrong direction returns error" do
       {:ok, ascending} = Sequence.start_link(first: 0, step: 1)
 
-      assert Sequence.queue_front(ascending, 1..0) == {:error, "Range (1..0) direction is opposite step (1) direction"}
+      assert Sequence.push_front(ascending, 1..0) == {:error, "Range (1..0) direction is opposite step (1) direction"}
 
       {:ok, descending} = Sequence.start_link(ranges: [1..0], step: -1)
 
-      assert Sequence.queue_front(descending, 0..1) ==
-               {:error, "Range (0..1) direction is opposite step (-1) direction"}
+      assert Sequence.push_front(descending, 0..1) == {:error, "Range (0..1) direction is opposite step (-1) direction"}
     end
 
     test "with infinite mode range is chunked and is returned prior to calculated ranges" do
       {:ok, pid} = Sequence.start_link(first: 5, step: 1)
 
-      assert :ok = Sequence.queue_front(pid, 3..4)
+      assert :ok = Sequence.push_front(pid, 3..4)
 
-      assert Sequence.pop(pid) == 4..4
-      assert Sequence.pop(pid) == 3..3
+      assert Sequence.pop_front(pid) == 4..4
+      assert Sequence.pop_front(pid) == 3..3
       # infinite sequence takes over
-      assert Sequence.pop(pid) == 5..5
-      assert Sequence.pop(pid) == 6..6
+      assert Sequence.pop_front(pid) == 5..5
+      assert Sequence.pop_front(pid) == 6..6
+    end
+
+    test "with size == maximum_size, returns error" do
+      {:ok, pid} = Sequence.start_link(ranges: [1..0], step: -1)
+
+      :ok = Shrinkable.shrink(pid)
+
+      # error if currently size == maximumm_size
+      assert {:error, :maximum_size} = Sequence.push_front(pid, 2..2)
+
+      assert Sequence.pop_front(pid) == 1..1
+
+      # error if range would make sequence exceed maximum size
+      assert {:error, :maximum_size} = Sequence.push_front(pid, 3..2)
+
+      # no error if range makes it under maximum size
+      assert :ok = Sequence.push_front(pid, 2..2)
+
+      assert Sequence.pop_front(pid) == 2..2
+      assert Sequence.pop_front(pid) == :halt
     end
   end
 
@@ -166,17 +206,17 @@ defmodule Indexer.SequenceTest do
     test "disables infinite mode that uses first and step" do
       {:ok, late_capped} = Sequence.start_link(first: 5, step: 1)
 
-      assert Sequence.pop(late_capped) == 5..5
-      assert Sequence.pop(late_capped) == 6..6
-      assert Sequence.queue(late_capped, 5..5) == :ok
+      assert Sequence.pop_front(late_capped) == 5..5
+      assert Sequence.pop_front(late_capped) == 6..6
+      assert Sequence.push_back(late_capped, 5..5) == :ok
       assert Sequence.cap(late_capped) == :infinite
-      assert Sequence.pop(late_capped) == 5..5
-      assert Sequence.pop(late_capped) == :halt
+      assert Sequence.pop_front(late_capped) == 5..5
+      assert Sequence.pop_front(late_capped) == :halt
 
       {:ok, immediately_capped} = Sequence.start_link(first: 5, step: 1)
 
       assert Sequence.cap(immediately_capped) == :infinite
-      assert Sequence.pop(immediately_capped) == :halt
+      assert Sequence.pop_front(immediately_capped) == :halt
     end
   end
 
@@ -184,23 +224,23 @@ defmodule Indexer.SequenceTest do
     test "with a non-empty queue in finite mode" do
       {:ok, pid} = Sequence.start_link(ranges: [1..4, 6..9], step: 5)
 
-      assert Sequence.pop(pid) == 1..4
-      assert Sequence.pop(pid) == 6..9
-      assert Sequence.pop(pid) == :halt
-      assert Sequence.pop(pid) == :halt
+      assert Sequence.pop_front(pid) == 1..4
+      assert Sequence.pop_front(pid) == 6..9
+      assert Sequence.pop_front(pid) == :halt
+      assert Sequence.pop_front(pid) == :halt
     end
 
     test "with an empty queue in infinite mode returns range from next step from current" do
       {:ok, pid} = Sequence.start_link(first: 5, step: 5)
 
-      assert 5..9 == Sequence.pop(pid)
+      assert 5..9 == Sequence.pop_front(pid)
     end
 
     test "with an empty queue in finite mode halts immediately" do
       {:ok, pid} = Sequence.start_link(first: 5, step: 5)
       :infinite = Sequence.cap(pid)
 
-      assert Sequence.pop(pid) == :halt
+      assert Sequence.pop_front(pid) == :halt
     end
   end
 end

--- a/apps/indexer/test/indexer/token/fetcher_test.exs
+++ b/apps/indexer/test/indexer/token/fetcher_test.exs
@@ -23,7 +23,7 @@ defmodule Indexer.Token.FetcherTest do
     test "skips tokens that have already been cataloged", %{json_rpc_named_arguments: json_rpc_named_arguments} do
       expect(EthereumJSONRPC.Mox, :json_rpc, 0, fn _, _ -> :ok end)
       %Token{contract_address_hash: contract_address_hash} = insert(:token, cataloged: true)
-      assert Fetcher.run([contract_address_hash], 0, json_rpc_named_arguments) == :ok
+      assert Fetcher.run([contract_address_hash], json_rpc_named_arguments) == :ok
     end
 
     test "catalogs tokens that haven't been cataloged", %{json_rpc_named_arguments: json_rpc_named_arguments} do
@@ -60,7 +60,7 @@ defmodule Indexer.Token.FetcherTest do
           end
         )
 
-        assert Fetcher.run([contract_address_hash], 0, json_rpc_named_arguments) == :ok
+        assert Fetcher.run([contract_address_hash], json_rpc_named_arguments) == :ok
 
         expected_supply = Decimal.new(1_000_000_000_000_000_000)
 
@@ -111,7 +111,7 @@ defmodule Indexer.Token.FetcherTest do
           end
         )
 
-        assert Fetcher.run([contract_address_hash], 0, json_rpc_named_arguments) == :ok
+        assert Fetcher.run([contract_address_hash], json_rpc_named_arguments) == :ok
         assert {:ok, %Token{cataloged: true, name: "0x0000"}} = Chain.token_from_address_hash(contract_address_hash)
       end
     end
@@ -150,7 +150,7 @@ defmodule Indexer.Token.FetcherTest do
           end
         )
 
-        assert Fetcher.run([contract_address_hash], 0, json_rpc_named_arguments) == :ok
+        assert Fetcher.run([contract_address_hash], json_rpc_named_arguments) == :ok
         assert {:ok, %Token{cataloged: true, symbol: nil}} = Chain.token_from_address_hash(contract_address_hash)
       end
     end
@@ -184,7 +184,7 @@ defmodule Indexer.Token.FetcherTest do
           end
         )
 
-        assert Fetcher.run([contract_address_hash], 0, json_rpc_named_arguments) == :ok
+        assert Fetcher.run([contract_address_hash], json_rpc_named_arguments) == :ok
         assert {:ok, %Token{cataloged: true, name: nil}} = Chain.token_from_address_hash(contract_address_hash)
       end
     end
@@ -214,7 +214,7 @@ defmodule Indexer.Token.FetcherTest do
           end
         )
 
-        assert Fetcher.run([contract_address_hash], 0, json_rpc_named_arguments) == :ok
+        assert Fetcher.run([contract_address_hash], json_rpc_named_arguments) == :ok
 
         assert {:ok, %Token{cataloged: true, name: ^long_token_name_shortened}} =
                  Chain.token_from_address_hash(contract_address_hash)

--- a/apps/indexer/test/indexer/token_balance/fetcher_test.exs
+++ b/apps/indexer/test/indexer/token_balance/fetcher_test.exs
@@ -51,7 +51,7 @@ defmodule Indexer.TokenBalance.FetcherTest do
         end
       )
 
-      assert TokenBalance.Fetcher.run([{address_hash_bytes, token_contract_address_hash_bytes, block_number}], 0, nil) ==
+      assert TokenBalance.Fetcher.run([{address_hash_bytes, token_contract_address_hash_bytes, block_number}], nil) ==
                :ok
 
       token_balance_updated = Explorer.Repo.get_by(Address.TokenBalance, address_hash: address_hash)

--- a/apps/indexer/test/support/indexer/block/uncle/supervisor/case.ex
+++ b/apps/indexer/test/support/indexer/block/uncle/supervisor/case.ex
@@ -6,7 +6,6 @@ defmodule Indexer.Block.Uncle.Supervisor.Case do
       Keyword.merge(
         fetcher_arguments,
         flush_interval: 50,
-        init_chunk_size: 1,
         max_batch_size: 1,
         max_concurrency: 1
       )

--- a/apps/indexer/test/support/indexer/coin_balance/supervisor/case.ex
+++ b/apps/indexer/test/support/indexer/coin_balance/supervisor/case.ex
@@ -6,7 +6,6 @@ defmodule Indexer.CoinBalance.Supervisor.Case do
       Keyword.merge(
         fetcher_arguments,
         flush_interval: 50,
-        init_chunk_size: 1,
         max_batch_size: 1,
         max_concurrency: 1
       )

--- a/apps/indexer/test/support/indexer/internal_transaction/supervisor/case.ex
+++ b/apps/indexer/test/support/indexer/internal_transaction/supervisor/case.ex
@@ -6,7 +6,6 @@ defmodule Indexer.InternalTransaction.Supervisor.Case do
       Keyword.merge(
         fetcher_arguments,
         flush_interval: 50,
-        init_chunk_size: 1,
         max_batch_size: 1,
         max_concurrency: 1
       )

--- a/apps/indexer/test/support/indexer/pending_transaction/supervisor/case.ex
+++ b/apps/indexer/test/support/indexer/pending_transaction/supervisor/case.ex
@@ -6,7 +6,6 @@ defmodule Indexer.PendingTransaction.Supervisor.Case do
       Keyword.merge(
         fetcher_arguments,
         flush_interval: 50,
-        init_chunk_size: 1,
         max_batch_size: 1,
         max_concurrency: 1
       )

--- a/apps/indexer/test/support/indexer/token/supervisor/case.ex
+++ b/apps/indexer/test/support/indexer/token/supervisor/case.ex
@@ -6,7 +6,6 @@ defmodule Indexer.Token.Supervisor.Case do
       Keyword.merge(
         fetcher_arguments,
         flush_interval: 50,
-        init_chunk_size: 1,
         max_batch_size: 1,
         max_concurrency: 1
       )

--- a/apps/indexer/test/support/indexer/token_balance/supervisor/case.ex
+++ b/apps/indexer/test/support/indexer/token_balance/supervisor/case.ex
@@ -6,7 +6,6 @@ defmodule Indexer.TokenBalance.Supervisor.Case do
       Keyword.merge(
         fetcher_arguments,
         flush_interval: 50,
-        init_chunk_size: 1,
         max_batch_size: 1,
         max_concurrency: 1
       )

--- a/apps/indexer/test/test_helper.exs
+++ b/apps/indexer/test/test_helper.exs
@@ -16,6 +16,7 @@ end
 
 Mox.defmock(EthereumJSONRPC.Mox, for: EthereumJSONRPC.Transport)
 Mox.defmock(Indexer.BufferedTaskTest.RetryableTask, for: Indexer.BufferedTask)
+Mox.defmock(Indexer.BufferedTaskTest.ShrinkableTask, for: Indexer.BufferedTask)
 
 ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
 ExUnit.start()

--- a/apps/indexer/test/test_helper.exs
+++ b/apps/indexer/test/test_helper.exs
@@ -15,6 +15,7 @@ end
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 
 Mox.defmock(EthereumJSONRPC.Mox, for: EthereumJSONRPC.Transport)
+Mox.defmock(Indexer.BufferedTaskTest.RetryableTask, for: Indexer.BufferedTask)
 
 ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
 ExUnit.start()


### PR DESCRIPTION
Fixes #888

## Changelog

### Enhancements
* Add documentation on configuring the `Indexer.Memory.Monitor` soft-limit to the READMEs.
* Don't store `pid` in `%Indexer.BufferedTask{}` and instead get it as needed.
* Instead of queuing up batches, store entries in queue and only form a batch when run is called.  This ensures that the batch size is maximized and previously partial adjacent batches will go out as a full batch.

### Bug Fixes
* `Indexer.Memory.Monitor` checks the total VM memory usage (`:erlang.memory(:total)`) every (1) minute.  If the memory usage exceeds the soft-limit, shrinkable processes are asked to shrink.
  * Memory soft-limit defaults to 1 GiB for safety on laptops, but you'll want to raise this for production deploys @acravenho.  It can be configured with `config :indexer, memory: bytes` with
    * Default set in `apps/indexer/config/config.exs`
    * Default can be per environment like any other config if you'd prefer we ship a higher default for `prod` @acravenho.
* Processes with work queues register themselves as shrinkable with `Indexer.Memory.Monitor`.
  * `:block_catchup_sequence` `Indexer.Sequence`
  * `Indexer.BufferedTask`s

### Incompatible Changes
* `c:Indexer.BufferedTask.run/3` is now `c:Indexer.BufferedTask.run/2` with the `retries` count being removed.  No implementations used the `retries` count and removing it allowed for batching optimizations.
* Remove `Indexer.BufferedTask` `:init_chunk_size` as it didn't really do much besides decided when to send `GenServer.call`s from the `init_task`.