### PR TITLE
Fix CircleCI Tests and add Ganache as default Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ The [development stack page](https://github.com/poanetwork/blockscout/wiki/Devel
   `cd apps/block_scout_web/assets && npm install; cd -`  
   `cd apps/explorer && npm install; cd -`
 
-  7. Start Phoenix Server.  
+  7. Update your JSON RPC Variant in `apps/explorer/config/dev.exs` and `apps/indexer/config/dev.exs`.
+  For `variant`, enter `ganache`, `geth`, or `parity`
+
+  8. Update your JSON RPC Endpoint in `apps/explorer/config/dev/` and `apps/indexer/config/dev/`
+  For the `variant` chosen in step 7, enter the correct information for the corresponding JSON RPC Endpoint in `parity.exs`, `geth.exs`, or `ganache.exs`
+
+  9. Start Phoenix Server.  
   `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ mix coveralls.html --umbrella --exclude no_parity
 
 | Protocol  | URL                                |
 |:----------|:-----------------------------------|
-| HTTP      | `https://sokol-trace.poa.network`  |
-| WebSocket | `wss://sokol-ws.poa.network/ws`    |
+| HTTP      | `http://54.234.12.105:8545`  |
+| WebSocket | `ws://54.234.12.105:8546`    |
 
 ##### Geth
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ mix coveralls.html --umbrella --exclude no_parity
 
 | Protocol  | URL                                |
 |:----------|:-----------------------------------|
-| HTTP      | `http://54.234.12.105:8545`  |
-| WebSocket | `ws://54.234.12.105:8546`    |
+| HTTP      | `http://localhost:8545`  |
+| WebSocket | `ws://localhost:8546`    |
 
 ##### Geth
 

--- a/apps/ethereum_jsonrpc/README.md
+++ b/apps/ethereum_jsonrpc/README.md
@@ -9,8 +9,8 @@ config:
 
 ```elixir
 config :ethereum_jsonrpc,
-  url: "https://sokol.poa.network",
-  trace_url: "https://sokol-trace.poa.network",
+  url: "http://54.234.12.105:8545",
+  trace_url: "http://54.234.12.105:8545",
   http: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
 ```
 
@@ -44,8 +44,8 @@ mix test --exclude no_parity
 
 | Protocol  | URL                                |
 |:----------|:-----------------------------------|
-| HTTP      | `https://sokol-trace.poa.network`  |
-| WebSocket | `wss://sokol-ws.poa.network/ws`    |
+| HTTP      | `http://54.234.12.105:8545`  |
+| WebSocket | `ws://54.234.12.105:8546`    |
 
 ### Geth
 

--- a/apps/ethereum_jsonrpc/README.md
+++ b/apps/ethereum_jsonrpc/README.md
@@ -9,8 +9,8 @@ config:
 
 ```elixir
 config :ethereum_jsonrpc,
-  url: "http://54.234.12.105:8545",
-  trace_url: "http://54.234.12.105:8545",
+  url: "http://localhost:8545",
+  trace_url: "http://localhost:8545",
   http: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
 ```
 
@@ -44,8 +44,8 @@ mix test --exclude no_parity
 
 | Protocol  | URL                                |
 |:----------|:-----------------------------------|
-| HTTP      | `http://54.234.12.105:8545`  |
-| WebSocket | `ws://54.234.12.105:8546`    |
+| HTTP      | `http://localhost:8545`  |
+| WebSocket | `ws://localhost:8546`    |
 
 ### Geth
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -7,8 +7,8 @@ defmodule EthereumJSONRPC do
   Configuration for parity URLs can be provided with the following mix config:
 
       config :ethereum_jsonrpc,
-        url: "http://54.234.12.105:8545",
-        trace_url: "http://54.234.12.105:8545",
+        url: "http://localhost:8545",
+        trace_url: "http://localhost:8545",
         http: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
 
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -7,8 +7,8 @@ defmodule EthereumJSONRPC do
   Configuration for parity URLs can be provided with the following mix config:
 
       config :ethereum_jsonrpc,
-        url: "https://sokol.poa.network",
-        trace_url: "https://sokol-trace.poa.network",
+        url: "http://54.234.12.105:8545",
+        trace_url: "http://54.234.12.105:8545",
         http: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
 
 

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/parity/http_websocket.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/parity/http_websocket.ex
@@ -12,7 +12,7 @@ defmodule EthereumJSONRPC.Case.Parity.HTTPWebSocket do
       transport_options: [
         http: EthereumJSONRPC.HTTP.HTTPoison,
         http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]],
