### PR TITLE
Gsf increase limit of token decimals field

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/currency_helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/currency_helpers.ex
@@ -25,24 +25,24 @@ defmodule BlockScoutWeb.CurrencyHelpers do
 
   ## Examples
 
-      iex> format_according_to_decimals(Decimal.new(20500000), 5)
+      iex> format_according_to_decimals(Decimal.new(20500000), Decimal.new(5))
       "205"
 
-      iex> format_according_to_decimals(Decimal.new(20500000), 7)
+      iex> format_according_to_decimals(Decimal.new(20500000), Decimal.new(7))
       "2.05"
 
-      iex> format_according_to_decimals(Decimal.new(205000), 12)
+      iex> format_according_to_decimals(Decimal.new(205000), Decimal.new(12))
       "0.000000205"
 
-      iex> format_according_to_decimals(Decimal.new(205000), 2)
+      iex> format_according_to_decimals(Decimal.new(205000), Decimal.new(2))
       "2,050"
 
-      iex> format_according_to_decimals(205000, 2)
+      iex> format_according_to_decimals(205000, Decimal.new(2))
       "2,050"
   """
-  @spec format_according_to_decimals(non_neg_integer(), non_neg_integer()) :: String.t()
+  @spec format_according_to_decimals(non_neg_integer(), nil) :: String.t()
   def format_according_to_decimals(value, nil) do
-    format_according_to_decimals(value, 0)
+    format_according_to_decimals(value, Decimal.new(0))
   end
 
   def format_according_to_decimals(value, decimals) when is_integer(value) do
@@ -51,10 +51,10 @@ defmodule BlockScoutWeb.CurrencyHelpers do
     |> format_according_to_decimals(decimals)
   end
 
-  @spec format_according_to_decimals(Decimal.t(), non_neg_integer()) :: String.t()
+  @spec format_according_to_decimals(Decimal.t(), Decimal.t()) :: String.t()
   def format_according_to_decimals(%Decimal{sign: sign, coef: coef, exp: exp}, decimals) do
     sign
-    |> Decimal.new(coef, exp - decimals)
+    |> Decimal.new(coef, exp - Decimal.to_integer(decimals))
     |> Decimal.reduce()
     |> thousands_separator()
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/helpers.ex
@@ -25,7 +25,7 @@ defmodule BlockScoutWeb.Tokens.Helpers do
   end
 
   defp do_token_transfer_amount(%Token{type: "ERC-20", decimals: nil}, amount, _token_id) do
-    CurrencyHelpers.format_according_to_decimals(amount, 0)
+    CurrencyHelpers.format_according_to_decimals(amount, Decimal.new(0))
   end
 
   defp do_token_transfer_amount(%Token{type: "ERC-20", decimals: decimals}, amount, _token_id) do

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/holder_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/holder_view.ex
@@ -49,7 +49,7 @@ defmodule BlockScoutWeb.Tokens.HolderView do
 
   ## Examples
 
-    iex> token = build(:token, type: "ERC-20", decimals: 2)
+    iex> token = build(:token, type: "ERC-20", decimals: Decimal.new(2))
     iex> BlockScoutWeb.Tokens.HolderView.format_token_balance_value(100000, token)
     "1,000"
 

--- a/apps/block_scout_web/test/block_scout_web/views/currency_helpers_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/currency_helpers_test.exs
@@ -8,42 +8,42 @@ defmodule BlockScoutWeb.CurrencyHelpersTest do
   describe "format_according_to_decimals/1" do
     test "formats the amount as value considering the given decimals" do
       amount = Decimal.new(205_000_000_000_000)
-      decimals = 12
+      decimals = Decimal.new(12)
 
       assert CurrencyHelpers.format_according_to_decimals(amount, decimals) == "205"
     end
 
     test "considers the decimal places according to the given decimals" do
       amount = Decimal.new(205_000)
-      decimals = 12
+      decimals = Decimal.new(12)
 
       assert CurrencyHelpers.format_according_to_decimals(amount, decimals) == "0.000000205"
     end
 
     test "does not consider right zeros in decimal places" do
       amount = Decimal.new(90_000_000)
-      decimals = 6
+      decimals = Decimal.new(6)
 
       assert CurrencyHelpers.format_according_to_decimals(amount, decimals) == "90"
     end
 
     test "returns the full number when there is no right zeros in decimal places" do
       amount = Decimal.new(9_324_876)
-      decimals = 6
+      decimals = Decimal.new(6)
 
       assert CurrencyHelpers.format_according_to_decimals(amount, decimals) == "9.324876"
     end
 
     test "formats the value considering thousands separators" do
       amount = Decimal.new(1_000_450)
-      decimals = 2
+      decimals = Decimal.new(2)
 
       assert CurrencyHelpers.format_according_to_decimals(amount, decimals) == "10,004.5"
     end
 
     test "supports value as integer" do
       amount = 1_000_450
-      decimals = 2
+      decimals = Decimal.new(2)
 
       assert CurrencyHelpers.format_according_to_decimals(amount, decimals) == "10,004.5"
     end

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/helpers_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/helpers_test.exs
@@ -12,7 +12,7 @@ defmodule BlockScoutWeb.Tokens.HelpersTest do
     end
 
     test "returns the formatted amount according to token decimals with ERC-20 token" do
-      token = build(:token, type: "ERC-20", decimals: 6)
+      token = build(:token, type: "ERC-20", decimals: Decimal.new(6))
       token_transfer = build(:token_transfer, token: token, amount: Decimal.new(1_000_000))
 
       assert Helpers.token_transfer_amount(token_transfer) == "1"

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/holder_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/holder_view_test.exs
@@ -44,7 +44,7 @@ defmodule BlockScoutWeb.Tokens.HolderViewTest do
 
   describe "format_token_balance_value/1" do
     test "formats according to token decimals when it's a ERC-20" do
-      token = build(:token, type: "ERC-20", decimals: 2)
+      token = build(:token, type: "ERC-20", decimals: Decimal.new(2))
       token_balance = build(:token_balance, value: 2_000_000)
 
       assert HolderView.format_token_balance_value(token_balance.value, token) == "20,000"

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -50,7 +50,7 @@ defmodule Explorer.Chain.Token do
     field(:name, :string)
     field(:symbol, :string)
     field(:total_supply, :decimal)
-    field(:decimals, :integer)
+    field(:decimals, :decimal)
     field(:type, :string)
     field(:cataloged, :boolean)
 

--- a/apps/explorer/priv/repo/migrations/20181029174420_update_tokens_table_decimals_from_bigint_to_numeric.exs
+++ b/apps/explorer/priv/repo/migrations/20181029174420_update_tokens_table_decimals_from_bigint_to_numeric.exs
@@ -1,0 +1,17 @@
+defmodule Explorer.Repo.Migrations.UpdateTokensTableDecimalsFromBigintToNumeric do
+  use Ecto.Migration
+
+  def up do
+    alter table("tokens") do
+      modify(:decimals, :decimal)
+    end
+  end
+
+  def down do
+    execute("""
+    ALTER TABLE tokens
+    ALTER COLUMN decimals TYPE bigint
+    USING CASE WHEN decimals > 9223372036854775807 THEN NULL ELSE decimals END;
+    """)
+  end
+end

--- a/apps/explorer/test/explorer/chain/address/token_test.exs
+++ b/apps/explorer/test/explorer/chain/address/token_test.exs
@@ -48,7 +48,7 @@ defmodule Explorer.Chain.Address.TokenTest do
                name: "token-c",
                symbol: "TC",
                balance: Decimal.new(1000),
-               decimals: 0,
+               decimals: Decimal.new(0),
                type: "ERC-721",
                transfers_count: 2
              }

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2795,7 +2795,7 @@ defmodule Explorer.ChainTest do
         name: "Hodl Token",
         symbol: "HT",
         total_supply: 10,
-        decimals: 1,
+        decimals: Decimal.new(1),
         cataloged: true
       }
 

--- a/apps/indexer/test/indexer/token/fetcher_test.exs
+++ b/apps/indexer/test/indexer/token/fetcher_test.exs
@@ -64,12 +64,14 @@ defmodule Indexer.Token.FetcherTest do
 
         expected_supply = Decimal.new(1_000_000_000_000_000_000)
 
+        decimals_expected = Decimal.new(18)
+
         assert {:ok,
                 %Token{
                   name: "Bancor",
                   symbol: "BNT",
                   total_supply: ^expected_supply,
-                  decimals: 18,
+                  decimals: ^decimals_expected,
                   cataloged: true
                 }} = Chain.token_from_address_hash(contract_address_hash)
       end


### PR DESCRIPTION
resolves #1002 

## Changelog

### Bug Fixes
* now large values for decimals column won't break

### Incompatible Changes
 * change type of field decimals to decimal

## Upgrading
 you can do either of the following
1. run `mix ecto.migrate`
2.  run the following query:
    ```sql
    ALTER TABLE tokens
    ALTER COLUMN decimals TYPE numeric;
    ```