### PR TITLE
Allows other sites to open blockscout in iframe

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/plug/allow_iframe.ex
+++ b/apps/block_scout_web/lib/block_scout_web/plug/allow_iframe.ex
@@ -1,0 +1,14 @@
+defmodule BlockScoutWeb.Plug.AllowIframe do
+  @moduledoc """
+  Allows for iframes by deleting the
+  [`X-Frame-Options` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options)
+  """
+
+  alias Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    Conn.delete_resp_header(conn, "x-frame-options")
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -55,8 +55,14 @@ defmodule BlockScoutWeb.Router do
     max_complexity: @max_complexity
   )
 
+  # Disallows Iframes (write routes)
   scope "/", BlockScoutWeb do
     pipe_through(:browser)
+  end
+
+  # Allows Iframes (read-only routes)
+  scope "/", BlockScoutWeb do
+    pipe_through([:browser, BlockScoutWeb.Plug.AllowIframe])
 
     resources("/", ChainController, only: [:show], singleton: true, as: :chain)
 


### PR DESCRIPTION
## Motivation

* For our partners to be able to open BlockScout in an iframe.

## Changelog

### Enhancements
* Creating `AllowIframe` plug.
* Editing router to have a new scope for write-only routes and a
separate one for read-only routes which allows for iframes (using the
plug mentioned above).

(This comment was edited to reflect the latest changes, after the conversation below.)