### PR TITLE
Improve performance in token holders tab on Token's page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -16,7 +16,7 @@ defmodule BlockScoutWeb.Chain do
 
   alias Explorer.Chain.{
     Address,
-    Address.TokenBalance,
+    Address.CurrentTokenBalance,
     Block,
     InternalTransaction,
     Log,
@@ -198,7 +198,7 @@ defmodule BlockScoutWeb.Chain do
     %{"token_name" => name, "token_type" => type, "token_inserted_at" => inserted_at_datetime}
   end
 
-  defp paging_params(%TokenBalance{address_hash: address_hash, value: value}) do
+  defp paging_params(%CurrentTokenBalance{address_hash: address_hash, value: value}) do
     %{"address_hash" => to_string(address_hash), "value" => Decimal.to_integer(value)}
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/tokens/holder_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/tokens/holder_controller_test.exs
@@ -22,7 +22,7 @@ defmodule BlockScoutWeb.Tokens.HolderControllerTest do
 
       insert_list(
         2,
-        :token_balance,
+        :address_current_token_balance,
         token_contract_address_hash: token.contract_address_hash
       )
 
@@ -43,7 +43,7 @@ defmodule BlockScoutWeb.Tokens.HolderControllerTest do
         1..50
         |> Enum.map(
           &insert(
-            :token_balance,
+            :address_current_token_balance,
             token_contract_address_hash: token.contract_address_hash,
             value: &1 + 1000
           )
@@ -52,7 +52,7 @@ defmodule BlockScoutWeb.Tokens.HolderControllerTest do
 
       token_balance =
         insert(
-          :token_balance,
+          :address_current_token_balance,
           token_contract_address_hash: token.contract_address_hash,
           value: 50000
         )
@@ -78,7 +78,7 @@ defmodule BlockScoutWeb.Tokens.HolderControllerTest do
       Enum.each(
         1..51,
         &insert(
-          :token_balance,
+          :address_current_token_balance,
           token_contract_address_hash: token.contract_address_hash,
           value: &1 + 1000
         )

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_tokens_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_tokens_test.exs
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.ViewingTokensTest do
 
       insert_list(
         2,
-        :token_balance,
+        :address_current_token_balance,
         token_contract_address_hash: token.contract_address_hash
       )
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -23,6 +23,7 @@ defmodule Explorer.Chain do
   alias Explorer.Chain.{
     Address,
     Address.CoinBalance,
+    Address.CurrentTokenBalance,
     Address.TokenBalance,
     Block,
     Data,
@@ -2070,7 +2071,7 @@ defmodule Explorer.Chain do
   @spec fetch_token_holders_from_token_hash(Hash.Address.t(), [paging_options]) :: [TokenBalance.t()]
   def fetch_token_holders_from_token_hash(contract_address_hash, options) do
     contract_address_hash
-    |> TokenBalance.token_holders_ordered_by_value(options)
+    |> CurrentTokenBalance.token_holders_ordered_by_value(options)
     |> Repo.all()
   end
 

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -1,0 +1,60 @@
+defmodule Explorer.Chain.Address.CurrentTokenBalance do
+  @moduledoc """
+  Represents the current token balance from addresses according to the last block.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Explorer.Chain.{Address, Block, Hash, Token}
+
+  @typedoc """
+   *  `address` - The `t:Explorer.Chain.Address.t/0` that is the balance's owner.
+   *  `address_hash` - The address hash foreign key.
+   *  `token` - The `t:Explorer.Chain.Token/0` so that the address has the balance.
+   *  `token_contract_address_hash` - The contract address hash foreign key.
+   *  `block_number` - The block's number that the transfer took place.
+   *  `value` - The value that's represents the balance.
+  """
+  @type t :: %__MODULE__{
+          address: %Ecto.Association.NotLoaded{} | Address.t(),
+          address_hash: Hash.Address.t(),
+          token: %Ecto.Association.NotLoaded{} | Token.t(),
+          token_contract_address_hash: Hash.Address,
+          block_number: Block.block_number(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t(),
+          value: Decimal.t() | nil
+        }
+
+  schema "address_current_token_balances" do
+    field(:value, :decimal)
+    field(:block_number, :integer)
+    field(:value_fetched_at, :utc_datetime)
+
+    belongs_to(:address, Address, foreign_key: :address_hash, references: :hash, type: Hash.Address)
+
+    belongs_to(
+      :token,
+      Token,
+      foreign_key: :token_contract_address_hash,
+      references: :contract_address_hash,
+      type: Hash.Address
+    )
+
+    timestamps()
+  end
+
+  @optional_fields ~w(value value_fetched_at)a
+  @required_fields ~w(address_hash block_number token_contract_address_hash)a
+  @allowed_fields @optional_fields ++ @required_fields
+
+  @doc false
+  def changeset(%__MODULE__{} = token_balance, attrs) do
+    token_balance
+    |> cast(attrs, @allowed_fields)
+    |> validate_required(@required_fields)
+    |> foreign_key_constraint(:address_hash)
+    |> foreign_key_constraint(:token_contract_address_hash)
+  end
+end

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -19,6 +19,7 @@ defmodule Explorer.Chain.Import do
     Import.Logs,
     Import.Tokens,
     Import.TokenTransfers,
+    Import.Address.CurrentTokenBalances,
     Import.Address.TokenBalances
   ]
 

--- a/apps/explorer/lib/explorer/chain/import/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/address/current_token_balances.ex
@@ -1,0 +1,124 @@
+defmodule Explorer.Chain.Import.Address.CurrentTokenBalances do
+  @moduledoc """
+  Bulk imports `t:Explorer.Chain.Address.CurrentTokenBalance.t/0`.
+  """
+
+  require Ecto.Query
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Ecto.{Changeset, Multi}
+  alias Explorer.Chain.Address.CurrentTokenBalance
+  alias Explorer.Chain.Import
+
+  @behaviour Import.Runner
+
+  # milliseconds
+  @timeout 60_000
+
+  @type imported :: [CurrentTokenBalance.t()]
+
+  @impl Import.Runner
+  def ecto_schema_module, do: CurrentTokenBalance
+
+  @impl Import.Runner
+  def option_key, do: :address_current_token_balances
+
+  @impl Import.Runner
+  def imported_table_row do
+    %{
+      value_type: "[#{ecto_schema_module()}.t()]",
+      value_description: "List of `t:#{ecto_schema_module()}.t/0`s"
+    }
+  end
+
+  @impl Import.Runner
+  def run(multi, changes_list, %{timestamps: timestamps} = options) do
+    insert_options =
+      options
+      |> Map.get(option_key(), %{})
+      |> Map.take(~w(on_conflict timeout)a)
+      |> Map.put_new(:timeout, @timeout)
+      |> Map.put(:timestamps, timestamps)
+
+    Multi.run(multi, :address_current_token_balances, fn _ ->
+      insert(changes_list, insert_options)
+    end)
+  end
+
+  @impl Import.Runner
+  def timeout, do: @timeout
+
+  @spec insert([map()], %{
+          optional(:on_conflict) => Import.Runner.on_conflict(),
+          required(:timeout) => timeout(),
+          required(:timestamps) => Import.timestamps()
+        }) ::
+          {:ok, [CurrentTokenBalance.t()]}
+          | {:error, [Changeset.t()]}
+  def insert(changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
+    on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
+
+    {:ok, _} =
+      Import.insert_changes_list(
+        unique_token_balances(changes_list),
+        conflict_target: ~w(address_hash token_contract_address_hash)a,
+        on_conflict: on_conflict,
+        for: CurrentTokenBalance,
+        returning: true,
+        timeout: timeout,
+        timestamps: timestamps
+      )
+  end
+
+  # Remove duplicated token balances based on `{address_hash, token_hash}` considering the last block
+  # to avoid `cardinality_violation` error in Postgres. This error happens when there are duplicated
+  # rows being inserted.
+  defp unique_token_balances(changes_list) do
+    changes_list
+    |> Enum.sort(&(&1.block_number > &2.block_number))
+    |> Enum.uniq_by(fn %{address_hash: address_hash, token_contract_address_hash: token_hash} ->
+      {address_hash, token_hash}
+    end)
+  end
+
+  defp default_on_conflict do
+    from(
+      current_token_balance in CurrentTokenBalance,
+      update: [
+        set: [
+          block_number:
+            fragment(
+              "CASE WHEN EXCLUDED.block_number > ? THEN EXCLUDED.block_number ELSE ? END",
+              current_token_balance.block_number,
+              current_token_balance.block_number
+            ),
+          inserted_at:
+            fragment(
+              "CASE WHEN EXCLUDED.block_number > ? THEN EXCLUDED.inserted_at ELSE ? END",
+              current_token_balance.block_number,
+              current_token_balance.inserted_at
+            ),
+          updated_at:
+            fragment(
+              "CASE WHEN EXCLUDED.block_number > ? THEN EXCLUDED.updated_at ELSE ? END",
+              current_token_balance.block_number,
+              current_token_balance.updated_at
+            ),
+          value:
+            fragment(
+              "CASE WHEN EXCLUDED.block_number > ? THEN EXCLUDED.value ELSE ? END",
+              current_token_balance.block_number,
+              current_token_balance.value
+            ),
+          value_fetched_at:
+            fragment(
+              "CASE WHEN EXCLUDED.block_number > ? THEN EXCLUDED.value_fetched_at ELSE ? END",
+              current_token_balance.block_number,
+              current_token_balance.value_fetched_at
+            )
+        ]
+      ]
+    )
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20181026180921_create_address_current_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20181026180921_create_address_current_token_balances.exs
@@ -1,0 +1,32 @@
+defmodule Explorer.Repo.Migrations.CreateAddressCurrentTokenBalances do
+  use Ecto.Migration
+
+  def change do
+    create table(:address_current_token_balances) do
+      add(:address_hash, references(:addresses, column: :hash, type: :bytea), null: false)
+      add(:block_number, :bigint, null: false)
+
+      add(
+        :token_contract_address_hash,
+        references(:tokens, column: :contract_address_hash, type: :bytea),
+        null: false
+      )
+
+      add(:value, :decimal, null: true)
+      add(:value_fetched_at, :utc_datetime, default: fragment("NULL"), null: true)
+
+      timestamps(null: false, type: :utc_datetime)
+    end
+
+    create(unique_index(:address_current_token_balances, ~w(address_hash token_contract_address_hash)a))
+
+    create(
+      index(
+        :address_current_token_balances,
+        [:value],
+        name: :address_current_token_balances_value,
+        where: "value IS NOT NULL"
+      )
+    )
+  end
+end

--- a/apps/explorer/test/explorer/chain/address/current_token_balance_test.exs
+++ b/apps/explorer/test/explorer/chain/address/current_token_balance_test.exs
@@ -1,0 +1,149 @@
+defmodule Explorer.Chain.Address.CurrentTokenBalanceTest do
+  use Explorer.DataCase
+
+  alias Explorer.{Chain, PagingOptions, Repo}
+  alias Explorer.Chain.Token
+  alias Explorer.Chain.Address.CurrentTokenBalance
+
+  describe "token_holders_ordered_by_value/2" do
+    test "returns the last value for each address" do
+      %Token{contract_address_hash: contract_address_hash} = insert(:token)
+      address_a = insert(:address)
+      address_b = insert(:address)
+
+      insert(
+        :address_current_token_balance,
+        address: address_a,
+        token_contract_address_hash: contract_address_hash,
+        value: 5000
+      )
+
+      insert(
+        :address_current_token_balance,
+        address: address_b,
+        block_number: 1001,
+        token_contract_address_hash: contract_address_hash,
+        value: 4000
+      )
+
+      token_holders_count =
+        contract_address_hash
+        |> CurrentTokenBalance.token_holders_ordered_by_value()
+        |> Repo.all()
+        |> Enum.count()
+
+      assert token_holders_count == 2
+    end
+
+    test "sort by the highest value" do
+      %Token{contract_address_hash: contract_address_hash} = insert(:token)
+      address_a = insert(:address)
+      address_b = insert(:address)
+      address_c = insert(:address)
+
+      insert(
+        :address_current_token_balance,
+        address: address_a,
+        token_contract_address_hash: contract_address_hash,
+        value: 5000
+      )
+
+      insert(
+        :address_current_token_balance,
+        address: address_b,
+        token_contract_address_hash: contract_address_hash,
+        value: 4000
+      )
+
+      insert(
+        :address_current_token_balance,
+        address: address_c,
+        token_contract_address_hash: contract_address_hash,
+        value: 15000
+      )
+
+      token_holders_values =
+        contract_address_hash
+        |> CurrentTokenBalance.token_holders_ordered_by_value()
+        |> Repo.all()
+        |> Enum.map(&Decimal.to_integer(&1.value))
+
+      assert token_holders_values == [15_000, 5_000, 4_000]
+    end
+
+    test "returns only token balances that have value greater than 0" do
+      %Token{contract_address_hash: contract_address_hash} = insert(:token)
+
+      insert(
+        :address_current_token_balance,
+        token_contract_address_hash: contract_address_hash,
+        value: 0
+      )
+
+      result =
+        contract_address_hash
+        |> CurrentTokenBalance.token_holders_ordered_by_value()
+        |> Repo.all()
+
+      assert result == []
+    end
+
+    test "ignores the burn address" do
+      {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+
+      burn_address = insert(:address, hash: burn_address_hash)
+
+      %Token{contract_address_hash: contract_address_hash} = insert(:token)
+
+      insert(
+        :address_current_token_balance,
+        address: burn_address,
+        token_contract_address_hash: contract_address_hash,
+        value: 1000
+      )
+
+      result =
+        contract_address_hash
+        |> CurrentTokenBalance.token_holders_ordered_by_value()
+        |> Repo.all()
+
+      assert result == []
+    end
+
+    test "paginates the result by value and different address" do
+      address_a = build(:address, hash: "0xcb2cf1fd3199584ac5faa16c6aca49472dc6495a")
+      address_b = build(:address, hash: "0x5f26097334b6a32b7951df61fd0c5803ec5d8354")
+
+      %Token{contract_address_hash: contract_address_hash} = insert(:token)
+
+      first_page =
+        insert(
+          :address_current_token_balance,
+          address: address_a,
+          token_contract_address_hash: contract_address_hash,
+          value: 4000
+        )
+
+      second_page =
+        insert(
+          :address_current_token_balance,
+          address: address_b,
+          token_contract_address_hash: contract_address_hash,
+          value: 4000
+        )
+
+      paging_options = %PagingOptions{
+        key: {first_page.value, first_page.address_hash},
+        page_size: 2
+      }
+
+      result_paginated =
+        contract_address_hash
+        |> CurrentTokenBalance.token_holders_ordered_by_value(paging_options: paging_options)
+        |> Repo.all()
+        |> Enum.map(& &1.address_hash)
+
+      assert result_paginated == [second_page.address_hash]
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/import/address/address/current_token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/address/address/current_token_balances_test.exs
@@ -1,0 +1,95 @@
+defmodule Explorer.Chain.Import.Address.CurrentTokenBalancesTest do
+  use Explorer.DataCase
+
+  alias Explorer.Chain.Import.Address.CurrentTokenBalances
+
+  alias Explorer.Chain.{Address.CurrentTokenBalance}
+
+  describe "insert/2" do
+    setup do
+      address = insert(:address, hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca")
+      token = insert(:token)
+
+      insert_options = %{
+        timeout: :infinity,
+        timestamps: %{inserted_at: DateTime.utc_now(), updated_at: DateTime.utc_now()}
+      }
+
+      %{address: address, token: token, insert_options: insert_options}
+    end
+
+    test "inserts in the current token balances", %{address: address, token: token, insert_options: insert_options} do
+      changes = [
+        %{
+          address_hash: address.hash,
+          block_number: 1,
+          token_contract_address_hash: token.contract_address_hash,
+          value: Decimal.new(100)
+        }
+      ]
+
+      CurrentTokenBalances.insert(changes, insert_options)
+
+      current_token_balances =
+        CurrentTokenBalance
+        |> Explorer.Repo.all()
+        |> Enum.count()
+
+      assert current_token_balances == 1
+    end
+
+    test "considers the last block upserting", %{address: address, token: token, insert_options: insert_options} do
+      insert(
+        :address_current_token_balance,
+        address: address,
+        block_number: 1,
+        token_contract_address_hash: token.contract_address_hash,
+        value: 100
+      )
+
+      changes = [
+        %{
+          address_hash: address.hash,
+          block_number: 2,
+          token_contract_address_hash: token.contract_address_hash,
+          value: Decimal.new(200)
+        }
+      ]
+
+      CurrentTokenBalances.insert(changes, insert_options)
+
+      current_token_balance = Explorer.Repo.get_by(CurrentTokenBalance, address_hash: address.hash)
+
+      assert current_token_balance.block_number == 2
+      assert current_token_balance.value == Decimal.new(200)
+    end
+
+    test "considers the last block when there are duplicated params", %{
+      address: address,
+      token: token,
+      insert_options: insert_options
+    } do
+      changes = [
+        %{
+          address_hash: address.hash,
+          block_number: 4,
+          token_contract_address_hash: token.contract_address_hash,
+          value: Decimal.new(200)
+        },
+        %{
+          address_hash: address.hash,
+          block_number: 1,
+          token_contract_address_hash: token.contract_address_hash,
+          value: Decimal.new(100)
+        }
+      ]
+
+      CurrentTokenBalances.insert(changes, insert_options)
+
+      current_token_balance = Explorer.Repo.get_by(CurrentTokenBalance, address_hash: address.hash)
+
+      assert current_token_balance.block_number == 4
+      assert current_token_balance.value == Decimal.new(200)
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -6,6 +6,7 @@ defmodule Explorer.Chain.ImportTest do
   alias Explorer.Chain.{
     Address,
     Address.TokenBalance,
+    Address.CurrentTokenBalance,
     Block,
     Data,
     Log,
@@ -393,6 +394,55 @@ defmodule Explorer.Chain.ImportTest do
       count = Explorer.Repo.one(Ecto.Query.from(t in TokenBalance, select: count(t.id)))
 
       assert 3 == count
+    end
+
+    test "inserts a current_token_balance" do
+      params = %{
+        addresses: %{
+          params: [
+            %{hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca"},
+            %{hash: "0x515c09c5bba1ed566b02a5b0599ec5d5d0aee73d"},
+            %{hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"}
+          ],
+          timeout: 5
+        },
+        tokens: %{
+          on_conflict: :nothing,
+          params: [
+            %{
+              contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+              type: "ERC-20"
+            }
+          ],
+          timeout: 5
+        },
+        address_current_token_balances: %{
+          params: [
+            %{
+              address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+              token_contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+              block_number: "37",
+              value: 200
+            },
+            %{
+              address_hash: "0x515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+              token_contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+              block_number: "37",
+              value: 100
+            }
+          ],
+          timeout: 5
+        }
+      }
+
+      Import.all(params)
+
+      count =
+        CurrentTokenBalance
+        |> Explorer.Repo.all()
+        |> Enum.count()
+
+      assert count == 2
     end
 
     test "with empty map" do

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2956,173 +2956,32 @@ defmodule Explorer.ChainTest do
   end
 
   describe "fetch_token_holders_from_token_hash/2" do
-    test "returns the last value for each address" do
+    test "returns the token holders" do
       %Token{contract_address_hash: contract_address_hash} = insert(:token)
-      address = insert(:address)
+      address_a = insert(:address)
+      address_b = insert(:address)
 
       insert(
-        :token_balance,
-        address: address,
-        block_number: 1000,
+        :address_current_token_balance,
+        address: address_a,
         token_contract_address_hash: contract_address_hash,
         value: 5000
       )
 
       insert(
-        :token_balance,
+        :address_current_token_balance,
+        address: address_b,
         block_number: 1001,
         token_contract_address_hash: contract_address_hash,
         value: 4000
       )
 
-      insert(
-        :token_balance,
-        address: address,
-        block_number: 1002,
-        token_contract_address_hash: contract_address_hash,
-        value: 2000
-      )
-
-      values =
+      token_holders_count =
         contract_address_hash
         |> Chain.fetch_token_holders_from_token_hash([])
-        |> Enum.map(&Decimal.to_integer(&1.value))
+        |> Enum.count()
 
-      assert values == [4000, 2000]
-    end
-
-    test "sort by the highest value" do
-      %Token{contract_address_hash: contract_address_hash} = insert(:token)
-
-      insert(
-        :token_balance,
-        block_number: 1000,
-        token_contract_address_hash: contract_address_hash,
-        value: 2000
-      )
-
-      insert(
-        :token_balance,
-        block_number: 1001,
-        token_contract_address_hash: contract_address_hash,
-        value: 1000
-      )
-
-      insert(
-        :token_balance,
-        block_number: 1002,
-        token_contract_address_hash: contract_address_hash,
-        value: 4000
-      )
-
-      insert(
-        :token_balance,
-        block_number: 1002,
-        token_contract_address_hash: contract_address_hash,
-        value: 3000
-      )
-
-      values =
-        contract_address_hash
-        |> Chain.fetch_token_holders_from_token_hash([])
-        |> Enum.map(&Decimal.to_integer(&1.value))
-
-      assert values == [4000, 3000, 2000, 1000]
-    end
-
-    test "returns only token balances that have value" do
-      %Token{contract_address_hash: contract_address_hash} = insert(:token)
-
-      insert(
-        :token_balance,
-        token_contract_address_hash: contract_address_hash,
-        value: 0
-      )
-
-      assert Chain.fetch_token_holders_from_token_hash(contract_address_hash, []) == []
-    end
-
-    test "returns an empty list when there are no address with value greater than 0" do
-      %Token{contract_address_hash: contract_address_hash} = insert(:token)
-
-      insert(:token_balance, value: 1000)
-
-      assert Chain.fetch_token_holders_from_token_hash(contract_address_hash, []) == []
-    end
-
-    test "ignores the burn address" do
-      {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
-
-      burn_address = insert(:address, hash: burn_address_hash)
-
-      %Token{contract_address_hash: contract_address_hash} = insert(:token)
-
-      insert(
-        :token_balance,
-        address: burn_address,
-        token_contract_address_hash: contract_address_hash,
-        value: 1000
-      )
-
-      assert Chain.fetch_token_holders_from_token_hash(contract_address_hash, []) == []
-    end
-
-    test "paginates the result by value and different address" do
-      address_a = build(:address, hash: "0xcb2cf1fd3199584ac5faa16c6aca49472dc6495a")
-      address_b = build(:address, hash: "0x5f26097334b6a32b7951df61fd0c5803ec5d8354")
-
-      %Token{contract_address_hash: contract_address_hash} = insert(:token)
-
-      first_page =
-        insert(
-          :token_balance,
-          address: address_a,
-          token_contract_address_hash: contract_address_hash,
-          value: 4000
-        )
-
-      second_page =
-        insert(
-          :token_balance,
-          address: address_b,
-          token_contract_address_hash: contract_address_hash,
-          value: 4000
-        )
-
-      paging_options = %PagingOptions{
-        key: {first_page.value, first_page.address_hash},
-        page_size: 2
-      }
-
-      holders_paginated =
-        contract_address_hash
-        |> Chain.fetch_token_holders_from_token_hash(paging_options: paging_options)
-        |> Enum.map(& &1.address_hash)
-
-      assert holders_paginated == [second_page.address_hash]
-    end
-
-    test "considers the last block only if it has value" do
-      address = insert(:address, hash: "0x5f26097334b6a32b7951df61fd0c5803ec5d8354")
-      %Token{contract_address_hash: contract_address_hash} = insert(:token)
-
-      insert(
-        :token_balance,
-        address: address,
-        block_number: 1000,
-        token_contract_address_hash: contract_address_hash,
-        value: 5000
-      )
-
-      insert(
-        :token_balance,
-        address: address,
-        block_number: 1002,
-        token_contract_address_hash: contract_address_hash,
-        value: 0
-      )
-
-      assert Chain.fetch_token_holders_from_token_hash(contract_address_hash, []) == []
+      assert token_holders_count == 2
     end
   end
 

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -13,6 +13,7 @@ defmodule Explorer.Factory do
 
   alias Explorer.Chain.{
     Address,
+    Address.CurrentTokenBalance,
     Address.TokenBalance,
     Address.CoinBalance,
     Block,
@@ -472,6 +473,16 @@ defmodule Explorer.Factory do
 
   def token_balance_factory() do
     %TokenBalance{
+      address: build(:address),
+      token_contract_address_hash: insert(:token).contract_address_hash,
+      block_number: block_number(),
+      value: Enum.random(1..100_000),
+      value_fetched_at: DateTime.utc_now()
+    }
+  end
+
+  def address_current_token_balance_factory() do
+    %CurrentTokenBalance{
       address: build(:address),
       token_contract_address_hash: insert(:token).contract_address_hash,
       block_number: block_number(),

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -107,6 +107,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
            |> put_in([:addresses, :params], balances_addresses_params)
            |> put_in([:blocks, :params, Access.all(), :consensus], true)
            |> put_in([Access.key(:address_coin_balances, %{}), :params], balances_params)
+           |> put_in([Access.key(:address_current_token_balances, %{}), :params], address_token_balances)
            |> put_in([Access.key(:address_token_balances), :params], address_token_balances)
            |> put_in([Access.key(:internal_transactions, %{}), :params], internal_transactions_params),
          {:ok, imported} = ok <- Chain.import(chain_import_options) do

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -80,7 +80,13 @@ defmodule Indexer.TokenBalance.Fetcher do
   end
 
   def import_token_balances(token_balances_params) do
-    case Chain.import(%{address_token_balances: %{params: token_balances_params}, timeout: :infinity}) do
+    import_params = %{
+      address_token_balances: %{params: token_balances_params},
+      address_current_token_balances: %{params: token_balances_params},
+      timeout: :infinity
+    }
+
+    case Chain.import(import_params) do
       {:ok, _} ->
         :ok
 

--- a/apps/indexer/lib/indexer/token_balances.ex
+++ b/apps/indexer/lib/indexer/token_balances.ex
@@ -29,7 +29,7 @@ defmodule Indexer.TokenBalances do
       token_balances
       |> Task.async_stream(&fetch_token_balance/1, on_timeout: :kill_task)
       |> Stream.map(&format_task_results/1)
-      |> Enum.filter(&ignore_request_with_timeouts/1)
+      |> Enum.filter(&ignore_request_with_errors/1)
 
     token_balances
     |> MapSet.new()
@@ -70,11 +70,12 @@ defmodule Indexer.TokenBalances do
     |> TokenBalance.Fetcher.async_fetch()
   end
 
-  def format_task_results({:exit, :timeout}), do: {:error, :timeout}
-  def format_task_results({:ok, token_balance}), do: token_balance
+  defp format_task_results({:exit, :timeout}), do: {:error, :timeout}
+  defp format_task_results({:ok, token_balance}), do: token_balance
 
-  def ignore_request_with_timeouts({:error, :timeout}), do: false
-  def ignore_request_with_timeouts(_token_balance), do: true
+  defp ignore_request_with_errors({:error, :timeout}), do: false
+  defp ignore_request_with_errors(%{value: nil, value_fetched_at: nil, error: _error}), do: false
+  defp ignore_request_with_errors(_token_balance), do: true
 
   def log_fetching_errors(from, token_balances_params) do
     error_messages =

--- a/apps/indexer/test/indexer/token_balances_test.exs
+++ b/apps/indexer/test/indexer/token_balances_test.exs
@@ -45,28 +45,21 @@ defmodule Indexer.TokenBalancesTest do
              } = List.first(result)
     end
 
-    test "does not ignore calls that were returned with error" do
-      address = insert(:address)
+    test "ignores calls that gave errors to try fetch they again later" do
+      address = insert(:address, hash: "0x7113ffcb9c18a97da1b9cfc43e6cb44ed9165509")
       token = insert(:token, contract_address: build(:contract_address))
-      address_hash_string = Hash.to_string(address.hash)
 
-      data = %{
-        token_contract_address_hash: token.contract_address_hash,
-        address_hash: address_hash_string,
-        block_number: 1_000
-      }
+      token_balances = [
+        %{
+          address_hash: to_string(address.hash),
+          block_number: 1_000,
+          token_contract_address_hash: to_string(token.contract_address_hash)
+        }
+      ]
 
       get_balance_from_blockchain_with_error()
 
-      {:ok, result} = TokenBalances.fetch_token_balances_from_blockchain([data])
-
-      assert %{
-               value: nil,
-               token_contract_address_hash: token_contract_address_hash,
-               address_hash: address_hash,
-               block_number: 1_000,
-               value_fetched_at: nil
-             } = List.first(result)
+      assert TokenBalances.fetch_token_balances_from_blockchain(token_balances) == {:ok, []}
     end
 
     test "ignores results that raised :timeout" do


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/962

## Motivation
Querying against `address_token_balances` to fetch the last balance from a specific Address is very slow because we need to apply a distinct token and sort by the last block number. In Ethereum mainnet, this kind of query was taking 50s with 100 million token balances (we probably will have more than 1 billion 😱).

Since most of our use cases are knowing the last balance from address, I'm creating a new table called `address_current_token_balances` that will store only the current token balances based on the last block. We still will keep the `address_token_balances` since it will be useful in the future.

## Changelog
* Fix token balances fetcher to schedule requests that gave errors to be fetched again later.
* Create table `address_current_token_balances`.
* Change Token Holders query to fetch data from `address_current_token_balance`.

### Enhancements
* Improve Token Holders page performance.

### Bug Fixes
* Fix token balances fetcher to schedule requests that gave errors to be fetched again later.

## Upgrading

* If the machine already has token balances, it's necessary to run a task to populate the `address_current_current_token_balances` from `address_token_balances` table.

## TODO
- [x] Improve documentation
- [x] Improve tests
- [x] Change Token Holder's query
- [x] Add task to populate the `address_current_current_token_balances` from `address_token_balances` (It will be executed directly in DB)