### PR TITLE
Fix project timeline link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The first release will include a block explorer for the POA core and Sokol test 
 
 ### Features
 
-Development is ongoing. Please see the [project timeline](https://github.com/poanetwork/blockscout/wiki/Timeline-for-POA-Block-Explorer) for projected milestones.
+Development is ongoing. Please see the [project timeline](https://github.com/poanetwork/blockscout/wiki/Timeline-for-BlockScout-explorer) for projected milestones.
 
 - [x] **Open source development**: The code is community driven and available for anyone to use, explore and improve.
 


### PR DESCRIPTION
## Motivation

The current project timeline link in the README points to a page that doesn't exist in the Wiki. Probably because the project changed names.

## Changelog

### Enhancements
The link will now redirect users to the correct page.