### PR TITLE
Composite primary keys and eliminating use of on_conflict: replace_all

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
@@ -1,4 +1,4 @@
-<div class="tile tile-type-internal-transaction fade-in" data-test="internal_transaction" data-internal-transaction-id="<%= @internal_transaction.id %>">
+<div class="tile tile-type-internal-transaction fade-in" data-test="internal_transaction" data-internal-transaction-transaction-hash="<%= @internal_transaction.transaction_hash %>" data-internal-transaction-index="<%= @internal_transaction.index %>">
   <div class="row">
     <div class="col-md-2 d-flex flex-row flex-md-column align-items-left justify-content-start justify-content-lg-center mb-1 mb-md-0 pl-md-4">
       <%= gettext("Internal Transaction") %>

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
@@ -50,12 +50,18 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
       path = address_internal_transaction_path(conn, :index, address)
       conn = get(conn, path)
 
-      actual_transaction_ids =
-        conn.assigns.internal_transactions
-        |> Enum.map(fn internal_transaction -> internal_transaction.id end)
+      actual_internal_transaction_primary_keys =
+        Enum.map(conn.assigns.internal_transactions, &{&1.transaction_hash, &1.index})
 
-      assert Enum.member?(actual_transaction_ids, from_internal_transaction.id)
-      assert Enum.member?(actual_transaction_ids, to_internal_transaction.id)
+      assert Enum.member?(
+               actual_internal_transaction_primary_keys,
+               {from_internal_transaction.transaction_hash, from_internal_transaction.index}
+             )
+
+      assert Enum.member?(
+               actual_internal_transaction_primary_keys,
+               {to_internal_transaction.transaction_hash, to_internal_transaction.index}
+             )
     end
 
     test "includes USD exchange rate value for address in assigns", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_internal_transaction_controller_test.exs
@@ -59,13 +59,12 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
 
       conn = get(conn, path)
 
-      actual_internal_transaction_ids =
-        conn.assigns.internal_transactions
-        |> Enum.map(fn it -> it.id end)
+      actual_internal_transaction_primary_keys =
+        Enum.map(conn.assigns.internal_transactions, &{&1.transaction_hash, &1.index})
 
       assert html_response(conn, 200)
 
-      assert Enum.member?(actual_internal_transaction_ids, expected_internal_transaction.id)
+      assert {expected_internal_transaction.transaction_hash, expected_internal_transaction.index} in actual_internal_transaction_primary_keys
     end
 
     test "includes USD exchange rate value for address in assigns", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_token_transfer_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_token_transfer_controller_test.exs
@@ -12,7 +12,10 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
 
       conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
 
-      assert List.first(conn.assigns.transaction.token_transfers).id == token_transfer.id
+      assigned_token_transfer = List.first(conn.assigns.transaction.token_transfers)
+
+      assert {assigned_token_transfer.transaction_hash, assigned_token_transfer.log_index} ==
+               {token_transfer.transaction_hash, token_transfer.log_index}
     end
 
     test "with missing transaction", %{conn: conn} do
@@ -53,13 +56,16 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
 
       conn = get(conn, path)
 
-      actual_token_transfer_ids =
+      actual_token_transfer_primary_keys =
         conn.assigns.token_transfers
-        |> Enum.map(fn it -> it.id end)
+        |> Enum.map(&{&1.transaction_hash, &1.log_index})
 
       assert html_response(conn, 200)
 
-      assert Enum.member?(actual_token_transfer_ids, expected_token_transfer.id)
+      assert Enum.member?(
+               actual_token_transfer_primary_keys,
+               {expected_token_transfer.transaction_hash, expected_token_transfer.log_index}
+             )
     end
 
     test "includes USD exchange rate value for address in assigns", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
@@ -75,20 +75,36 @@ defmodule BlockScoutWeb.AddressPage do
     css("[data-test='address_detail_hash']", text: to_string(address_hash))
   end
 
-  def internal_transaction(%InternalTransaction{id: id}) do
-    css("[data-test='internal_transaction'][data-internal-transaction-id='#{id}']")
+  def internal_transaction(%InternalTransaction{transaction_hash: transaction_hash, index: index}) do
+    css(
+      "[data-test='internal_transaction']" <>
+        "[data-internal-transaction-transaction-hash='#{transaction_hash}']" <>
+        "[data-internal-transaction-index='#{index}']"
+    )
   end
 
   def internal_transactions(count: count) do
     css("[data-test='internal_transaction']", count: count)
   end
 
-  def internal_transaction_address_link(%InternalTransaction{id: id, from_address_hash: address_hash}, :from) do
-    css("[data-internal-transaction-id='#{id}'] [data-test='address_hash_link'] [data-address-hash='#{address_hash}']")
+  def internal_transaction_address_link(
+        %InternalTransaction{transaction_hash: transaction_hash, index: index, from_address_hash: address_hash},
+        :from
+      ) do
+    css(
+      "[data-internal-transaction-transaction-hash='#{transaction_hash}'][data-internal-transaction-index='#{index}']" <>
+        " [data-test='address_hash_link']" <> " [data-address-hash='#{address_hash}']"
+    )
   end
 
-  def internal_transaction_address_link(%InternalTransaction{id: id, to_address_hash: address_hash}, :to) do
-    css("[data-internal-transaction-id='#{id}'] [data-test='address_hash_link'] [data-address-hash='#{address_hash}']")
+  def internal_transaction_address_link(
+        %InternalTransaction{transaction_hash: transaction_hash, index: index, to_address_hash: address_hash},
+        :to
+      ) do
+    css(
+      "[data-internal-transaction-transaction-hash='#{transaction_hash}'][data-internal-transaction-index='#{index}']" <>
+        " [data-test='address_hash_link']" <> " [data-address-hash='#{address_hash}']"
+    )
   end
 
   def pending_transaction(%Transaction{hash: transaction_hash}), do: pending_transaction(transaction_hash)

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_app_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_app_test.exs
@@ -7,9 +7,11 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   describe "loading bar when indexing" do
     test "shows blocks indexed percentage", %{session: session} do
-      for index <- 6..10 do
+      for index <- 5..9 do
         insert(:block, number: index)
       end
