### PR TITLE
Add primary names to accounts page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
@@ -1,6 +1,11 @@
 <span class="<%= if @contract do %>contract-address<% end %>" data-address-hash="<%= @address.hash %>">
   <%= if name = primary_name(@address) do %>
-    <span data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= short_hash(@address) %>...)</span>
+    <%= if assigns[:truncate] do %>
+      <span data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= short_hash(@address) %>...)</span>
+    <% else %>
+      <span class="d-none d-md-none d-lg-inline" data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= @address.hash %>)</span>
+      <span class="d-md-inline-block d-lg-none" data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %>)</span>
+    <% end %>
   <% else %>
     <%= if assigns[:truncate] do %>
       <%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %>

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_controller_test.exs
@@ -14,6 +14,15 @@ defmodule BlockScoutWeb.AddressControllerTest do
              |> Enum.map(fn {address, _transaction_count} -> address end)
              |> Enum.map(& &1.hash) == address_hashes
     end
+
+    test "returns an address's primary name when present", %{conn: conn} do
+      address = insert(:address)
+      address_name = insert(:address_name, address: address, primary: true, name: "POA Wallet3")
+
+      conn = get(conn, address_path(conn, :index))
+
+      assert html_response(conn, 200) =~ address_name.name
+    end
   end
 
   describe "GET show/3" do

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_controller_test.exs
@@ -16,8 +16,8 @@ defmodule BlockScoutWeb.AddressControllerTest do
     end
 
     test "returns an address's primary name when present", %{conn: conn} do
-      address = insert(:address)
-      address_name = insert(:address_name, address: address, primary: true, name: "POA Wallet3")
+      address = insert(:address, fetched_coin_balance: 1)
+      address_name = insert(:address_name, address: address, primary: true, name: "POA Wallet")
 
       conn = get(conn, address_path(conn, :index))
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -913,6 +913,7 @@ defmodule Explorer.Chain do
       from(a in Address,
         where: a.fetched_coin_balance > ^0,
         order_by: [desc: a.fetched_coin_balance, asc: a.hash],
+        preload: [:names],
         select: {a, fragment("coalesce(1 + ?, 0)", a.nonce)},
         limit: 250
       )


### PR DESCRIPTION
Resolves [#1080](https://github.com/poanetwork/blockscout/issues/1080)

## Motivation

Top accounts page can contain addresses with primary names. This PR allows to display them on the page.

![primary_name_1](https://user-images.githubusercontent.com/8477052/49501620-2cdf1d80-f828-11e8-8b4b-a4302b13d013.png)

Address will be trimmed on small screen:

![primary_name_2](https://user-images.githubusercontent.com/8477052/49501632-310b3b00-f828-11e8-9a6e-5755d6464001.png)


## Changelog

### Enhancements
* Add primary names to the top accounts page
* Display trimmed address only if truncate variable is set to true or on small screens