-        url: "https://sokol-trace.poa.network"
+        url: "http://54.234.12.105:8545"
       ],
       variant: EthereumJSONRPC.Parity
     )

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/parity/http_websocket.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/parity/http_websocket.ex
@@ -12,7 +12,7 @@ defmodule EthereumJSONRPC.Case.Parity.HTTPWebSocket do
       transport_options: [
         http: EthereumJSONRPC.HTTP.HTTPoison,
         http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]],
-        url: "http://54.234.12.105:8545"
+        url: "http://18.207.247.30:8545"
       ],
       variant: EthereumJSONRPC.Parity
     )

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/web_socket/case/parity.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/web_socket/case/parity.ex
@@ -6,7 +6,7 @@ defmodule EthereumJSONRPC.WebSocket.Case.Parity do
   import ExUnit.Callbacks, only: [start_supervised!: 1]
 
   def setup do
-    url = "wss://sokol-ws.poa.network/ws"
+    url = "ws://54.234.12.105:8546"
     web_socket_module = EthereumJSONRPC.WebSocket.WebSocketClient
     web_socket = start_supervised!({web_socket_module, [url, []]})
 

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/web_socket/case/parity.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/web_socket/case/parity.ex
@@ -6,7 +6,7 @@ defmodule EthereumJSONRPC.WebSocket.Case.Parity do
   import ExUnit.Callbacks, only: [start_supervised!: 1]
 
   def setup do
-    url = "ws://54.234.12.105:8546"
+    url = "ws://18.207.247.30:8546"
     web_socket_module = EthereumJSONRPC.WebSocket.WebSocketClient
     web_socket = start_supervised!({web_socket_module, [url, []]})
 

--- a/apps/explorer/config/dev.exs
+++ b/apps/explorer/config/dev.exs
@@ -22,7 +22,7 @@ import_config "dev.secret.exs"
 
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
-    "parity"
+    "ganache"
   else
     System.get_env("ETHEREUM_JSONRPC_VARIANT")
     |> String.split(".")

--- a/apps/explorer/config/dev/parity.exs
+++ b/apps/explorer/config/dev/parity.exs
@@ -5,11 +5,11 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://54.234.12.105:8545",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
       method_to_url: [
-        eth_call: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545",
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545"
+        eth_call: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
+        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
+        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
@@ -19,7 +19,7 @@ config :explorer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://54.234.12.105:8546"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://localhost:8546"
     ],
     variant: EthereumJSONRPC.Parity
   ]

--- a/apps/explorer/config/dev/parity.exs
+++ b/apps/explorer/config/dev/parity.exs
@@ -5,11 +5,11 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://sokol.poa.network",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://54.234.12.105:8545",
       method_to_url: [
-        eth_call: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network",
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network"
+        eth_call: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545",
+        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545",
+        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545"
       ],
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
@@ -19,7 +19,7 @@ config :explorer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "wss://sokol-ws.poa.network/ws"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://54.234.12.105:8546"
     ],
     variant: EthereumJSONRPC.Parity
   ]

--- a/apps/explorer/config/prod/parity.exs
+++ b/apps/explorer/config/prod/parity.exs
@@ -5,11 +5,11 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://sokol.poa.network",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
       method_to_url: [
-        eth_call: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network",
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network"
+        eth_call: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
+        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
+        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
@@ -19,7 +19,7 @@ config :explorer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "wss://sokol-ws.poa.network/ws"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ],
     variant: EthereumJSONRPC.Parity
   ]