+
+      assert Explorer.Chain.indexed_ratio() == 0.5
 
       session
       |> AppPage.visit_page()
@@ -17,9 +19,11 @@ defmodule BlockScoutWeb.ViewingAppTest do
     end
 
     test "shows tokens loading", %{session: session} do
-      for index <- 1..10 do
+      for index <- 0..9 do
         insert(:block, number: index)
       end
+
+      assert Explorer.Chain.indexed_ratio() == 1.0
 
       session
       |> AppPage.visit_page()
@@ -27,30 +31,34 @@ defmodule BlockScoutWeb.ViewingAppTest do
     end
 
     test "live updates blocks indexed percentage", %{session: session} do
-      for index <- 6..10 do
+      for index <- 5..9 do
         insert(:block, number: index)
       end
+
+      assert Explorer.Chain.indexed_ratio() == 0.5
 
       session
       |> AppPage.visit_page()
       |> assert_has(AppPage.indexed_status("50% Blocks Indexed"))
 
-      insert(:block, number: 5)
+      insert(:block, number: 4)
       Notifier.handle_event({:chain_event, :blocks, :catchup, []})
 
       assert_has(session, AppPage.indexed_status("60% Blocks Indexed"))
     end
 
     test "live updates when blocks are fully indexed", %{session: session} do
-      for index <- 2..10 do
+      for index <- 1..9 do
         insert(:block, number: index)
       end
+
+      assert Explorer.Chain.indexed_ratio() == 0.9
 
       session
       |> AppPage.visit_page()
       |> assert_has(AppPage.indexed_status("90% Blocks Indexed"))
 
-      insert(:block, number: 1)
+      insert(:block, number: 0)
       Notifier.handle_event({:chain_event, :blocks, :catchup, []})
 
       assert_has(session, AppPage.indexed_status("Indexing Tokens"))
@@ -58,9 +66,11 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
     test "live removes message when chain is indexed", %{session: session} do
       [block | _] =
-        for index <- 1..10 do
+        for index <- 0..9 do
           insert(:block, number: index)
         end
+
+      assert Explorer.Chain.indexed_ratio() == 1.0
 
       session
       |> AppPage.visit_page()

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_transactions_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_transactions_test.exs
@@ -9,7 +9,6 @@ defmodule BlockScoutWeb.ViewingTransactionsTest do
   setup do
     block =
       insert(:block, %{
-        number: 555,
         timestamp: Timex.now() |> Timex.shift(hours: -2),
         gas_used: 123_987
       })

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -883,7 +883,7 @@ defmodule Explorer.Chain do
 
   """
   def internal_transaction_count do
-    Repo.aggregate(InternalTransaction, :count, :id)
+    Repo.one!(from(it in "internal_transactions", select: fragment("COUNT(*)")))
   end
 
   @doc """
