### PR TITLE
Add TokenID to tokentx API endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -106,7 +106,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "from" => to_string(token_transfer.from_address_hash),
       "contractAddress" => to_string(token_transfer.token_contract_address_hash),
       "to" => to_string(token_transfer.to_address_hash),
-      "value" => to_string(token_transfer.amount),
+      "value" => get_token_value(token_transfer),
       "tokenName" => token_transfer.token_name,
       "tokenSymbol" => token_transfer.token_symbol,
       "tokenDecimal" => to_string(token_transfer.token_decimals),
@@ -118,6 +118,14 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "input" => to_string(token_transfer.transaction_input),
       "confirmations" => to_string(token_transfer.confirmations)
     }
+  end
+
+  defp get_token_value(%{token_type: "ERC-721"} = token_transfer) do
+    to_string(token_transfer.token_id)
+  end
+
+  defp get_token_value(token_transfer) do
+    to_string(token_transfer.amount)
   end
 
   defp prepare_block(block) do

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -344,9 +344,11 @@ defmodule Explorer.Etherscan do
             block_number: b.number,
             block_timestamp: b.timestamp,
             confirmations: fragment("? - ?", ^max_block_number, t.block_number),
+            token_id: tt.token_id,
             token_name: tkn.name,
             token_symbol: tkn.symbol,
-            token_decimals: tkn.decimals
+            token_decimals: tkn.decimals,
+            token_type: tkn.type
           })
       )
 


### PR DESCRIPTION
Resolves #1046 

## Changelog

### Enhancements
* Tokentx API endpoint now shows Token ID as token value when retrieving ERC-721 tokens. 
