### PR TITLE
Fix address[] display when reading Smart Contracts

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -45,13 +45,13 @@
                 <div data-wei-ether-converter>
                   <span data-conversion-unit><%= output["value"] %></span>
                   <span class="py-2 px-2">
-                    <input class="wei-ether" type="checkbox" autocomplete="off"> 
+                    <input class="wei-ether" type="checkbox" autocomplete="off">
                     <span class="d-inline-block" data-conversion-text-wei><%= gettext("WEI")%></span>
                     <span class="d-none" data-conversion-text-eth><%= gettext("ETH")%></span>
                   </span>
                 </div>
               <% else %>
-                <%= output["value"] %>
+                <%= values(output["value"], output["type"]) %>
               <% end %>
           <% end %>
         <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -10,6 +10,12 @@ defmodule BlockScoutWeb.SmartContractView do
   def named_argument?(%{"name" => _}), do: true
   def named_argument?(_), do: false
 
+  def values(addresses, type) when type == "address[]" do
+    addresses
+    |> Enum.map(& values(&1, "address"))
+    |> Enum.join(",")
+  end
+
   def values(value, type) when type in ["address", "address payable"] do
     {:ok, address} = Explorer.Chain.Hash.Address.cast(value)
     to_string(address)

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
@@ -80,6 +80,13 @@ defmodule BlockScoutWeb.SmartContractViewTest do
       assert SmartContractView.values(value, "address payable") == "0x5f26097334b6a32b7951df61fd0c5803ec5d8354"
     end
 
+    test "convert each value to string and join them when receiving 'address[]' as the type" do
+      value = [<<95, 38, 9, 115, 52, 182, 163, 43, 121, 81, 223, 97, 253, 12, 88, 3, 236, 93, 131, 84>>, <<207, 38, 14, 163, 23, 85, 86, 55, 197, 95, 112, 229, 93, 186, 141, 90,
+      216, 65, 76, 176>>]
+
+      assert SmartContractView.values(value, "address[]") == "0x5f26097334b6a32b7951df61fd0c5803ec5d8354,0xcf260ea317555637c55f70e55dba8d5ad8414cb0"
+    end
+
     test "returns the value when the type is neither 'address' nor 'address payable'" do
       value = "POA"
 


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/991

WIP: There are questions in the issue page that could change this code.

## Changelog

### Bug Fixes

- When passively (without user input) reading a function from a smart contract, if that function was a list of addresses, the display was broken. Fix that by parsing the display correctly.

### Screenshot

![image](https://user-images.githubusercontent.com/10884247/47894355-27657080-de41-11e8-8c51-9d3b63cfd663.png)
