### PR TITLE
transaction not found page and transaction hash invalid page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
@@ -85,9 +85,18 @@ defmodule BlockScoutWeb.TransactionController do
   end
 
   def show(conn, %{"id" => id}) do
-    {:ok, transaction_hash} = Chain.string_to_transaction_hash(id)
+    case Chain.string_to_transaction_hash(id) do
+      {:ok, transaction_hash} -> show_transaction(conn, id, Chain.hash_to_transaction(transaction_hash))
+      :error -> conn |> put_status(422) |> render("invalid.html", transaction_hash: id)
+    end
+  end
 
-    if Chain.transaction_has_token_transfers?(transaction_hash) do
+  defp show_transaction(conn, id, {:error, :not_found}) do
+    conn |> put_status(404) |> render("not_found.html", transaction_hash: id)
+  end
+
+  defp show_transaction(conn, id, {:ok, %Chain.Transaction{} = transaction}) do
+    if Chain.transaction_has_token_transfers?(transaction.hash) do
       redirect(conn, to: transaction_token_transfer_path(conn, :index, id))
     else
       redirect(conn, to: transaction_internal_transaction_path(conn, :index, id))

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
+  alias BlockScoutWeb.TransactionView
   alias Explorer.{Chain, Market}
   alias Explorer.ExchangeRates.Token
 
@@ -50,10 +51,16 @@ defmodule BlockScoutWeb.TransactionInternalTransactionController do
       )
     else
       :error ->
-        not_found(conn)
+        conn
+        |> put_status(422)
+        |> put_view(TransactionView)
+        |> render("invalid.html", transaction_hash: hash_string)
 
       {:error, :not_found} ->
-        not_found(conn)
+        conn
+        |> put_status(404)
+        |> put_view(TransactionView)
+        |> render("not_found.html", transaction_hash: hash_string)
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_log_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_log_controller.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.TransactionLogController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
+  alias BlockScoutWeb.TransactionView
   alias Explorer.{Chain, Market}
   alias Explorer.ExchangeRates.Token
 
@@ -46,10 +47,16 @@ defmodule BlockScoutWeb.TransactionLogController do
       )
     else
       :error ->
-        not_found(conn)
+        conn
+        |> put_status(422)
+        |> put_view(TransactionView)
+        |> render("invalid.html", transaction_hash: transaction_hash_string)
 
       {:error, :not_found} ->
-        not_found(conn)
+        conn
+        |> put_status(404)
+        |> put_view(TransactionView)
+        |> render("not_found.html", transaction_hash: transaction_hash_string)
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
+  alias BlockScoutWeb.TransactionView
   alias Explorer.{Chain, Market}
   alias Explorer.ExchangeRates.Token
 
@@ -49,10 +50,16 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
       )
     else
       :error ->
-        not_found(conn)
+        conn
+        |> put_status(422)
+        |> put_view(TransactionView)
+        |> render("invalid.html", transaction_hash: hash_string)
 
       {:error, :not_found} ->
-        not_found(conn)
+        conn
+        |> put_status(404)
+        |> put_view(TransactionView)
+        |> render("not_found.html", transaction_hash: hash_string)
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/invalid.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/invalid.html.eex
@@ -1,0 +1,14 @@
+<section class="container">
+  <div class="row">
+    <div class="col-12"> 
+      <div class="card">
+        <div class="card-body">
+          <h1 class="card-title"><%= gettext "Invalid Transaction Hash" %></h1>
+          <div class="tile tile-muted text-center">
+            <span> <span class="font-weight-bold"><%= @transaction_hash %></span> <%= gettext "is not a valid transaction hash" %> </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/not_found.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/not_found.html.eex
@@ -1,0 +1,39 @@
+<section class="container">
+  <section data-page="transaction-details" data-page-transaction-hash="<%= @transaction_hash %>">
+    <div class="row">
+      <div class="col-12"> 
+        <div class="card">
+          <div class="card-body">
+            <div class="icon-links float-right">
+              <span data-clipboard-text="<%= @transaction_hash %>">
+                <button type="button" class="icon-link" id="button" data-toggle="tooltip" data-placement="top" title="<%= gettext("Copy Txn Hash") %>" aria-label="<%= gettext("Copy Transaction Hash") %>">
+                  <i class="fas fa-clone"></i>
+                </button>
+              </span>
+            </div>
+            <h1 class="card-title"><%= gettext "Transaction Details" %> </h1>
+            <div class="tile tile-muted text-center">
+              <div class="loading-spinner mx-auto">
+                <span class="loading-spinner-block-1"></span>
+                <span class="loading-spinner-block-2"></span>
+              </div>
+              <br>
+              <span><%= gettext("The transaction %{bold_hash} was not processed yet", bold_hash: "<span class=\"font-weight-bold\">#{@transaction_hash}</span>") |> raw() %> <span>
+            </div>
+            <hr>
+            <div class="text-center">
+              <h2><%= gettext "Once we have the transaction's data this page will refresh automatically" %></h2>
+              <h3><%= gettext "The possible reasons for this transaction not being processed include the following:" %></h3>
+              <ul class="d-inline-block text-left">
+                <li><%= gettext "The transaction was made a few seconds ago" %></li>
+                <li><%= gettext "The transaction may be in the pool of a node that didn't broadcast it yet" %></li>
+                <li><%= gettext "Some transactions may take a while longer to be indexed depending on the load on the network" %></li>
+                <li><%= gettext "The transaction still does not exist" %></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</section>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -328,11 +328,13 @@ msgid "Copy Code"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:9
 #: lib/block_scout_web/templates/transaction/overview.html.eex:10
 msgid "Copy Transaction Hash"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:9
 #: lib/block_scout_web/templates/transaction/overview.html.eex:10
 msgid "Copy Txn Hash"
 msgstr ""
