### PR TITLE
Prevent stampedes via sleeping for throttle_timeout even when request is not made

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
@@ -67,6 +67,8 @@ defmodule EthereumJSONRPC.RequestCoordinator do
       |> transport.json_rpc(transport_options)
       |> handle_transport_response()
     else
+      :timer.sleep(throttle_timeout)
+
       {:error, :timeout}
     end
   end


### PR DESCRIPTION
## Motivation

Currently we are seeing a large amount of immediate timeouts due to the first implementation of how we handle throttle_timeout. The idea was that if we knew we were going to timeout eventually, why not just timeout immediately and let the caller go on with their day. @alexgaribay pointed out at the time that may have unexpected behavior, and we're seeing that behavior now. Callers fail and then repeatedly call until they reach their restart limit and crash.

## Changelog

### Bug Fixes
Prevent stampedes via sleeping for the `throttle_timeout`, even when we've decided not to make the request to the API.
