### PR TITLE
import addresses when importing token balances

### DIFF
--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -80,7 +80,10 @@ defmodule Indexer.TokenBalance.Fetcher do
   end
 
   def import_token_balances(token_balances_params) do
+    addresses_params = format_and_filter_address_params(token_balances_params)
+
     import_params = %{
+      addresses: %{params: addresses_params},
       address_token_balances: %{params: token_balances_params},
       address_current_token_balances: %{params: token_balances_params},
       timeout: :infinity
@@ -95,6 +98,12 @@ defmodule Indexer.TokenBalance.Fetcher do
 
         :error
     end
+  end
+
+  defp format_and_filter_address_params(token_balances_params) do
+    token_balances_params
+    |> Enum.map(&%{hash: &1.address_hash})
+    |> Enum.uniq()
   end
 
   defp entry(%{


### PR DESCRIPTION
closes #1007 
## Changelog

### Bug Fixes
  
- import addresses along with token balances in case an address wasn't indexed yet for some reason