### PR TITLE
address type is printed weird on smart contracts

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_function_response.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_function_response.html.eex
@@ -5,6 +5,6 @@
 [<%= for item <- @outputs do %>
 <span class="function-response-item"><%= if named_argument?(item) do %><%= item["name"] %>
 <% end %>
-<span class="text-muted">(<%= item["type"] %>)</span> : <%= values(item["value"]) %></span><% end %>]
+<span class="text-muted">(<%= item["type"] %>)</span> : <%= values(item["value"], item["type"]) %></span><% end %>]
 </pre>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -3,14 +3,14 @@ defmodule BlockScoutWeb.SmartContractView do
 
   def queryable?(inputs), do: Enum.any?(inputs)
 
-  def address?(type), do: type == "address"
+  def address?(type), do: type in ["address", "address payable"]
 
   def named_argument?(%{"name" => ""}), do: false
   def named_argument?(%{"name" => nil}), do: false
   def named_argument?(%{"name" => _}), do: true
   def named_argument?(_), do: false
 
-  def values(value, "address") do
+  def values(value, type) when type in ["address", "address payable"] do
     {:ok, address} = Explorer.Chain.Hash.Address.cast(value)
     to_string(address)
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -10,6 +10,11 @@ defmodule BlockScoutWeb.SmartContractView do
   def named_argument?(%{"name" => _}), do: true
   def named_argument?(_), do: false
 
-  def values(values) when is_list(values), do: Enum.join(values, ",")
-  def values(value), do: value
+  def values(value, "address") do
+    {:ok, address} = Explorer.Chain.Hash.Address.cast(value)
+    to_string(address)
+  end
+
+  def values(values, _) when is_list(values), do: Enum.join(values, ",")
+  def values(value, _), do: value
 end

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
@@ -24,6 +24,12 @@ defmodule BlockScoutWeb.SmartContractViewTest do
       assert SmartContractView.address?(type)
     end
 
+    test "returns true when the type is equal to the string 'address payable'" do
+      type = "address payable"
+
+      assert SmartContractView.address?(type)
+    end
+
     test "returns false when the type is not equal the string 'address'" do
       type = "name"
 
@@ -57,17 +63,27 @@ defmodule BlockScoutWeb.SmartContractViewTest do
     end
   end
 
-  describe "values/1" do
-    test "joins the values when it is a list" do
+  describe "values/2" do
+    test "joins the values when it is a list of a given type" do
       values = [8, 6, 9, 2, 2, 37]
 
-      assert SmartContractView.values(values) == "8,6,9,2,2,37"
+      assert SmartContractView.values(values, "type") == "8,6,9,2,2,37"
     end
 
-    test "returns the value" do
+    test "convert the value to string receiving a value and the 'address' type" do
+      value = <<95, 38, 9, 115, 52, 182, 163, 43, 121, 81, 223, 97, 253, 12, 88, 3, 236, 93, 131, 84>>
+      assert SmartContractView.values(value, "address") == "0x5f26097334b6a32b7951df61fd0c5803ec5d8354"
+    end
+
+    test "convert the value to string receiving a value and the 'address payable' type" do
+      value = <<95, 38, 9, 115, 52, 182, 163, 43, 121, 81, 223, 97, 253, 12, 88, 3, 236, 93, 131, 84>>
+      assert SmartContractView.values(value, "address payable") == "0x5f26097334b6a32b7951df61fd0c5803ec5d8354"
+    end
+
+    test "returns the value when the type is neither 'address' nor 'address payable'" do
       value = "POA"
 
-      assert SmartContractView.values(value) == "POA"
+      assert SmartContractView.values(value, "not address") == "POA"
     end
   end
 end


### PR DESCRIPTION
resolves #1004 

## Changelog

### Enhancements
 * when the contract returns something of type `address` it'll be treated as such now
 * doing the same for the type `address payable` as it is a [valid type in solidity](https://solidity.readthedocs.io/en/develop/types.html#address)

### print screen
<img width="466" alt="captura de tela 2018-10-31 as 14 26 56" src="https://user-images.githubusercontent.com/18328258/47806688-17527180-dd19-11e8-82cc-b6e92b3b5837.png">


