### PR TITLE
Fix Block Validated page to show all tabs

### DIFF
--- a/apps/block_scout_web/assets/css/components/_nav_tabs.scss
+++ b/apps/block_scout_web/assets/css/components/_nav_tabs.scss
@@ -1,7 +1,7 @@
 .nav-tabs {
 
   .nav-link {
-    padding: 1.25rem 3rem;
+    padding: 1.25rem 2.5rem;
     color: $text-muted;
     font-size: 14px;
     border-top-left-radius: 0;

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
@@ -38,7 +38,7 @@
     <li class="nav-item">
       <%= link(
         gettext("Blocks Validated"),
-        class: "nav-link",
+        class: "nav-link #{tab_status("validations", @conn.request_path)}",
         "data-test": "validations_tab_link",
         to: address_validation_path(@conn, :index, @address.hash)
       ) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_validation/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_validation/index.html.eex
@@ -4,59 +4,8 @@
   <section data-page="blocks-validated">
     <div class="card">
       <div class="card-header">
-        <!-- DESKTOP TAB NAV -->
-        <ul class="nav nav-tabs card-header-tabs d-none d-md-inline-flex">
-          <li class="nav-item">
-            <%= link(
-              gettext("Transactions"),
-              class: "nav-link",
-              to: address_transaction_path(@conn, :index, @address.hash)
-            ) %>
-          </li>
-          <li class="nav-item">
-            <%= link(
-              gettext("Tokens"),
-              class: "nav-link",
-              to: address_token_path(@conn, :index, @address.hash)
-            ) %>
-          </li>
-          <li class="nav-item"> <%= link(
-            gettext("Internal Transactions"),
-            class: "nav-link",
-            "data-test": "internal_transactions_tab_link",
-            to: address_internal_transaction_path(@conn, :index, @address.hash)
-          ) %>
-          </li>
-          <li class="nav-item">
-            <%= link(
-              gettext("Blocks Validated"),
-              class: "nav-link active",
-              "data-test": "validations_tab_link",
-              to: address_validation_path(@conn, :index, @address.hash)
-            ) %>
-          </li>
-          <%= if contract?(@address) do %>
-            <li class="nav-item">
-              <%= link(
-                  to: address_contract_path(@conn, :index, @address.hash),
-                  class: "nav-link") do %>
-                <%= gettext("Code") %>
-                <%= if smart_contract_verified?(@address) do %>
-                  <i class="far fa-check-circle"></i>
-                <% end %>
-              <% end %>
-            </li>
-          <% end %>
-          <%= if smart_contract_with_read_only_functions?(@address) do %>
-            <li class="nav-item">
-              <%= link(
-                gettext("Read Contract"),
-                to: address_read_contract_path(@conn, :index, @address.hash),
-                class: "nav-link")%>
-            </li>
-          <% end %>
-        </ul>
-        <!-- MOBILE DROPDOWN NAV -->
+        <%= render BlockScoutWeb.AddressView, "_tabs.html", assigns %>
+
         <ul class="nav nav-tabs card-header-tabs d-md-none">
           <li class="nav-item dropdown flex-fill text-center">
             <a class="nav-link active dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><%= gettext "Tokens" %></a>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_validation_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_validation_view.ex
@@ -1,6 +1,5 @@
 defmodule BlockScoutWeb.AddressValidationView do
   use BlockScoutWeb, :view
 
-  import BlockScoutWeb.AddressView,
-    only: [contract?: 1, smart_contract_verified?: 1, smart_contract_with_read_only_functions?: 1]
+  import BlockScoutWeb.AddressView, only: [contract?: 1, smart_contract_verified?: 1]
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -9,7 +9,15 @@ defmodule BlockScoutWeb.AddressView do
 
   @dialyzer :no_match
 
-  @tabs ["tokens", "transactions", "internal_transactions", "contracts", "read_contract", "coin_balances"]
+  @tabs [
+    "coin_balances",
+    "contracts",
+    "internal_transactions",
+    "read_contract",
+    "tokens",
+    "transactions",
+    "validations"
+  ]
 
   def address_partial_selector(struct_to_render_from, direction, current_address, truncate \\ false)
 
@@ -214,6 +222,7 @@ defmodule BlockScoutWeb.AddressView do
   defp tab_name(["contracts"]), do: gettext("Code")
   defp tab_name(["read_contract"]), do: gettext("Read Contract")
   defp tab_name(["coin_balances"]), do: gettext("Coin Balance History")
+  defp tab_name(["validations"]), do: gettext("Blocks Validated")
 
   def short_hash(%Address{hash: hash}) do
     <<

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -105,7 +105,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:15
-#: lib/block_scout_web/views/address_view.ex:84
+#: lib/block_scout_web/views/address_view.ex:92
 msgid "Address"
 msgstr ""
 
@@ -196,9 +196,9 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:40
 #: lib/block_scout_web/templates/address/_tabs.html.eex:103
 #: lib/block_scout_web/templates/address/overview.html.eex:37
-#: lib/block_scout_web/templates/address_validation/index.html.eex:32
-#: lib/block_scout_web/templates/address_validation/index.html.eex:81
-#: lib/block_scout_web/templates/address_validation/index.html.eex:108
+#: lib/block_scout_web/templates/address_validation/index.html.eex:30
+#: lib/block_scout_web/templates/address_validation/index.html.eex:57
+#: lib/block_scout_web/views/address_view.ex:225
 msgid "Blocks Validated"
 msgstr ""
 
@@ -226,11 +226,10 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:53
 #: lib/block_scout_web/templates/address/_tabs.html.eex:113
-#: lib/block_scout_web/templates/address_validation/index.html.eex:43
-#: lib/block_scout_web/templates/address_validation/index.html.eex:90
+#: lib/block_scout_web/templates/address_validation/index.html.eex:39
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:119
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
-#: lib/block_scout_web/views/address_view.ex:214
+#: lib/block_scout_web/views/address_view.ex:222
 msgid "Code"
 msgstr ""
 
@@ -263,7 +262,7 @@ msgid "Connection Lost, click to load newer transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_validation/index.html.eex:104
+#: lib/block_scout_web/templates/address_validation/index.html.eex:53
 msgid "Connection Lost, click to load newer validations"
 msgstr ""
 
@@ -274,14 +273,14 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:12
-#: lib/block_scout_web/views/address_view.ex:82
+#: lib/block_scout_web/views/address_view.ex:90
 msgid "Contract Address"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:15
-#: lib/block_scout_web/views/address_view.ex:26
-#: lib/block_scout_web/views/address_view.ex:60
+#: lib/block_scout_web/views/address_view.ex:34
+#: lib/block_scout_web/views/address_view.ex:68
 msgid "Contract Address Pending"
 msgstr ""
 
@@ -509,11 +508,10 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:90
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:58
 #: lib/block_scout_web/templates/address_validation/index.html.eex:24
-#: lib/block_scout_web/templates/address_validation/index.html.eex:75
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:213
+#: lib/block_scout_web/views/address_view.ex:221
 #: lib/block_scout_web/views/transaction_view.ex:190
 msgid "Internal Transactions"
 msgstr ""
@@ -547,7 +545,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:18
 #: lib/block_scout_web/templates/layout/app.html.eex:49
-#: lib/block_scout_web/views/address_view.ex:104
+#: lib/block_scout_web/views/address_view.ex:112
 msgid "Market Cap"
 msgstr ""
 
@@ -643,7 +641,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:76
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:31
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:75
-#: lib/block_scout_web/templates/address_validation/index.html.eex:126
+#: lib/block_scout_web/templates/address_validation/index.html.eex:75
 #: lib/block_scout_web/templates/block/index.html.eex:25
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:39
@@ -730,10 +728,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:65
 #: lib/block_scout_web/templates/address/_tabs.html.eex:122
-#: lib/block_scout_web/templates/address_validation/index.html.eex:53
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
-#: lib/block_scout_web/views/address_view.ex:215
+#: lib/block_scout_web/views/address_view.ex:223
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -929,10 +926,9 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:85
 #: lib/block_scout_web/templates/address_token/index.html.eex:11
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:12
-#: lib/block_scout_web/templates/address_validation/index.html.eex:18
-#: lib/block_scout_web/templates/address_validation/index.html.eex:62
-#: lib/block_scout_web/templates/address_validation/index.html.eex:70
-#: lib/block_scout_web/views/address_view.ex:211
+#: lib/block_scout_web/templates/address_validation/index.html.eex:11
+#: lib/block_scout_web/templates/address_validation/index.html.eex:19
+#: lib/block_scout_web/views/address_view.ex:219
 msgid "Tokens"
 msgstr ""
 
@@ -986,15 +982,14 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:5
 #: lib/block_scout_web/templates/address/_tabs.html.eex:80
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:53
-#: lib/block_scout_web/templates/address_validation/index.html.eex:11
-#: lib/block_scout_web/templates/address_validation/index.html.eex:65
+#: lib/block_scout_web/templates/address_validation/index.html.eex:14
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:26
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:35
 #: lib/block_scout_web/templates/chain/show.html.eex:69
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:35
-#: lib/block_scout_web/views/address_view.ex:212
+#: lib/block_scout_web/views/address_view.ex:220
 msgid "Transactions"
 msgstr ""
 
@@ -1192,8 +1187,8 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:17
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19
-#: lib/block_scout_web/templates/address_validation/index.html.eex:114
-#: lib/block_scout_web/templates/address_validation/index.html.eex:133
+#: lib/block_scout_web/templates/address_validation/index.html.eex:63
+#: lib/block_scout_web/templates/address_validation/index.html.eex:82
 #: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:25
 msgid "Loading..."
 msgstr ""
@@ -1418,7 +1413,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:60
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:26
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:55
-#: lib/block_scout_web/templates/address_validation/index.html.eex:121
+#: lib/block_scout_web/templates/address_validation/index.html.eex:70
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/tokens/holder/index.html.eex:23
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:21
@@ -1427,7 +1422,7 @@ msgid "Something went wrong, click to reload."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_validation/index.html.eex:117
+#: lib/block_scout_web/templates/address_validation/index.html.eex:66
 msgid "There are no blocks validated by this address."
 msgstr ""
 
@@ -1449,7 +1444,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:30
 #: lib/block_scout_web/templates/address/_tabs.html.eex:96
-#: lib/block_scout_web/views/address_view.ex:216
+#: lib/block_scout_web/views/address_view.ex:224
 msgid "Coin Balance History"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -105,7 +105,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:15
-#: lib/block_scout_web/views/address_view.ex:84
+#: lib/block_scout_web/views/address_view.ex:92
 msgid "Address"
 msgstr ""
 
@@ -196,9 +196,9 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:40
 #: lib/block_scout_web/templates/address/_tabs.html.eex:103
 #: lib/block_scout_web/templates/address/overview.html.eex:37
-#: lib/block_scout_web/templates/address_validation/index.html.eex:32
-#: lib/block_scout_web/templates/address_validation/index.html.eex:81
-#: lib/block_scout_web/templates/address_validation/index.html.eex:108
+#: lib/block_scout_web/templates/address_validation/index.html.eex:30
+#: lib/block_scout_web/templates/address_validation/index.html.eex:57
+#: lib/block_scout_web/views/address_view.ex:225
 msgid "Blocks Validated"
 msgstr ""
 
@@ -226,11 +226,10 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:53
 #: lib/block_scout_web/templates/address/_tabs.html.eex:113
-#: lib/block_scout_web/templates/address_validation/index.html.eex:43
-#: lib/block_scout_web/templates/address_validation/index.html.eex:90
+#: lib/block_scout_web/templates/address_validation/index.html.eex:39
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:119
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
-#: lib/block_scout_web/views/address_view.ex:214
+#: lib/block_scout_web/views/address_view.ex:222
 msgid "Code"
 msgstr ""
 
@@ -263,7 +262,7 @@ msgid "Connection Lost, click to load newer transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_validation/index.html.eex:104
+#: lib/block_scout_web/templates/address_validation/index.html.eex:53
 msgid "Connection Lost, click to load newer validations"
 msgstr ""
 
@@ -274,14 +273,14 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:12
-#: lib/block_scout_web/views/address_view.ex:82
+#: lib/block_scout_web/views/address_view.ex:90
 msgid "Contract Address"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:15
-#: lib/block_scout_web/views/address_view.ex:26
-#: lib/block_scout_web/views/address_view.ex:60
+#: lib/block_scout_web/views/address_view.ex:34
+#: lib/block_scout_web/views/address_view.ex:68
 msgid "Contract Address Pending"
 msgstr ""
 
@@ -509,11 +508,10 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:90
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:58
 #: lib/block_scout_web/templates/address_validation/index.html.eex:24
-#: lib/block_scout_web/templates/address_validation/index.html.eex:75
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:213
+#: lib/block_scout_web/views/address_view.ex:221
 #: lib/block_scout_web/views/transaction_view.ex:190
 msgid "Internal Transactions"
 msgstr ""
@@ -547,7 +545,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:18
 #: lib/block_scout_web/templates/layout/app.html.eex:49
-#: lib/block_scout_web/views/address_view.ex:104
+#: lib/block_scout_web/views/address_view.ex:112
 msgid "Market Cap"
 msgstr ""
 
@@ -643,7 +641,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:76
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:31
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:75
-#: lib/block_scout_web/templates/address_validation/index.html.eex:126
+#: lib/block_scout_web/templates/address_validation/index.html.eex:75
 #: lib/block_scout_web/templates/block/index.html.eex:25
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:39
@@ -730,10 +728,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:65
 #: lib/block_scout_web/templates/address/_tabs.html.eex:122
-#: lib/block_scout_web/templates/address_validation/index.html.eex:53
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
-#: lib/block_scout_web/views/address_view.ex:215
+#: lib/block_scout_web/views/address_view.ex:223
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -929,10 +926,9 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:85
 #: lib/block_scout_web/templates/address_token/index.html.eex:11
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:12
-#: lib/block_scout_web/templates/address_validation/index.html.eex:18
-#: lib/block_scout_web/templates/address_validation/index.html.eex:62
-#: lib/block_scout_web/templates/address_validation/index.html.eex:70
-#: lib/block_scout_web/views/address_view.ex:211
+#: lib/block_scout_web/templates/address_validation/index.html.eex:11
+#: lib/block_scout_web/templates/address_validation/index.html.eex:19
+#: lib/block_scout_web/views/address_view.ex:219
 msgid "Tokens"
 msgstr ""
 
@@ -986,15 +982,14 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:5
 #: lib/block_scout_web/templates/address/_tabs.html.eex:80
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:53
-#: lib/block_scout_web/templates/address_validation/index.html.eex:11
-#: lib/block_scout_web/templates/address_validation/index.html.eex:65
+#: lib/block_scout_web/templates/address_validation/index.html.eex:14
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:26
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:35
 #: lib/block_scout_web/templates/chain/show.html.eex:69
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:35
-#: lib/block_scout_web/views/address_view.ex:212
+#: lib/block_scout_web/views/address_view.ex:220
 msgid "Transactions"
 msgstr ""
 
@@ -1192,8 +1187,8 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:17
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19
-#: lib/block_scout_web/templates/address_validation/index.html.eex:114
-#: lib/block_scout_web/templates/address_validation/index.html.eex:133
+#: lib/block_scout_web/templates/address_validation/index.html.eex:63
+#: lib/block_scout_web/templates/address_validation/index.html.eex:82
 #: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:25
 msgid "Loading..."
 msgstr ""
@@ -1418,7 +1413,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:60
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:26
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:55
-#: lib/block_scout_web/templates/address_validation/index.html.eex:121
+#: lib/block_scout_web/templates/address_validation/index.html.eex:70
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/tokens/holder/index.html.eex:23
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:21
@@ -1427,7 +1422,7 @@ msgid "Something went wrong, click to reload."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_validation/index.html.eex:117
+#: lib/block_scout_web/templates/address_validation/index.html.eex:66
 msgid "There are no blocks validated by this address."
 msgstr ""
 
@@ -1449,7 +1444,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:30
 #: lib/block_scout_web/templates/address/_tabs.html.eex:96
-#: lib/block_scout_web/views/address_view.ex:216
+#: lib/block_scout_web/views/address_view.ex:224
 msgid "Coin Balance History"
 msgstr ""
 

--- a/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
@@ -307,6 +307,18 @@ defmodule BlockScoutWeb.AddressViewTest do
 
       assert AddressView.current_tab_name(path) == "Read Contract"
     end
+
+    test "generates the correct tab name for the coin_balances path" do
+      path = address_coin_balance_path(Endpoint, :index, "0x4ddr3s")
+
+      assert AddressView.current_tab_name(path) == "Coin Balance History"
+    end
+
+    test "generates the correct tab name for the validations path" do
+      path = address_validation_path(Endpoint, :index, "0x4ddr3s")
+
+      assert AddressView.current_tab_name(path) == "Blocks Validated"
+    end
   end
 
   describe "short_hash/1" do


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/1203

It was happening because the Blocks Validated page wasn't using the `address/_tabs.html` partial.

### Bug fixes
* User will see all tabs on the Block validated page.
* Decrease tabs padding

### Screenshots

* Block Validated page
![image](https://user-images.githubusercontent.com/27698968/49820751-df9b0880-fd5f-11e8-960f-9182a70f04c3.png)

* All tabs in the same line thanks to the new padding
![image](https://user-images.githubusercontent.com/27698968/49822743-250e0480-fd65-11e8-9722-cc173d824820.png)