@@ -1894,7 +1894,7 @@ defmodule Explorer.Chain do
       internal_transaction.type != ^:call or
         fragment(
           """
-          (SELECT COUNT(sibling.id)
+          (SELECT COUNT(sibling.*)
           FROM internal_transactions AS sibling
           WHERE sibling.transaction_hash = ?
           LIMIT 2

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1167,7 +1167,7 @@ defmodule Explorer.Chain do
 
   """
   def log_count do
-    Repo.aggregate(Log, :count, :id)
+    Repo.one!(from(log in "logs", select: fragment("COUNT(*)")))
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -842,7 +842,7 @@ defmodule Explorer.Chain do
   @doc """
   The percentage of indexed blocks on the chain.
 
-      iex> for index <- 6..10 do
+      iex> for index <- 5..9 do
       ...>   insert(:block, number: index)
       ...> end
       iex> Explorer.Chain.indexed_ratio()
@@ -859,7 +859,7 @@ defmodule Explorer.Chain do
     with {:ok, min_block_number} <- min_block_number(),
          {:ok, max_block_number} <- max_block_number() do
       indexed_blocks = max_block_number - min_block_number + 1
-      indexed_blocks / max_block_number
+      indexed_blocks / (max_block_number + 1)
     else
       {:error, _} -> 0
     end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1967,7 +1967,7 @@ defmodule Explorer.Chain do
         left_join: tf in TokenTransfer,
         on: tf.transaction_hash == l.transaction_hash and tf.log_index == l.index,
         where: l.first_topic == unquote(TokenTransfer.constant()),
-        where: is_nil(tf.id),
+        where: is_nil(tf.transaction_hash) and is_nil(tf.log_index),
         select: t.block_number,
         distinct: t.block_number
       )

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2038,7 +2038,7 @@ defmodule Explorer.Chain do
     token_changeset = Token.changeset(token, params)
     address_name_changeset = Address.Name.changeset(%Address.Name{}, Map.put(params, :address_hash, address_hash))
 
-    token_opts = [on_conflict: :replace_all, conflict_target: :contract_address_hash]
+    token_opts = [on_conflict: Import.Tokens.default_on_conflict(), conflict_target: :contract_address_hash]
     address_name_opts = [on_conflict: :nothing, conflict_target: [:address_hash, :name]]
 
     insert_result =

--- a/apps/explorer/lib/explorer/chain/import/address/coin_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/address/coin_balances.ex
@@ -35,12 +35,16 @@ defmodule Explorer.Chain.Import.Address.CoinBalances do
   end
 
   @impl Import.Runner
-  def run(multi, changes_list, options) when is_map(options) do
-    timestamps = Map.fetch!(options, :timestamps)
-    timeout = options[option_key()][:timeout] || @timeout
+  def run(multi, changes_list, %{timestamps: timestamps} = options) do
+    insert_options =
+      options
+      |> Map.get(option_key(), %{})
+      |> Map.take(~w(on_conflict timeout)a)
+      |> Map.put_new(:timeout, @timeout)
+      |> Map.put(:timestamps, timestamps)
 
     Multi.run(multi, :address_coin_balances, fn _ ->
-      insert(changes_list, %{timeout: timeout, timestamps: timestamps})
+      insert(changes_list, insert_options)
     end)
   end
 
@@ -56,6 +60,7 @@ defmodule Explorer.Chain.Import.Address.CoinBalances do
             }
           ],
           %{
+            optional(:on_conflict) => Import.Runner.on_conflict(),
             required(:timeout) => timeout,
             required(:timestamps) => Import.timestamps()
           }

--- a/apps/explorer/lib/explorer/chain/import/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/internal_transactions.ex
@@ -69,7 +69,7 @@ defmodule Explorer.Chain.Import.InternalTransactions do
         conflict_target: [:transaction_hash, :index],
         for: InternalTransaction,
         on_conflict: on_conflict,
-        returning: [:id, :index, :transaction_hash],
+        returning: [:transaction_hash, :index],
         timeout: timeout,
         timestamps: timestamps
       )

--- a/apps/explorer/lib/explorer/chain/import/token_transfers.ex
+++ b/apps/explorer/lib/explorer/chain/import/token_transfers.ex
@@ -32,12 +32,16 @@ defmodule Explorer.Chain.Import.TokenTransfers do
   end
 
   @impl Import.Runner
-  def run(multi, changes_list, options) when is_map(options) do
-    timestamps = Map.fetch!(options, :timestamps)
-    timeout = options[option_key()][:timeout] || @timeout
+  def run(multi, changes_list, %{timestamps: timestamps} = options) do
+    insert_options =
+      options
+      |> Map.get(option_key(), %{})
+      |> Map.take(~w(on_conflict timeout)a)
+      |> Map.put_new(:timeout, @timeout)
+      |> Map.put(:timestamps, timestamps)
 
     Multi.run(multi, :token_transfers, fn _ ->
-      insert(changes_list, %{timeout: timeout, timestamps: timestamps})
+      insert(changes_list, insert_options)
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/tokens.ex
@@ -5,6 +5,8 @@ defmodule Explorer.Chain.Import.Tokens do
 
   require Ecto.Query
 
+  import Ecto.Query, only: [from: 2]
+
   alias Ecto.Multi
   alias Explorer.Chain.{Import, Token}
 
@@ -50,28 +52,40 @@ defmodule Explorer.Chain.Import.Tokens do
           required(:on_conflict) => Import.Runner.on_conflict(),
           required(:timeout) => timeout(),
           required(:timestamps) => Import.timestamps()
-        }) ::
-          {:ok, [Token.t()]}
-          | {:error, {:required, :on_conflict}}
+        }) :: {:ok, [Token.t()]}
   def insert(changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
-    case options do
-      %{on_conflict: on_conflict} ->
-        # order so that row ShareLocks are grabbed in a consistent order
-        ordered_changes_list = Enum.sort_by(changes_list, & &1.contract_address_hash)
+    on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
+    # order so that row ShareLocks are grabbed in a consistent order
+    ordered_changes_list = Enum.sort_by(changes_list, & &1.contract_address_hash)
 
-        {:ok, _} =
-          Import.insert_changes_list(
-            ordered_changes_list,
-            conflict_target: :contract_address_hash,
-            on_conflict: on_conflict,
-            for: Token,
-            returning: true,
-            timeout: timeout,
-            timestamps: timestamps
-          )
+    {:ok, _} =
+      Import.insert_changes_list(
+        ordered_changes_list,
+        conflict_target: :contract_address_hash,
+        on_conflict: on_conflict,
+        for: Token,
+        returning: true,
+        timeout: timeout,
+        timestamps: timestamps
+      )
+  end
 
-      _ ->
-        {:error, {:required, :on_conflict}}
-    end
+  def default_on_conflict do
+    from(
+      token in Token,
+      update: [
+        set: [
+          name: fragment("EXCLUDED.name"),
+          symbol: fragment("EXCLUDED.symbol"),
+          total_supply: fragment("EXCLUDED.total_supply"),
+          decimals: fragment("EXCLUDED.decimals"),
+          type: fragment("EXCLUDED.type"),
+          cataloged: fragment("EXCLUDED.cataloged"),
+          # Don't update `contract_address_hash` as it is the primary key and used for the conflict target
+          inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", token.inserted_at),
+          updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", token.updated_at)
+        ]
+      ]
+    )
   end
 end

--- a/apps/explorer/lib/explorer/chain/import/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/tokens.ex
@@ -30,12 +30,16 @@ defmodule Explorer.Chain.Import.Tokens do
   end
 
   @impl Import.Runner
-  def run(multi, changes_list, options) when is_map(options) do
-    %{timestamps: timestamps, tokens: %{on_conflict: on_conflict}} = options
-    timeout = options[option_key()][:timeout] || @timeout
+  def run(multi, changes_list, %{timestamps: timestamps} = options) do
+    insert_options =
+      options
+      |> Map.get(option_key(), %{})
+      |> Map.take(~w(on_conflict timeout)a)
+      |> Map.put_new(:timeout, @timeout)
+      |> Map.put(:timestamps, timestamps)
 
     Multi.run(multi, :tokens, fn _ ->
-      insert(changes_list, %{on_conflict: on_conflict, timeout: timeout, timestamps: timestamps})
+      insert(changes_list, insert_options)
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/transactions.ex
@@ -32,14 +32,13 @@ defmodule Explorer.Chain.Import.Transactions do
   end
 
   @impl Import.Runner
-  def run(multi, changes_list, options) when is_map(options) do
-    %{timestamps: timestamps, transactions: transactions_options} = options
-
+  def run(multi, changes_list, %{timestamps: timestamps} = options) do
     insert_options =
-      transactions_options
+      options
+      |> Map.get(option_key(), %{})
       |> Map.take(~w(on_conflict timeout)a)
       |> Map.put_new(:timeout, @timeout)
-      |> Map.put_new(:timestamps, timestamps)
+      |> Map.put(:timestamps, timestamps)
 
     Multi.run(multi, :transactions, fn _ ->
       insert(changes_list, insert_options)

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -49,13 +49,14 @@ defmodule Explorer.Chain.InternalTransaction do
           value: Wei.t()
         }
 
+  @primary_key false
   schema "internal_transactions" do
     field(:call_type, CallType)
     field(:created_contract_code, Data)
     field(:error, :string)
     field(:gas, :decimal)
     field(:gas_used, :decimal)
-    field(:index, :integer)
+    field(:index, :integer, primary_key: true)
     field(:init, Data)
     field(:input, Data)
     field(:output, Data)
@@ -91,7 +92,12 @@ defmodule Explorer.Chain.InternalTransaction do
       type: Hash.Address
     )
 
-    belongs_to(:transaction, Transaction, foreign_key: :transaction_hash, references: :hash, type: Hash.Full)
+    belongs_to(:transaction, Transaction,
+      foreign_key: :transaction_hash,
+      primary_key: true,
+      references: :hash,
+      type: Hash.Full
+    )
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -7,6 +7,7 @@ defmodule Explorer.Chain.InternalTransaction do
   alias Explorer.Chain.InternalTransaction.{CallType, Type}
 
   @typedoc """
+   * `block_number` - the `t:Explorer.Chain.Block.t/0` `number` that the `transaction` is collated into.
    * `call_type` - the type of call.  `nil` when `type` is not `:call`.
    * `created_contract_code` - the code of the contract that was created when `type` is `:create`.
    * `error` - error message when `:call` or `:create` `type` errors
@@ -23,13 +24,15 @@ defmodule Explorer.Chain.InternalTransaction do
    * `trace_address` - list of traces
    * `transaction` - transaction in which this transaction occurred
    * `transaction_hash` - foreign key for `transaction`
+   * `transaction_index` - the `t:Explorer.Chain.Transaction.t/0` `index` of `transaction` in `block_number`.
    * `type` - type of internal transaction
    * `value` - value of transferred from `from_address` to `to_address`
   """
   @type t :: %__MODULE__{
+          block_number: Explorer.Chain.Block.block_number() | nil,
           call_type: CallType.t() | nil,
           created_contract_address: %Ecto.Association.NotLoaded{} | Address.t() | nil,
-          created_contract_address_hash: Explorer.Chain.Hash.t() | nil,
+          created_contract_address_hash: Hash.t() | nil,
           created_contract_code: Data.t() | nil,
           error: String.t(),
           from_address: %Ecto.Association.NotLoaded{} | Address.t(),
@@ -44,7 +47,8 @@ defmodule Explorer.Chain.InternalTransaction do
           to_address_hash: Hash.Address.t() | nil,
           trace_address: [non_neg_integer()],
           transaction: %Ecto.Association.NotLoaded{} | Transaction.t(),
-          transaction_hash: Explorer.Chain.Hash.t(),
+          transaction_hash: Hash.t(),
+          transaction_index: Transaction.transaction_index() | nil,
           type: Type.t(),
           value: Wei.t()
         }

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -35,11 +35,12 @@ defmodule Explorer.Chain.Log do
           type: String.t() | nil
         }
 
+  @primary_key false
   schema "logs" do
     field(:data, Data)
     field(:first_topic, :string)
     field(:fourth_topic, :string)
-    field(:index, :integer)
+    field(:index, :integer, primary_key: true)
     field(:second_topic, :string)
     field(:third_topic, :string)
     field(:type, :string)
@@ -47,7 +48,13 @@ defmodule Explorer.Chain.Log do
     timestamps()
 
     belongs_to(:address, Address, foreign_key: :address_hash, references: :hash, type: Hash.Address)
-    belongs_to(:transaction, Transaction, foreign_key: :transaction_hash, references: :hash, type: Hash.Full)
+
+    belongs_to(:transaction, Transaction,
+      foreign_key: :transaction_hash,
+      primary_key: true,
+      references: :hash,
+      type: Hash.Full
+    )
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -13,12 +13,12 @@ defmodule Explorer.Chain.Log do
    * `address_hash` - foreign key for `address`
    * `data` - non-indexed log parameters.
    * `first_topic` - `topics[0]`
-   * `fourth_topic` - `topics[3]`
-   * `index` - index of the log entry in all logs for the `transaction`
    * `second_topic` - `topics[1]`
+   * `third_topic` - `topics[2]`
+   * `fourth_topic` - `topics[3]`
    * `transaction` - transaction for which `log` is
    * `transaction_hash` - foreign key for `transaction`.
-   * `third_topic` - `topics[2]`
+   * `index` - index of the log entry in all logs for the `transaction`
    * `type` - type of event.  *Parity-only*
   """
   @type t :: %__MODULE__{
@@ -26,12 +26,12 @@ defmodule Explorer.Chain.Log do
           address_hash: Hash.Address.t(),
           data: Data.t(),
           first_topic: String.t(),
-          fourth_topic: String.t(),
-          index: non_neg_integer(),
           second_topic: String.t(),
+          third_topic: String.t(),
+          fourth_topic: String.t(),
           transaction: %Ecto.Association.NotLoaded{} | Transaction.t(),
           transaction_hash: Hash.Full.t(),
-          third_topic: String.t(),
+          index: non_neg_integer(),
           type: String.t() | nil
         }
 
@@ -39,10 +39,10 @@ defmodule Explorer.Chain.Log do
   schema "logs" do
     field(:data, Data)
     field(:first_topic, :string)
-    field(:fourth_topic, :string)
-    field(:index, :integer, primary_key: true)
     field(:second_topic, :string)
     field(:third_topic, :string)
+    field(:fourth_topic, :string)
+    field(:index, :integer, primary_key: true)
     field(:type, :string)
 
     timestamps()

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -62,9 +62,10 @@ defmodule Explorer.Chain.TokenTransfer do
 
   @constant "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 
+  @primary_key false
   schema "token_transfers" do
     field(:amount, :decimal)
-    field(:log_index, :integer)
+    field(:log_index, :integer, primary_key: true)
     field(:token_id, :decimal)
 
     belongs_to(:from_address, Address, foreign_key: :from_address_hash, references: :hash, type: Hash.Address)
@@ -78,7 +79,12 @@ defmodule Explorer.Chain.TokenTransfer do
       type: Hash.Address
     )
 
