### PR TITLE
Fix realtime address balance update

### DIFF
--- a/apps/block_scout_web/assets/js/pages/address.js
+++ b/apps/block_scout_web/assets/js/pages/address.js
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import URI from 'urijs'
 import humps from 'humps'
 import numeral from 'numeral'
-import socket from '../socket'
+import socket, { subscribeChannel } from '../socket'
 import { createStore, connectElements } from '../lib/redux_helpers.js'
 import { updateAllCalculatedUsdValues } from '../lib/currency.js'
 import { loadTokenBalanceDropdown } from '../lib/token_balance_dropdown'
@@ -105,8 +105,8 @@ if ($addressDetailsPage.length) {
   })
   connectElements({ store, elements })
 
-  const addressChannel = socket.channel(`addresses:${addressHash}`, {})
-  addressChannel.join()
+  const addressChannel = subscribeChannel(`addresses:${addressHash}`)
+
   addressChannel.onError(() => store.dispatch({
     type: 'CHANNEL_DISCONNECTED'
   }))

--- a/apps/block_scout_web/assets/js/pages/address/transactions.js
+++ b/apps/block_scout_web/assets/js/pages/address/transactions.js
@@ -2,7 +2,7 @@ import $ from 'jquery'
 import _ from 'lodash'
 import URI from 'urijs'
 import humps from 'humps'
-import socket from '../../socket'
+import { subscribeChannel } from '../../socket'
 import { connectElements } from '../../lib/redux_helpers.js'
 import { createAsyncLoadStore } from '../../lib/async_listing_load'
 
@@ -61,8 +61,8 @@ if ($('[data-page="address-transactions"]').length) {
     beyondPageOne: !!blockNumber
   })
 
-  const addressChannel = socket.channel(`addresses:${addressHash}`, {})
-  addressChannel.join()
+  const addressChannel = subscribeChannel(`addresses:${addressHash}`)
+
   addressChannel.onError(() => store.dispatch({ type: 'CHANNEL_DISCONNECTED' }))
   addressChannel.on('transaction', (msg) => {
     store.dispatch({

--- a/apps/block_scout_web/assets/js/socket.js
+++ b/apps/block_scout_web/assets/js/socket.js
@@ -5,3 +5,26 @@ const socket = new Socket('/socket', {params: {locale: locale}})
 socket.connect()
 
 export default socket
+
+/**
+ * Subscribes the client in the channel given the topic.
+ *
+ * This function will check if already exist a channel before creating one. This is useful because
+ * when the client is attempting to create a duplicated subscription, the server will close the
+ * existing subscription and create a new one.
+ *
+ * See more about it in https://hexdocs.pm/phoenix/js/#phoenix.
+ *
+ * Returns a Channel instance.
+ */
+export function subscribeChannel (topic) {
+  const channel = socket.channels.find(channel => channel.topic === topic)
+
+  if (channel) {
+    return channel
+  } else {
+    const channel = socket.channel(topic, {})
+    channel.join()
+    return channel
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/1188

## Bug fixes

The balance update stopped working because the client was trying to subscribe twice in the channel topic. When the server receives a duplicated subscription, he closes the first connection to open a new
one.

See more about it: https://hexdocs.pm/phoenix/js/#phoenix

In our case, the client subscribed in the address channel in `address.js` and `transactions.js`, then the server was keeping only the last subscription.

## Now it's working again :)

![2018-12-07 19 39 45](https://user-images.githubusercontent.com/27698968/49674147-056e9780-fa58-11e8-9465-54d94b0068ee.gif)
