### PR TITLE
Highlight code tab when a contract is verified

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
@@ -44,7 +44,7 @@
           <%= gettext("Code") %>
 
         <%= if smart_contract_verified?(@address) do %>
-          <i class="far fa-check-circle"></i>
+          <i class="far fa-check-circle text-success"></i>
         <% end %>
       <% end %>
     </li>


### PR DESCRIPTION
Resolves: #986 

## Motivation

Add a visual indicator to the code tab that a contract has been verified.

## Changelog

### Enhancements
- Add text color to the check icon in the code tab

### Screenshots
<img width="1156" alt="screen shot 2018-10-29 at 3 25 18 pm" src="https://user-images.githubusercontent.com/1641169/47675268-d0854000-db8f-11e8-9a15-877b1260a8b9.png">
<img width="1158" alt="screen shot 2018-10-29 at 3 24 51 pm" src="https://user-images.githubusercontent.com/1641169/47675277-d5e28a80-db8f-11e8-8f3c-728499799405.png">
