### PR TITLE
ignore decimals values too big for postgres' bigint

### DIFF
--- a/apps/indexer/test/indexer/token/fetcher_test.exs
+++ b/apps/indexer/test/indexer/token/fetcher_test.exs
@@ -116,6 +116,47 @@ defmodule Indexer.Token.FetcherTest do
       end
     end
 
+    test "considers the decimals nil when it is too large a number", %{
+      json_rpc_named_arguments: json_rpc_named_arguments
+    } do
+      token = insert(:token, name: nil, symbol: nil, total_supply: nil, decimals: nil, cataloged: false)
+      contract_address_hash = token.contract_address_hash
+
+      if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
+        expect(
+          EthereumJSONRPC.Mox,
+          :json_rpc,
+          1,
+          fn [%{id: "decimals"}, %{id: "name"}, %{id: "symbol"}, %{id: "totalSupply"}], _opts ->
+            {:ok,
+             [
+               %{
+                 id: "decimals",
+                 result: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+               },
+               %{
+                 id: "name",
+                 result:
+                   "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003424e540000000000000000000000000000000000000000000000000000000000"
+               },
+               %{
+                 id: "symbol",
+                 result:
+                   "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003424e540000000000000000000000000000000000000000000000000000000000"
+               },
+               %{
+                 id: "totalSupply",
+                 result: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
+               }
+             ]}
+          end
+        )
+
+        assert Fetcher.run([contract_address_hash], json_rpc_named_arguments) == :ok
+        assert {:ok, %Token{cataloged: true, decimals: nil}} = Chain.token_from_address_hash(contract_address_hash)
+      end
+    end
+
     test "considers the symbol nil when it is an invalid string", %{json_rpc_named_arguments: json_rpc_named_arguments} do
       token = insert(:token, name: nil, symbol: nil, total_supply: nil, decimals: nil, cataloged: false)
       contract_address_hash = token.contract_address_hash


### PR DESCRIPTION
resolves #1002 

## Changelog

### Bug Fixes
 * replace numbers in the `decimals` field that are too big for the `bigint` type in postgres with `nil` during indexing of tokens