-    belongs_to(:transaction, Transaction, foreign_key: :transaction_hash, references: :hash, type: Hash.Full)
+    belongs_to(:transaction, Transaction,
+      foreign_key: :transaction_hash,
+      primary_key: true,
+      references: :hash,
+      type: Hash.Full
+    )
 
     has_one(:token, through: [:token_contract_address, :token])
 
@@ -195,7 +201,7 @@ defmodule Explorer.Chain.TokenTransfer do
         tt in TokenTransfer,
         join: t in Token,
         on: tt.token_contract_address_hash == t.contract_address_hash,
-        select: {tt.token_contract_address_hash, count(tt.id)},
+        select: {tt.token_contract_address_hash, fragment("COUNT(*)")},
         group_by: tt.token_contract_address_hash
       )
 

--- a/apps/explorer/priv/repo/migrations/20181024141113_internal_transactions_composite_primary_key.exs
+++ b/apps/explorer/priv/repo/migrations/20181024141113_internal_transactions_composite_primary_key.exs
@@ -1,0 +1,22 @@
+defmodule Explorer.Repo.Migrations.InternalTransactionsCompositePrimaryKey do
+  use Ecto.Migration
+
+  def up do
+    # Remove old id
+    alter table(:internal_transactions) do
+      remove(:id)
+    end
+
+    # Don't use `modify` as it requires restating the whole column description
+    execute("ALTER TABLE internal_transactions ADD PRIMARY KEY (transaction_hash, index)")
+  end
+
+  def down do
+    execute("ALTER TABLE internal_transactions DROP CONSTRAINT internal_transactions_pkey")
+
+    # Add back old id
+    alter table(:internal_transactions) do
+      add(:id, :bigserial, primary_key: true)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20181024164623_logs_composite_primary_key.exs
+++ b/apps/explorer/priv/repo/migrations/20181024164623_logs_composite_primary_key.exs
@@ -1,0 +1,22 @@
+defmodule Explorer.Repo.Migrations.LogsCompositePrimaryKey do
+  use Ecto.Migration
+
+  def up do
+    # Remove old id
+    alter table(:logs) do
+      remove(:id)
+    end
+
+    # Don't use `modify` as it requires restating the whole column description
+    execute("ALTER TABLE logs ADD PRIMARY KEY (transaction_hash, index)")
+  end
+
+  def down do
+    execute("ALTER TABLE logs DROP CONSTRAINT logs_pkey")
+
+    # Add back old id
+    alter table(:logs) do
+      add(:id, :bigserial, primary_key: true)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20181024172010_token_transfers_composite_primary_key.exs
+++ b/apps/explorer/priv/repo/migrations/20181024172010_token_transfers_composite_primary_key.exs
@@ -1,0 +1,22 @@
+defmodule Explorer.Repo.Migrations.TokenTransfersCompositePrimaryKey do
+  use Ecto.Migration
+
+  def up do
+    # Remove old id
+    alter table(:token_transfers) do
+      remove(:id)
+    end
+
+    # Don't use `modify` as it requires restating the whole column description
+    execute("ALTER TABLE token_transfers ADD PRIMARY KEY (transaction_hash, log_index)")
+  end
+
+  def down do
+    execute("ALTER TABLE token_transfers DROP CONSTRAINT token_transfers_pkey")
+
+    # Add back old id
+    alter table(:token_transfers) do
+      add(:id, :bigserial, primary_key: true)
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -429,7 +429,9 @@ defmodule Explorer.Chain.ImportTest do
     test "publishes internal_transaction data to subscribers on insert" do
       Chain.subscribe_to_events(:internal_transactions)
       Import.all(@import_data)
