### PR TITLE
fix overlapping names on token transfers

### DIFF
--- a/apps/block_scout_web/assets/css/components/_tile.scss
+++ b/apps/block_scout_web/assets/css/components/_tile.scss
@@ -81,6 +81,13 @@
       .tile-label {
         color: $orange;
       }
+
+      &-short-name {
+        overflow: hidden;
+        max-width: 45%;
+        vertical-align: middle;
+        text-overflow: ellipsis;
+      }
     }
 
     &-unique-token {

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
@@ -11,9 +11,13 @@
         </span>
       <% end %>
     <% end %>
+    <span class="d-inline-block tile-type-token-transfer-short-name">
     <%= @token_transfer |> BlockScoutWeb.AddressView.address_partial_selector(:from, @address, true) |> BlockScoutWeb.RenderHelpers.render_partial() %>
+    </span>
     &rarr;
+    <span class="d-inline-block tile-type-token-transfer-short-name">
     <%= @token_transfer |> BlockScoutWeb.AddressView.address_partial_selector(:to, @address, true) |> BlockScoutWeb.RenderHelpers.render_partial() %>
+    </span>
   </span>
   <span class="col-12 col-md-7 ml-3 ml-sm-0">
   <%= token_transfer_amount(@token_transfer) %>


### PR DESCRIPTION
resolves #1165

## Changelog

### Enhancements
* limit the width of the addresses and names by truncating the excess text

### screenshot
<img width="586" alt="captura de tela 2018-12-10 as 15 41 34" src="https://user-images.githubusercontent.com/18328258/49750619-929d3080-fc92-11e8-95ff-85d003bf089d.png">
