### PR TITLE
Add GraphiQL link to topnav

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/api_docs/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/api_docs/index.html.eex
@@ -4,7 +4,7 @@
 
       <h1 class="card-title mb-0">API Documentation</h2>
       <small class="text-monospace text-primary" data-endpoint-url="<%= BlockScoutWeb.Endpoint.url() %>/api">[ <%= gettext "Base URL:" %> <%= @conn.host %>/api ]</small>
-      <p class="mt-4"><%= gettext "This API is provided for developers transitioning their applications from Etherscan to Explorer. It supports GET and POST requests." %></p>
+      <p class="mt-4"><%= gettext "This API is provided for developers transitioning their applications from Etherscan to BlockScout. It supports GET and POST requests." %></p>
 
     </div>
   </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -56,13 +56,25 @@
             <%= gettext("Accounts") %>
           <% end %>
         </li>
-        <li class="nav-item">
-          <%= link to: api_docs_path(@conn, :index), class: "nav-link topnav-nav-link" do %>
+        <li class="nav-item dropdown">
+          <a href="#" role="button" id="navbarAPIsDropdown" class="nav-link topnav-nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="nav-link-icon">
               <%= render BlockScoutWeb.IconsView, "_api_icon.html" %>
             </span>
-            <%= gettext("API") %>
-          <% end %>
+            <%= gettext("APIs") %>
+          </a>
+          <div class="dropdown-menu" aria-labeledby="navbarTransactionsDropdown">
+            <%= link(
+                  gettext("GraphQL"),
+                  class: "dropdown-item",
+                  to: "/graphiql"
+                ) %>
+            <%= link(
+                  gettext("RPC"),
+                  class: "dropdown-item",
+                  to: api_docs_path(@conn, :index)
+                ) %>
+          </div>
         </li>
       </ul>
       <div class="search-form d-lg-flex d-inline-block">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -84,11 +84,6 @@ msgid "A string with the name of the module to be invoked."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:64
-msgid "API"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/api_docs/_metatags.html.eex:4
 msgid "API endpoints for the %{subnetwork}"
 msgstr ""
@@ -660,12 +655,12 @@ msgid "Owner Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:95
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:107
 msgid "POA Core"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:94
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:106
 msgid "POA Sokol"
 msgstr ""
 
@@ -757,13 +752,13 @@ msgid "Responses"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:71
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:78
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:83
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:90
 msgid "Search"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:71
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:83
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
@@ -870,11 +865,6 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:28
 msgid "There are no transfers for this Token."
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/api_docs/index.html.eex:7
-msgid "This API is provided for developers transitioning their applications from Etherscan to Explorer. It supports GET and POST requests."
 msgstr ""
 
 #, elixir-format
@@ -1220,4 +1210,23 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:82
 msgid "Loading"
+msgstr ""
+
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:64
+msgid "APIs"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:68
+msgid "GraphQL"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/api_docs/index.html.eex:7
+msgid "This API is provided for developers transitioning their applications from Etherscan to BlockScout. It supports GET and POST requests."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:73
+msgid "RPC"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -84,11 +84,6 @@ msgid "A string with the name of the module to be invoked."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:64
-msgid "API"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/api_docs/_metatags.html.eex:4
 msgid "API endpoints for the %{subnetwork}"
 msgstr ""
@@ -660,12 +655,12 @@ msgid "Owner Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:95
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:107
 msgid "POA Core"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:94
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:106
 msgid "POA Sokol"
 msgstr ""
 
@@ -757,13 +752,13 @@ msgid "Responses"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:71
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:78
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:83
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:90
 msgid "Search"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:71
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:83
 msgid "Search by address, transaction hash, or block number"
 msgstr ""
 
@@ -870,11 +865,6 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:28
 msgid "There are no transfers for this Token."
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/api_docs/index.html.eex:7
-msgid "This API is provided for developers transitioning their applications from Etherscan to Explorer. It supports GET and POST requests."
 msgstr ""
 
 #, elixir-format
@@ -1220,4 +1210,23 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:82
 msgid "Loading"
+msgstr ""
+
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:64
+msgid "APIs"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:68
+msgid "GraphQL"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/api_docs/index.html.eex:7
+msgid "This API is provided for developers transitioning their applications from Etherscan to BlockScout. It supports GET and POST requests."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:73
+msgid "RPC"
 msgstr ""


### PR DESCRIPTION
## Motivation

* For BlockScout users to learn about our GraphQL API.

## Changelog

### Enhancements
* Editing `_topnav.html.eex` template to include link to `/graphiql`.
* Fixing `/api_docs/index.html.eex` template to use "BlockScout" instead
of "Explorer".