### PR TITLE
Fix performance issue at token transfers tab on Token's page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -130,9 +130,6 @@ defmodule BlockScoutWeb.Chain do
     end
   end
 
-  def paging_options(%{"inserted_at" => inserted_at}),
-    do: [paging_options: %{@default_paging_options | key: inserted_at}]
-
   def paging_options(%{"token_name" => name, "token_type" => type, "token_inserted_at" => inserted_at}),
     do: [paging_options: %{@default_paging_options | key: {name, type, inserted_at}}]
 
@@ -180,13 +177,8 @@ defmodule BlockScoutWeb.Chain do
     %{"block_number" => block_number, "index" => index}
   end
 
-  defp paging_params(%TokenTransfer{inserted_at: inserted_at}) do
-    inserted_at_datetime =
-      inserted_at
-      |> DateTime.from_naive!("Etc/UTC")
-      |> DateTime.to_iso8601()
-
-    %{"inserted_at" => inserted_at_datetime}
+  defp paging_params(%TokenTransfer{block_number: block_number, log_index: index}) do
+    %{"block_number" => block_number, "index" => index}
   end
 
   defp paging_params(%Address.Token{name: name, type: type, inserted_at: inserted_at}) do

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex
@@ -43,7 +43,7 @@
           <%= link(
             gettext(
               "Block #%{number}",
-              number: @transfer.transaction.block_number
+              number: @transfer.block_number
             ),
             class: "mr-2 mr-sm-0 text-muted",
             to: block_path(BlockScoutWeb.Endpoint, :show, @transfer.transaction.block_number)

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -26,7 +26,7 @@ defmodule Explorer.Chain.TokenTransfer do
 
   import Ecto.{Changeset, Query}
 
-  alias Explorer.Chain.{Address, Block, Hash, Token, TokenTransfer, Transaction}
+  alias Explorer.Chain.{Address, Hash, Token, TokenTransfer, Transaction}
   alias Explorer.{PagingOptions, Repo}
 
   @default_paging_options %PagingOptions{page_size: 50}
@@ -121,13 +121,9 @@ defmodule Explorer.Chain.TokenTransfer do
     query =
       from(
         tt in TokenTransfer,
-        join: t in Transaction,
-        on: tt.transaction_hash == t.hash,
-        join: b in Block,
-        on: t.block_hash == b.hash,
         where: tt.token_contract_address_hash == ^token_address_hash,
         preload: [{:transaction, :block}, :token, :from_address, :to_address],
-        order_by: [desc: b.timestamp]
+        order_by: [desc: tt.block_number]
       )
 
     query

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -33,6 +33,7 @@ defmodule Explorer.Chain.TokenTransfer do
 
   @typedoc """
   * `:amount` - The token transferred amount
+  * `:block_number` - The block number that the transfer took place.
   * `:from_address` - The `t:Explorer.Chain.Address.t/0` that sent the tokens
   * `:from_address_hash` - Address hash foreign key
   * `:to_address` - The `t:Explorer.Chain.Address.t/0` that received the tokens
@@ -46,6 +47,7 @@ defmodule Explorer.Chain.TokenTransfer do
   """
   @type t :: %TokenTransfer{
           amount: Decimal.t(),
+          block_number: non_neg_integer() | nil,
           from_address: %Ecto.Association.NotLoaded{} | Address.t(),
           from_address_hash: Hash.Address.t(),
           to_address: %Ecto.Association.NotLoaded{} | Address.t(),
@@ -65,6 +67,7 @@ defmodule Explorer.Chain.TokenTransfer do
   @primary_key false
   schema "token_transfers" do
     field(:amount, :decimal)
+    field(:block_number, :integer)
     field(:log_index, :integer, primary_key: true)
     field(:token_id, :decimal)
 
@@ -91,7 +94,7 @@ defmodule Explorer.Chain.TokenTransfer do
     timestamps()
   end
 
-  @required_attrs ~w(log_index from_address_hash to_address_hash token_contract_address_hash transaction_hash)a
+  @required_attrs ~w(block_number log_index from_address_hash to_address_hash token_contract_address_hash transaction_hash)a
   @optional_attrs ~w(amount token_id)a
 
   @doc false

--- a/apps/explorer/priv/repo/migrations/20181121170616_add_block_number_to_token_transfers.exs
+++ b/apps/explorer/priv/repo/migrations/20181121170616_add_block_number_to_token_transfers.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddBlockNumberToTokenTransfers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:token_transfers) do
+      add(:block_number, :integer)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20181121170616_add_block_number_to_token_transfers.exs
+++ b/apps/explorer/priv/repo/migrations/20181121170616_add_block_number_to_token_transfers.exs
@@ -1,4 +1,13 @@
 defmodule Explorer.Repo.Migrations.AddBlockNumberToTokenTransfers do
+  @moduledoc """
+  Use `priv/repo/migrations/scripts/20181121170616_token_transfers_update_block_number_in_batches.sql` to migrate data.
+
+  ```sh
+  mix ecto.migrate
+  psql -d $DATABASE -a -f priv/repo/migrations/scripts/20181121170616_token_transfers_update_block_number_in_batches.sql
+  ```
+  """
+
   use Ecto.Migration
 
   def change do

--- a/apps/explorer/priv/repo/migrations/scripts/20181121170616_token_transfers_update_block_number_in_batches.sql
+++ b/apps/explorer/priv/repo/migrations/scripts/20181121170616_token_transfers_update_block_number_in_batches.sql
@@ -1,0 +1,39 @@
+DO $$
+DECLARE
+   row_count integer;
+   batch_size  integer := 100000; -- HOW MANY ITEMS WILL BE UPDATED AT TIME
+   affected integer;
+BEGIN
+  RAISE NOTICE 'Counting items to be updated';
+
+  row_count := (SELECT COUNT(*) FROM token_transfers WHERE block_number IS NULL);
+
+  RAISE NOTICE '% items', row_count;
+
+  WHILE row_count > 0 LOOP
+    WITH cte AS (
+     SELECT
+       t.hash,
+       t.block_number
+     FROM token_transfers AS tt
+     INNER JOIN transactions AS t ON t.hash = tt.transaction_hash
+	   WHERE tt.block_number IS NULL
+     LIMIT batch_size
+    )
+    UPDATE token_transfers
+    SET
+      block_number = cte.block_number
+    FROM cte
+    WHERE token_transfers.transaction_hash = cte.hash;
+
+    GET DIAGNOSTICS affected = ROW_COUNT;
+    RAISE NOTICE '-> % token transfers updated!', affected;
+
+    -- UPDATES THE COUNTER SO IT DOESN'T TURN INTO AN INFINITE LOOP
+    row_count := row_count - batch_size;
+
+    RAISE NOTICE '-> % items missing to update', row_count;
+
+    CHECKPOINT; -- COMMITS THE BATCH UPDATES
+  END LOOP;
+END $$;

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -1517,7 +1517,9 @@ defmodule Explorer.Chain.ImportTest do
                  },
                  token_transfers: %{
                    params: [
-                     params_for(:token_transfer,
+                     params_for(
+                       :token_transfer,
+                       block_number: 35,
                        from_address_hash: from_address_hash,
                        to_address_hash: to_address_hash,
                        token_contract_address_hash: token_contract_address_hash,

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -3112,6 +3112,7 @@ defmodule Explorer.ChainTest do
       first_page =
         insert(
           :token_transfer,
+          block_number: 1000,
           to_address: build(:address),
           transaction: transaction,
           token_contract_address: token_contract_address,
@@ -3122,6 +3123,7 @@ defmodule Explorer.ChainTest do
       second_page =
         insert(
           :token_transfer,
+          block_number: 999,
           to_address: build(:address),
           transaction: transaction,
           token_contract_address: token_contract_address,
@@ -3129,13 +3131,11 @@ defmodule Explorer.ChainTest do
           token_id: 29
         )
 
-      paging_options = %PagingOptions{key: {first_page.token_id}, page_size: 1}
+      paging_options = %PagingOptions{key: {first_page.block_number, first_page.log_index}, page_size: 1}
 
       unique_tokens_ids_paginated =
-        Chain.address_to_unique_tokens(
-          token_contract_address.hash,
-          paging_options: paging_options
-        )
+        token_contract_address.hash
+        |> Chain.address_to_unique_tokens(paging_options: paging_options)
         |> Enum.map(& &1.token_id)
 
       assert unique_tokens_ids_paginated == [second_page.token_id]

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -387,6 +387,7 @@ defmodule Explorer.Factory do
 
     %TokenTransfer{
       amount: Decimal.new(1),
+      block_number: block_number(),
       from_address: from_address,
       to_address: to_address,
       token_contract_address: token_address,


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/1053

## Changelog

### Enhancements
* Denormalized the `block_number` from the transaction to token transfers to avoid joins with the transactions' table and block's table.
* Paginates the results using the `block_number` and the `log_index`. It was using the `inserted_at` that would make the pagination inconsistent.

### Bug Fixes
* The application will be able to open tokens that have several transfers.

## Upgrading
* This need run the migration to add the `block_number` column at token transfer's table. You may need to run the script that copies the `block_number` from the transactions' table to token transfers' table

### Benchmark

* Token tested: `0xd2f81cd7a20d60c0d558496c7169a20968389b40`
* Old query: 6s
* New query: 400ms

Also, sometimes the page didn't open when the users' click on the next page using the `old query`. It works normally with the `new query` introduced at this PR.