### PR TITLE
Fix no schema on GraphiQL

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -38,10 +38,13 @@ defmodule BlockScoutWeb.Router do
     })
   end
 
+  # Needs to be 200 to support the schema introspection for graphiql
+  @max_complexity 200
+
   forward("/graphql", Absinthe.Plug,
     schema: BlockScoutWeb.Schema,
     analyze_complexity: true,
-    max_complexity: 50
+    max_complexity: @max_complexity
   )
 
   forward("/graphiql", Absinthe.Plug.GraphiQL,
@@ -49,7 +52,7 @@ defmodule BlockScoutWeb.Router do
     interface: :playground,
     socket: BlockScoutWeb.UserSocket,
     analyze_complexity: true,
-    max_complexity: 50
+    max_complexity: @max_complexity
   )
 
   scope "/", BlockScoutWeb do

--- a/apps/block_scout_web/test/block_scout_web/schema/query/address_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/schema/query/address_test.exs
@@ -114,10 +114,10 @@ defmodule BlockScoutWeb.Schema.Query.AddressTest do
     end
 
     test "correlates complexity to size of 'hashes' argument", %{conn: conn} do
-      # max of 12 addresses with four fields of complexity 1 can be fetched
+      # max of 50 addresses with four fields of complexity 1 can be fetched
       # per query:
-      # 12 * 4 = 48, which is less than a max complexity of 50
-      hashes = 13 |> build_list(:address) |> Enum.map(&to_string(&1.hash))
+      # 50 * 4 = 200, which is equal to a max complexity of 200
+      hashes = 51 |> build_list(:address) |> Enum.map(&to_string(&1.hash))
 
       query = """
       query ($hashes: [AddressHash!]!) {


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/1042

## Motivation

* For the schema to be available at `/graphiql`

## Changelog
### Bug Fixes
* Changing GraphQL `max_complexity` from 50 to 200 for introspection to
be possible on GraphiQL.
* Editing test that relied on a `max_complexity` of 50.