### PR TITLE
ETS streaming

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1007,21 +1007,14 @@ defmodule Explorer.Chain do
         ) :: {:ok, accumulator}
         when accumulator: term()
   def stream_unfetched_balances(initial, reducer) when is_function(reducer, 2) do
-    Repo.transaction(
-      fn ->
-        query =
-          from(
-            balance in CoinBalance,
-            where: is_nil(balance.value_fetched_at),
-            select: %{address_hash: balance.address_hash, block_number: balance.block_number}
-          )
+    query =
+      from(
+        balance in CoinBalance,
+        where: is_nil(balance.value_fetched_at),
+        select: %{address_hash: balance.address_hash, block_number: balance.block_number}
+      )
 
-        query
-        |> Repo.stream(timeout: :infinity)
-        |> Enum.reduce(initial, reducer)
-      end,
-      timeout: :infinity
-    )
+    Repo.stream_reduce(query, initial, reducer)
   end
 
   @doc """
@@ -1033,16 +1026,8 @@ defmodule Explorer.Chain do
         ) :: {:ok, accumulator}
         when accumulator: term()
   def stream_unfetched_token_balances(initial, reducer) when is_function(reducer, 2) do
-    Repo.transaction(
-      fn ->
-        query = TokenBalance.unfetched_token_balances()
-
-        query
-        |> Repo.stream(timeout: :infinity)
-        |> Enum.reduce(initial, reducer)
-      end,
-      timeout: :infinity
-    )
+    TokenBalance.unfetched_token_balances()
+    |> Repo.stream_reduce(initial, reducer)
   end
 
   @doc """
@@ -1097,22 +1082,15 @@ defmodule Explorer.Chain do
         ) :: {:ok, accumulator}
         when accumulator: term()
   def stream_transactions_with_unfetched_internal_transactions(fields, initial, reducer) when is_function(reducer, 2) do
-    Repo.transaction(
-      fn ->
-        query =
-          from(
-            t in Transaction,
-            # exclude pending transactions
-            where: not is_nil(t.block_hash) and is_nil(t.internal_transactions_indexed_at),
-            select: ^fields
-          )
+    query =
+      from(
+        t in Transaction,
+        # exclude pending transactions
+        where: not is_nil(t.block_hash) and is_nil(t.internal_transactions_indexed_at),
+        select: ^fields
+      )
 
-        query
-        |> Repo.stream(timeout: :infinity)
-        |> Enum.reduce(initial, reducer)
-      end,
-      timeout: :infinity
-    )
+    Repo.stream_reduce(query, initial, reducer)
   end
 
   @doc """
@@ -1129,21 +1107,14 @@ defmodule Explorer.Chain do
         ) :: {:ok, accumulator}
         when accumulator: term()
   def stream_unfetched_uncle_hashes(initial, reducer) when is_function(reducer, 2) do
-    Repo.transaction(
-      fn ->
-        query =
-          from(bsdr in Block.SecondDegreeRelation,
-            where: is_nil(bsdr.uncle_fetched_at),
-            select: bsdr.uncle_hash,
-            group_by: bsdr.uncle_hash
-          )
+    query =
+      from(bsdr in Block.SecondDegreeRelation,
+        where: is_nil(bsdr.uncle_fetched_at),
+        select: bsdr.uncle_hash,
+        group_by: bsdr.uncle_hash
+      )
 
-        query
-        |> Repo.stream(timeout: :infinity)
-        |> Enum.reduce(initial, reducer)
-      end,
-      timeout: :infinity
-    )
+    Repo.stream_reduce(query, initial, reducer)
   end
 
   @doc """
@@ -1938,22 +1909,15 @@ defmodule Explorer.Chain do
           reducer :: (entry :: Hash.Address.t(), accumulator -> accumulator)
         ) :: {:ok, accumulator}
         when accumulator: term()
