### PR TITLE
Add `dev` dependency to cowboy in the `ethereum_jsonrpc` app

### DIFF
--- a/apps/ethereum_jsonrpc/mix.exs
+++ b/apps/ethereum_jsonrpc/mix.exs
@@ -61,7 +61,7 @@ defmodule EthereumJsonrpc.MixProject do
       # CACerts bundle for `EthereumJSONRPC.WebSocket.WebSocketClient`
       {:certifi, "~> 2.3"},
       # WebSocket-server for testing `EthereumJSONRPC.WebSocket.WebSocketClient`.
-      {:cowboy, "~> 1.1", only: :test},
+      {:cowboy, "~> 1.1", only: [:dev, :test]},
       # Style Checking
       {:credo, "0.10.2", only: [:dev, :test], runtime: false},
       # Static Type Checking


### PR DESCRIPTION
This dependency was only being set to test and every time we tried to open an iex an error was raised.

**ethereum_jsonrpc**
```
Erlang/OTP 21 [erts-10.0.7] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe] [dtrace]

** (Mix) Could not start application cowboy: could not find application file: cowboy.app
```

**explorer**
```
Erlang/OTP 21 [erts-10.0.7] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe] [dtrace]

Compiling 83 files (.ex)
Generated explorer app
** (Mix) Could not start application cowboy: could not find application file: cowboy.app
```

## Changelog

### Bug Fixes
* Include `cowboy` as a `dev` dependency in the `ethereum_jsonrpc` app.
