### PR TITLE
Support Parity 2.1 pending tag output

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -566,7 +566,9 @@ defmodule EthereumJSONRPC do
     end
   end
 
-  defp handle_get_block_by_tag({:ok, %{"number" => quantity}}) do
+  defp handle_get_block_by_tag({:ok, %{"number" => nil}}), do: {:error, :not_found}
+
+  defp handle_get_block_by_tag({:ok, %{"number" => quantity}}) when is_binary(quantity) do
     {:ok, quantity_to_integer(quantity)}
   end
 


### PR DESCRIPTION
## Changelog

### Bug Fixes
* Support Parity 2.1 `pending` tag output: it returns `number: null` instead of `null` or an error.