### PR TITLE
Do not store token_hash as address_hash in token balances

### DIFF
--- a/apps/indexer/lib/indexer/address/token_balances.ex
+++ b/apps/indexer/lib/indexer/address/token_balances.ex
@@ -30,11 +30,6 @@ defmodule Indexer.Address.TokenBalances do
         token_contract_address_hash: token_contract_address_hash,
         block_number: block_number
       })
-      |> MapSet.put(%{
-        address_hash: token_contract_address_hash,
-        token_contract_address_hash: token_contract_address_hash,
-        block_number: block_number
-      })
     end)
   end
 

--- a/apps/indexer/test/indexer/address/token_balances_test.exs
+++ b/apps/indexer/test/indexer/address/token_balances_test.exs
@@ -29,7 +29,7 @@ defmodule Indexer.Address.TokenBalancesTest do
 
       params_set = TokenBalances.params_set(%{token_transfers_params: [token_transfer_params]})
 
-      assert MapSet.size(params_set) == 3
+      assert MapSet.size(params_set) == 2
       assert %{address_hash: from_address_hash, block_number: block_number}
       assert %{address_hash: to_address_hash, block_number: block_number}
       assert %{address_hash: token_contract_address_hash, block_number: block_number}


### PR DESCRIPTION
relates to https://github.com/poanetwork/blockscout/issues/962

## Motivation

We don't need this extraction because it will try to fetch the balance from the own token in its contract and it doesn't make sense for us. We will stop to store a lot of unnecessary data and requests to the smart contract  removing this extraction.

If some token transfer takes place to the token, as it will be the `to_address_hash`, the token balance will be indexed normally.