### PR TITLE
GraphQL token transfers subscription

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/application.ex
+++ b/apps/block_scout_web/lib/block_scout_web/application.ex
@@ -17,6 +17,7 @@ defmodule BlockScoutWeb.Application do
     children = [
       # Start the endpoint when the application starts
       supervisor(Endpoint, []),
+      supervisor(Absinthe.Subscription, [Endpoint]),
       {EventHandler, name: EventHandler}
     ]
 

--- a/apps/block_scout_web/lib/block_scout_web/channels/user_socket.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/user_socket.ex
@@ -1,5 +1,6 @@
 defmodule BlockScoutWeb.UserSocket do
   use Phoenix.Socket
+  use Absinthe.Phoenix.Socket, schema: BlockScoutWeb.Schema
 
   channel("addresses:*", BlockScoutWeb.AddressChannel)
   channel("blocks:*", BlockScoutWeb.BlockChannel)
@@ -11,6 +12,10 @@ defmodule BlockScoutWeb.UserSocket do
 
   def connect(%{"locale" => locale}, socket) do
     {:ok, assign(socket, :locale, locale)}
+  end
+
+  def connect(_params, socket) do
+    {:ok, socket}
   end
 
   def id(_socket), do: nil

--- a/apps/block_scout_web/lib/block_scout_web/endpoint.ex
+++ b/apps/block_scout_web/lib/block_scout_web/endpoint.ex
@@ -1,5 +1,6 @@
 defmodule BlockScoutWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :block_scout_web
+  use Absinthe.Phoenix.Endpoint
 
   if Application.get_env(:block_scout_web, :sql_sandbox) do
     plug(Phoenix.Ecto.SQL.Sandbox, repo: Explorer.Repo)

--- a/apps/block_scout_web/lib/block_scout_web/event_handler.ex
+++ b/apps/block_scout_web/lib/block_scout_web/event_handler.ex
@@ -22,6 +22,7 @@ defmodule BlockScoutWeb.EventHandler do
     Chain.subscribe_to_events(:exchange_rate)
     Chain.subscribe_to_events(:internal_transactions)
     Chain.subscribe_to_events(:transactions)
+    Chain.subscribe_to_events(:token_transfers)
     {:ok, []}
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -42,7 +42,8 @@ defmodule BlockScoutWeb.Router do
 
   forward("/graphiql", Absinthe.Plug.GraphiQL,
     schema: BlockScoutWeb.Schema,
-    interface: :playground
+    interface: :playground,
+    socket: BlockScoutWeb.UserSocket
   )
 
   scope "/", BlockScoutWeb do

--- a/apps/block_scout_web/lib/block_scout_web/schema.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema.ex
@@ -20,4 +20,14 @@ defmodule BlockScoutWeb.Schema do
       resolve(&Transaction.get_by/3)
     end
   end
+
+  subscription do
+    field :token_transfers, list_of(:token_transfer) do
+      arg(:token_contract_address_hash, non_null(:address_hash))
+
+      config(fn args, _info ->
+        {:ok, topic: to_string(args.token_contract_address_hash)}
+      end)
+    end
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/schema/types.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema/types.ex
@@ -48,4 +48,15 @@ defmodule BlockScoutWeb.Schema.Types do
     field(:to_address_hash, :address_hash)
     field(:created_contract_address_hash, :address_hash)
   end
+
+  @desc """
+  Represents a token transfer between addresses.
+  """
+  object :token_transfer do
+    field(:amount, :decimal)
+    field(:from_address_hash, :address_hash)
+    field(:to_address_hash, :address_hash)
+    field(:token_contract_address_hash, :address_hash)
+    field(:transaction_hash, :full_hash)
+  end
 end

