### PR TITLE
Add balance history tab to address page

### DIFF
--- a/apps/block_scout_web/assets/css/app.scss
+++ b/apps/block_scout_web/assets/css/app.scss
@@ -85,6 +85,7 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "components/dropdown";
 @import "components/loading-spinner";
 @import "components/transaction-input";
+@import "components/coin-balance-tile";
 @import "components/highlight";
 
 :export {

--- a/apps/block_scout_web/assets/css/components/_coin-balance-tile.scss
+++ b/apps/block_scout_web/assets/css/components/_coin-balance-tile.scss
@@ -1,0 +1,9 @@
+.tile.tile-type-coin-balance {
+  [data-balance-change-sign="Positive"] {
+    color: $green;
+  }
+
+  [data-balance-change-sign="Negative"] {
+    color: $red;
+  }
+}

--- a/apps/block_scout_web/assets/js/app.js
+++ b/apps/block_scout_web/assets/js/app.js
@@ -21,6 +21,7 @@ import 'bootstrap'
 import './locale'
 
 import './pages/address'
+import './pages/address/coin_balances'
 import './pages/address/transactions'
 import './pages/address/validations'
 import './pages/address/internal_transactions'

--- a/apps/block_scout_web/assets/js/lib/coin_balance_history_chart.js
+++ b/apps/block_scout_web/assets/js/lib/coin_balance_history_chart.js
@@ -1,0 +1,60 @@
+import $ from 'jquery'
+import Chart from 'chart.js'
+import humps from 'humps'
+
+export function createCoinBalanceHistoryChart (el) {
+  const $chartContainer = $('[data-chart-container]')
+  const $chartLoading = $('[data-chart-loading-message]')
+  const $chartError = $('[data-chart-error-message]')
+  const dataPath = el.dataset.coin_balance_history_data_path
+
+  $.getJSON(dataPath, {type: 'JSON'})
+    .done(data => {
+      $chartContainer.show()
+
+      const coinBalanceHistoryData = humps.camelizeKeys(data)
+        .map(balance => ({
+          x: balance.date,
+          y: balance.value
+        }))
+
+      return new Chart(el, {
+        type: 'line',
+        data: {
+          datasets: [{
+            label: 'coin balance',
+            data: coinBalanceHistoryData
+          }]
+        },
+        options: {
+          legend: {
+            display: false
+          },
+          scales: {
+            xAxes: [{
+              type: 'time',
+              time: {
+                unit: 'day',
+                stepSize: 3
+              }
+            }],
+            yAxes: [{
+              ticks: {
+                beginAtZero: true
+              },
+              scaleLabel: {
+                display: true,
+                labelString: window.localized['Ether']
+              }
+            }]
+          }
+        }
+      })
+    })
+    .fail(() => {
+      $chartError.show()
+    })
+    .always(() => {
+      $chartLoading.hide()
+    })
+}

--- a/apps/block_scout_web/assets/js/lib/market_history_chart.js
+++ b/apps/block_scout_web/assets/js/lib/market_history_chart.js
@@ -121,9 +121,9 @@ class MarketHistoryChart {
   }
 }
 
