### PR TITLE
Fix performance issue in address page

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -187,18 +187,45 @@ defmodule Explorer.Chain do
 
     token_transfers_dynamic = TokenTransfer.dynamic_any_address_fields_match(direction, address_bytes)
 
-    transaction_dynamic =
-      Transaction.dynamic_where_address_hash_matches(address_hash, direction, token_transfers_dynamic)
-
     base_query =
       paging_options
       |> fetch_transactions()
       |> join_associations(necessity_by_association)
       |> Transaction.preload_token_transfers(address_hash)
 
-    base_query
-    |> from(where: ^transaction_dynamic)
-    |> Repo.all()
+    token_transfers_query =
+      base_query
+      |> from(where: ^token_transfers_dynamic)
+
+    from_address_query =
+      base_query
+      |> where([t], t.from_address_hash == ^address_hash)
+
+    to_address_query =
+      base_query
+      |> where([t], t.to_address_hash == ^address_hash)
+
+    created_contract_query =
+      base_query
+      |> where([t], t.created_contract_address_hash == ^address_hash)
+
+    queries =
+      [token_transfers_query] ++
+        case direction do
+          :from -> [from_address_query]
+          :to -> [to_address_query, created_contract_query]
+          _ -> [from_address_query, to_address_query, created_contract_query]
+        end
+
+    result = queries |> Enum.flat_map(&Repo.all/1)
+
+    sorted_result =
+      result
+      |> Enum.uniq()
+      |> Enum.sort_by(fn x -> {-x.block_number, -x.index} end)
+      |> Enum.take(paging_options.page_size)
+
+    sorted_result
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -217,7 +217,7 @@ defmodule Explorer.Chain do
           _ -> [from_address_query, to_address_query, created_contract_query]
         end
 
-    result = queries |> Enum.flat_map(&Repo.all/1)
+    result = Enum.flat_map(queries, &Repo.all/1)
 
     sorted_result =
       result

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Chain.Transaction do
 
   require Logger
 
-  import Ecto.Query, only: [dynamic: 2, from: 2, preload: 3, subquery: 1, where: 3]
+  import Ecto.Query, only: [from: 2, preload: 3, subquery: 1, where: 3]
 
   alias ABI.FunctionSelector
 
@@ -477,32 +477,6 @@ defmodule Explorer.Chain.Transaction do
   """
   def where_address_fields_match(query, address_hash, address_field) do
     where(query, [t], field(t, ^address_field) == ^address_hash)
-  end
-
-  @doc """
-  Builds a dynamic query expression to identify if there is a transaction
-  related to the hash.
-  """
-  def dynamic_where_address_hash_matches(address_hash, :to, dynamic) do
-    dynamic(
-      [t],
-      t.to_address_hash == ^address_hash or t.created_contract_address_hash == ^address_hash or ^dynamic
-    )
-  end
-
-  def dynamic_where_address_hash_matches(address_hash, :from, dynamic) do
-    dynamic(
-      [t],
-      t.from_address_hash == ^address_hash or ^dynamic
-    )
-  end
-
-  def dynamic_where_address_hash_matches(address_hash, _, dynamic) do
-    dynamic(
-      [t],
-      t.to_address_hash == ^address_hash or t.from_address_hash == ^address_hash or
-        t.created_contract_address_hash == ^address_hash or ^dynamic
-    )
   end
 
   @collated_fields ~w(block_number cumulative_gas_used gas_used index)a


### PR DESCRIPTION
The address page was taking a long time to load, and the server was failing with a 504.

The slow query was composed of several `where`s and limiting the result to the page size (51). For some reason, running all of the filters together was very slow. This solutions runs a separate query for each filter, limiting the result to the same number. Then, the results are merged, sorted and limited again. This is done in the backend because there are few rows involved, but it could be done using `UNION` and an outer query too.

Notice that the queries are done sequentially. This could be further improved if each query is done in parallel.