### PR TITLE
Color code internal transaction type labels

### DIFF
--- a/apps/block_scout_web/assets/css/_typography.scss
+++ b/apps/block_scout_web/assets/css/_typography.scss
@@ -99,10 +99,24 @@ label, textarea.form-control {
     }
 }
 
-[data-transaction-status="Success"] {
+[data-transaction-status="Success"],
+[data-internal-transaction-type="Reward"] {
   color: $success;
 }
 
-[data-transaction-status^="Error"] {
+[data-internal-transaction-type="Call"] {
+  color: $info;
+}
+
+[data-internal-transaction-type="Delegate Call"] {
+  color: $purple;
+}
+
+[data-internal-transaction-type="Create"] {
+  color: $pink;
+}
+
+[data-transaction-status^="Error"],
+[data-internal-transaction-type="Suicide"] {
   color: $danger;
 }

--- a/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-2 d-flex flex-row flex-md-column align-items-left justify-content-start justify-content-lg-center mb-1 mb-md-0 pl-md-4">
       <%= gettext("Internal Transaction") %>
-      <span>(<%= type(@internal_transaction) %>)</span>
+      <span data-internal-transaction-type="<%= type(@internal_transaction) %>"><%= type(@internal_transaction) %></span>
     </div>
     <div class="col-md-7 col-lg-8 d-flex flex-column text-nowrap pr-2 pr-sm-2 pr-md-0">
       <%= render BlockScoutWeb.TransactionView, "_link.html", transaction_hash: @internal_transaction.transaction_hash %>


### PR DESCRIPTION
## Motivation

- Color code the internal transaction type labels so that they are more easily recognizable.

## Changelog

### Enhancements
- Add a signifying color to the type label within the internal transaction tile.

### Screenshots
<img width="1155" alt="screen shot 2018-10-30 at 1 19 39 pm" src="https://user-images.githubusercontent.com/1641169/47737114-88752480-dc46-11e8-81c0-02c5f5319f48.png">


### Bug Fixes
n/a

### Incompatible Changes
n/a

## Upgrading
n/a
