### PR TITLE
Fix Address Trasaction query

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -174,7 +174,18 @@ defmodule Explorer.Chain do
   end
 
   @doc """
-  `t:Explorer.Chain.Transaction/0`s from `address`.
+  Fetches the transactions related to the given address, including transactions
+  that only have the address in the `token_transfers` related table.
+
+  This query is divided into multiple subqueries intentionally in order to
+  improve the listing performance.
+
+  The `token_trasfers` table tends to grow exponentially, and the query results
+  with a `transactions` `join` statement takes too long.
+
+  To solve this the `transaction_hashes` are fetched in a separate query, and
+  paginated through the `block_number` already present in the `token_transfers`
+  table.
 
   ## Options
 
@@ -196,19 +207,21 @@ defmodule Explorer.Chain do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    {:ok, address_bytes} = Explorer.Chain.Hash.Address.dump(address_hash)
+    transaction_hashes_from_token_transfers =
+      TokenTransfer.where_any_address_fields_match(direction, address_hash, paging_options)
 
-    token_transfers_dynamic = TokenTransfer.dynamic_any_address_fields_match(direction, address_bytes)
+    token_transfers_query =
+      transaction_hashes_from_token_transfers
+      |> Transaction.where_transaction_hashes_match()
+      |> join_associations(necessity_by_association)
+      |> order_by([transaction], desc: transaction.block_number, desc: transaction.index)
+      |> Transaction.preload_token_transfers(address_hash)
 
     base_query =
       paging_options
       |> fetch_transactions()
       |> join_associations(necessity_by_association)
       |> Transaction.preload_token_transfers(address_hash)
-
-    token_transfers_query =
-      base_query
-      |> from(where: ^token_transfers_dynamic)
 
     from_address_query =
       base_query

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Chain.Transaction do
 
   require Logger
 
-  import Ecto.Query, only: [from: 2, preload: 3, subquery: 1]
+  import Ecto.Query, only: [from: 2, order_by: 3, preload: 3, subquery: 1, where: 3]
 
   alias ABI.FunctionSelector
 
@@ -465,6 +465,18 @@ defmodule Explorer.Chain.Transaction do
     _ ->
       Logger.warn(fn -> ["Could not decode input data for transaction: ", Hash.to_iodata(hash)] end)
       {:error, :could_not_decode}
+  end
+
+  @doc """
+  Builds a query that will check for transactions within the hashes params.
+
+  Be careful to not pass a large list, because this will lead to performance
+  problems.
+  """
+  def where_transaction_hashes_match(transaction_hashes) do
+    Transaction
+    |> where([t], t.hash == fragment("ANY (?)", ^transaction_hashes))
+    |> order_by([transaction], desc: transaction.block_number, desc: transaction.index)
   end
 
   @collated_fields ~w(block_number cumulative_gas_used gas_used index)a

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Chain.Transaction do
 
   require Logger
 
-  import Ecto.Query, only: [from: 2, preload: 3, subquery: 1, where: 3]
+  import Ecto.Query, only: [from: 2, preload: 3, subquery: 1]
 
   alias ABI.FunctionSelector
 
@@ -465,18 +465,6 @@ defmodule Explorer.Chain.Transaction do
     _ ->
       Logger.warn(fn -> ["Could not decode input data for transaction: ", Hash.to_iodata(hash)] end)
       {:error, :could_not_decode}
-  end
-
-  @doc """
-  Adds to the given transaction's query a `where` with one of the conditions that the matched
-  function returns.
-
-  `where_address_fields_match(query, address, address_field)`
-  - returns a query constraining the given address_hash to be equal to the given
-    address field from transactions' table.
-  """
-  def where_address_fields_match(query, address_hash, address_field) do
-    where(query, [t], field(t, ^address_field) == ^address_hash)
   end
 
   @collated_fields ~w(block_number cumulative_gas_used gas_used index)a

--- a/apps/explorer/priv/repo/migrations/20181212115448_add_indexes_to_token_transfers.exs
+++ b/apps/explorer/priv/repo/migrations/20181212115448_add_indexes_to_token_transfers.exs
@@ -1,0 +1,8 @@
+defmodule Explorer.Repo.Migrations.AddIndexesToTokenTransfers do
+  use Ecto.Migration
+
+  def change do
+    create(index("token_transfers", [:from_address_hash]))
+    create(index("token_transfers", [:to_address_hash]))
+  end
+end


### PR DESCRIPTION
Resolves #1183

The `address` `transaction` listing (with an `address`  that has 7MM `transactions`) is loading within 7s using a db similar to the ethereum mainnet.

<img width="1439" alt="screen shot 2018-12-11 at 17 27 39" src="https://user-images.githubusercontent.com/840531/49824886-3e657f80-fd6a-11e8-9f21-e2f1af14e722.png">

Normal addresses continue to load quickly as well

<img width="1439" alt="screen shot 2018-12-11 at 17 28 28" src="https://user-images.githubusercontent.com/840531/49824933-5d641180-fd6a-11e8-97c4-2c3553df0950.png">


## Motivation

When a token is sent, the recipient (to) address of the token transfer is not seeing the token transfer on the transactions tab. 

## Changelog

### Bug Fixes

* The bug was that only the first transaction that had token transfers was being shown.
