### PR TITLE
Fix pattern matching error when transaction does not loads to_address.smart_contract

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
@@ -17,6 +17,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
                [created_contract_address: :names] => :optional,
                [from_address: :names] => :optional,
                [to_address: :names] => :optional,
+               [to_address: :smart_contract] => :optional,
                :token_transfers => :optional
              }
            ) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_token_transfer_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_token_transfer_controller_test.exs
@@ -142,5 +142,15 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
 
       assert is_nil(conn.assigns.next_page_params)
     end
+
+    test "preloads to_address smart contract verified", %{conn: conn} do
+      transaction = insert(:transaction_to_verified_contract)
+
+      conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, transaction.hash))
+
+      assert html_response(conn, 200)
+      assert conn.assigns.transaction.hash == transaction.hash
+      assert conn.assigns.transaction.to_address.smart_contract != nil
+    end
   end
 end


### PR DESCRIPTION
Fixes #1082

## Changelog

### Bug Fixes

Preloads `smart_contract` from `transaction` `to_address`.