--- a/apps/block_scout_web/test/block_scout_web/schema/subscription/token_transfers_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/schema/subscription/token_transfers_test.exs
@@ -1,0 +1,103 @@
+defmodule BlockScoutWeb.Schema.Subscription.TokenTransfersTest do
+  use BlockScoutWeb.SubscriptionCase
+
+  alias BlockScoutWeb.Notifier
+
+  describe "token_transfers field" do
+    test "with valid argument, returns all expected fields", %{socket: socket} do
+      transaction = insert(:transaction)
+      token_transfer = insert(:token_transfer, transaction: transaction)
+      address_hash = to_string(token_transfer.token_contract_address_hash)
+
+      subscription = """
+      subscription ($hash: AddressHash!) {
+        token_transfers(token_contract_address_hash: $hash) {
+          amount
+          from_address_hash
+          to_address_hash
+          token_contract_address_hash
+          transaction_hash
+        }
+      }
+      """
+
+      variables = %{"hash" => address_hash}
+
+      ref = push_doc(socket, subscription, variables: variables)
+
+      assert_reply(ref, :ok, %{subscriptionId: subscription_id})
+
+      Notifier.handle_event({:chain_event, :token_transfers, :realtime, [token_transfer]})
+
+      expected = %{
+        result: %{
+          data: %{
+            "token_transfers" => [
+              %{
+                "amount" => to_string(token_transfer.amount),
+                "from_address_hash" => to_string(token_transfer.from_address_hash),
+                "to_address_hash" => to_string(token_transfer.to_address_hash),
+                "token_contract_address_hash" => to_string(token_transfer.token_contract_address_hash),
+                "transaction_hash" => to_string(token_transfer.transaction_hash)
+              }
+            ]
+          }
+        },
+        subscriptionId: subscription_id
+      }
+
+      assert_push("subscription:data", push)
+      assert push == expected
+    end
+
+    test "ignores irrelevant tokens", %{socket: socket} do
+      transaction = insert(:transaction)
+      [token_transfer1, token_transfer2] = insert_list(2, :token_transfer, transaction: transaction)
+      address_hash1 = to_string(token_transfer1.token_contract_address_hash)
+
+      subscription = """
+      subscription ($hash: AddressHash!) {
+        token_transfers(token_contract_address_hash: $hash) {
+          amount
+          token_contract_address_hash
+        }
+      }
+      """
+
+      variables = %{"hash" => address_hash1}
+
+      ref = push_doc(socket, subscription, variables: variables)
+
+      assert_reply(ref, :ok, %{subscriptionId: _subscription_id})
+
+      Notifier.handle_event({:chain_event, :token_transfers, :realtime, [token_transfer2]})
+
+      refute_push("subscription:data", _push)
+    end
+
+    test "ignores non-realtime updates", %{socket: socket} do
+      transaction = insert(:transaction)
+      token_transfer = insert(:token_transfer, transaction: transaction)
+      address_hash = to_string(token_transfer.token_contract_address_hash)
+
+      subscription = """
+      subscription ($hash: AddressHash!) {
+        token_transfers(token_contract_address_hash: $hash) {
+          amount
+          token_contract_address_hash
+        }
+      }
+      """
+
+      variables = %{"hash" => address_hash}
+
+      ref = push_doc(socket, subscription, variables: variables)
+
+      assert_reply(ref, :ok, %{subscriptionId: _subscription_id})
+
+      Notifier.handle_event({:chain_event, :token_transfers, :catchup, [token_transfer]})
+
+      refute_push("subscription:data", _push)
+    end
+  end
+end

--- a/apps/block_scout_web/test/support/subscription_case.ex
+++ b/apps/block_scout_web/test/support/subscription_case.ex
@@ -1,0 +1,27 @@
+defmodule BlockScoutWeb.SubscriptionCase do
+  @moduledoc """
+  This module defines the test case to be used by GraphQL subscription tests.
+  """
+
+  use ExUnit.CaseTemplate
+
+  import Phoenix.ChannelTest, only: [connect: 2]
+
+  @endpoint BlockScoutWeb.Endpoint
+
+  using do
+    quote do
+      # Import conveniences for testing with channels
+      use BlockScoutWeb.ChannelCase
+      use Absinthe.Phoenix.SubscriptionTest, schema: BlockScoutWeb.Schema
+    end
+  end
+
+  @dialyzer {:nowarn_function, __ex_unit_setup_0: 1}
+  setup do
+    {:ok, socket} = connect(BlockScoutWeb.UserSocket, %{})
+    {:ok, socket} = Absinthe.Phoenix.SubscriptionTest.join_absinthe(socket)
+
+    {:ok, socket: socket}
+  end
+end


### PR DESCRIPTION
## Motivation

* We'd like to support a GraphQL API subscription that allows users to
subscribe to token transfers for a given token.

  Example subscription document:
  ```
  subscription ($hash: AddressHash!) {
  token_transfers(token_contract_address_hash: $hash) {
    amount
    from_address_hash
    to_address_hash
    token_contract_address_hash
    transaction_hash
    }
  }

  ```

## Changelog

### Enhancements
* Adding an `Absinthe.Subscription` supervisor to BlockScoutWeb's
supervision tree.
* Adding `Absinthe.Phoenix.Endpoint` to `BlockScoutWeb.Endpoint`.
* Configuring `BlockScoutWeb.UserSocket` to use `Absinthe`.
* Configure GraphiQL to use `BlockScoutWeb.UserSocket`.
* Editing `BlockScoutWeb.EventHandler` to subscribe to
`:token_transfers` type chain events.
* Adding `BlockScoutWeb.Notifier.handle_event/1` function head to handle
`:token_transfers` events. Here we publish events to GraphQL API
subscribers of a given token.
* Adding `:token_transfers` subscription field to `BlockScoutWeb.Schema`
* Adding `:token_transfer` object type to `BlockScoutWeb.Types`
* Creating `BlockScoutWeb.SubscriptionCase` to be used by GraphQL
subscription tests.
