### PR TITLE
fetch_beneficiaries/2 works with all reward types

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity.ex
@@ -74,7 +74,7 @@ defmodule EthereumJSONRPC.Parity do
 
   defp extract_beneficiaries(traces) when is_list(traces) do
     Enum.reduce(traces, MapSet.new(), fn
-      %{"action" => %{"rewardType" => "block", "author" => author}, "blockNumber" => block_number}, beneficiaries ->
+      %{"type" => "reward", "blockNumber" => block_number, "action" => %{"author" => author}}, beneficiaries ->
         beneficiary = %{
           block_number: block_number,
           address_hash: author

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/parity_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/parity_test.exs
@@ -294,6 +294,64 @@ defmodule EthereumJSONRPC.ParityTest do
       assert fetched_beneficiaries == expected_beneficiaries
     end
 
+    test "with 'external' 'rewardType'", %{
+      json_rpc_named_arguments: json_rpc_named_arguments
+    } do
+      block_number = 5_609_295
+      block_quantity = EthereumJSONRPC.integer_to_quantity(block_number)
+      hash1 = "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca"
+      hash2 = "0x523b6539ff08d72a6c8bb598af95bf50c1ea839c"
+
+      if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
+        expect(EthereumJSONRPC.Mox, :json_rpc, fn %{params: [^block_quantity]}, _options ->
+          {:ok,
+           [
+             %{
+               "action" => %{
+                 "author" => hash1,
+                 "rewardType" => "external",
+                 "value" => "0xde0b6b3a7640000"
+               },
+               "blockHash" => "0xf19a4ea2bb4f2d8839f4c3ec11e0e86c29d57799d7073713958fe1990e197cf5",
+               "blockNumber" => 5_609_295,
+               "result" => nil,
+               "subtraces" => 0,
+               "traceAddress" => [],
+               "transactionHash" => nil,
+               "transactionPosition" => nil,
+               "type" => "reward"
+             },
+             %{
+               "action" => %{
+                 "author" => hash2,
+                 "rewardType" => "external",
+                 "value" => "0xde0b6b3a7640000"
+               },
+               "blockHash" => "0xf19a4ea2bb4f2d8839f4c3ec11e0e86c29d57799d7073713958fe1990e197cf5",
+               "blockNumber" => 5_609_295,
+               "result" => nil,
+               "subtraces" => 0,
+               "traceAddress" => [],
+               "transactionHash" => nil,
+               "transactionPosition" => nil,
+               "type" => "reward"
+             }
+           ]}
+        end)
+      end
+
+      expected_beneficiaries =
+        MapSet.new([
+          %{block_number: block_number, address_hash: hash2},
+          %{block_number: block_number, address_hash: hash1}
+        ])
+
+      {:ok, fetched_beneficiaries} =
+        EthereumJSONRPC.Parity.fetch_beneficiaries(5_609_295..5_609_295, json_rpc_named_arguments)
+
+      assert fetched_beneficiaries == expected_beneficiaries
+    end
+
     test "with no rewards, returns {:ok, []}", %{
       json_rpc_named_arguments: json_rpc_named_arguments
     } do
@@ -309,7 +367,7 @@ defmodule EthereumJSONRPC.ParityTest do
       end
     end
 
-    test "with nil rewards, returns {:error, }", %{
+    test "with nil rewards, returns {:error, reason}", %{
       json_rpc_named_arguments: json_rpc_named_arguments
     } do
       if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/767 but note that @KronicDeth will be introducing, in an upcoming PR, a more involved approach to fixing this that will prevent these type of bugs from slipping through the cracks if Parity changes again in the future. As of this writing you can see Luke's changes here: https://github.com/poanetwork/blockscout/commit/2d0b0db1dd3ca8e4ccb6846c4237fd1f82e2b831

## Motivation

* For the indexer to update block reward contract beneficiaries for all
types (e.g. block, external, uncle, etc). For details on Parity's reward
types please see:
https://github.com/paritytech/parity-ethereum/blob/0f90696528e11e3e697a808e2d7983b9733d02bc/rpc/src/v1/types/trace.rs#L299-L308