### PR TITLE
Lookup internal_txs by {hash, index} in BlockScoutWeb.Notifier handle_event()

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -55,7 +55,7 @@ defmodule BlockScoutWeb.Notifier do
     internal_transactions
     |> Stream.map(
       &(InternalTransaction
-        |> Repo.get_by([transaction_hash: &1.transaction_hash, index: &1.index])
+        |> Repo.get_by(transaction_hash: &1.transaction_hash, index: &1.index)
         |> Repo.preload([:from_address, :to_address, transaction: :block]))
     )
     |> Enum.each(&broadcast_internal_transaction/1)

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -55,7 +55,7 @@ defmodule BlockScoutWeb.Notifier do
     internal_transactions
     |> Stream.map(
       &(InternalTransaction
-        |> Repo.get(&1.id)
+        |> Repo.get_by([transaction_hash: &1.transaction_hash, index: &1.index])
         |> Repo.preload([:from_address, :to_address, transaction: :block]))
     )
     |> Enum.each(&broadcast_internal_transaction/1)


### PR DESCRIPTION
In certain instances the (auto generated) primary key for internal transactions can change, causing a lookup failure in the Notifier.

As the internal_transactions table has a not null, unique index on the {transaction_hash, index} fields and as these fields are already present in the message sent to the Notifier, this simple change addresses the situation where the primary key has changed due to the record being imported twice.

## Changelog

### Bug Fixes
- Addresses GenServer BlockScoutWeb.EventHandler error due to nil internal_transactions pulled from database