### PR TITLE
Fix GraphiQL CSP issue on prod

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/csp_header.ex
+++ b/apps/block_scout_web/lib/block_scout_web/csp_header.ex
@@ -13,10 +13,10 @@ defmodule BlockScoutWeb.CSPHeader do
       "content-security-policy" => "\
         connect-src 'self' #{websocket_endpoints(conn)}; \
         default-src 'self';\
-        script-src 'self' 'unsafe-inline' 'unsafe-eval';\
-        style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com;\
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net;\
+        style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com https://cdn.jsdelivr.net;\
         img-src 'self' 'unsafe-inline' 'unsafe-eval' data:;\
-        font-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.gstatic.com data:;\
+        font-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.gstatic.com https://cdn.jsdelivr.net data:;\
       "
     })
   end

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -44,13 +44,17 @@ defmodule BlockScoutWeb.Router do
     max_complexity: 50
   )
 
-  forward("/graphiql", Absinthe.Plug.GraphiQL,
-    schema: BlockScoutWeb.Schema,
-    interface: :playground,
-    socket: BlockScoutWeb.UserSocket,
-    analyze_complexity: true,
-    max_complexity: 50
-  )
+  scope "/" do
+    pipe_through([BlockScoutWeb.CSPHeader])
+
+    forward("/graphiql", Absinthe.Plug.GraphiQL,
+      schema: BlockScoutWeb.Schema,
+      interface: :playground,
+      socket: BlockScoutWeb.UserSocket,
+      analyze_complexity: true,
+      max_complexity: 50
+    )
+  end
 
   scope "/", BlockScoutWeb do
     pipe_through(:browser)


### PR DESCRIPTION
## Motivation
* For GraphiQL to load on prod.

## Changelog

### Enhancements
* Editing `CSPHeader` for content security policy to include jsdelivr
which is required by GraphiQL.