### PR TITLE
Improve TokenBalance.Fetcher to ignore the ones that always raise errors

### DIFF
--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -100,8 +100,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
              addresses_params: internal_transactions_addresses_params,
              balances_params: address_coin_balances_params
            }),
-         {:ok, address_token_balances} <-
-           TokenBalances.fetch_token_balances_from_blockchain(address_token_balances_params),
+         {:ok, address_token_balances} <- fetch_token_balances(address_token_balances_params),
          chain_import_options =
            options
            |> Map.drop(@import_options)
@@ -298,5 +297,11 @@ defmodule Indexer.Block.Realtime.Fetcher do
     Enum.into(balances_params, MapSet.new(), fn %{address_hash: address_hash, block_number: block_number} ->
       %{hash_data: address_hash, block_quantity: integer_to_quantity(block_number)}
     end)
+  end
+
+  defp fetch_token_balances(address_token_balances_params) do
+    address_token_balances_params
+    |> MapSet.to_list()
+    |> TokenBalances.fetch_token_balances_from_blockchain()
   end
 end

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -112,7 +112,6 @@ defmodule Indexer.Block.Realtime.Fetcher do
            |> put_in([Access.key(:address_token_balances), :params], address_token_balances)
            |> put_in([Access.key(:internal_transactions, %{}), :params], internal_transactions_params),
          {:ok, imported} = ok <- Chain.import(chain_import_options) do
-      TokenBalances.log_fetching_errors(__MODULE__, address_token_balances)
       async_import_remaining_block_data(imported)
       ok
     end

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -58,8 +58,6 @@ defmodule Indexer.TokenBalance.Fetcher do
 
   @impl BufferedTask
   def run(entries, _json_rpc_named_arguments) do
-    Logger.debug(fn -> "fetching #{length(entries)} token balances" end)
-
     result =
       entries
       |> Enum.map(&format_params/1)
@@ -79,8 +77,6 @@ defmodule Indexer.TokenBalance.Fetcher do
       params_list
       |> Enum.filter(&(&1.retries_count <= @max_retries))
       |> TokenBalances.fetch_token_balances_from_blockchain()
-
-    TokenBalances.log_fetching_errors(__MODULE__, token_balances)
 
     token_balances
   end

--- a/apps/indexer/lib/indexer/token_balances.ex
+++ b/apps/indexer/lib/indexer/token_balances.ex
@@ -24,6 +24,8 @@ defmodule Indexer.TokenBalances do
   * `address_hash` - The address_hash that we want to know the balance.
   * `block_number` - The block number that the address_hash has the balance.
   """
+  def fetch_token_balances_from_blockchain([]), do: {:ok, []}
+
   def fetch_token_balances_from_blockchain(token_balances) do
     Logger.debug(fn -> "fetching #{Enum.count(token_balances)} token balances" end)
 

--- a/apps/indexer/lib/indexer/token_balances.ex
+++ b/apps/indexer/lib/indexer/token_balances.ex
@@ -25,14 +25,16 @@ defmodule Indexer.TokenBalances do
   * `block_number` - The block number that the address_hash has the balance.
   """
   def fetch_token_balances_from_blockchain(token_balances) do
-    fetched_token_balances =
+    requested_token_balances =
       token_balances
       |> Task.async_stream(&fetch_token_balance/1, on_timeout: :kill_task)
       |> Stream.map(&format_task_results/1)
-      |> Enum.filter(&ignore_request_with_errors/1)
+      |> Enum.filter(&ignore_killed_task/1)
 
-    token_balances
-    |> MapSet.new()
+    fetched_token_balances = Enum.filter(requested_token_balances, &ignore_request_with_errors/1)
+
+    requested_token_balances
+    |> handle_killed_tasks(token_balances)
     |> unfetched_token_balances(fetched_token_balances)
     |> schedule_token_balances
 
@@ -59,13 +61,19 @@ defmodule Indexer.TokenBalances do
     Map.merge(token_balance, %{value: nil, value_fetched_at: nil, error: error_message})
   end
 
+  defp schedule_token_balances([]), do: nil
+
   defp schedule_token_balances(unfetched_token_balances) do
     unfetched_token_balances
     |> Enum.map(fn token_balance ->
       {:ok, address_hash} = Chain.string_to_address_hash(token_balance.address_hash)
       {:ok, token_hash} = Chain.string_to_address_hash(token_balance.token_contract_address_hash)
 
-      %{address_hash: address_hash, token_contract_address_hash: token_hash, block_number: token_balance.block_number}
+      Map.merge(token_balance, %{
+        address_hash: address_hash,
+        token_contract_address_hash: token_hash,
+        block_number: token_balance.block_number
+      })
     end)
     |> TokenBalance.Fetcher.async_fetch()
   end
@@ -73,9 +81,17 @@ defmodule Indexer.TokenBalances do
   defp format_task_results({:exit, :timeout}), do: {:error, :timeout}
   defp format_task_results({:ok, token_balance}), do: token_balance
 
-  defp ignore_request_with_errors({:error, :timeout}), do: false
+  defp ignore_killed_task({:error, :timeout}), do: false
+  defp ignore_killed_task(_token_balance), do: true
+
   defp ignore_request_with_errors(%{value: nil, value_fetched_at: nil, error: _error}), do: false
   defp ignore_request_with_errors(_token_balance), do: true
+
+  defp handle_killed_tasks(requested_token_balances, token_balances) do
+    token_balances
+    |> Enum.reject(&present?(requested_token_balances, &1))
+    |> Enum.map(&Map.merge(&1, %{value: nil, value_fetched_at: nil, error: :timeout}))
+  end
 
   def log_fetching_errors(from, token_balances_params) do
     error_messages =
@@ -102,18 +118,24 @@ defmodule Indexer.TokenBalances do
   @doc """
   Finds the unfetched token balances given all token balances and the ones that were fetched.
 
-  This function compares the two given lists using the `MapSet.difference/2` and return the difference.
+  * token_balances - all token balances that were received in this module.
+  * fetched_token_balances - only the token balances that were fetched without error from the Smart contract
+
+  This function compares the two given lists and return the difference.
   """
   def unfetched_token_balances(token_balances, fetched_token_balances) do
-    fetched_token_balances_set =
-      MapSet.new(fetched_token_balances, fn token_balance ->
-        %{
-          address_hash: token_balance.address_hash,
-          token_contract_address_hash: token_balance.token_contract_address_hash,
-          block_number: token_balance.block_number
-        }
-      end)
+    if Enum.count(token_balances) == Enum.count(fetched_token_balances) do
+      []
+    else
+      Enum.reject(token_balances, &present?(fetched_token_balances, &1))
+    end
+  end
 
-    MapSet.difference(token_balances, fetched_token_balances_set)
+  defp present?(list, token_balance) do
+    Enum.any?(list, fn item ->
+      token_balance.address_hash == item.address_hash &&
+        token_balance.token_contract_address_hash == item.token_contract_address_hash &&
+        token_balance.block_number == item.block_number
+    end)
   end
 end


### PR DESCRIPTION
Closes https://github.com/poanetwork/blockscout/issues/1093

For ignoring those token balances, we added a `retries_count` to `TokenBalance.Fetcher` consider whether it should be retried or not based on the number configured in `:token_balance_max_retries` within `apps/indexer/config.exs`

### Enhancements
* Ignore tokens balances that raised errors according to the configured number
* Add a new log to see how many token balances will be retried

### Bug Fixes
* Fix log of token balances that raised errors