### PR TITLE
Add 404 page for not found blocks

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
@@ -5,7 +5,6 @@ defmodule BlockScoutWeb.BlockTransactionController do
     only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
   import Explorer.Chain, only: [hash_to_block: 2, number_to_block: 2, string_to_block_hash: 1]
-  import BlockScoutWeb.Gettext, only: [gettext: 1]
   alias Explorer.Chain
 
   def index(conn, %{"block_hash_or_number" => formatted_block_hash_or_number} = params) do
@@ -52,24 +51,12 @@ defmodule BlockScoutWeb.BlockTransactionController do
         not_found(conn)
 
       {:error, :not_found} ->
-        message =
-          case block_above_tip?(formatted_block_hash_or_number) do
-            false ->
-              gettext("This block has not been processed yet.")
-
-            nil ->
-              gettext("Block not found, please try again later.")
-
-            true ->
-              gettext("Easy Cowboy! This block does not exist yet!")
-          end
-
         conn
         |> put_status(:not_found)
         |> render(
           "404.html",
           block: nil,
-          message: message
+          block_above_tip: block_above_tip?(formatted_block_hash_or_number)
         )
     end
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
@@ -1,9 +1,11 @@
 defmodule BlockScoutWeb.BlockTransactionController do
   use BlockScoutWeb, :controller
 
-  import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
-  import Explorer.Chain, only: [hash_to_block: 2, number_to_block: 2, string_to_block_hash: 1]
+  import BlockScoutWeb.Chain,
+    only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
+  import Explorer.Chain, only: [hash_to_block: 2, number_to_block: 2, string_to_block_hash: 1]
+  import BlockScoutWeb.Gettext, only: [gettext: 1]
   alias Explorer.Chain
 
   def index(conn, %{"block_hash_or_number" => formatted_block_hash_or_number} = params) do
@@ -50,7 +52,25 @@ defmodule BlockScoutWeb.BlockTransactionController do
         not_found(conn)
 
       {:error, :not_found} ->
-        not_found(conn)
+        message =
+          case block_above_tip?(formatted_block_hash_or_number) do
+            false ->
+              gettext("This block has not been processed yet.")
+
+            nil ->
+              gettext("Block not found, please try again later.")
+
+            true ->
+              gettext("Easy Cowboy! This block does not exist yet!")
+          end
+
+        conn
+        |> put_status(:not_found)
+        |> render(
+          "404.html",
+          block: nil,
+          message: message
+        )
     end
   end
 
@@ -62,11 +82,23 @@ defmodule BlockScoutWeb.BlockTransactionController do
     end
   end
 
-  defp param_block_hash_or_number_to_block(number_string, options) when is_binary(number_string) do
+  defp param_block_hash_or_number_to_block(number_string, options)
+       when is_binary(number_string) do
     with {:ok, number} <- BlockScoutWeb.Chain.param_to_block_number(number_string) do
       number_to_block(number, options)
     else
       {:error, :invalid} -> {:error, {:invalid, :number}}
+    end
+  end
+
+  defp block_above_tip?("0x" <> _), do: nil
+
+  defp block_above_tip?(block_hash_or_number) when is_binary(block_hash_or_number) do
+    with {:ok, max_block_number} <- Chain.max_block_number() do
+      {block_number, _} = Integer.parse(block_hash_or_number)
+      block_number > max_block_number
+    else
+      _ -> true
     end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/404.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/404.html.eex
@@ -7,7 +7,7 @@
             <%= gettext("Block Details") %>
           </h1>
           <div class="tile tile-muted text-center">
-            <%= @message %>
+            <%= block_not_found_message(@block_above_tip) %>
           </div>
         </div>
       </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/404.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/404.html.eex
@@ -1,0 +1,16 @@
+<section class="container">
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-body">
+          <h1 class="card-title" data-test="detail_type">
+            <%= gettext("Block Details") %>
+          </h1>
+          <div class="tile tile-muted text-center">
+            <%= @message %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/apps/block_scout_web/lib/block_scout_web/views/block_transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/block_transaction_view.ex
@@ -1,3 +1,18 @@
 defmodule BlockScoutWeb.BlockTransactionView do
   use BlockScoutWeb, :view