-  def stream_uncataloged_token_contract_address_hashes(initial_acc, reducer) when is_function(reducer, 2) do
-    Repo.transaction(
-      fn ->
-        query =
-          from(
-            token in Token,
-            where: token.cataloged == false,
-            select: token.contract_address_hash
-          )
+  def stream_uncataloged_token_contract_address_hashes(initial, reducer) when is_function(reducer, 2) do
+    query =
+      from(
+        token in Token,
+        where: token.cataloged == false,
+        select: token.contract_address_hash
+      )
 
-        query
-        |> Repo.stream(timeout: :infinity)
-        |> Enum.reduce(initial_acc, reducer)
-      end,
-      timeout: :infinity
-    )
+    Repo.stream_reduce(query, initial, reducer)
   end
 
   @doc """
@@ -1964,16 +1928,10 @@ defmodule Explorer.Chain do
           reducer :: (entry :: Hash.Address.t(), accumulator -> accumulator)
         ) :: {:ok, accumulator}
         when accumulator: term()
-  def stream_cataloged_token_contract_address_hashes(initial_acc, reducer) when is_function(reducer, 2) do
-    Repo.transaction(
-      fn ->
-        Chain.Token.cataloged_tokens()
-        |> order_by(asc: :updated_at)
-        |> Repo.stream(timeout: :infinity)
-        |> Enum.reduce(initial_acc, reducer)
-      end,
-      timeout: :infinity
-    )
+  def stream_cataloged_token_contract_address_hashes(initial, reducer) when is_function(reducer, 2) do
+    Chain.Token.cataloged_tokens()
+    |> order_by(asc: :updated_at)
+    |> Repo.stream_reduce(initial, reducer)
   end
 
   @doc """
@@ -1992,14 +1950,7 @@ defmodule Explorer.Chain do
         distinct: t.block_number
       )
 
-    Repo.transaction(
-      fn ->
-        query
-        |> Repo.stream(timeout: :infinity)
-        |> Enum.reduce([], &[&1 | &2])
-      end,
-      timeout: :infinity
-    )
+    Repo.stream_reduce(query, [], &[&1 | &2])
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -955,7 +955,7 @@ defmodule Explorer.Chain do
   @doc """
   Counts all of the block validations and groups by the `miner_hash`.
   """
-  def group_block_validations_by_address do
+  def each_address_block_validation_count(fun) when is_function(fun, 1) do
     query =
       from(
         b in Block,
@@ -965,7 +965,7 @@ defmodule Explorer.Chain do
         group_by: b.miner_hash
       )
 
-    Repo.all(query)
+    Repo.stream_each(query, fun)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -226,7 +226,7 @@ defmodule Explorer.Chain.TokenTransfer do
   @doc """
   Counts all the token transfers and groups by token contract address hash.
   """
-  def count_token_transfers do
+  def each_count(fun) when is_function(fun, 1) do
     query =
       from(
         tt in TokenTransfer,
@@ -236,6 +236,6 @@ defmodule Explorer.Chain.TokenTransfer do
         group_by: tt.token_contract_address_hash
       )
 
-    Repo.all(query)
+    Repo.stream_each(query, fun)
   end
 end

--- a/apps/explorer/lib/explorer/counters/block_validation_counter.ex
+++ b/apps/explorer/lib/explorer/counters/block_validation_counter.ex
@@ -60,11 +60,9 @@ defmodule Explorer.Counters.BlockValidationCounter do
   Consolidates the number of block validations grouped by `address_hash`.
   """
   def consolidate_blocks do
-    total_block_validations = Chain.group_block_validations_by_address()
-
-    for {address_hash, total} <- total_block_validations do
+    Chain.each_address_block_validation_count(fn {address_hash, total} ->
       insert_or_update_counter(address_hash, total)
-    end
+    end)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/counters/token_transfer_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_transfer_counter.ex
@@ -51,11 +51,9 @@ defmodule Explorer.Counters.TokenTransferCounter do
   Consolidates the number of token transfers grouped by token.
   """
   def consolidate do
-    total_token_transfers = TokenTransfer.count_token_transfers()
-
-    for {token_hash, total} <- total_token_transfers do
+    TokenTransfer.each_count(fn {token_hash, total} ->
       insert_or_update_counter(token_hash, total)
-    end
+    end)
   end
 
   @doc """


### PR DESCRIPTION
Related to #1159.  Extracted from #1185.

## Changelog

### Enhancements
* Have all uses of `Repo.stream` use new `Repo.stream_in_transaction`, so that none of them miss the `:infinite` timeouts if they are copied for a new one later.

### Bug Fixes
* Instead of collecting everything with `Repo.all` before inserting into ETS tables, use `Repo.stream_each` to stream rows into ETS tables.  This will let data appear in the ETS table before all rows are returned from the database, so the readers will appear more responsive on restart.
  * `Explorer.Counters.TokenTransferCounter`
  * `Explorer.Counters.BlockValidationCounter`
  * `Explorer.Counters.TokenHoldersCounter`
