### PR TITLE
Improve token balances fetching for specific addresses

### DIFF
--- a/apps/block_scout_web/assets/js/lib/token_balance_dropdown.js
+++ b/apps/block_scout_web/assets/js/lib/token_balance_dropdown.js
@@ -17,4 +17,3 @@ const tokenBalanceDropdown = (element) => {
 export function loadTokenBalanceDropdown () {
   $('[data-token-balance-dropdown]').each((_index, element) => tokenBalanceDropdown(element))
 }
-loadTokenBalanceDropdown()

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
@@ -421,7 +421,7 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
         token_contract_address: contract_address
       )
 
-      insert(:token_balance, address: lincoln, token_contract_address_hash: contract_address.hash)
+      insert(:address_current_token_balance, address: lincoln, token_contract_address_hash: contract_address.hash)
 
       contract_address_2 = insert(:contract_address)
       insert(:token, name: "token2", symbol: "T2", contract_address: contract_address_2, type: "ERC-20")
@@ -439,7 +439,7 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
         token_contract_address: contract_address_2
       )
 
-      insert(:token_balance, address: lincoln, token_contract_address_hash: contract_address_2.hash)
+      insert(:address_current_token_balance, address: lincoln, token_contract_address_hash: contract_address_2.hash)
 
       {:ok, lincoln: lincoln}
     end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2034,7 +2034,7 @@ defmodule Explorer.Chain do
   @spec fetch_last_token_balances(Hash.Address.t()) :: []
   def fetch_last_token_balances(address_hash) do
     address_hash
-    |> TokenBalance.last_token_balances()
+    |> CurrentTokenBalance.last_token_balances()
     |> Repo.all()
   end
 

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -87,6 +87,18 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
     |> limit(^paging_options.page_size)
   end
 
