### PR TITLE
Fix InternalTransaction listing page by removing transaction fields.

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
@@ -19,8 +19,8 @@
     <div class="col-md-3 col-lg-2 d-flex flex-row flex-md-column flex-nowrap justify-content-start text-md-right mt-3 mt-md-0">
       <span class="mr-2 mr-md-0 order-1">
         <%= link(
-          gettext("Block #%{number}", number: to_string(@internal_transaction.transaction.block_number)),
-          to: block_path(BlockScoutWeb.Endpoint, :show, @internal_transaction.transaction.block)
+          gettext("Block #%{number}", number: to_string(@internal_transaction.block_number)),
+          to: block_path(BlockScoutWeb.Endpoint, :show, @internal_transaction.block_number)
         ) %>
       </span>
       <span class="mr-2 mr-md-0 order-2" data-from-now="<%= @internal_transaction.transaction.block.timestamp %>"></span>

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
@@ -27,12 +27,25 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
       transaction =
         :transaction
         |> insert()
-        |> with_block()
+        |> with_block(insert(:block, number: 1))
 
       from_internal_transaction =
-        insert(:internal_transaction, transaction: transaction, from_address: address, index: 1)
+        insert(:internal_transaction,
+          transaction: transaction,
+          from_address: address,
+          index: 1,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index
+        )
 
-      to_internal_transaction = insert(:internal_transaction, transaction: transaction, to_address: address, index: 2)
+      to_internal_transaction =
+        insert(:internal_transaction,
+          transaction: transaction,
+          to_address: address,
+          index: 2,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index
+        )
 
       path = address_internal_transaction_path(conn, :index, address)
       conn = get(conn, path)
@@ -145,7 +158,7 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
 
     test "next_page_params exist if not on last page", %{conn: conn} do
       address = insert(:address)
-      block = %Block{number: number} = insert(:block)
+      block = %Block{number: number} = insert(:block, number: 7000)
 
       transaction =
         %Transaction{index: transaction_index} =
@@ -159,7 +172,9 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
           :internal_transaction,
           transaction: transaction,
           from_address: address,
-          index: index
+          index: index,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index
         )
       end)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_internal_transaction_controller_test.exs
@@ -38,10 +38,22 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
       transaction =
         :transaction
         |> insert()
-        |> with_block()
+        |> with_block(insert(:block, number: 1))
 
-      expected_internal_transaction = insert(:internal_transaction, transaction: transaction, index: 0)
-      insert(:internal_transaction, transaction: transaction, index: 1)
+      expected_internal_transaction =
+        insert(:internal_transaction,
+          transaction: transaction,
+          index: 0,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index
+        )
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        transaction_index: transaction.index,
+        block_number: transaction.block_number
+      )
 
       path = transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, transaction.hash)
 
@@ -71,11 +83,16 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
         :transaction
         |> insert(to_address: nil)
         |> with_contract_creation(contract_address)
-        |> with_block()
+        |> with_block(insert(:block, number: 7000))
 
       internal_transaction =
         :internal_transaction_create
-        |> insert(transaction: transaction, index: 0)
+        |> insert(
+          transaction: transaction,
+          index: 0,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index
+        )
         |> with_contract_creation(contract_address)
 
       conn =
@@ -95,13 +112,26 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
       transaction =
         :transaction
         |> insert()
-        |> with_block()
+        |> with_block(insert(:block, number: 7000))
 
-      %InternalTransaction{index: index} = insert(:internal_transaction, transaction: transaction, index: 0)
+      %InternalTransaction{index: index} =
+        insert(:internal_transaction,
+          transaction: transaction,
+          index: 0,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index
+        )
 
       second_page_indexes =
         1..50
-        |> Enum.map(fn index -> insert(:internal_transaction, transaction: transaction, index: index) end)
+        |> Enum.map(fn index ->
+          insert(:internal_transaction,
+            transaction: transaction,
+            index: index,
+            block_number: transaction.block_number,
+            transaction_index: transaction.index
+          )
+        end)
         |> Enum.map(& &1.index)
 
       conn =
@@ -117,7 +147,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
     end
 
     test "next_page_params exist if not on last page", %{conn: conn} do
-      block = %Block{number: number} = insert(:block)
+      block = %Block{number: number} = insert(:block, number: 7000)
 
       transaction =
         %Transaction{index: transaction_index} =
@@ -130,7 +160,9 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
         insert(
           :internal_transaction,
           transaction: transaction,
-          index: index
+          index: index,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index
         )
       end)
 
@@ -144,14 +176,16 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
       transaction =
         :transaction
         |> insert()