-      assert_received {:chain_event, :internal_transactions, :realtime, [%{id: _}, %{id: _}]}
+
+      assert_received {:chain_event, :internal_transactions, :realtime,
+                       [%{transaction_hash: _, index: _}, %{transaction_hash: _, index: _}]}
     end
 
     test "publishes log data to subscribers on insert" do

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -1476,7 +1476,6 @@ defmodule Explorer.Chain.ImportTest do
                  },
                  tokens: %{
                    params: [params_for(:token, contract_address_hash: token_contract_address_hash)],
-                   on_conflict: :replace_all,
                    timeout: 1
                  },
                  transactions: %{

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -95,7 +95,6 @@ defmodule Explorer.Chain.ImportTest do
         timeout: 5
       },
       transactions: %{
-        on_conflict: :replace_all,
         params: [
           %{
             block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
@@ -570,8 +569,7 @@ defmodule Explorer.Chain.ImportTest do
               v: 0,
               value: 0
             }
-          ],
-          on_conflict: :replace_all
+          ]
         },
         internal_transactions: %{
           params: [
@@ -662,8 +660,7 @@ defmodule Explorer.Chain.ImportTest do
               v: 0,
               value: 0
             }
-          ],
-          on_conflict: :replace_all
+          ]
         },
         internal_transactions: %{
           params: [
@@ -733,7 +730,6 @@ defmodule Explorer.Chain.ImportTest do
                    timeout: 5
                  },
                  transactions: %{
-                   on_conflict: :replace_all,
                    params: [
                      %{
                        block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
@@ -880,7 +876,6 @@ defmodule Explorer.Chain.ImportTest do
                  },
                  broadcast: false,
                  transactions: %{
-                   on_conflict: :replace_all,
                    params: [
                      %{
                        block_hash: "0x1f8cde8bd326702c49e065d56b08bdc82caa0c4820d914e27026c9c68ca1cf09",
@@ -1040,8 +1035,7 @@ defmodule Explorer.Chain.ImportTest do
                        v: 0,
                        value: 0
                      }
-                   ],
-                   on_conflict: :replace_all
+                   ]
                  },
                  transaction_forks: %{
                    params: [
@@ -1230,8 +1224,7 @@ defmodule Explorer.Chain.ImportTest do
                        value: 0,
                        status: :ok
                      }
-                   ],
-                   on_conflict: :replace_all
+                   ]
                  }
                })
 
@@ -1343,8 +1336,7 @@ defmodule Explorer.Chain.ImportTest do
                        value: 0,
                        status: :ok
                      }
-                   ],
-                   on_conflict: :replace_all
+                   ]
                  }
                })
 
@@ -1500,7 +1492,6 @@ defmodule Explorer.Chain.ImportTest do
                        cumulative_gas_used: 0
                      )
                    ],
-                   on_conflict: :replace_all,
                    timeout: 1
                  },
                  transaction_forks: %{
@@ -1713,8 +1704,7 @@ defmodule Explorer.Chain.ImportTest do
                        value: 0,
                        status: :error
                      }
