### PR TITLE
Optmize address transactions page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -19,7 +19,10 @@ defmodule BlockScoutWeb.AddressTransactionController do
       [created_contract_address: :names] => :optional,
       [from_address: :names] => :optional,
       [to_address: :names] => :optional,
-      :token_transfers => :optional
+      [token_transfers: :token] => :optional,
+      [token_transfers: :to_address] => :optional,
+      [token_transfers: :from_address] => :optional,
+      [token_transfers: :token_contract_address] => :optional
     }
   ]
 
@@ -81,7 +84,7 @@ defmodule BlockScoutWeb.AddressTransactionController do
          {:ok, address} <- Chain.hash_to_address(address_hash) do
       pending_options =
         @transaction_necessity_by_association
-        |> Keyword.merge(paging_options(%{}))
+        |> Keyword.merge(paging_options(params))
         |> Keyword.merge(current_filter(params))
 
       full_options = put_in(pending_options, [:necessity_by_association, :block], :required)

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tile.html.eex
@@ -52,14 +52,17 @@
 
     <%= if involves_token_transfers?(@transaction) do %>
       <div class="offset-md-2 col-md-10 col-lg-8 d-flex flex-column mt-2 mb-2">
-        <% [first_token_transfer | remaining_token_transfers]= @transaction.token_transfers %>
+        <% [first_token_transfer | remaining_token_transfers] = @transaction.token_transfers %>
+
         <%= render "_token_transfer.html", address: assigns[:current_address], token_transfer: first_token_transfer %>
+
         <div class="collapse token-transfer-toggle" id="transaction-<%= @transaction.hash %>">
           <%= for token_transfer <- remaining_token_transfers do %>
             <%= render "_token_transfer.html", address: assigns[:current_address], token_transfer: token_transfer %>
           <% end %>
         </div>
       </div>
+
       <%= if Enum.any?(remaining_token_transfers) do %>
         <div class="col-md-12 d-flex flex-column mt-1 mb-2 text-center token-tile-view-more">
           <span class="token-tile-more-lines">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1080,12 +1080,12 @@ msgid "View Contract"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_tile.html.eex:67
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:70
 msgid "View Less Transfers"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_tile.html.eex:66
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:69
 msgid "View More Transfers"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1080,12 +1080,12 @@ msgid "View Contract"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_tile.html.eex:67
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:70
 msgid "View Less Transfers"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_tile.html.eex:66
+#: lib/block_scout_web/templates/transaction/_tile.html.eex:69
 msgid "View More Transfers"
 msgstr ""
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -219,38 +219,22 @@ defmodule Explorer.Chain do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    transaction_matches =
-      direction
-      |> case do
-        :from -> [:from_address_hash]
-        :to -> [:to_address_hash, :created_contract_address_hash]
-        _ -> [:from_address_hash, :to_address_hash, :created_contract_address_hash]
-      end
-      |> Enum.map(fn address_field ->
-        paging_options
-        |> fetch_transactions()
-        |> Transaction.where_address_fields_match(address_hash, address_field)
-        |> join_associations(necessity_by_association)
-        |> Transaction.preload_token_transfers(address_hash)
-        |> Repo.all()
-        |> MapSet.new()
-      end)
+    {:ok, address_bytes} = Explorer.Chain.Hash.Address.dump(address_hash)
 
-    token_transfer_matches =
+    token_transfers_dynamic = TokenTransfer.dynamic_any_address_fields_match(direction, address_bytes)
+
+    transaction_dynamic =
+      Transaction.dynamic_where_address_hash_matches(address_hash, direction, token_transfers_dynamic)
+
+    base_query =
       paging_options
       |> fetch_transactions()
-      |> TokenTransfer.where_address_fields_match(address_hash, direction)
       |> join_associations(necessity_by_association)
       |> Transaction.preload_token_transfers(address_hash)
-      |> Repo.all()
-      |> MapSet.new()
 
