### PR TITLE
Fix displayed address length when a primary name presents

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
@@ -1,11 +1,6 @@
 <span class="<%= if @contract do %>contract-address<% end %>" data-address-hash="<%= @address.hash %>">
   <%= if name = primary_name(@address) do %>
-    <%= if assigns[:truncate] do %>
-      <span data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= short_hash(@address) %>...)</span>
-    <% else %>
-      <span class="d-none d-md-none d-lg-inline" data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= @address.hash %>)</span>
-      <span class="d-md-inline-block d-lg-none" data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %>)</span>
-    <% end %>
+     <span data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= short_hash(@address) %>...)</span>
   <% else %>
     <%= if assigns[:truncate] do %>
       <%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %>


### PR DESCRIPTION

## Motivation

Hashes should be always trimmed if a primary name presents.

### Bug Fixes
`truncate` setting is used for addresses without primary names so can't be used when need to display short hashes along with name and long version for addresses without primary name. 


![accounts](https://user-images.githubusercontent.com/8477052/49830468-18c67f00-fd46-11e8-8893-266e0bec9336.png)