-                   ],
-                   on_conflict: :replace_all
+                   ]
                  },
                  internal_transactions: %{
                    params: [

--- a/apps/explorer/test/explorer/chain/token_transfer_test.exs
+++ b/apps/explorer/test/explorer/chain/token_transfer_test.exs
@@ -50,12 +50,15 @@ defmodule Explorer.Chain.TokenTransferTest do
         token: token
       )
 
-      transfers_ids =
+      transfers_primary_keys =
         token_contract_address.hash
         |> TokenTransfer.fetch_token_transfers_from_token_hash([])
-        |> Enum.map(& &1.id)
+        |> Enum.map(&{&1.transaction_hash, &1.log_index})
 
-      assert transfers_ids == [another_transfer.id, token_transfer.id]
+      assert transfers_primary_keys == [
+               {another_transfer.transaction_hash, another_transfer.log_index},
+               {token_transfer.transaction_hash, token_transfer.log_index}
+             ]
     end
 
     test "when there isn't token transfers won't show anything" do
@@ -101,14 +104,14 @@ defmodule Explorer.Chain.TokenTransferTest do
 
       paging_options = %PagingOptions{key: first_page.inserted_at, page_size: 1}
 
-      token_transfers_ids_paginated =
+      token_transfers_primary_keys_paginated =
         TokenTransfer.fetch_token_transfers_from_token_hash(
           token_contract_address.hash,
           paging_options: paging_options
         )
-        |> Enum.map(& &1.id)
+        |> Enum.map(&{&1.transaction_hash, &1.log_index})
 
-      assert token_transfers_ids_paginated == [second_page.id]
+      assert token_transfers_primary_keys_paginated == [{second_page.transaction_hash, second_page.log_index}]
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1941,9 +1941,9 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block()
 
-      %Log{id: id} = insert(:log, transaction: transaction)
+      %Log{transaction_hash: transaction_hash, index: index} = insert(:log, transaction: transaction)
 
-      assert [%Log{id: ^id}] = Chain.transaction_to_logs(transaction)
+      assert [%Log{transaction_hash: ^transaction_hash, index: ^index}] = Chain.transaction_to_logs(transaction)
     end
 
     test "with logs can be paginated" do

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1270,7 +1270,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block(block)
 
-      %InternalTransaction{id: first_id} =
+      %InternalTransaction{transaction_hash: first_transaction_hash, index: first_index} =
         insert(:internal_transaction,
           index: 1,
           transaction: transaction,
@@ -1279,7 +1279,7 @@ defmodule Explorer.ChainTest do
           transaction_index: transaction.index
         )
 
-      %InternalTransaction{id: second_id} =
+      %InternalTransaction{transaction_hash: second_transaction_hash, index: second_index} =
         insert(:internal_transaction,
           index: 2,
           transaction: transaction,
@@ -1291,10 +1291,10 @@ defmodule Explorer.ChainTest do
       result =
         address
         |> Chain.address_to_internal_transactions()
-        |> Enum.map(& &1.id)
+        |> Enum.map(&{&1.transaction_hash, &1.index})
 
-      assert Enum.member?(result, first_id)
-      assert Enum.member?(result, second_id)
+      assert Enum.member?(result, {first_transaction_hash, first_index})
+      assert Enum.member?(result, {second_transaction_hash, second_index})
     end
 
     test "loads associations in necessity_by_association" do
@@ -1359,7 +1359,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block(block)
 
-      %InternalTransaction{id: first_pending} =
+      %InternalTransaction{transaction_hash: first_pending_transaction_hash, index: first_pending_index} =
         insert(
           :internal_transaction,
           transaction: pending_transaction,
@@ -1369,7 +1369,7 @@ defmodule Explorer.ChainTest do
           transaction_index: pending_transaction.index
         )
 
-      %InternalTransaction{id: second_pending} =
+      %InternalTransaction{transaction_hash: second_pending_transaction_hash, index: second_pending_index} =
         insert(
           :internal_transaction,
           transaction: pending_transaction,
@@ -1386,7 +1386,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block(a_block)
 
-      %InternalTransaction{id: first} =
+      %InternalTransaction{transaction_hash: first_transaction_hash, index: first_index} =
         insert(
           :internal_transaction,
           transaction: first_a_transaction,
@@ -1396,7 +1396,7 @@ defmodule Explorer.ChainTest do
           transaction_index: first_a_transaction.index
         )
 
-      %InternalTransaction{id: second} =
+      %InternalTransaction{transaction_hash: second_transaction_hash, index: second_index} =
         insert(
           :internal_transaction,
           transaction: first_a_transaction,
@@ -1411,7 +1411,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block(a_block)
 
-      %InternalTransaction{id: third} =
+      %InternalTransaction{transaction_hash: third_transaction_hash, index: third_index} =
         insert(
           :internal_transaction,
           transaction: second_a_transaction,
@@ -1421,7 +1421,7 @@ defmodule Explorer.ChainTest do
           transaction_index: second_a_transaction.index
         )
 
-      %InternalTransaction{id: fourth} =
+      %InternalTransaction{transaction_hash: fourth_transaction_hash, index: fourth_index} =
         insert(
           :internal_transaction,
           transaction: second_a_transaction,
@@ -1438,7 +1438,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block(b_block)
 
-      %InternalTransaction{id: fifth} =
+      %InternalTransaction{transaction_hash: fifth_transaction_hash, index: fifth_index} =
         insert(
           :internal_transaction,
           transaction: first_b_transaction,
@@ -1448,7 +1448,7 @@ defmodule Explorer.ChainTest do
           transaction_index: first_b_transaction.index
         )
 
-      %InternalTransaction{id: sixth} =
+      %InternalTransaction{transaction_hash: sixth_transaction_hash, index: sixth_index} =
         insert(
           :internal_transaction,
           transaction: first_b_transaction,
@@ -1461,9 +1461,18 @@ defmodule Explorer.ChainTest do
       result =
         address
         |> Chain.address_to_internal_transactions()
-        |> Enum.map(& &1.id)
+        |> Enum.map(&{&1.transaction_hash, &1.index})
 
-      assert [second_pending, first_pending, sixth, fifth, fourth, third, second, first] == result
+      assert [
+               {second_pending_transaction_hash, second_pending_index},
+               {first_pending_transaction_hash, first_pending_index},
+               {sixth_transaction_hash, sixth_index},
+               {fifth_transaction_hash, fifth_index},
+               {fourth_transaction_hash, fourth_index},
+               {third_transaction_hash, third_index},
+               {second_transaction_hash, second_index},
+               {first_transaction_hash, first_index}
+             ] == result
     end
 
     test "pages by {block_number, transaction_index, index}" do
@@ -1492,7 +1501,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block(a_block)
 
-      %InternalTransaction{id: first} =
+      %InternalTransaction{transaction_hash: first_transaction_hash, index: first_index} =
         insert(
           :internal_transaction,
           transaction: first_a_transaction,
@@ -1502,7 +1511,7 @@ defmodule Explorer.ChainTest do
           transaction_index: first_a_transaction.index
         )
 
-      %InternalTransaction{id: second} =
+      %InternalTransaction{transaction_hash: second_transaction_hash, index: second_index} =
         insert(
           :internal_transaction,
           transaction: first_a_transaction,
@@ -1517,7 +1526,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block(a_block)
 
-      %InternalTransaction{id: third} =
+      %InternalTransaction{transaction_hash: third_transaction_hash, index: third_index} =
         insert(
           :internal_transaction,
           transaction: second_a_transaction,
@@ -1527,7 +1536,7 @@ defmodule Explorer.ChainTest do
           transaction_index: second_a_transaction.index
         )
 
-      %InternalTransaction{id: fourth} =
+      %InternalTransaction{transaction_hash: fourth_transaction_hash, index: fourth_index} =
         insert(
           :internal_transaction,
           transaction: second_a_transaction,
@@ -1544,7 +1553,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block(b_block)
 
-      %InternalTransaction{id: fifth} =
+      %InternalTransaction{transaction_hash: fifth_transaction_hash, index: fifth_index} =
         insert(
           :internal_transaction,
           transaction: first_b_transaction,
@@ -1554,7 +1563,7 @@ defmodule Explorer.ChainTest do
           transaction_index: first_b_transaction.index
         )
 
-      %InternalTransaction{id: sixth} =
+      %InternalTransaction{transaction_hash: sixth_transaction_hash, index: sixth_index} =
         insert(
           :internal_transaction,
           transaction: first_b_transaction,
@@ -1566,28 +1575,45 @@ defmodule Explorer.ChainTest do
 
       # When paged, internal transactions need an associated block number, so `second_pending` and `first_pending` are
       # excluded.
-      assert [sixth, fifth, fourth, third, second, first] ==
+      assert [
+               {sixth_transaction_hash, sixth_index},
+               {fifth_transaction_hash, fifth_index},
+               {fourth_transaction_hash, fourth_index},
+               {third_transaction_hash, third_index},
+               {second_transaction_hash, second_index},
+               {first_transaction_hash, first_index}
+             ] ==
                address
                |> Chain.address_to_internal_transactions(
                  paging_options: %PagingOptions{key: {6001, 3, 2}, page_size: 8}
                )
-               |> Enum.map(& &1.id)
+               |> Enum.map(&{&1.transaction_hash, &1.index})
 
       # block number ==, transaction index ==, internal transaction index <
-      assert [fourth, third, second, first] ==
+      assert [
+               {fourth_transaction_hash, fourth_index},
+               {third_transaction_hash, third_index},
+               {second_transaction_hash, second_index},
+               {first_transaction_hash, first_index}
+             ] ==
                address
                |> Chain.address_to_internal_transactions(
                  paging_options: %PagingOptions{key: {6000, 0, 1}, page_size: 8}
                )
-               |> Enum.map(& &1.id)
+               |> Enum.map(&{&1.transaction_hash, &1.index})
 
       # block number ==, transaction index <
-      assert [fourth, third, second, first] ==
+      assert [
+               {fourth_transaction_hash, fourth_index},
+               {third_transaction_hash, third_index},
+               {second_transaction_hash, second_index},
+               {first_transaction_hash, first_index}
+             ] ==
                address
                |> Chain.address_to_internal_transactions(
                  paging_options: %PagingOptions{key: {6000, -1, -1}, page_size: 8}
                )
-               |> Enum.map(& &1.id)
+               |> Enum.map(&{&1.transaction_hash, &1.index})
 
       # block number <
       assert [] ==
@@ -1595,7 +1621,7 @@ defmodule Explorer.ChainTest do
                |> Chain.address_to_internal_transactions(
                  paging_options: %PagingOptions{key: {2000, -1, -1}, page_size: 8}
                )
-               |> Enum.map(& &1.id)
+               |> Enum.map(&{&1.transaction_hash, &1.index})
     end
 
     test "excludes internal transactions of type `call` when they are alone in the parent transaction" do
@@ -1637,7 +1663,7 @@ defmodule Explorer.ChainTest do
 
       actual = Enum.at(Chain.address_to_internal_transactions(address), 0)
 
-      assert actual.id == expected.id
+      assert {actual.transaction_hash, actual.index} == {expected.transaction_hash, expected.index}
     end
   end
 
@@ -1708,7 +1734,15 @@ defmodule Explorer.ChainTest do
       results = [internal_transaction | _] = Chain.transaction_to_internal_transactions(transaction)
 
       assert 2 == length(results)
-      assert Enum.all?(results, &(&1.id in [first.id, second.id]))
+
+      assert Enum.all?(
+               results,
+               &({&1.transaction_hash, &1.index} in [
+                   {first.transaction_hash, first.index},
+                   {second.transaction_hash, second.index}
+                 ])
+             )
+
       assert internal_transaction.transaction.block.number == block.number
     end
 
@@ -1781,7 +1815,7 @@ defmodule Explorer.ChainTest do
 
       actual = Enum.at(Chain.transaction_to_internal_transactions(transaction), 0)
 
-      assert actual.id == expected.id
+      assert {actual.transaction_hash, actual.index} == {expected.transaction_hash, expected.index}
     end
 
     test "includes internal transactions of type `reward` even when they are alone in the parent transaction" do
@@ -1801,7 +1835,7 @@ defmodule Explorer.ChainTest do
 
       actual = Enum.at(Chain.transaction_to_internal_transactions(transaction), 0)
 
-      assert actual.id == expected.id
+      assert {actual.transaction_hash, actual.index} == {expected.transaction_hash, expected.index}
     end
 
     test "includes internal transactions of type `suicide` even when they are alone in the parent transaction" do
@@ -1822,7 +1856,7 @@ defmodule Explorer.ChainTest do
 
       actual = Enum.at(Chain.transaction_to_internal_transactions(transaction), 0)
 
-      assert actual.id == expected.id
+      assert {actual.transaction_hash, actual.index} == {expected.transaction_hash, expected.index}
     end
 
     test "returns the internal transactions in ascending index order" do
@@ -1831,7 +1865,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block()
 
-      %InternalTransaction{id: first_id} =
+      %InternalTransaction{transaction_hash: first_transaction_hash, index: first_index} =
         insert(:internal_transaction,
           transaction: transaction,
           index: 0,
@@ -1839,7 +1873,7 @@ defmodule Explorer.ChainTest do
           transaction_index: transaction.index
         )
 
-      %InternalTransaction{id: second_id} =
+      %InternalTransaction{transaction_hash: second_transaction_hash, index: second_index} =
         insert(:internal_transaction,
           transaction: transaction,
           index: 1,
@@ -1850,9 +1884,9 @@ defmodule Explorer.ChainTest do
       result =
         transaction
         |> Chain.transaction_to_internal_transactions()
-        |> Enum.map(& &1.id)
+        |> Enum.map(&{&1.transaction_hash, &1.index})
 
-      assert [first_id, second_id] == result
+      assert [{first_transaction_hash, first_index}, {second_transaction_hash, second_index}] == result
     end
 
     test "pages by index" do
@@ -1861,7 +1895,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block()
 
-      %InternalTransaction{id: first_id} =
+      %InternalTransaction{transaction_hash: first_transaction_hash, index: first_index} =
         insert(:internal_transaction,
           transaction: transaction,
           index: 0,
@@ -1869,7 +1903,7 @@ defmodule Explorer.ChainTest do
           transaction_index: transaction.index
         )
 
-      %InternalTransaction{id: second_id} =
+      %InternalTransaction{transaction_hash: second_transaction_hash, index: second_index} =
         insert(:internal_transaction,
           transaction: transaction,
           index: 1,
@@ -1877,20 +1911,20 @@ defmodule Explorer.ChainTest do
           transaction_index: transaction.index
         )
 
-      assert [^first_id, ^second_id] =
+      assert [{first_transaction_hash, first_index}, {second_transaction_hash, second_index}] ==
                transaction
                |> Chain.transaction_to_internal_transactions(paging_options: %PagingOptions{key: {-1}, page_size: 2})
-               |> Enum.map(& &1.id)
+               |> Enum.map(&{&1.transaction_hash, &1.index})
 
-      assert [^first_id] =
+      assert [{first_transaction_hash, first_index}] ==
                transaction
                |> Chain.transaction_to_internal_transactions(paging_options: %PagingOptions{key: {-1}, page_size: 1})
-               |> Enum.map(& &1.id)
+               |> Enum.map(&{&1.transaction_hash, &1.index})
 
-      assert [^second_id] =
+      assert [{second_transaction_hash, second_index}] ==
                transaction
                |> Chain.transaction_to_internal_transactions(paging_options: %PagingOptions{key: {0}, page_size: 2})
-               |> Enum.map(& &1.id)
+               |> Enum.map(&{&1.transaction_hash, &1.index})
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -903,7 +903,6 @@ defmodule Explorer.ChainTest do
         ]
       },
       transactions: %{
-        on_conflict: :replace_all,
         params: [
           %{
             block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -820,7 +820,7 @@ defmodule Explorer.ChainTest do
 
   describe "indexed_ratio/0" do
     test "returns indexed ratio" do
-      for index <- 6..10 do
+      for index <- 5..9 do
         insert(:block, number: index)
       end
 
@@ -832,7 +832,7 @@ defmodule Explorer.ChainTest do
     end
 
     test "returns 1.0 if fully indexed blocks" do
-      for index <- 1..10 do
+      for index <- 0..9 do
         insert(:block, number: index)
       end
 

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -132,7 +132,7 @@ defmodule Indexer.Block.Fetcher do
                logs: %{params: logs},
                token_transfers: %{params: token_transfers},
                tokens: %{on_conflict: :nothing, params: tokens},
-               transactions: %{params: transactions_with_receipts, on_conflict: :replace_all}
+               transactions: %{params: transactions_with_receipts}
              }
            ) do
       {:ok, {inserted, next}}

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -564,7 +564,7 @@ defmodule Indexer.Block.FetcherTest do
 
           assert Repo.aggregate(Chain.Block, :count, :hash) == 1
           assert Repo.aggregate(Address, :count, :hash) == 2
-          assert Repo.aggregate(Log, :count, :id) == 1
+          assert Chain.log_count() == 1
           assert Repo.aggregate(Transaction, :count, :hash) == 1
 
           first_address = Repo.get!(Address, first_address_hash)


### PR DESCRIPTION
Fixes #978

## Changelog

### Bug Fixes
* Instead of addressing the problems with `replace_all` and `id`-based primary keys only for internal transactions as described in #978, fix the problem across all tables that could be affected by the same design issue.
  * Tables that had an `id` primary keys, but unique indexes on composites key, now use those composite keys as their primary key and remove `id`.  This eliminates the `id` changing if the row is replaced.
    * `internal_transactions` loses `id` and has `(transaction_hash, index)` promoted to be the composite primary key.
    * `logs` loses `id` and has `(transaction_hash, index)` promoted to be the composite primary key.
    * `token_transfers`  loses `id` and has `(transaction_hash, log_index)` promoted to be the composite primary key.
  * All uses of `on_conflict: :replace_all` has been replaced with a a `default_on_conflict` function.  In all cases this is an `Ecto.Query`, which skips updating the primary key and takes the outer most bounds of the timestamp columns.
* Fix divide-by-zero error in `Explorer.Chain.indexed_ratio/0` where dividing by `max_block_number` assumed it is 1-based, but it is 0-based, so add 1 to prevent divide by zero.

## Upgrading

The changes to the primary key can be migrated with `mix ecto.migrate`.