### PR TITLE
Add custom GraphQL scalar types

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schema.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema.ex
@@ -5,7 +5,6 @@ defmodule BlockScoutWeb.Schema do
 
   alias BlockScoutWeb.Resolvers.Block
 
-  import_types(Absinthe.Type.Custom)
   import_types(BlockScoutWeb.Schema.Types)
 
   query do

--- a/apps/block_scout_web/lib/block_scout_web/schema/scalars.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema/scalars.ex
@@ -1,0 +1,56 @@
+defmodule BlockScoutWeb.Schema.Scalars do
+  @moduledoc false
+
+  use Absinthe.Schema.Notation
+
+  alias Explorer.Chain.Hash
+  alias Explorer.Chain.Hash.{Address, Full, Nonce}
+
+  @desc """
+  The address (40 (hex) characters / 160 bits / 20 bytes) is derived from the public key (128 (hex) characters /
+  512 bits / 64 bytes) which is derived from the private key (64 (hex) characters / 256 bits / 32 bytes).
+
+  The address is actually the last 40 characters of the keccak-256 hash of the public key with `0x` appended.
+  """
+  scalar :address_hash do
+    parse(fn
+      %Absinthe.Blueprint.Input.String{value: value} ->
+        Hash.cast(Address, value)
+
+      _ ->
+        :error
+    end)
+
+    serialize(&to_string/1)
+  end
+
+  @desc """
+  A 32-byte [KECCAK-256](https://en.wikipedia.org/wiki/SHA-3) hash.
+  """
+  scalar :full_hash do
+    parse(fn
+      %Absinthe.Blueprint.Input.String{value: value} ->
+        Hash.cast(Full, value)
+
+      _ ->
+        :error
+    end)
+
+    serialize(&to_string/1)
+  end
+
+  @desc """
+  The nonce (16 (hex) characters / 128 bits / 8 bytes) is derived from the Proof-of-Work.
+  """
+  scalar :nonce_hash do
+    parse(fn
+      %Absinthe.Blueprint.Input.String{value: value} ->
+        Hash.cast(Nonce, value)
+
+      _ ->
+        :error
+    end)
+
+    serialize(&to_string/1)
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/schema/types.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema/types.ex
@@ -3,6 +3,9 @@ defmodule BlockScoutWeb.Schema.Types do
 
   use Absinthe.Schema.Notation
 
+  import_types(Absinthe.Type.Custom)
+  import_types(BlockScoutWeb.Schema.Scalars)
+
   @desc """
   A package of data that contains zero or more transactions, the hash of the previous block ("parent"), and optionally
   other data. Because each block (except for the initial "genesis block") points to the previous block, the data
@@ -13,12 +16,12 @@ defmodule BlockScoutWeb.Schema.Types do
     field(:difficulty, :decimal)
     field(:gas_limit, :decimal)
     field(:gas_used, :decimal)
-    field(:nonce, :string)
+    field(:nonce, :nonce_hash)
     field(:number, :integer)
     field(:size, :integer)
     field(:timestamp, :datetime)
     field(:total_difficulty, :decimal)
-    field(:miner_hash, :string)
-    field(:parent_hash, :string)
+    field(:miner_hash, :address_hash)
+    field(:parent_hash, :full_hash)
   end
 end


### PR DESCRIPTION
## Motivation

* We'd like to document the hash lengths for the different hashes
(nonce, full, address) in graphiql.

## Changelog

### Enhancements
* Adding `BlockScoutWeb.Schema.Scalars` with address_hash, full_hash,
and nonce_hash scalars.
* Editing `BlockScoutWeb.Schema.Types` for the `block` object to use the
new scalars.
* Moving the `Absinthe.Type.Custom` `import_types/1` call to
`BlockScoutWeb.Schema.Types` where it's actually being used at the
moment (for `:decimal`). It was in `BlockScoutWeb.Schema`.