-    transaction_matches
-    |> Enum.reduce(token_transfer_matches, &MapSet.union/2)
-    |> MapSet.to_list()
-    |> Enum.sort_by(& &1.index, &>=/2)
-    |> Enum.sort_by(& &1.block_number, &>=/2)
-    |> Enum.slice(0..paging_options.page_size)
+    base_query
+    |> from(where: ^transaction_dynamic)
+    |> Repo.all()
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -151,22 +151,57 @@ defmodule Explorer.Chain.TokenTransfer do
     )
   end
 
-  def where_address_fields_match(query, address_hash, :from) do
-    query
-    |> join(:left, [transaction], tt in assoc(transaction, :token_transfers))
-    |> where([_transaction, tt], tt.from_address_hash == ^address_hash)
+  @doc """
+  Builds a dynamic query expression to identify if there is a token transfer
+  related to the hash.
+  """
+  def dynamic_any_address_fields_match(:to, address_bytes) do
+    dynamic(
+      [t],
+      t.hash ==
+        fragment(
+          ~s"""
+          (SELECT tt.transaction_hash
+          FROM "token_transfers" AS tt
+          WHERE (tt."to_address_hash" = ?)
+          LIMIT 1)
+          """,
+          ^address_bytes
+        )
+    )
   end
 
-  def where_address_fields_match(query, address_hash, :to) do
-    query
-    |> join(:left, [transaction], tt in assoc(transaction, :token_transfers))
-    |> where([_transaction, tt], tt.to_address_hash == ^address_hash)
+  def dynamic_any_address_fields_match(:from, address_bytes) do
+    dynamic(
+      [t],
+      t.hash ==
+        fragment(
+          ~s"""
+          (SELECT tt.transaction_hash
+          FROM "token_transfers" AS tt
+          WHERE (tt."from_address_hash" = ?)
+          LIMIT 1)
+          """,
+          ^address_bytes
+        )
+    )
   end
 
-  def where_address_fields_match(query, address_hash, _) do
-    query
-    |> join(:left, [transaction], tt in assoc(transaction, :token_transfers))
-    |> where([_transaction, tt], tt.to_address_hash == ^address_hash or tt.from_address_hash == ^address_hash)
+  def dynamic_any_address_fields_match(_, address_bytes) do
+    dynamic(
+      [t],
+      t.hash ==
+        fragment(
+          ~s"""
+          (SELECT tt.transaction_hash
+          FROM "token_transfers" AS tt
+          WHERE ((tt."to_address_hash" = ?) OR (tt."from_address_hash" = ?))
+          LIMIT 1)
+          """,
+          ^address_bytes,
+          ^address_bytes
+        )
+    )
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.Transaction do
 
   use Explorer.Schema
 
-  import Ecto.Query, only: [from: 2, preload: 3, where: 3, subquery: 1]
+  import Ecto.Query, only: [dynamic: 2, from: 2, preload: 3, subquery: 1, where: 3]
 
   alias Ecto.Changeset
 
@@ -425,6 +425,32 @@ defmodule Explorer.Chain.Transaction do
   """
   def where_address_fields_match(query, address_hash, address_field) do
     where(query, [t], field(t, ^address_field) == ^address_hash)
+  end
+
+  @doc """
+  Builds a dynamic query expression to identify if there is a transaction
+  related to the hash.
+  """
+  def dynamic_where_address_hash_matches(address_hash, :to, dynamic) do
+    dynamic(
+      [t],
+      t.to_address_hash == ^address_hash or t.created_contract_address_hash == ^address_hash or ^dynamic
+    )
+  end
+
+  def dynamic_where_address_hash_matches(address_hash, :from, dynamic) do
+    dynamic(
+      [t],
+      t.from_address_hash == ^address_hash or ^dynamic
+    )
+  end
+
+  def dynamic_where_address_hash_matches(address_hash, _, dynamic) do
+    dynamic(
+      [t],
+      t.to_address_hash == ^address_hash or t.from_address_hash == ^address_hash or
+        t.created_contract_address_hash == ^address_hash or ^dynamic
+    )
   end
 
   @collated_fields ~w(block_number cumulative_gas_used gas_used index)a


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/947

## Changelog

### Enhancements

Shorten `Chain.address_to_transactions/2` by removing the query that was `left outer join` with token transfers, making it way faster to be processed.
