### PR TITLE
Adds hash to GraphQL block object

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schema/types.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema/types.ex
@@ -12,6 +12,7 @@ defmodule BlockScoutWeb.Schema.Types do
   structure that they form is called a "blockchain".
   """
   object :block do
+    field(:hash, :full_hash)
     field(:consensus, :boolean)
     field(:difficulty, :decimal)
     field(:gas_limit, :decimal)

--- a/apps/block_scout_web/test/block_scout_web/schema/query/block_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/schema/query/block_test.exs
@@ -8,6 +8,7 @@ defmodule BlockScoutWeb.Schema.Query.BlockTest do
       query = """
       query ($number: Int!) {
         block(number: $number) {
+          hash
           consensus
           difficulty
           gas_limit
@@ -31,6 +32,7 @@ defmodule BlockScoutWeb.Schema.Query.BlockTest do
       assert json_response(conn, 200) == %{
                "data" => %{
                  "block" => %{
+                   "hash" => to_string(block.hash),
                    "consensus" => block.consensus,
                    "difficulty" => to_string(block.difficulty),
                    "gas_limit" => to_string(block.gas_limit),


### PR DESCRIPTION
## Motivation

* For GraphQL API consumers to be able to fetch the hash for a given
block.

  Sample usage:
  ```
  query ($number: Int!) {
    block(number: $number) {
      hash
   }
  }
  ```

## Changelog

### Enhancements
* Editing the block object in `BlockScoutWeb.Schema.Types` to include a
hash field of type `:full_hash`.