+
+  import BlockScoutWeb.Gettext, only: [gettext: 1]
+
+  def block_not_found_message(block_above_tip) do
+    case block_above_tip do
+      true ->
+        gettext("Easy Cowboy! This block does not exist yet!")
+
+      false ->
+        gettext("This block has not been processed yet.")
+
+      _ ->
+        gettext("Block not found, please try again later.")
+    end
+  end
 end

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1244,3 +1244,23 @@ msgstr ""
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:64
 msgid "Error trying to fetch transactions."
 msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block_transaction/404.html.eex:7
+msgid "Block Details"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_transaction_view.ex:15
+msgid "Block not found, please try again later."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_transaction_view.ex:9
+msgid "Easy Cowboy! This block does not exist yet!"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_transaction_view.ex:12
+msgid "This block has not been processed yet."
+msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1244,3 +1244,23 @@ msgstr ""
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:64
 msgid "Error trying to fetch transactions."
 msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block_transaction/404.html.eex:7
+msgid "Block Details"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_transaction_view.ex:15
+msgid "Block not found, please try again later."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_transaction_view.ex:9
+msgid "Easy Cowboy! This block does not exist yet!"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_transaction_view.ex:12
+msgid "This block has not been processed yet."
+msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/controllers/block_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/block_transaction_controller_test.exs
@@ -11,10 +11,20 @@ defmodule BlockScoutWeb.BlockTransactionControllerTest do
       assert html_response(conn, 404)
     end
 
-    test "with valid block number without block", %{conn: conn} do
+    test "with valid block number below the tip", %{conn: conn} do
+      insert(:block, number: 666)
+
       conn = get(conn, block_transaction_path(conn, :index, "1"))
 
-      assert html_response(conn, 404)
+      assert html_response(conn, 404) =~ "This block has not been processed yet."
+    end
+
+    test "with valid block number above the tip", %{conn: conn} do
+      block = insert(:block)
+
+      conn = get(conn, block_transaction_path(conn, :index, block.number + 1))
+
+      assert html_response(conn, 404) =~ "Easy Cowboy! This block does not exist yet!"
     end
 
     test "returns transactions for the block", %{conn: conn} do
@@ -44,7 +54,7 @@ defmodule BlockScoutWeb.BlockTransactionControllerTest do
 
       conn = get(conn, block_transaction_path(conn, :index, block.number))
 
-      assert html_response(conn, 404)
+      assert html_response(conn, 404) =~ "This block has not been processed yet."
     end
 
     test "returns transactions for consensus block hash", %{conn: conn} do
@@ -77,6 +87,12 @@ defmodule BlockScoutWeb.BlockTransactionControllerTest do
       conn = get(conn, block_transaction_path(conn, :index, "0x0"))
 
       assert html_response(conn, 404)
+    end
+
+    test "with valid not-indexed hash", %{conn: conn} do
+      conn = get(conn, block_transaction_path(conn, :index, block_hash()))
+
+      assert html_response(conn, 404) =~ "Block not found, please try again later."
     end
 
     test "does not return unrelated transactions", %{conn: conn} do


### PR DESCRIPTION
Resolves #36 

## Changelog

### Enhancements
- Better messages when a block is not found in the system
  - Shows the block is not yet indexed if below the tip of the chain
  - Shows the block is not yet generated if above the tip of the chain

### Old
![image](https://user-images.githubusercontent.com/1727723/48207714-62433900-e358-11e8-9bf8-7a6ea96df238.png)

### New
#### Block number above the tip
![image](https://user-images.githubusercontent.com/1727723/48207686-4d66a580-e358-11e8-9ae0-85f368d7d998.png)

#### Block number below the tip
![image](https://user-images.githubusercontent.com/1727723/48207590-1ee8ca80-e358-11e8-87f3-42da789e900d.png)

#### Hash not found
![image](https://user-images.githubusercontent.com/1727723/48209794-1e9efe00-e35d-11e8-8ea7-0f09d0185007.png)
