### PR TITLE
Fix typo in "validation count" reducer when loading state.

### DIFF
--- a/apps/block_scout_web/assets/js/pages/address.js
+++ b/apps/block_scout_web/assets/js/pages/address.js
@@ -177,7 +177,7 @@ const elements = {
   },
   '[data-selector="validation-count"]': {
     load ($el) {
-      return { validationCount: numeral($el.text()).value }
+      return { validationCount: numeral($el.text()).value() }
     },
     render ($el, state, oldState) {
       if (oldState.validationCount === state.validationCount) return


### PR DESCRIPTION
closes #1092

## Motivation

The validation count number was being wrongly updated at the page loading.

## Changelog

### Bug Fixes
* Fix typo in `validation count` `load`.