-        |> with_block()
+        |> with_block(insert(:block, number: 7000))
 
       1..2
       |> Enum.map(fn index ->
         insert(
           :internal_transaction,
           transaction: transaction,
-          index: index
+          index: index,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index
         )
       end)
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -124,6 +124,7 @@ defmodule Explorer.Chain do
     InternalTransaction
     |> InternalTransaction.where_address_fields_match(hash, direction)
     |> InternalTransaction.where_is_different_from_parent_transaction()
+    |> InternalTransaction.where_block_number_is_not_null()
     |> page_internal_transaction(paging_options)
     |> limit(^paging_options.page_size)
     |> order_by(

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -476,4 +476,8 @@ defmodule Explorer.Chain.InternalTransaction do
       (it.type == ^:call and it.index > 0) or it.type != ^:call
     )
   end
+
+  def where_block_number_is_not_null(query) do
+    where(query, [t], not is_nil(t.block_number))
+  end
 end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1262,7 +1262,13 @@ defmodule Explorer.ChainTest do
   describe "address_to_internal_transactions/1" do
     test "with single transaction containing two internal transactions" do
       address = insert(:address)
-      transaction = insert(:transaction)
+
+      block = insert(:block, number: 2000)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block)
 
       %InternalTransaction{id: first_id} =
         insert(:internal_transaction,
@@ -1293,7 +1299,12 @@ defmodule Explorer.ChainTest do
 
     test "loads associations in necessity_by_association" do
       address = insert(:address)
-      transaction = insert(:transaction, to_address: address)
+      block = insert(:block, number: 2000)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block)
 
       insert(:internal_transaction,
         transaction: transaction,
@@ -1341,7 +1352,12 @@ defmodule Explorer.ChainTest do
     test "returns results in reverse chronological order by block number, transaction index, internal transaction index" do
       address = insert(:address)
 
-      pending_transaction = insert(:transaction)
+      block = insert(:block, number: 7000)
+
+      pending_transaction =
+        :transaction
+        |> insert()
+        |> with_block(block)
 
       %InternalTransaction{id: first_pending} =
         insert(


### PR DESCRIPTION
## Motivation

After the merge of the Internal Transaction listing performance an error started to show:

```
18:40:26.599 [error] #PID<0.714.0> running BlockScoutWeb.Endpoint terminated
Server: localhost:4000 (http)
Request: GET /address/0x2a0c0dbecc7e4d658f48e01e3fa353f44050c208/internal_transactions
** (exit) an exception was raised:
    ** (ArgumentError) cannot convert nil to param
        (phoenix) lib/phoenix/param.ex:67: Phoenix.Param.Atom.to_param/1
        (block_scout_web) lib/block_scout_web/router.ex:1: BlockScoutWeb.Router.Helpers.block_path/4
        (block_scout_web) lib/block_scout_web/templates/internal_transaction/_tile.html.eex:23: BlockScoutWeb.InternalTransactionView."_tile.html"/1
        (block_scout_web) lib/block_scout_web/templates/address_internal_transaction/index.html.eex:61: anonymous fn/3 in BlockScoutWeb.AddressInternalTransactionView."index.html"/1
        (elixir) lib/enum.ex:1925: Enum."-reduce/3-lists^foldl/2-0-"/3
        (block_scout_web) lib/block_scout_web/templates/address_internal_transaction/index.html.eex:60: BlockScoutWeb.AddressInternalTransactionView."index.html"/1
        (block_scout_web) lib/block_scout_web/templates/layout/app.html.eex:39: BlockScoutWeb.LayoutView."app.html"/1
        (phoenix) lib/phoenix/view.ex:332: Phoenix.View.render_to_iodata/3
        (block_scout_web) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.instrument/4
        (phoenix) lib/phoenix/controller.ex:740: Phoenix.Controller.do_render/4
        (block_scout_web) lib/block_scout_web/controllers/address_internal_transaction_controller.ex:1: BlockScoutWeb.AddressInternalTransactionController.action/2
        (block_scout_web) lib/block_scout_web/controllers/address_internal_transaction_controller.ex:1: BlockScoutWeb.AddressInternalTransactionController.phoenix_controller_pipeline/2
        (block_scout_web) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.instrument/4
        (phoenix) lib/phoenix/router.ex:278: Phoenix.Router.__call__/1
        (block_scout_web) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.plug_builder_call/2
        (block_scout_web) lib/plug/debugger.ex:99: BlockScoutWeb.Endpoint."call (overridable 3)"/2
        (block_scout_web) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.call/2
        (plug) lib/plug/adapters/cowboy/handler.ex:15: Plug.Adapters.Cowboy.Handler.upgrade/4
        (cowboy) 
```

## Changelog

### Bug Fixes
* After the query optimization in the `Internal Transaction` listing, we removed the `join` with the `transactions ` table, but at the view there were still some calls to this `join` that needed to be removed. 
* There are some blocks with null information that were raising errors on the `internal transaction` listing, now there is a check to this.

