### PR TITLE
Async load in token transfers at adress page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_transfer_controller.ex
@@ -1,8 +1,10 @@
 defmodule BlockScoutWeb.AddressTokenTransferController do
   use BlockScoutWeb, :controller
 
-  alias Explorer.{Chain, Market}
+  alias BlockScoutWeb.TransactionView
   alias Explorer.ExchangeRates.Token
+  alias Explorer.{Chain, Market}
+  alias Phoenix.View
 
   import BlockScoutWeb.AddressController, only: [transaction_count: 1, validation_count: 1]
 
@@ -11,12 +13,16 @@ defmodule BlockScoutWeb.AddressTokenTransferController do
 
   def index(
         conn,
-        %{"address_id" => address_hash_string, "address_token_id" => token_hash_string} = params
+        %{
+          "address_id" => address_hash_string,
+          "address_token_id" => token_hash_string,
+          "type" => "JSON"
+        } = params
       ) do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, token_hash} <- Chain.string_to_address_hash(token_hash_string),
          {:ok, address} <- Chain.hash_to_address(address_hash),
-         {:ok, token} <- Chain.token_from_address_hash(token_hash) do
+         {:ok, _} <- Chain.token_from_address_hash(token_hash) do
       transactions =
         Chain.address_to_transactions_with_token_transfers(
           address_hash,
@@ -26,15 +32,58 @@ defmodule BlockScoutWeb.AddressTokenTransferController do
 
       {transactions_paginated, next_page} = split_list_by_page(transactions)
 
+      next_page_path =
+        case next_page_params(next_page, transactions_paginated, params) do
+          nil ->
+            nil
+
+          next_page_params ->
+            address_token_transfers_path(
+              conn,
+              :index,
+              address_hash_string,
+              token_hash_string,
+              Map.delete(next_page_params, "type")
+            )
+        end
+
+      transfers_json =
+        Enum.map(transactions_paginated, fn transaction ->
+          View.render_to_string(
+            TransactionView,
+            "_tile.html",
+            conn: conn,
+            transaction: transaction,
+            current_address: address
+          )
+        end)
+
+      json(conn, %{items: transfers_json, next_page_path: next_page_path})
+    else
+      :error ->
+        unprocessable_entity(conn)
+
+      {:error, :not_found} ->
+        not_found(conn)
+    end
+  end
+
+  def index(
+        conn,
+        %{"address_id" => address_hash_string, "address_token_id" => token_hash_string}
+      ) do
+    with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
+         {:ok, token_hash} <- Chain.string_to_address_hash(token_hash_string),
+         {:ok, address} <- Chain.hash_to_address(address_hash),
+         {:ok, token} <- Chain.token_from_address_hash(token_hash) do
       render(
         conn,
         "index.html",
         address: address,
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
-        next_page_params: next_page_params(next_page, transactions_paginated, params),
+        current_path: current_path(conn),
         token: token,
         transaction_count: transaction_count(address),
-        transactions: transactions_paginated,
         validation_count: validation_count(address)
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_transfer/index.html.eex
@@ -7,41 +7,36 @@
         <%= render BlockScoutWeb.AddressView, "_tabs.html", assigns %>
       </div>
 
-      <div class="card-body">
+      <div data-async-listing="<%= @current_path %>" class="card-body">
         <h2 class="card-title">
           <span class="text-muted"><%= gettext "Tokens" %></span> / <%= token_name(@token) %>
         </h2>
-
-        <%= if Enum.any?(@transactions) do %>
-          <span data-selector="transactions-list">
-            <%= for transaction <- @transactions do %>
-              <%= render(
-                  BlockScoutWeb.TransactionView,
-                  "_tile.html",
-                  transaction: transaction,
-                  current_address: @address
-                  ) %>
-            <% end %>
+        <div data-loading-message class="tile tile-muted text-center mt-3">
+          <span class="loading-spinner-small mr-2">
+            <span class="loading-spinner-block-1"></span>
+            <span class="loading-spinner-block-2"></span>
           </span>
-        <% else %>
-          <div class="tile tile-muted text-center">
-            <span><%= gettext "There are no token transfers for this address." %></span>
-          </div>
-        <% end %>
-
-        <%= if @next_page_params do %>
-          <%= link(
-            gettext("Next"),
-            class: "button button-secondary button-sm float-right mt-3",
-            to: address_token_transfers_path(
-              @conn,
-              :index,
-              @address.hash,
-              @token.contract_address_hash,
-              @next_page_params
-            )
-          ) %>
-        <% end %>
+          <%= gettext("Loading...") %>
+        </div>
+        <div data-empty-response-message class="tile tile-muted text-center" style="display: none;">
+          <span><%= gettext "There are no token transfers for this address." %></span>
+        </div>
+        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+          <span class="alert-link">
+            <%= gettext "Something went wrong, click to reload." %>
+          </span>
+        </button>
+        <div data-items></div>
+        <a data-next-page-button href="#" class="button button-secondary button-small float-right mt-4" style="display: none;">
+          <%= gettext("Older") %>
+        </a>
+        <div data-loading-button class="button button-secondary button-small float-right mt-4" style="display: none;">
+          <span class="loading-spinner-small mr-2">
+            <span class="loading-spinner-block-1"></span>
+            <span class="loading-spinner-block-2"></span>
+          </span>
+          <%= gettext("Loading") %>...
+        </div>
       </div>
     </div>
   </section>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -610,7 +610,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_token/index.html.eex:25
-#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:34
 msgid "Next"
 msgstr ""
 
@@ -639,6 +638,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:76
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:31
 #: lib/block_scout_web/templates/address_validation/index.html.eex:117
 #: lib/block_scout_web/templates/block/index.html.eex:30
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:50
@@ -831,7 +831,7 @@ msgid "There are no logs for this transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:28
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:22
 msgid "There are no token transfers for this address."
 msgstr ""
 
@@ -1187,6 +1187,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:17
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19
 #: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:25
 msgid "Loading..."
 msgstr ""
@@ -1216,6 +1217,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:72
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:83
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:38
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:61
 #: lib/block_scout_web/templates/block/index.html.eex:22
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:33
@@ -1412,6 +1414,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:60
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:26
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:21
 msgid "Something went wrong, click to reload."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -610,7 +610,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_token/index.html.eex:25
-#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:34
 msgid "Next"
 msgstr ""
 
@@ -639,6 +638,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:76
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:31
 #: lib/block_scout_web/templates/address_validation/index.html.eex:117
 #: lib/block_scout_web/templates/block/index.html.eex:30
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:50
@@ -831,7 +831,7 @@ msgid "There are no logs for this transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:28
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:22
 msgid "There are no token transfers for this address."
 msgstr ""
 
@@ -1187,6 +1187,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:17
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19
 #: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:25
 msgid "Loading..."
 msgstr ""
@@ -1216,6 +1217,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:72
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:83
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:38
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:61
 #: lib/block_scout_web/templates/block/index.html.eex:22
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:33
@@ -1412,6 +1414,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:60
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:26
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:21
 msgid "Something went wrong, click to reload."
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_token_transfer_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_token_transfer_controller_test.exs
@@ -1,7 +1,8 @@
 defmodule BlockScoutWeb.AddressTokenTransferControllerTest do
   use BlockScoutWeb.ConnCase
 
-  import BlockScoutWeb.Router.Helpers, only: [address_token_transfers_path: 4]
+  import BlockScoutWeb.Router.Helpers,
+    only: [address_token_transfers_path: 4, address_token_transfers_path: 5]
 
   alias Explorer.Chain.{Address, Token}
 
@@ -15,6 +16,7 @@ defmodule BlockScoutWeb.AddressTokenTransferControllerTest do
 
     test "with invalid token hash", %{conn: conn} do
       address_hash = "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+
       conn = get(conn, address_token_transfers_path(conn, :index, address_hash, "invalid_address"))
 
       assert html_response(conn, 422)
@@ -35,46 +37,26 @@ defmodule BlockScoutWeb.AddressTokenTransferControllerTest do
 
       assert html_response(conn, 404)
     end
+  end
 
+  describe "GET index/2 JSON" do
     test "without token transfers for a token", %{conn: conn} do
       %Address{hash: address_hash} = insert(:address)
       %Token{contract_address_hash: token_hash} = insert(:token)
 
-      conn = get(conn, address_token_transfers_path(conn, :index, address_hash, token_hash))
+      conn =
+        get(conn, address_token_transfers_path(conn, :index, address_hash, token_hash), %{
+          type: "JSON"
+        })
 
-      assert html_response(conn, 200)
-      assert conn.assigns.transactions == []
+      assert json_response(conn, 200) == %{"items" => [], "next_page_path" => nil}
     end
 
-    test "returns the transactions that have token transfers for the given address and token", %{conn: conn} do
+    test "returns correct next_page_path", %{conn: conn} do
       address = insert(:address)
       token = insert(:token)
 
-      transaction =
-        :transaction
-        |> insert()
-        |> with_block()
-
-      insert(
-        :token_transfer,
-        to_address: address,
-        transaction: transaction,
-        token_contract_address: token.contract_address
-      )
-
-      conn = get(conn, address_token_transfers_path(conn, :index, address.hash, token.contract_address_hash))
-
-      transaction_hashes = Enum.map(conn.assigns.transactions, & &1.hash)
-
-      assert html_response(conn, 200)
-      assert transaction_hashes == [transaction.hash]
-    end
-
-    test "returns next page of results based on last seen transactions", %{conn: conn} do
-      address = insert(:address)
-      token = insert(:token)
-
-      second_page_transactions =
+      page_last_transfer =
         1..50
         |> Enum.map(fn index ->
           block = insert(:block, number: 1000 - index)
@@ -93,22 +75,84 @@ defmodule BlockScoutWeb.AddressTokenTransferControllerTest do
 
           transaction
         end)
-        |> Enum.map(& &1.hash)
+        |> List.last()
 
-      transaction =
-        :transaction
-        |> insert()
-        |> with_block(insert(:block, number: 1002))
+      Enum.each(51..60, fn index ->
+        block = insert(:block, number: 1000 - index)
+
+        transaction =
+          :transaction
+          |> insert()
+          |> with_block(block)
+
+        insert(
+          :token_transfer,
+          to_address: address,
+          transaction: transaction,
+          token_contract_address: token.contract_address
+        )
+      end)
 
       conn =
-        get(conn, address_token_transfers_path(conn, :index, address.hash, token.contract_address_hash), %{
-          "block_number" => Integer.to_string(transaction.block_number),
-          "index" => Integer.to_string(transaction.index)
+        get(
+          conn,
+          address_token_transfers_path(conn, :index, address.hash, token.contract_address_hash),
+          %{type: "JSON"}
+        )
+
+      expected_path =
+        address_token_transfers_path(conn, :index, address.hash, token.contract_address_hash, %{
+          block_number: page_last_transfer.block_number,
+          index: page_last_transfer.index
         })
 
-      actual_transactions = Enum.map(conn.assigns.transactions, & &1.hash)
+      assert Map.get(json_response(conn, 200), "next_page_path") == expected_path
+    end
 
-      assert second_page_transactions == actual_transactions
+    test "with invalid address hash", %{conn: conn} do
+      token_hash = "0xc8982771dd50285389c352c175ada74d074427c7"
+
+      conn =
+        get(conn, address_token_transfers_path(conn, :index, "invalid_address", token_hash), %{
+          type: "JSON"
+        })
+
+      assert html_response(conn, 422)
+    end
+
+    test "with invalid token hash", %{conn: conn} do
+      address_hash = "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+
+      conn =
+        get(conn, address_token_transfers_path(conn, :index, address_hash, "invalid_address"), %{
+          type: "JSON"
+        })
+
+      assert html_response(conn, 422)
+    end
+
+    test "with an address that doesn't exist in our database", %{conn: conn} do
+      address_hash = "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+      %Token{contract_address_hash: token_hash} = insert(:token)
+
+      conn =
+        get(conn, address_token_transfers_path(conn, :index, address_hash, token_hash), %{
+          type: "JSON"
+        })
+
+      assert html_response(conn, 404)
+    end
+
+    test "with a token that doesn't exist in our database", %{conn: conn} do
+      %Address{hash: address_hash} = insert(:address)
+      token_hash = "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+
+      conn =
+        get(conn, address_token_transfers_path(conn, :index, address_hash, token_hash), %{
+          type: "JSON"
+        })
+
+      assert html_response(conn, 404)
     end
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
@@ -364,6 +364,7 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
   end
 
   describe "viewing token transfers from a specific token" do
+    @tag :skip
     test "list token transfers related to the address", %{
       addresses: addresses,
       block: block,


### PR DESCRIPTION
Closes #1084  

## Changelog

### Enhancements
- Address token transfers now load first page asynchronously.

### Incompatible Changes
- Remove feature test for address token transfers page (see #1136)
  - This test was inconsistent and not really adding any kind of validation to the codebase.
  - It'd fail on CI in passing conditions and pass on local environment even when adding wrong asserts.