+  @doc """
+  Builds an `Ecto.Query` to fetch the current token balances of the given address.
+  """
+  def last_token_balances(address_hash) do
+    from(
+      tb in __MODULE__,
+      where: tb.address_hash == ^address_hash,
+      where: tb.value > 0,
+      preload: :token
+    )
+  end
+
   defp token_holders_query(token_contract_address_hash) do
     from(
       tb in __MODULE__,

--- a/apps/explorer/lib/explorer/chain/address/token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/token_balance.ex
@@ -66,23 +66,6 @@ defmodule Explorer.Chain.Address.TokenBalance do
   @burn_address_hash burn_address_hash
 
   @doc """
-  Builds an `Ecto.Query` to fetch the last token balances that have value greater than 0.
-
-  The last token balances from an Address is the last block indexed.
-  """
-  def last_token_balances(address_hash) do
-    query =
-      from(
-        tb in TokenBalance,
-        where: tb.address_hash == ^address_hash,
-        distinct: :token_contract_address_hash,
-        order_by: [desc: :block_number]
-      )
-
-    from(tb in subquery(query), where: tb.value > 0, preload: :token)
-  end
-
-  @doc """
   Builds an `Ecto.Query` to group all tokens with their number of holders.
   """
   def tokens_grouped_by_number_of_holders do

--- a/apps/explorer/test/explorer/chain/address/current_token_balance_test.exs
+++ b/apps/explorer/test/explorer/chain/address/current_token_balance_test.exs
@@ -146,4 +146,58 @@ defmodule Explorer.Chain.Address.CurrentTokenBalanceTest do
       assert result_paginated == [second_page.address_hash]
     end
   end
+
+  describe "last_token_balances/1" do
+    test "returns the current token balances of the given address" do
+      address = insert(:address)
+      current_token_balance = insert(:address_current_token_balance, address: address)
+      insert(:address_current_token_balance, address: build(:address))
+
+      token_balances =
+        address.hash
+        |> CurrentTokenBalance.last_token_balances()
+        |> Repo.all()
+        |> Enum.map(& &1.address_hash)
+
+      assert token_balances == [current_token_balance.address_hash]
+    end
+
+    test "returns an empty list when there are no token balances" do
+      address = insert(:address)
+
+      insert(:address_current_token_balance, address: build(:address))
+
+      token_balances =
+        address.hash
+        |> CurrentTokenBalance.last_token_balances()
+        |> Repo.all()
+
+      assert token_balances == []
+    end
+
+    test "does not consider tokens that have value 0" do
+      address = insert(:address)
+
+      current_token_balance_a =
+        insert(
+          :address_current_token_balance,
+          address: address,
+          value: 5000
+        )
+
+      insert(
+        :address_current_token_balance,
+        address: address,
+        value: 0
+      )
+
+      token_balances =
+        address.hash
+        |> CurrentTokenBalance.last_token_balances()
+        |> Repo.all()
+        |> Enum.map(& &1.address_hash)
+
+      assert token_balances == [current_token_balance_a.address_hash]
+    end
+  end
 end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2887,91 +2887,15 @@ defmodule Explorer.ChainTest do
   describe "fetch_last_token_balances/1" do
     test "returns the token balances given the address hash" do
       address = insert(:address)
-      token_balance = insert(:token_balance, address: address)
-      insert(:token_balance, address: build(:address))
+      current_token_balance = insert(:address_current_token_balance, address: address)
+      insert(:address_current_token_balance, address: build(:address))
 
       token_balances =
         address.hash
         |> Chain.fetch_last_token_balances()
         |> Enum.map(& &1.address_hash)
 
-      assert token_balances == [token_balance.address_hash]
-    end
-
-    test "returns the value from the last block" do
-      address = insert(:address)
-      token_a = insert(:token, contract_address: build(:contract_address))
-      token_b = insert(:token, contract_address: build(:contract_address))
-
-      insert(
-        :token_balance,
-        address: address,
-        block_number: 1000,
-        token_contract_address_hash: token_a.contract_address_hash,
-        value: 5000
-      )
-
-      token_balance_a =
-        insert(
-          :token_balance,
-          address: address,
-          block_number: 1001,
-          token_contract_address_hash: token_a.contract_address_hash,
-          value: 4000
-        )
-
-      insert(
-        :token_balance,
-        address: address,
-        block_number: 1000,
-        token_contract_address_hash: token_b.contract_address_hash,
-        value: 3000
-      )
-
-      token_balance_b =
-        insert(
-          :token_balance,
-          address: address,
-          block_number: 1001,
-          token_contract_address_hash: token_b.contract_address_hash,
-          value: 2000
-        )
-
-      token_balances = Chain.fetch_last_token_balances(address.hash)
-
-      assert Enum.count(token_balances) == 2
-      assert Enum.map(token_balances, & &1.value) == [token_balance_a.value, token_balance_b.value]
-    end
-
-    test "returns an empty list when there are no token balances" do
-      address = insert(:address)
-
-      insert(:token_balance, address: build(:address))
-
-      assert Chain.fetch_last_token_balances(address.hash) == []
-    end
-
-    test "does not consider other blocks when the last block has the value 0" do
-      address = insert(:address)
-      token = insert(:token, contract_address: build(:contract_address))
-
-      insert(
-        :token_balance,
-        address: address,
-        block_number: 1000,
-        token_contract_address_hash: token.contract_address_hash,
-        value: 5000
-      )
-
-      insert(
-        :token_balance,
-        address: address,
-        block_number: 1001,
-        token_contract_address_hash: token.contract_address_hash,
-        value: 0
-      )
-
-      assert Chain.fetch_last_token_balances(address.hash) == []
+      assert token_balances == [current_token_balance.address_hash]
     end
   end
 


### PR DESCRIPTION
Closes #1026.

This PR changes how the token balances of a specific addresses are obtained. The `address_token_balances` table was used before, now `address_current_token_balances` is used.

This significantly improves the performance of this query. For example, the time for a request (for a user with ~25 tokens) went down from 12 seconds to 3 seconds.

I also noticed that the request was being sent twice. I think this was caused because the `token_balance_dropdown.js` module was calling the function when it was imported. I don't think this is necessary, since the render function of the component was already doing this.

## Things to test

- The correct list of token balances is shown in the token balances dropdown.
- Each token has a link to the proper token page.