-export function createMarketHistoryChart (ctx) {
-  const availableSupply = JSON.parse(ctx.dataset.available_supply)
-  const marketHistoryData = humps.camelizeKeys(JSON.parse(ctx.dataset.market_history_data))
+export function createMarketHistoryChart (el) {
+  const availableSupply = JSON.parse(el.dataset.available_supply)
+  const marketHistoryData = humps.camelizeKeys(JSON.parse(el.dataset.market_history_data))
 
-  return new MarketHistoryChart(ctx, availableSupply, marketHistoryData)
+  return new MarketHistoryChart(el, availableSupply, marketHistoryData)
 }

--- a/apps/block_scout_web/assets/js/pages/address/coin_balances.js
+++ b/apps/block_scout_web/assets/js/pages/address/coin_balances.js
@@ -1,0 +1,69 @@
+import $ from 'jquery'
+import _ from 'lodash'
+import humps from 'humps'
+import socket from '../../socket'
+import { connectElements } from '../../lib/redux_helpers.js'
+import { createAsyncLoadStore } from '../../lib/async_listing_load'
+import { createCoinBalanceHistoryChart } from '../../lib/coin_balance_history_chart'
+
+export const initialState = {
+  channelDisconnected: false
+}
+
+export function reducer (state, action) {
+  switch (action.type) {
+    case 'PAGE_LOAD':
+    case 'ELEMENTS_LOAD': {
+      return Object.assign({}, state, _.omit(action, 'type'))
+    }
+    case 'CHANNEL_DISCONNECTED': {
+      if (state.beyondPageOne) return state
+
+      return Object.assign({}, state, {
+        channelDisconnected: true
+      })
+    }
+    case 'RECEIVED_NEW_COIN_BALANCE': {
+      if (state.channelDisconnected || state.beyondPageOne) return state
+
+      return Object.assign({}, state, {
+        items: [action.msg.coinBalanceHtml, ...state.items]
+      })
+    }
+    default:
+      return state
+  }
+}
+
+const elements = {
+  '[data-selector="channel-disconnected-message"]': {
+    render ($el, state) {
+      if (state.channelDisconnected) $el.show()
+    }
+  }
+}
+
+if ($('[data-page="coin-balance-history"]').length) {
+  const store = createAsyncLoadStore(reducer, initialState, 'dataset.blockNumber')
+  const addressHash = $('[data-page="address-details"]')[0].dataset.pageAddressHash
+
+  store.dispatch({type: 'PAGE_LOAD', addressHash})
+  connectElements({ store, elements })
+
+  const addressChannel = socket.channel(`addresses:${addressHash}`, {})
+  addressChannel.join()
+  addressChannel.onError(() => store.dispatch({
+    type: 'CHANNEL_DISCONNECTED'
+  }))
+  addressChannel.on('coin_balance', (msg) => {
+    store.dispatch({
+      type: 'RECEIVED_NEW_COIN_BALANCE',
+      msg: humps.camelizeKeys(msg)
+    })
+  })
+
+  const chartContainer = $('[data-chart="coinBalanceHistoryChart"]')[0]
+  if (chartContainer) {
+    createCoinBalanceHistoryChart(chartContainer)
+  }
+}

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -16,6 +16,7 @@ defmodule BlockScoutWeb.Chain do
 
   alias Explorer.Chain.{
     Address,
+    Address.CoinBalance,
     Address.CurrentTokenBalance,
     Block,
     InternalTransaction,
@@ -192,6 +193,10 @@ defmodule BlockScoutWeb.Chain do
 
   defp paging_params(%CurrentTokenBalance{address_hash: address_hash, value: value}) do
     %{"address_hash" => to_string(address_hash), "value" => Decimal.to_integer(value)}
+  end
+
+  defp paging_params(%CoinBalance{block_number: block_number}) do
+    %{"block_number" => block_number}
   end
 
   defp block_or_transaction_from_param(param) do

--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -4,11 +4,11 @@ defmodule BlockScoutWeb.AddressChannel do
   """
   use BlockScoutWeb, :channel
 
-  alias BlockScoutWeb.{AddressView, InternalTransactionView, TransactionView}
+  alias BlockScoutWeb.{AddressCoinBalanceView, AddressView, InternalTransactionView, TransactionView}
   alias Explorer.Chain.Hash
   alias Phoenix.View
 
-  intercept(["balance_update", "count", "internal_transaction", "transaction"])
+  intercept(["balance_update", "coin_balance", "count", "internal_transaction", "transaction"])
 
   def join("addresses:" <> _address_hash, _params, socket) do
     {:ok, %{}, socket}
@@ -62,6 +62,24 @@ defmodule BlockScoutWeb.AddressChannel do
   end
 
   def handle_out("transaction", data, socket), do: handle_transaction(data, socket, "transaction")
+
+  def handle_out("coin_balance", %{coin_balance: coin_balance}, socket) do
+    Gettext.put_locale(BlockScoutWeb.Gettext, socket.assigns.locale)
+
+    rendered_coin_balance =
+      View.render_to_string(
+        AddressCoinBalanceView,
+        "_coin_balances.html",
+        conn: socket,
+        coin_balance: coin_balance
+      )
+
+    push(socket, "coin_balance", %{
+      coin_balance_html: rendered_coin_balance
+    })
+
+    {:noreply, socket}
+  end
 
   def handle_transaction(%{address: address, transaction: transaction}, socket, event) do
     Gettext.put_locale(BlockScoutWeb.Gettext, socket.assigns.locale)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_by_day_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_by_day_controller.ex
@@ -1,0 +1,17 @@
+defmodule BlockScoutWeb.AddressCoinBalanceByDayController do
+  @moduledoc """
+  Manages the grouping by day of the coin balance history of an address
+  """
+
+  use BlockScoutWeb, :controller
+
+  alias Explorer.Chain
+
+  def index(conn, %{"address_id" => address_hash_string, "type" => "JSON"}) do
+    with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string) do
+      balances_by_day = Chain.address_to_balances_by_day(address_hash)
+
+      json(conn, balances_by_day)
+    end
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
@@ -1,0 +1,71 @@
+defmodule BlockScoutWeb.AddressCoinBalanceController do
+  @moduledoc """
+  Manages the displaying of information about the coin balance history of an address
+  """
+
+  use BlockScoutWeb, :controller
+
+  import BlockScoutWeb.AddressController, only: [transaction_count: 1, validation_count: 1]
+  import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
+
+  alias BlockScoutWeb.AddressCoinBalanceView
+  alias Explorer.{Chain, Market}
+  alias Explorer.ExchangeRates.Token
+  alias Phoenix.View
+
+  def index(conn, %{"address_id" => address_hash_string, "type" => "JSON"} = params) do
+    with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
+         {:ok, address} <- Chain.hash_to_address(address_hash) do
+      full_options = paging_options(params)
+
+      coin_balances_plus_one = Chain.address_to_coin_balances(address_hash, full_options)
+
+      {coin_balances, next_page} = split_list_by_page(coin_balances_plus_one)
+
+      next_page_url =
+        case next_page_params(next_page, coin_balances, params) do
+          nil ->
+            nil
+
+          next_page_params ->
+            address_coin_balance_path(
+              conn,
+              :index,
+              address,
+              Map.delete(next_page_params, "type")
+            )
+        end
+
+      coin_balances_json =
+        Enum.map(coin_balances, fn coin_balance ->
+          View.render_to_string(
+            AddressCoinBalanceView,
+            "_coin_balances.html",
+            conn: conn,
+            coin_balance: coin_balance
+          )
+        end)
+
+      json(conn, %{items: coin_balances_json, next_page_path: next_page_url})
+    else
+      :error ->
+        unprocessable_entity(conn)
+
+      {:error, :not_found} ->
+        not_found(conn)
+    end
+  end
+
+  def index(conn, %{"address_id" => address_hash_string}) do
+    with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
+         {:ok, address} <- Chain.hash_to_address(address_hash) do
+      render(conn, "index.html",
+        address: address,
+        exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
+        transaction_count: transaction_count(address),
+        validation_count: validation_count(address),
+        current_path: current_path(conn)
+      )
+    end
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/event_handler.ex
+++ b/apps/block_scout_web/lib/block_scout_web/event_handler.ex
@@ -18,6 +18,7 @@ defmodule BlockScoutWeb.EventHandler do
 
   def init([]) do
     Chain.subscribe_to_events(:addresses)
+    Chain.subscribe_to_events(:address_coin_balances)
     Chain.subscribe_to_events(:blocks)
     Chain.subscribe_to_events(:exchange_rate)
     Chain.subscribe_to_events(:internal_transactions)

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -149,6 +149,20 @@ defmodule BlockScoutWeb.Router do
         only: [:index],
         as: :token_balance
       )
+
+      resources(
+        "/coin_balances",
+        AddressCoinBalanceController,
+        only: [:index],
+        as: :coin_balance
+      )
+
+      resources(
+        "/coin_balances/by_day",
+        AddressCoinBalanceByDayController,
+        only: [:index],
+        as: :coin_balance_by_day
+      )
     end
 
     resources "/tokens", Tokens.TokenController, only: [:show], as: :token do

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
@@ -25,6 +25,15 @@
         ) %>
   </li>
 
+  <li class="nav-item">
+    <%= link(
+          gettext("Coin Balance History"),
+          class: "nav-link #{tab_status("coin_balances", @conn.request_path)}",
+          "data-test": "coin_balance_tab_link",
+          to: address_coin_balance_path(@conn, :index, @address.hash)
+        ) %>
+  </li>
+
   <%= if BlockScoutWeb.AddressView.validator?(@validation_count) do %>
     <li class="nav-item">
       <%= link(
@@ -82,6 +91,12 @@
             class: "dropdown-item #{tab_status("internal_transactions", @conn.request_path)}",
             "data-test": "internal_transactions_tab_link",
             to: address_internal_transaction_path(@conn, :index, @address.hash)
+          ) %>
+      <%= link(
+            gettext("Coin Balance History"),
+            class: "dropdown-item #{tab_status("coin_balances", @conn.request_path)}",
+            "data-test": "coin_balance_tab_link",
+            to: address_coin_balance_path(@conn, :index, @address.hash)
           ) %>
       <%= if validator?(@validation_count) do %>
         <%= link(

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_coin_balance/_coin_balances.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_coin_balance/_coin_balances.html.eex
@@ -1,0 +1,24 @@
+<div class="tile tile-type-coin-balance fade-up" data-test="coin_balance" data-block-number="<%= to_string(@coin_balance.block_number) %>">
+  <div class="row justify-content align-items-center">
+    <div class="col-md-3 d-flex flex-column mt-3 mt-md-0">
+      <%= link(
+            to: block_path(@conn, :show, @coin_balance.block_number),
+            class: "tile-title-lg"
+        ) do %>
+        <%= gettext "Block"  %> <%= @coin_balance.block_number %>
+      <% end %>
+      <span data-from-now="<%= @coin_balance.block_timestamp %>"></span>
+    </div>
+    <div class="col-md-3 offset-md-3 d-flex flex-column text-md-right mt-3 mt-md-0">
+      <span class="tile-title-lg align-bottom" data-balance-change-sign="<%= delta_sign(@coin_balance.delta) %>">
+        <%= delta_arrow(@coin_balance.delta) %>
+        <%= format_delta(@coin_balance.delta) %>
+      </span>
+    </div>
+    <div class="col-md-3 d-flex flex-column mt-3 mt-md-0 text-md-right">
+      <span class="tile-title-lg align-bottom">
+        <%= format(@coin_balance.value) %>
+      </span>
+    </div>
+  </div>
+</div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_coin_balance/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_coin_balance/index.html.eex
@@ -1,0 +1,67 @@
+<section class="container" data-page="coin-balance-history">
+  <%= render BlockScoutWeb.AddressView, "overview.html", assigns %>
+
+  <section>
+    <div class="card">
+      <div class="card-header">
+        <%= render BlockScoutWeb.AddressView, "_tabs.html", assigns %>
+      </div>
+
+      <div class="card-body" data-async-listing="<%= @current_path %>">
+        <div data-selector="channel-disconnected-message" style="display:none;">
+          <div data-selector="reload-button" class="alert alert-danger">
+            <a href="#" class="alert-link"><%= gettext "Connection Lost, click to load newer blocks" %></a>
+          </div>
+        </div>
+
+        <h2 class="card-title"><%= gettext "Balances" %></h2>
+
+        <div data-chart-loading-message class="tile tile-muted text-center mt-3">
+          <span class="loading-spinner-small mr-2">
+            <span class="loading-spinner-block-1"></span>
+            <span class="loading-spinner-block-2"></span>
+          </span>
+          <%= gettext("Loading chart") %>...
+        </div>
+        <button data-chart-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+          <span><%= gettext("There was a problem loading the chart.") %></span>
+        </button>
+        <div data-chart-container style="display: none;">
+          <canvas data-chart="coinBalanceHistoryChart" data-coin_balance_history_data_path="<%= address_coin_balance_by_day_path(@conn, :index, @address) %>" width="350" height="152"></canvas>
+        </div>
+
+
+        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+          <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
+        </button>
+
+        <div data-empty-response-message style="display: none;">
+          <div class="tile tile-muted text-center" data-selector="empty-coin-balances-list">
+            <%= gettext "There is no coin history for this address." %>
+          </div>
+        </div>
+
+        <div data-loading-message class="tile tile-muted text-center mt-3">
+          <span class="loading-spinner-small mr-2">
+            <span class="loading-spinner-block-1"></span>
+            <span class="loading-spinner-block-2"></span>
+          </span>
+          <%= gettext("Loading balances") %>...
+        </div>
+
+        <div data-selector="coin-balances-list" data-items></div>
+
+        <a href="#" class="button button-secondary button-small float-right mt-4" data-next-page-button style="display: none;">
+          <%= gettext("Older") %>
+        </a>
+
+        <div class="button button-secondary button-small float-right mt-4" data-loading-button style="display: none;">
+          <span class="loading-spinner-small mr-2">
+            <span class="loading-spinner-block-1"></span>
+            <span class="loading-spinner-block-2"></span>
+          </span>
+          <%= gettext("Loading") %>...
+      </div>
+    </div>
+  </section>
+</section>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -48,6 +48,7 @@
         'Less than': '<%= gettext("Less than") %>',
         'Market Cap': '<%= gettext("Market Cap") %>',
         'Price': '<%= gettext("Price") %>',
+        'Ether': '<%= gettext("Ether") %>'
       }
     </script>
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_coin_balance_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_coin_balance_view.ex
@@ -1,0 +1,32 @@
+defmodule BlockScoutWeb.AddressCoinBalanceView do
+  use BlockScoutWeb, :view
+
+  alias Explorer.Chain.Wei
+
+  def format(%Wei{} = value) do
+    format_wei_value(value, :ether)
+  end
+
+  def delta_arrow(value) do
+    if value.sign == 1 do
+      "▲"
+    else
+      "▼"
+    end
+  end
+
+  def delta_sign(value) do
+    if value.sign == 1 do
+      "Positive"
+    else
+      "Negative"
+    end
+  end
+
+  def format_delta(%Decimal{} = value) do
+    value
+    |> Decimal.abs()
+    |> Wei.from(:wei)
+    |> format_wei_value(:ether)
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.AddressView do
 
   @dialyzer :no_match
 
-  @tabs ["tokens", "transactions", "internal_transactions", "contracts", "read_contract"]
+  @tabs ["tokens", "transactions", "internal_transactions", "contracts", "read_contract", "coin_balances"]
 
   def address_partial_selector(struct_to_render_from, direction, current_address, truncate \\ false)
 
@@ -213,6 +213,7 @@ defmodule BlockScoutWeb.AddressView do
   defp tab_name(["internal_transactions"]), do: gettext("Internal Transactions")
   defp tab_name(["contracts"]), do: gettext("Code")
   defp tab_name(["read_contract"]), do: gettext("Read Contract")
+  defp tab_name(["coin_balances"]), do: gettext("Coin Balance History")
 
   def short_hash(%Address{hash: hash}) do
     <<

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -193,8 +193,8 @@ msgid "Blocks Indexed"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:31
-#: lib/block_scout_web/templates/address/_tabs.html.eex:88
+#: lib/block_scout_web/templates/address/_tabs.html.eex:40
+#: lib/block_scout_web/templates/address/_tabs.html.eex:103
 #: lib/block_scout_web/templates/address/overview.html.eex:37
 #: lib/block_scout_web/templates/address_validation/index.html.eex:32
 #: lib/block_scout_web/templates/address_validation/index.html.eex:81
@@ -224,8 +224,8 @@ msgid "Close"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:44
-#: lib/block_scout_web/templates/address/_tabs.html.eex:98
+#: lib/block_scout_web/templates/address/_tabs.html.eex:53
+#: lib/block_scout_web/templates/address/_tabs.html.eex:113
 #: lib/block_scout_web/templates/address_validation/index.html.eex:43
 #: lib/block_scout_web/templates/address_validation/index.html.eex:90
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:119
@@ -245,6 +245,7 @@ msgid "Compiler version"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:13
 #: lib/block_scout_web/templates/block/index.html.eex:6
 msgid "Connection Lost, click to load newer blocks"
 msgstr ""
@@ -408,6 +409,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_balance_card.html.eex:12
 #: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:16
+#: lib/block_scout_web/templates/layout/app.html.eex:51
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:26
 #: lib/block_scout_web/templates/transaction/overview.html.eex:110
@@ -504,7 +506,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:21
-#: lib/block_scout_web/templates/address/_tabs.html.eex:81
+#: lib/block_scout_web/templates/address/_tabs.html.eex:90
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:58
 #: lib/block_scout_web/templates/address_validation/index.html.eex:24
 #: lib/block_scout_web/templates/address_validation/index.html.eex:75
@@ -637,6 +639,7 @@ msgid "OUT"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:55
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:76
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:31
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:75
@@ -725,8 +728,8 @@ msgid "Query"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:56
-#: lib/block_scout_web/templates/address/_tabs.html.eex:107
+#: lib/block_scout_web/templates/address/_tabs.html.eex:65
+#: lib/block_scout_web/templates/address/_tabs.html.eex:122
 #: lib/block_scout_web/templates/address_validation/index.html.eex:53
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
@@ -923,7 +926,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:13
-#: lib/block_scout_web/templates/address/_tabs.html.eex:76
+#: lib/block_scout_web/templates/address/_tabs.html.eex:85
 #: lib/block_scout_web/templates/address_token/index.html.eex:11
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:12
 #: lib/block_scout_web/templates/address_validation/index.html.eex:18
@@ -981,7 +984,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:5
-#: lib/block_scout_web/templates/address/_tabs.html.eex:71
+#: lib/block_scout_web/templates/address/_tabs.html.eex:80
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:53
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
 #: lib/block_scout_web/templates/address_validation/index.html.eex:65
@@ -1211,6 +1214,7 @@ msgid "GraphQL"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:63
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:72
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:83
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:38
@@ -1410,6 +1414,7 @@ msgid "Log Data"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:35
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:60
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:26
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:55
@@ -1432,11 +1437,48 @@ msgid "There are no transactions."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/index.html.eex:21
-msgid "There are no blocks."
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:17
+msgid "Balances"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/_coin_balances.html.eex:8
+msgid "Block"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/_tabs.html.eex:30
+#: lib/block_scout_web/templates/address/_tabs.html.eex:96
+#: lib/block_scout_web/views/address_view.ex:216
+msgid "Coin Balance History"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:49
+msgid "Loading balances"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:24
+msgid "Loading chart"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:40
+msgid "There is no coin history for this address."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:27
+msgid "There was a problem loading the chart."
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:27
 msgid "There are no pending transactions."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block/index.html.eex:21
+msgid "There are no blocks."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -193,8 +193,8 @@ msgid "Blocks Indexed"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:31
-#: lib/block_scout_web/templates/address/_tabs.html.eex:88
+#: lib/block_scout_web/templates/address/_tabs.html.eex:40
+#: lib/block_scout_web/templates/address/_tabs.html.eex:103
 #: lib/block_scout_web/templates/address/overview.html.eex:37
 #: lib/block_scout_web/templates/address_validation/index.html.eex:32
 #: lib/block_scout_web/templates/address_validation/index.html.eex:81
@@ -224,8 +224,8 @@ msgid "Close"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:44
-#: lib/block_scout_web/templates/address/_tabs.html.eex:98
+#: lib/block_scout_web/templates/address/_tabs.html.eex:53
+#: lib/block_scout_web/templates/address/_tabs.html.eex:113
 #: lib/block_scout_web/templates/address_validation/index.html.eex:43
 #: lib/block_scout_web/templates/address_validation/index.html.eex:90
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:119
@@ -245,6 +245,7 @@ msgid "Compiler version"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:13
 #: lib/block_scout_web/templates/block/index.html.eex:6
 msgid "Connection Lost, click to load newer blocks"
 msgstr ""
@@ -408,6 +409,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_balance_card.html.eex:12
 #: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:16
+#: lib/block_scout_web/templates/layout/app.html.eex:51
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:26
 #: lib/block_scout_web/templates/transaction/overview.html.eex:110
@@ -504,7 +506,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:21
-#: lib/block_scout_web/templates/address/_tabs.html.eex:81
+#: lib/block_scout_web/templates/address/_tabs.html.eex:90
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:58
 #: lib/block_scout_web/templates/address_validation/index.html.eex:24
 #: lib/block_scout_web/templates/address_validation/index.html.eex:75
@@ -637,6 +639,7 @@ msgid "OUT"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:55
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:76
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:31
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:75
@@ -725,8 +728,8 @@ msgid "Query"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:56
-#: lib/block_scout_web/templates/address/_tabs.html.eex:107
+#: lib/block_scout_web/templates/address/_tabs.html.eex:65
+#: lib/block_scout_web/templates/address/_tabs.html.eex:122
 #: lib/block_scout_web/templates/address_validation/index.html.eex:53
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
@@ -923,7 +926,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:13
-#: lib/block_scout_web/templates/address/_tabs.html.eex:76
+#: lib/block_scout_web/templates/address/_tabs.html.eex:85
 #: lib/block_scout_web/templates/address_token/index.html.eex:11
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:12
 #: lib/block_scout_web/templates/address_validation/index.html.eex:18
@@ -981,7 +984,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:5
-#: lib/block_scout_web/templates/address/_tabs.html.eex:71
+#: lib/block_scout_web/templates/address/_tabs.html.eex:80
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:53
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
 #: lib/block_scout_web/templates/address_validation/index.html.eex:65
@@ -1211,6 +1214,7 @@ msgid "GraphQL"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:63
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:72
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:83
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:38
@@ -1410,6 +1414,7 @@ msgid "Log Data"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:35
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:60
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:26
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:55
@@ -1432,11 +1437,48 @@ msgid "There are no transactions."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/index.html.eex:21
-msgid "There are no blocks."
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:17
+msgid "Balances"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/_coin_balances.html.eex:8
+msgid "Block"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/_tabs.html.eex:30
+#: lib/block_scout_web/templates/address/_tabs.html.eex:96
+#: lib/block_scout_web/views/address_view.ex:216
+msgid "Coin Balance History"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:49
+msgid "Loading balances"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:24
+msgid "Loading chart"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:40
+msgid "There is no coin history for this address."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_coin_balance/index.html.eex:27
+msgid "There was a problem loading the chart."
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:27
 msgid "There are no pending transactions."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block/index.html.eex:21
+msgid "There are no blocks."
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_coin_balance_by_day_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_coin_balance_by_day_controller_test.exs
@@ -1,0 +1,20 @@
+defmodule BlockScoutWeb.AddressCoinBalanceByDayControllerTest do
+  use BlockScoutWeb.ConnCase
+
+  describe "GET index/2" do
+    test "returns the coin balance history grouped by date", %{conn: conn} do
+      address = insert(:address)
+      noon = Timex.now() |> Timex.beginning_of_day() |> Timex.set(hour: 12)
+      block = insert(:block, timestamp: noon)
+      block_one_day_ago = insert(:block, timestamp: Timex.shift(noon, days: -1))
+      insert(:fetched_balance, address_hash: address.hash, value: 1000, block_number: block.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 2000, block_number: block_one_day_ago.number)
+
+      conn = get(conn, address_coin_balance_by_day_path(conn, :index, address), %{"type" => "JSON"})
+
+      response = json_response(conn, 200)
+
+      assert length(response) == 2
+    end
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
@@ -47,6 +47,10 @@ defmodule BlockScoutWeb.AddressPage do
     click(session, css("[data-test='tokens_tab_link']"))
   end
 
+  def click_coin_balance_history(session) do
+    click(session, css("[data-test='coin_balance_tab_link']"))
+  end
+
   def click_balance_dropdown_toggle(session) do
     click(session, css("[data-dropdown-toggle]"))
   end
@@ -65,6 +69,10 @@ defmodule BlockScoutWeb.AddressPage do
 
   def click_show_pending_transactions(session) do
     click(session, css("[data-selector='pending-transactions-open']"))
+  end
+
+  def coin_balances(count: count) do
+    css("[data-test='coin_balance']", count: count)
   end
 
   def contract_creation(%InternalTransaction{created_contract_address_hash: hash}) do

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
@@ -476,4 +476,24 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
       |> assert_has(AddressPage.token_balance_counter("2"))
     end
   end
+
+  describe "viewing coin balance history" do
+    setup do
+      address = insert(:address, fetched_coin_balance: 5)
+      noon = Timex.now() |> Timex.beginning_of_day() |> Timex.set(hour: 12)
+      block = insert(:block, timestamp: noon)
+      block_one_day_ago = insert(:block, timestamp: Timex.shift(noon, days: -1))
+      insert(:fetched_balance, address_hash: address.hash, value: 5, block_number: block.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 10, block_number: block_one_day_ago.number)
+
+      {:ok, address: address}
+    end
+
+    test "see list of coin balances", %{session: session, address: address} do
+      session
+      |> AddressPage.visit_page(address)
+      |> AddressPage.click_coin_balance_history()
+      |> assert_has(AddressPage.coin_balances(count: 2))
+    end
+  end
 end

--- a/apps/block_scout_web/test/block_scout_web/views/address_coin_balance_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/address_coin_balance_view_test.exs
@@ -1,0 +1,62 @@
+defmodule BlockScoutWeb.AddressCoinBalanceViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.AddressCoinBalanceView
+  alias Explorer.Chain.Wei
+
+  describe "format/1" do
+    test "format the wei value in ether" do
+      wei = Wei.from(Decimal.new(1_340_000_000), :gwei)
+
+      assert AddressCoinBalanceView.format(wei) == "1.34 POA"
+    end
+
+    test "format negative values" do
+      wei = Wei.from(Decimal.new(-1_340_000_000), :gwei)
+
+      assert AddressCoinBalanceView.format(wei) == "-1.34 POA"
+    end
+  end
+
+  describe "delta_arrow/1" do
+    test "return up pointing arrow for positive value" do
+      value = Decimal.new(123)
+
+      assert AddressCoinBalanceView.delta_arrow(value) == "▲"
+    end
+
+    test "return down pointing arrow for negative value" do
+      value = Decimal.new(-123)
+
+      assert AddressCoinBalanceView.delta_arrow(value) == "▼"
+    end
+  end
+
+  describe "delta_sign/1" do
+    test "return Positive for positive value" do
+      value = Decimal.new(123)
+
+      assert AddressCoinBalanceView.delta_sign(value) == "Positive"
+    end
+
+    test "return Negative for negative value" do
+      value = Decimal.new(-123)
+
+      assert AddressCoinBalanceView.delta_sign(value) == "Negative"
+    end
+  end
+
+  describe "format_delta/1" do
+    test "format positive values" do
+      value = Decimal.new(1_340_000_000_000_000_000)
+
+      assert AddressCoinBalanceView.format_delta(value) == "1.34 POA"
+    end
+
+    test "format negative values" do
+      value = Decimal.new(-1_340_000_000_000_000_000)
+
+      assert AddressCoinBalanceView.format_delta(value) == "1.34 POA"
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -86,6 +86,7 @@ defmodule Explorer.Chain do
 
   @typep necessity_by_association_option :: {:necessity_by_association, necessity_by_association}
   @typep paging_options :: {:paging_options, PagingOptions.t()}
+  @typep balance_by_day :: %{date: String.t(), value: Wei.t()}
 
   @doc """
   Gets from the cache the count of `t:Explorer.Chain.Address.t/0`'s where the `fetched_coin_balance` is > 0
@@ -1821,6 +1822,12 @@ defmodule Explorer.Chain do
     where(query, [block], block.number < ^block_number)
   end
 
+  defp page_coin_balances(query, %PagingOptions{key: nil}), do: query
+
+  defp page_coin_balances(query, %PagingOptions{key: {block_number}}) do
+    where(query, [coin_balance], coin_balance.block_number < ^block_number)
+  end
+
   defp page_internal_transaction(query, %PagingOptions{key: nil}), do: query
 
   defp page_internal_transaction(query, %PagingOptions{key: {block_number, transaction_index, index}}) do
@@ -2078,6 +2085,45 @@ defmodule Explorer.Chain do
     address_hash
     |> TokenBalance.last_token_balances()
     |> Repo.all()
+  end
+
+  @spec address_to_coin_balances(Hash.Address.t(), [paging_options]) :: []
+  def address_to_coin_balances(address_hash, options) do
+    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
+
+    address_hash
+    |> CoinBalance.fetch_coin_balances(paging_options)
+    |> page_coin_balances(paging_options)
+    |> Repo.all()
+  end
+
+  def get_coin_balance(address_hash, block_number) do
+    query = CoinBalance.fetch_coin_balance(address_hash, block_number)
+
+    Repo.one(query)
+  end
+
+  @spec address_to_balances_by_day(Hash.Address.t()) :: [balance_by_day]
+  def address_to_balances_by_day(address_hash) do
+    address_hash
+    |> CoinBalance.balances_by_day()
+    |> Repo.all()
+    |> normalize_balances_by_day()
+  end
+
+  defp normalize_balances_by_day(balances_by_day) do
+    balances_by_day
+    |> Enum.map(fn day -> Map.update(day, :date, nil, &tuple_to_date(&1)) end)
+    |> Enum.map(fn day -> Map.take(day, [:date, :value]) end)
+    |> Enum.filter(fn day -> day.value end)
+    |> Enum.map(fn day -> Map.update!(day, :date, &to_string(&1)) end)
+    |> Enum.map(fn day -> Map.update!(day, :value, &Wei.to(&1, :ether)) end)
+  end
+
+  defp tuple_to_date({date_tuple, _time_tuple}) do
+    case Date.from_erl(date_tuple) do
+      {:ok, date} -> date
+    end
   end
 
   @spec fetch_token_holders_from_token_hash(Hash.Address.t(), [paging_options]) :: [TokenBalance.t()]

--- a/apps/explorer/test/explorer/chain/address/coin_balance_test.exs
+++ b/apps/explorer/test/explorer/chain/address/coin_balance_test.exs
@@ -3,6 +3,8 @@ defmodule Explorer.Chain.Address.CoinBalanceTest do
 
   alias Ecto.Changeset
   alias Explorer.Chain.Address.CoinBalance
+  alias Explorer.Chain.Wei
+  alias Explorer.PagingOptions
 
   describe "changeset/2" do
     test "is valid with address_hash, block_number, and value" do
@@ -18,6 +20,254 @@ defmodule Explorer.Chain.Address.CoinBalanceTest do
       assert length(errors) == 2
       assert Keyword.get_values(errors, :address_hash) == [{"can't be blank", [validation: :required]}]
       assert Keyword.get_values(errors, :block_number) == [{"can't be blank", [validation: :required]}]
+    end
+  end
+
+  describe "fetch_coin_balances/2" do
+    test "returns the coin balances for the given address" do
+      address_a = insert(:address)
+      address_b = insert(:address)
+
+      block_a = insert(:block)
+      block_b = insert(:block)
+      insert(:fetched_balance, address_hash: address_a.hash, block_number: block_a.number)
+      insert(:fetched_balance, address_hash: address_b.hash, block_number: block_b.number)
+
+      result =
+        address_a.hash
+        |> CoinBalance.fetch_coin_balances(%PagingOptions{page_size: 50})
+        |> Repo.all()
+
+      assert(length(result) == 1, "Should return 1 coin balance")
+
+      result_address = List.first(result)
+      assert(result_address.address_hash == address_a.hash)
+    end
+
+    test "ignores unfetched balances" do
+      address = insert(:address)
+      block_a = insert(:block)
+      block_b = insert(:block)
+      insert(:fetched_balance, address_hash: address.hash, block_number: block_a.number)
+      insert(:unfetched_balance, address_hash: address.hash, block_number: block_b.number)
+
+      result =
+        address.hash
+        |> CoinBalance.fetch_coin_balances(%PagingOptions{page_size: 50})
+        |> Repo.all()
+
+      assert(length(result) == 1, "Should return 1 coin balance")
+    end
+
+    test "sorts the result by block number" do
+      address = insert(:address)
+      block_a = insert(:block)
+      block_b = insert(:block)
+      block_c = insert(:block)
+      insert(:fetched_balance, address_hash: address.hash, block_number: block_c.number)
+      insert(:fetched_balance, address_hash: address.hash, block_number: block_a.number)
+      insert(:fetched_balance, address_hash: address.hash, block_number: block_b.number)
+
+      result =
+        address.hash
+        |> CoinBalance.fetch_coin_balances(%PagingOptions{page_size: 50})
+        |> Repo.all()
+
+      assert(length(result) == 3, "Should return 3 coin balance")
+
+      block_numbers = result |> Enum.map(fn cb -> cb.block_number end)
+      assert(block_numbers == [block_c.number, block_b.number, block_a.number], "Should sort the results")
+    end
+
+    test "limits the result by the given page size" do
+      address = insert(:address)
+      blocks = insert_list(11, :block)
+
+      Enum.each(blocks, fn block ->
+        insert(:fetched_balance, address_hash: address.hash, block_number: block.number)
+      end)
+
+      result =
+        address.hash
+        |> CoinBalance.fetch_coin_balances(%PagingOptions{page_size: 10})
+        |> Repo.all()
+
+      assert(length(result) == 10, "Should return 10 coin balances")
+    end
+
+    test "includes the delta between successive blocks" do
+      address = insert(:address)
+      block_a = insert(:block)
+      block_b = insert(:block)
+      block_c = insert(:block)
+      insert(:fetched_balance, address_hash: address.hash, value: 1000, block_number: block_a.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 2200, block_number: block_b.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 1500, block_number: block_c.number)
+
+      result =
+        address.hash
+        |> CoinBalance.fetch_coin_balances(%PagingOptions{page_size: 50})
+        |> Repo.all()
+
+      deltas = result |> Enum.map(fn cb -> cb.delta end)
+      expected_deltas = [-700, 1200, 1000] |> Enum.map(&Decimal.new(&1))
+      assert(deltas == expected_deltas)
+    end
+
+    test "includes delta even when paginating" do
+      address = insert(:address)
+
+      values = [1000, 2200, 1500, 2000, 2800, 2500, 3100]
+
+      Enum.each(values, fn value ->
+        insert(:fetched_balance, address_hash: address.hash, value: value, block_number: insert(:block).number)
+      end)
+
+      result =
+        address.hash
+        |> CoinBalance.fetch_coin_balances(%PagingOptions{page_size: 5})
+        |> Repo.all()
+
+      deltas = result |> Enum.map(fn cb -> cb.delta end)
+      expected_deltas = [600, -300, 800, 500, -700] |> Enum.map(&Decimal.new(&1))
+      assert(deltas == expected_deltas)
+    end
+  end
+
+  describe "balances_by_day/1" do
+    test "returns one row per day" do
+      address = insert(:address)
+      noon = Timex.now() |> Timex.beginning_of_day() |> Timex.set(hour: 12)
+      block = insert(:block, timestamp: noon)
+      block_one_day_ago = insert(:block, timestamp: Timex.shift(noon, days: -1))
+      insert(:fetched_balance, address_hash: address.hash, value: 1000, block_number: block.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 2000, block_number: block_one_day_ago.number)
+
+      result =
+        address.hash
+        |> CoinBalance.balances_by_day()
+        |> Repo.all()
+
+      assert(length(result) == 2)
+
+      values = Enum.map(result, fn cb -> cb.value end)
+      expected_values = Enum.map([2000, 1000], fn x -> Wei.from(Decimal.new(x), :wei) end)
+      assert(values == expected_values)
+    end
+
+    test "returns only balances for the given address" do
+      address_a = insert(:address)
+      address_b = insert(:address)
+
+      noon = Timex.now() |> Timex.beginning_of_day() |> Timex.set(hour: 12)
+      block = insert(:block, timestamp: noon)
+      block_one_day_ago = insert(:block, timestamp: Timex.shift(noon, days: -1))
+
+      insert(:fetched_balance, address_hash: address_a.hash, value: 1000, block_number: block.number)
+      insert(:fetched_balance, address_hash: address_a.hash, value: 2000, block_number: block_one_day_ago.number)
+      insert(:fetched_balance, address_hash: address_b.hash, value: 3000, block_number: block.number)
+      insert(:fetched_balance, address_hash: address_b.hash, value: 4000, block_number: block_one_day_ago.number)
+
+      result =
+        address_a.hash
+        |> CoinBalance.balances_by_day()
+        |> Repo.all()
+
+      assert(length(result) == 2)
+
+      values = Enum.map(result, fn cb -> cb.value end)
+      expected_values = Enum.map([2000, 1000], fn x -> Wei.from(Decimal.new(x), :wei) end)
+      assert(values == expected_values)
+    end
+
+    test "returns dates at midnight" do
+      address = insert(:address)
+      noon = Timex.now() |> Timex.beginning_of_day() |> Timex.set(hour: 12)
+      block = insert(:block, timestamp: noon)
+      block_one_day_ago = insert(:block, timestamp: Timex.shift(noon, days: -1))
+      insert(:fetched_balance, address_hash: address.hash, value: 1000, block_number: block.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 2000, block_number: block_one_day_ago.number)
+
+      result =
+        address.hash
+        |> CoinBalance.balances_by_day()
+        |> Repo.all()
+
+      assert(length(result) == 2)
+
+      dates = result |> Enum.map(& &1.date) |> Enum.map(&Ecto.DateTime.cast!/1)
+
+      today = Timex.beginning_of_day(noon)
+      yesterday = today |> Timex.shift(days: -1)
+      expected_dates = [yesterday, today] |> Enum.map(&Ecto.DateTime.cast!/1)
+
+      assert(dates == expected_dates)
+    end
+
+    test "gets the max value of the day (value is at the beginning)" do
+      address = insert(:address)
+      noon = Timex.now() |> Timex.beginning_of_day() |> Timex.set(hour: 12)
+      block = insert(:block, timestamp: noon)
+      block_one_hour_ago = insert(:block, timestamp: Timex.shift(noon, hours: -1))
+      block_two_hours_ago = insert(:block, timestamp: Timex.shift(noon, hours: -2))
+      insert(:fetched_balance, address_hash: address.hash, value: 1000, block_number: block.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 2000, block_number: block_one_hour_ago.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 3000, block_number: block_two_hours_ago.number)
+
+      result =
+        address.hash
+        |> CoinBalance.balances_by_day()
+        |> Repo.all()
+
+      assert(length(result) == 1)
+
+      value = List.first(result) |> Map.get(:value)
+
+      assert(value == Wei.from(Decimal.new(3000), :wei))
+    end
+
+    test "gets the max value of the day (value is at the middle)" do
+      address = insert(:address)
+      noon = Timex.now() |> Timex.beginning_of_day() |> Timex.set(hour: 12)
+      block = insert(:block, timestamp: noon)
+      block_one_hour_ago = insert(:block, timestamp: Timex.shift(noon, hours: -1))
+      block_two_hours_ago = insert(:block, timestamp: Timex.shift(noon, hours: -2))
+      insert(:fetched_balance, address_hash: address.hash, value: 1000, block_number: block.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 3000, block_number: block_one_hour_ago.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 2000, block_number: block_two_hours_ago.number)
+
+      result =
+        address.hash
+        |> CoinBalance.balances_by_day()
+        |> Repo.all()
+
+      assert(length(result) == 1)
+
+      value = List.first(result) |> Map.get(:value)
+
+      assert(value == Wei.from(Decimal.new(3000), :wei))
+    end
+
+    test "gets the max value of the day (value is at the end)" do
+      address = insert(:address)
+      noon = Timex.now() |> Timex.beginning_of_day() |> Timex.set(hour: 12)
+      block = insert(:block, timestamp: noon)
+      block_one_hour_ago = insert(:block, timestamp: Timex.shift(noon, hours: -1))
+      block_two_hours_ago = insert(:block, timestamp: Timex.shift(noon, hours: -2))
+      insert(:fetched_balance, address_hash: address.hash, value: 3000, block_number: block.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 2000, block_number: block_one_hour_ago.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 1000, block_number: block_two_hours_ago.number)
+
+      result =
+        address.hash
+        |> CoinBalance.balances_by_day()
+        |> Repo.all()
+
+      assert(length(result) == 1)
+
+      value = List.first(result) |> Map.get(:value)
+
+      assert(value == Wei.from(Decimal.new(3000), :wei))
     end
   end
 end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -3158,4 +3158,22 @@ defmodule Explorer.ChainTest do
       assert {:ok, [^block_number]} = Chain.uncataloged_token_transfer_block_numbers()
     end
   end
+
+  describe "address_to_balances_by_day/1" do
+    test "return a list of balances by day" do
+      address = insert(:address)
+      noon = ~D[2018-12-06] |> Timex.to_datetime() |> Timex.set(hour: 12)
+      block = insert(:block, timestamp: noon)
+      block_one_day_ago = insert(:block, timestamp: Timex.shift(noon, days: -1))
+      insert(:fetched_balance, address_hash: address.hash, value: 1000, block_number: block.number)
+      insert(:fetched_balance, address_hash: address.hash, value: 2000, block_number: block_one_day_ago.number)
+
+      balances = Chain.address_to_balances_by_day(address.hash)
+
+      assert balances == [
+               %{date: "2018-12-05", value: Decimal.new("2E-15")},
+               %{date: "2018-12-06", value: Decimal.new("1E-15")}
+             ]
+    end
+  end
 end


### PR DESCRIPTION
Closes #433.

Add a tab to the address page showing the coin balance history for that address. There are two components in this tab: a chart showing how the balance changed in the last 90 days and a list of changes, each item being a block where the balance changed.

## Things to test

- List
  - The list is loaded asynchronously.
  - The list has simple paging. When you go to a previous page, only the list is updated.
  - If a new block appears with a coin balance change for this address, it should show up in real time, but only in the first page.
- Chart
  - The chart should load asynchronously.
  - Each point in the chart show the max balance of that accound in that day.
  - Days where the balance remained constant are not shown as points of the chart.
  - The chart only shows information for the past 90 days.