@@ -966,6 +968,7 @@ msgid "Transaction %{transaction}, %{subnetwork} %{transaction}"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:14
 #: lib/block_scout_web/templates/transaction/overview.html.eex:15
 msgid "Transaction Details"
 msgstr ""
@@ -1263,4 +1266,49 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/views/block_transaction_view.ex:12
 msgid "This block has not been processed yet."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/invalid.html.eex:6
+msgid "Invalid Transaction Hash"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:25
+msgid "Once we have the transaction's data this page will refresh automatically"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:30
+msgid "Some transactions may take a while longer to be indexed depending on the load on the network"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:26
+msgid "The possible reasons for this transaction not being processed include the following:"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:21
+msgid "The transaction %{bold_hash} was not processed yet"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:29
+msgid "The transaction may be in the pool of a node that didn't broadcast it yet"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:31
+msgid "The transaction still does not exist"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:28
+msgid "The transaction was made a few seconds ago"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/invalid.html.eex:8
+msgid "is not a valid transaction hash"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -328,11 +328,13 @@ msgid "Copy Code"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:9
 #: lib/block_scout_web/templates/transaction/overview.html.eex:10
 msgid "Copy Transaction Hash"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:9
 #: lib/block_scout_web/templates/transaction/overview.html.eex:10
 msgid "Copy Txn Hash"
 msgstr ""
@@ -966,6 +968,7 @@ msgid "Transaction %{transaction}, %{subnetwork} %{transaction}"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:14
 #: lib/block_scout_web/templates/transaction/overview.html.eex:15
 msgid "Transaction Details"
 msgstr ""
@@ -1263,4 +1266,49 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/views/block_transaction_view.ex:12
 msgid "This block has not been processed yet."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/invalid.html.eex:6
+msgid "Invalid Transaction Hash"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:25
+msgid "Once we have the transaction's data this page will refresh automatically"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:30
+msgid "Some transactions may take a while longer to be indexed depending on the load on the network"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:26
+msgid "The possible reasons for this transaction not being processed include the following:"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:21
+msgid "The transaction %{bold_hash} was not processed yet"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:29
+msgid "The transaction may be in the pool of a node that didn't broadcast it yet"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:31
+msgid "The transaction still does not exist"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/not_found.html.eex:28
+msgid "The transaction was made a few seconds ago"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/invalid.html.eex:8
+msgid "is not a valid transaction hash"
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_controller_test.exs
@@ -102,6 +102,19 @@ defmodule BlockScoutWeb.TransactionControllerTest do
   end
 
   describe "GET show/3" do
+    test "responds with 404 with the transaction missing", %{conn: conn} do
+      hash = transaction_hash()
+      conn = get(conn, transaction_path(BlockScoutWeb.Endpoint, :show, hash))
+
+      assert html_response(conn, 404)
+    end
+
+    test "responds with 422 when the hash is invalid" do
+      conn = get(conn, transaction_path(BlockScoutWeb.Endpoint, :show, "wrong"))
+
+      assert html_response(conn, 422)
+    end
+
     test "redirects to transactions/:transaction_id/token_transfers when there are token transfers", %{conn: conn} do
       transaction = insert(:transaction)
       insert(:token_transfer, transaction: transaction)

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_internal_transaction_controller_test.exs
@@ -17,7 +17,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionControllerTest do
     test "with invalid transaction hash", %{conn: conn} do
       conn = get(conn, transaction_internal_transaction_path(BlockScoutWeb.Endpoint, :index, "nope"))
 
-      assert html_response(conn, 404)
+      assert html_response(conn, 422)
     end
 
     test "includes transaction data", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_log_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_log_controller_test.exs
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
     test "with invalid transaction hash", %{conn: conn} do
       conn = get(conn, transaction_log_path(conn, :index, "invalid_transaction_string"))
 
-      assert html_response(conn, 404)
+      assert html_response(conn, 422)
     end
 
     test "with valid transaction hash without transaction", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_token_transfer_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_token_transfer_controller_test.exs
@@ -28,7 +28,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
     test "with invalid transaction hash", %{conn: conn} do
       conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, "nope"))
 
-      assert html_response(conn, 404)
+      assert html_response(conn, 422)
     end
 
     test "includes transaction data", %{conn: conn} do


### PR DESCRIPTION
closes #38

## Changelog

### Enhancements
 * show a 404 specific for transactions when the transaction was not found
 * show a 422 page for transactions when the transaction hash is invalid

### Screenshots

* 404
![tx not found](https://user-images.githubusercontent.com/18328258/48216435-d935fd00-e36b-11e8-819b-10375306d0de.PNG)

* 422
![invalid tx hash](https://user-images.githubusercontent.com/18328258/48216448-e2bf6500-e36b-11e8-92ff-e888f74f949a.PNG)