--- a/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_download_block_1_downloads_the_block.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_download_block_1_downloads_the_block.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_download_block_1_downloads_the_block.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_download_block_1_downloads_the_block.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_duplicate_block.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_duplicate_block.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_duplicate_block.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_duplicate_block.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_pending.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_pending.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_pending.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_pending.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_saves_the_block.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_saves_the_block.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_saves_the_block.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/block_importer_import_1_saves_the_block.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/ethereumex_extensions_trace_transaction_1.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/ethereumex_extensions_trace_transaction_1.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/ethereumex_extensions_trace_transaction_1.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/ethereumex_extensions_trace_transaction_1.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_duplicate.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_duplicate.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_duplicate.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_duplicate.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_earliest.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_earliest.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_earliest.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_earliest.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_integer.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_integer.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_integer.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_integer.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_latest.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_latest.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_latest.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_latest.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_string.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_string.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_string.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_block_perform_1_string.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_receipt_perform_1.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_receipt_perform_1.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/import_receipt_perform_1.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/import_receipt_perform_1.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/internal_transaction_importer_import_1.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/internal_transaction_importer_import_1.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/internal_transaction_importer_import_1.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/internal_transaction_importer_import_1.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/internal_transaction_importer_import_1_with_contract_creation.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/internal_transaction_importer_import_1_with_contract_creation.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/internal_transaction_importer_import_1_with_contract_creation.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/internal_transaction_importer_import_1_with_contract_creation.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_binds_internal_transactions.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_binds_internal_transactions.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_binds_internal_transactions.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_binds_internal_transactions.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_from_address.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_from_address.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_from_address.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_from_address.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_to_address.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_to_address.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_to_address.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_to_address.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_to_address_from_creates.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_to_address_from_creates.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_to_address_from_creates.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_creates_a_to_address_from_creates.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_download_transaction.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_download_transaction.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_download_transaction.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_download_transaction.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_download_transaction_with_a_bad_hash.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_download_transaction_with_a_bad_hash.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_download_transaction_with_a_bad_hash.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_download_transaction_with_a_bad_hash.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_failed.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_failed.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_failed.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_failed.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_out_of_gas.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_out_of_gas.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_out_of_gas.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_out_of_gas.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_pending.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_pending.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_pending.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_pending.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_receipt.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_receipt.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_receipt.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_1_receipt.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_saves_the_transaction.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_saves_the_transaction.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_saves_the_transaction.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_import_saves_the_transaction.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_saves_the_association.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_saves_the_association.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_saves_the_association.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_saves_the_association.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_txn_without_block.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_txn_without_block.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_txn_without_block.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_txn_without_block.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_updates_the_association.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_updates_the_association.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://54.234.12.105:8545"
+      "url": "http://18.207.247.30:8545"
     },
     "response": {
       "binary": false,

--- a/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_updates_the_association.json
+++ b/apps/explorer/test/support/fixture/vcr_cassettes/transaction_importer_updates_the_association.json
@@ -8,7 +8,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://sokol-trace.poa.network"
+      "url": "http://54.234.12.105:8545"
     },
     "response": {
       "binary": false,

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -53,8 +53,8 @@ mix test --exclude no_parity
 
 | Protocol  | URL                                |
 |:----------|:-----------------------------------|
-| HTTP      | `http://54.234.12.105:8545`  |
-| WebSocket | `ws://54.234.12.105:8546`    |
+| HTTP      | `http://localhost:8545`  |
+| WebSocket | `ws://localhost:8546`    |
 
 ### Geth
 

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -53,8 +53,8 @@ mix test --exclude no_parity
 
 | Protocol  | URL                                |
 |:----------|:-----------------------------------|
-| HTTP      | `https://sokol-trace.poa.network`  |
-| WebSocket | `wss://sokol-ws.poa.network/ws`    |
+| HTTP      | `http://54.234.12.105:8545`  |
+| WebSocket | `ws://54.234.12.105:8546`    |
 
 ### Geth
 

--- a/apps/indexer/config/dev.exs
+++ b/apps/indexer/config/dev.exs
@@ -11,7 +11,7 @@ config :logger, :indexer_token_balances,
 
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
-    "parity"
+    "ganache"
   else
     System.get_env("ETHEREUM_JSONRPC_VARIANT")
     |> String.split(".")

--- a/apps/indexer/config/dev/parity.exs
+++ b/apps/indexer/config/dev/parity.exs
@@ -6,11 +6,11 @@ config :indexer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://54.234.12.105:8545",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
       method_to_url: [
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545",
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545"
+        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
+        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
+        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
@@ -20,6 +20,6 @@ config :indexer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://54.234.12.105:8546"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://localhost:8546"
     ]
   ]

--- a/apps/indexer/config/dev/parity.exs
+++ b/apps/indexer/config/dev/parity.exs
@@ -6,11 +6,11 @@ config :indexer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://sokol.poa.network",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://54.234.12.105:8545",
       method_to_url: [
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network",
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network"
+        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545",
+        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545",
+        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://54.234.12.105:8545"
       ],
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
@@ -20,6 +20,6 @@ config :indexer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "wss://sokol-ws.poa.network/ws"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://54.234.12.105:8546"
     ]
   ]

--- a/apps/indexer/config/prod/parity.exs
+++ b/apps/indexer/config/prod/parity.exs
@@ -6,11 +6,11 @@ config :indexer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://sokol.poa.network",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
       method_to_url: [
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network",
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "https://sokol-trace.poa.network"
+        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
+        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
+        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
       http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
     ],
@@ -20,6 +20,6 @@ config :indexer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "wss://sokol-ws.poa.network/ws"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ]
   ]

--- a/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
@@ -20,12 +20,12 @@ defmodule Indexer.Block.Realtime.FetcherTest do
   setup %{json_rpc_named_arguments: json_rpc_named_arguments} do
     core_json_rpc_named_arguments =
       json_rpc_named_arguments
