### PR TITLE
Include fetcher in logger metadata

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -77,7 +77,7 @@
         {Credo.Check.Design.AliasUsage,
          excluded_namespaces: ~w(Block Blocks Import Socket SpandexDatadog Task),
          excluded_lastnames:
-           ~w(Address DateTime Exporter Fetcher Full Instrumenter Monitor Name Number Repo Spec Time Unit),
+           ~w(Address DateTime Exporter Fetcher Full Instrumenter Logger Monitor Name Number Repo Spec Time Unit),
          priority: :low},
 
         # For some checks, you can also set other parameters

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -48,7 +48,7 @@ config :ex_cldr,
 config :logger, :block_scout_web,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: [:application, :request_id],
+  metadata: ~w(application fetcher request_id)a,
   metadata_filter: [application: :block_scout_web]
 
 config :spandex_phoenix, tracer: BlockScoutWeb.Tracer

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -17,7 +17,7 @@ config :ethereum_jsonrpc, EthereumJSONRPC.Tracer,
 config :logger, :ethereum_jsonrpc,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: [:application, :request_id],
+  metadata: ~w(application fetcher request_id)a,
   metadata_filter: [application: :ethereum_jsonrpc]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -50,7 +50,7 @@ config :explorer,
 config :logger, :explorer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: [:application, :request_id],
+  metadata: ~w(application fetcher request_id)a,
   metadata_filter: [application: :explorer]
 
 config :spandex_ecto, SpandexEcto.EctoLogger,

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -19,7 +19,7 @@ config :indexer, Indexer.Tracer,
 config :logger, :indexer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: [:application, :request_id],
+  metadata: ~w(application fetcher request_id)a,
   metadata_filter: [application: :indexer]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -53,6 +53,8 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
 
   @impl GenServer
   def init(named_arguments) do
+    Logger.metadata(fetcher: :block_catchup)
+
     state = new(named_arguments)
 
     send(self(), :catchup_index)

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -58,6 +58,8 @@ defmodule Indexer.Block.Catchup.Fetcher do
           block_fetcher: %Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments}
         } = state
       ) do
+    Logger.metadata(fetcher: :block_catchup)
+
     {:ok, latest_block_number} = EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments)
 
     case latest_block_number do
@@ -172,6 +174,8 @@ defmodule Indexer.Block.Catchup.Fetcher do
          _.._ = range,
          sequence
        ) do
+    Logger.metadata(fetcher: :block_catchup)
+
     case fetch_and_import_range(block_fetcher, range) do
       {:ok, %{inserted: inserted, errors: errors}} ->
         errors = cap_seq(sequence, errors, range)

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -43,6 +43,8 @@ defmodule Indexer.Block.Realtime.Fetcher do
   @impl GenServer
   def init(%{block_fetcher: %Block.Fetcher{} = block_fetcher, subscribe_named_arguments: subscribe_named_arguments})
       when is_list(subscribe_named_arguments) do
+    Logger.metadata(fetcher: :block_realtime)
+
     {:ok, %__MODULE__{block_fetcher: %Block.Fetcher{block_fetcher | broadcast: :realtime, callback_module: __MODULE__}},
      {:continue, {:init, subscribe_named_arguments}}}
   end
@@ -157,6 +159,8 @@ defmodule Indexer.Block.Realtime.Fetcher do
 
   @decorate trace(name: "fetch", resource: "Indexer.Block.Realtime.Fetcher.fetch_and_import_block/3", tracer: Tracer)
   def fetch_and_import_block(block_number_to_fetch, block_fetcher, reorg?, retry \\ 3) do
+    Logger.metadata(fetcher: :block_realtime)
+
     if reorg? do
       # give previous fetch attempt (for same block number) a chance to finish
       # before fetching again, to reduce block consensus mistakes