-      |> put_in([:transport_options, :url], "https://core.poa.network")
+      |> put_in([:transport_options, :url], "http://54.144.107.14:8545")
       |> put_in(
         [:transport_options, :method_to_url],
-        eth_getBalance: "https://core-trace.poa.network",
-        trace_replayTransaction: "https://core-trace.poa.network",
-        trace_block: "https://core-trace.poa.network"
+        eth_getBalance: "http://54.144.107.14:8545",
+        trace_replayTransaction: "http://54.144.107.14:8545",
+        trace_block: "http://54.144.107.14:8545"
       )
 
     block_fetcher = %Indexer.Block.Fetcher{

--- a/docker/README.md
+++ b/docker/README.md
@@ -54,7 +54,7 @@ Available options are:
 | `ETHEREUM_JSONRPC_VARIANT` | Variant of your JSON RPC service: `parity`, `geth` or `ganache` | `parity` |
 | `ETHEREUM_JSONRPC_HTTP_URL` | HTTP JSON RPC URL Only for `geth` or `ganache` variant | Different per JSONRPC variant |
 | `ETHEREUM_JSONRPC_WS_URL` | WS JSON RPC url | Different per JSONRPC variant |
-| `ETHEREUM_JSONRPC_TRACE_URL` | Trace URL **Only for `parity` variant** | `http://54.234.12.105:8545` |
+| `ETHEREUM_JSONRPC_TRACE_URL` | Trace URL **Only for `parity` variant** | `http://localhost:8545` |
 | `COIN` | Default Coin | `POA` |
 | `LOGO` | Coin logo | Empty | 
 | `NETWORK` | Network | Empty |
@@ -65,13 +65,13 @@ Available options are:
 
 `ETHEREUM_JSONRPC_HTTP_URL` default values:
 
- * For `parity` - `http://54.234.12.105:8545`
+ * For `parity` - `http://localhost:8545`
  * For `geth` - `https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY`
  * For `ganache` - `http://localhost:7545`
 
 `ETHEREUM_JSONRPC_WS_URL` default values:
 
- * For `parity` - `ws://54.234.12.105:8546`
+ * For `parity` - `ws://localhost:8546`
  * For `geth` - `wss://mainnet.infura.io/8lTvJTKmHPCHazkneJsY/ws`
  * For `ganache` - `ws://localhost:7545`
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -54,7 +54,7 @@ Available options are:
 | `ETHEREUM_JSONRPC_VARIANT` | Variant of your JSON RPC service: `parity`, `geth` or `ganache` | `parity` |
 | `ETHEREUM_JSONRPC_HTTP_URL` | HTTP JSON RPC URL Only for `geth` or `ganache` variant | Different per JSONRPC variant |
 | `ETHEREUM_JSONRPC_WS_URL` | WS JSON RPC url | Different per JSONRPC variant |
-| `ETHEREUM_JSONRPC_TRACE_URL` | Trace URL **Only for `parity` variant** | `https://sokol-trace.poa.network` |
+| `ETHEREUM_JSONRPC_TRACE_URL` | Trace URL **Only for `parity` variant** | `http://54.234.12.105:8545` |
 | `COIN` | Default Coin | `POA` |
 | `LOGO` | Coin logo | Empty | 
 | `NETWORK` | Network | Empty |
@@ -65,13 +65,13 @@ Available options are:
 
 `ETHEREUM_JSONRPC_HTTP_URL` default values:
 
- * For `parity` - `https://sokol.poa.network`
+ * For `parity` - `http://54.234.12.105:8545`
  * For `geth` - `https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY`
  * For `ganache` - `http://localhost:7545`
 
 `ETHEREUM_JSONRPC_WS_URL` default values:
 
- * For `parity` - `wss://sokol-ws.poa.network/ws`
+ * For `parity` - `ws://54.234.12.105:8546`
  * For `geth` - `wss://mainnet.infura.io/8lTvJTKmHPCHazkneJsY/ws`
  * For `ganache` - `ws://localhost:7545`
 


### PR DESCRIPTION
## Motivation

This pull request fixes failing tests caused by the removal of `sokol.poa.network` and `sokol-trace.poa.network`. Ganache is also made the default client in this pull request. 

## Changelog

* Update README docs to reflect `localhost:8545` and `localhost:8546` the default RPC and WebSockets port from Parity.
* Makes Ganache the default client.
* Adds a working `sokol` node to CircleCI tests

### Incompatible Changes

* There is a bug in Ganache that is being worked on now by @sabondano 