@@ -176,13 +180,13 @@ defmodule Indexer.Block.Realtime.Fetcher do
         end
 
         Logger.debug(fn ->
-          ["realtime indexer fetched and imported block ", to_string(block_number_to_fetch)]
+          ["fetched and imported block ", to_string(block_number_to_fetch)]
         end)
 
       {:ok, %{inserted: _, errors: [_ | _] = errors}} ->
         Logger.error(fn ->
           [
-            "realtime indexer failed to fetch block",
+            "failed to fetch block ",
             to_string(block_number_to_fetch),
             ": ",
             inspect(errors),
@@ -193,7 +197,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
       {:error, {step, reason}} ->
         Logger.error(fn ->
           [
-            "realtime indexer failed to fetch ",
+            "failed to fetch ",
             to_string(step),
             " for block ",
             to_string(block_number_to_fetch),
@@ -214,7 +218,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
         if retry_fetch_and_import_block(params) == :ignore do
           Logger.error(fn ->
             [
-              "realtime indexer failed to validate for block ",
+              "failed to validate for block ",
               to_string(block_number_to_fetch),
               ": ",
               inspect(changesets),
@@ -226,7 +230,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
       {:error, {step, failed_value, _changes_so_far}} ->
         Logger.error(fn ->
           [
-            "realtime indexer failed to insert ",
+            "failed to insert ",
             to_string(step),
             " for block ",
             to_string(block_number_to_fetch),

--- a/apps/indexer/lib/indexer/block/uncle/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/uncle/fetcher.ex
@@ -20,7 +20,8 @@ defmodule Indexer.Block.Uncle.Fetcher do
     flush_interval: :timer.seconds(3),
     max_batch_size: 10,
     max_concurrency: 10,
-    task_supervisor: Indexer.Block.Uncle.TaskSupervisor
+    task_supervisor: Indexer.Block.Uncle.TaskSupervisor,
+    metadata: [fetcher: :block_uncle]
   ]
 
   @doc """
@@ -73,7 +74,7 @@ defmodule Indexer.Block.Uncle.Fetcher do
     # the same block could be included as an uncle on multiple blocks, but we only want to fetch it once
     unique_hashes = Enum.uniq(hashes)
 
-    Logger.debug(fn -> "fetching #{length(unique_hashes)} uncle blocks" end)
+    Logger.debug(fn -> "fetching #{length(unique_hashes)}" end)
 
     case EthereumJSONRPC.fetch_blocks_by_hash(unique_hashes, json_rpc_named_arguments) do
       {:ok, blocks} ->
@@ -81,7 +82,7 @@ defmodule Indexer.Block.Uncle.Fetcher do
 
       {:error, reason} ->
         Logger.error(fn ->
-          ["failed to fetch ", unique_hashes |> length |> to_string(), " uncle blocks: ", inspect(reason)]
+          ["failed to fetch ", unique_hashes |> length |> to_string(), ": ", inspect(reason)]
         end)
 
         {:retry, unique_hashes}
@@ -116,7 +117,7 @@ defmodule Indexer.Block.Uncle.Fetcher do
           [
             "failed to import ",
             original_entries |> length() |> to_string(),
-            "uncle blocks in step ",
+            " in step ",
             inspect(step),
             ": ",
             inspect(failed_value)
@@ -195,7 +196,7 @@ defmodule Indexer.Block.Uncle.Fetcher do
         retried_entries |> length() |> to_string(),
         "/",
         original_entries |> length() |> to_string(),
-        " uncles: ",
+        ": ",
         errors_to_iodata(errors)
       ]
     end)

--- a/apps/indexer/lib/indexer/coin_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/coin_balance/fetcher.ex
@@ -21,7 +21,8 @@ defmodule Indexer.CoinBalance.Fetcher do
     flush_interval: :timer.seconds(3),
     max_batch_size: 500,
     max_concurrency: 4,
-    task_supervisor: Indexer.CoinBalance.TaskSupervisor
+    task_supervisor: Indexer.CoinBalance.TaskSupervisor,
+    metadata: [fetcher: :coin_balance]
   ]
 
   @doc """
@@ -73,7 +74,7 @@ defmodule Indexer.CoinBalance.Fetcher do
     # `{address, block}`, so take unique params only
     unique_entries = Enum.uniq(entries)
 
-    Logger.debug(fn -> "fetching #{length(unique_entries)} balances" end)
+    Logger.debug(fn -> ["fetching ", unique_entries |> length() |> to_string()] end)
 
     unique_entries
     |> Enum.map(&entry_to_params/1)
@@ -84,7 +85,7 @@ defmodule Indexer.CoinBalance.Fetcher do
 
       {:error, reason} ->
         Logger.error(fn ->
-          ["failed to fetch ", unique_entries |> length() |> to_string(), " balances, ", inspect(reason)]
+          ["failed to fetch ", unique_entries |> length() |> to_string(), ": ", inspect(reason)]
         end)
 
         {:retry, unique_entries}
@@ -141,7 +142,7 @@ defmodule Indexer.CoinBalance.Fetcher do
         retried_entries |> length() |> to_string(),
         "/",
         original_entries |> length() |> to_string(),
-        " balances: ",
+        ": ",
         fetched_balance_errors_to_iodata(errors)
       ]
     end)

--- a/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
@@ -23,7 +23,8 @@ defmodule Indexer.InternalTransaction.Fetcher do
     flush_interval: :timer.seconds(3),
     max_concurrency: @max_concurrency,
     max_batch_size: @max_batch_size,
-    task_supervisor: Indexer.InternalTransaction.TaskSupervisor
+    task_supervisor: Indexer.InternalTransaction.TaskSupervisor,
+    metadata: [fetcher: :internal_transaction]
   ]
 
   @doc """

--- a/apps/indexer/lib/indexer/pending_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/pending_transaction/fetcher.ex
@@ -58,6 +58,8 @@ defmodule Indexer.PendingTransaction.Fetcher do
 
   @impl GenServer
   def init(opts) when is_list(opts) do
+    Logger.metadata(fetcher: :pending_transaction)
+
     opts =
       :indexer
       |> Application.get_all_env()
@@ -100,6 +102,8 @@ defmodule Indexer.PendingTransaction.Fetcher do
   end
 
   defp task(%PendingTransaction.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments} = _state) do
+    Logger.metadata(fetcher: :pending_transaction)
+
     case fetch_pending_transactions(json_rpc_named_arguments) do
       {:ok, transactions_params} ->
         addresses_params = AddressExtraction.extract_addresses(%{transactions: transactions_params}, pending: true)

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,19 +32,19 @@ config :logger,
 config :logger, :console,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: [:application, :request_id]
+  metadata: ~w(application fetcher request_id)a
 
 config :logger, :ecto,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: [:application, :request_id],
+  metadata: ~w(application fetcher request_id)a,
   metadata_filter: [application: :ecto]
 
 config :logger, :error,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
   level: :error,
-  metadata: [:application, :request_id]
+  metadata: ~w(application fetcher request_id)a
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.


### PR DESCRIPTION
Extracted from #1185.

```
2018-12-12T10:08:55.263 application=indexer fetcher=block_realtime [error] failed to fetch blocks for block 6069836: :timeout.  Block will be retried by catchup indexer.
                                            ^^^^^^^^^^^^^^^^^^^^^^
```


The underlined  (`^`) part is the new part of the format.

It works in a `BufferedTask` like `InternalTransaction.Fetcher` too

```
2018-12-12T10:08:18.621 application=indexer fetcher=internal_transaction [debug] fetching internal transactions for 10 transactions
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Changelog
### Enhancements
* For each fetcher set the `Logger.metadata(fetcher: ...)` to a short semantic name.  Having the fetcher names allow faster triaging of bugs when a stacktrace is not present.  It also allows filtering logs by the fetcher in log analysis tools.
   * For Fetchers that use `BufferedTask`, `BufferedTask` now has an option to set `metadata` passed to `Logger.metadata/1` in

     1. GenServer process
     2. The `c:init/3` Task
     3. The `c:run/2` Tasks