### PR TITLE
Metadata instead of prose

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -48,7 +48,7 @@ config :ex_cldr,
 config :logger, :block_scout_web,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a,
   metadata_filter: [application: :block_scout_web]
 
 config :spandex_phoenix, tracer: BlockScoutWeb.Tracer

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -48,7 +48,8 @@ config :ex_cldr,
 config :logger, :block_scout_web,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a,
+  metadata:
+    ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a,
   metadata_filter: [application: :block_scout_web]
 
 config :spandex_phoenix, tracer: BlockScoutWeb.Tracer

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -49,7 +49,8 @@ config :logger, :block_scout_web,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
-    ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a,
+    ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
+       block_number step count error_count)a,
   metadata_filter: [application: :block_scout_web]
 
 config :spandex_phoenix, tracer: BlockScoutWeb.Tracer

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -50,7 +50,7 @@ config :logger, :block_scout_web,
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count)a,
+       block_number step count error_count shrunk)a,
   metadata_filter: [application: :block_scout_web]
 
 config :spandex_phoenix, tracer: BlockScoutWeb.Tracer

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -48,7 +48,7 @@ config :ex_cldr,
 config :logger, :block_scout_web,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a,
   metadata_filter: [application: :block_scout_web]
 
 config :spandex_phoenix, tracer: BlockScoutWeb.Tracer

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -48,7 +48,7 @@ config :ex_cldr,
 config :logger, :block_scout_web,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id)a,
+  metadata: ~w(application fetcher request_id block_number)a,
   metadata_filter: [application: :block_scout_web]
 
 config :spandex_phoenix, tracer: BlockScoutWeb.Tracer

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -48,7 +48,7 @@ config :ex_cldr,
 config :logger, :block_scout_web,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id block_number)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a,
   metadata_filter: [application: :block_scout_web]
 
 config :spandex_phoenix, tracer: BlockScoutWeb.Tracer

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -17,7 +17,7 @@ config :ethereum_jsonrpc, EthereumJSONRPC.Tracer,
 config :logger, :ethereum_jsonrpc,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a,
   metadata_filter: [application: :ethereum_jsonrpc]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -18,7 +18,8 @@ config :logger, :ethereum_jsonrpc,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
-    ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a,
+    ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
+       block_number step count error_count)a,
   metadata_filter: [application: :ethereum_jsonrpc]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -19,7 +19,7 @@ config :logger, :ethereum_jsonrpc,
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count)a,
+       block_number step count error_count shrunk)a,
   metadata_filter: [application: :ethereum_jsonrpc]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -17,7 +17,7 @@ config :ethereum_jsonrpc, EthereumJSONRPC.Tracer,
 config :logger, :ethereum_jsonrpc,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id block_number)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a,
   metadata_filter: [application: :ethereum_jsonrpc]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -17,7 +17,8 @@ config :ethereum_jsonrpc, EthereumJSONRPC.Tracer,
 config :logger, :ethereum_jsonrpc,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a,
+  metadata:
+    ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a,
   metadata_filter: [application: :ethereum_jsonrpc]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -17,7 +17,7 @@ config :ethereum_jsonrpc, EthereumJSONRPC.Tracer,
 config :logger, :ethereum_jsonrpc,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a,
   metadata_filter: [application: :ethereum_jsonrpc]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -17,7 +17,7 @@ config :ethereum_jsonrpc, EthereumJSONRPC.Tracer,
 config :logger, :ethereum_jsonrpc,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id)a,
+  metadata: ~w(application fetcher request_id block_number)a,
   metadata_filter: [application: :ethereum_jsonrpc]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -52,7 +52,7 @@ config :logger, :explorer,
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count)a,
+       block_number step count error_count shrunk)a,
   metadata_filter: [application: :explorer]
 
 config :spandex_ecto, SpandexEcto.EctoLogger,

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -50,7 +50,7 @@ config :explorer,
 config :logger, :explorer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id block_number)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a,
   metadata_filter: [application: :explorer]
 
 config :spandex_ecto, SpandexEcto.EctoLogger,

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -50,7 +50,8 @@ config :explorer,
 config :logger, :explorer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a,
+  metadata:
+    ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a,
   metadata_filter: [application: :explorer]
 
 config :spandex_ecto, SpandexEcto.EctoLogger,

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -50,7 +50,7 @@ config :explorer,
 config :logger, :explorer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a,
   metadata_filter: [application: :explorer]
 
 config :spandex_ecto, SpandexEcto.EctoLogger,

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -50,7 +50,7 @@ config :explorer,
 config :logger, :explorer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id)a,
+  metadata: ~w(application fetcher request_id block_number)a,
   metadata_filter: [application: :explorer]
 
 config :spandex_ecto, SpandexEcto.EctoLogger,

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -51,7 +51,8 @@ config :logger, :explorer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
-    ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a,
+    ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
+       block_number step count error_count)a,
   metadata_filter: [application: :explorer]
 
 config :spandex_ecto, SpandexEcto.EctoLogger,

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -50,7 +50,7 @@ config :explorer,
 config :logger, :explorer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a,
   metadata_filter: [application: :explorer]
 
 config :spandex_ecto, SpandexEcto.EctoLogger,

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -19,7 +19,7 @@ config :indexer, Indexer.Tracer,
 config :logger, :indexer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a,
   metadata_filter: [application: :indexer]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -19,7 +19,7 @@ config :indexer, Indexer.Tracer,
 config :logger, :indexer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a,
   metadata_filter: [application: :indexer]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -20,7 +20,8 @@ config :logger, :indexer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
-    ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a,
+    ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
+       block_number step count error_count)a,
   metadata_filter: [application: :indexer]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -19,7 +19,7 @@ config :indexer, Indexer.Tracer,
 config :logger, :indexer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id)a,
+  metadata: ~w(application fetcher request_id block_number)a,
   metadata_filter: [application: :indexer]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -19,7 +19,8 @@ config :indexer, Indexer.Tracer,
 config :logger, :indexer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a,
+  metadata:
+    ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a,
   metadata_filter: [application: :indexer]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -21,7 +21,7 @@ config :logger, :indexer,
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count)a,
+       block_number step count error_count shrunk)a,
   metadata_filter: [application: :indexer]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -19,7 +19,7 @@ config :indexer, Indexer.Tracer,
 config :logger, :indexer,
   # keep synced with `config/config.exs`
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id block_number)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a,
   metadata_filter: [application: :indexer]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -195,21 +195,20 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
     new_bound_interval =
       case missing_block_count do
         0 ->
-          Logger.info(fn -> "Index already caught up." end, first_block_number: first_block_number, last_block_number: 0)
+          Logger.info("Index already caught up.",
+            first_block_number: first_block_number,
+            last_block_number: 0,
+            missing_block_count: 0
+          )
 
           BoundInterval.increase(bound_interval)
 
         _ ->
           Logger.info(
-            fn ->
-              [
-                "Index had to catch up ",
-                to_string(missing_block_count),
-                " blocks."
-              ]
-            end,
+            "Index had to catch up.",
             first_block_number: first_block_number,
-            last_block_number: 0
+            last_block_number: 0,
+            missing_block_count: missing_block_count
           )
 
           BoundInterval.decrease(bound_interval)
@@ -239,15 +238,10 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
     Process.demonitor(ref, [:flush])
 
     Logger.info(
-      fn ->
-        [
-          "Index had to catch up ",
-          to_string(missing_block_count),
-          " blocks, but the sequence was shrunk to save memory, so retrying immediately."
-        ]
-      end,
+      "Index had to catch up, but the sequence was shrunk to save memory, so retrying immediately.",
       first_block_number: first_block_number,
-      last_block_number: 0
+      last_block_number: 0,
+      missing_block_count: missing_block_count
     )
 
     send(self(), :catchup_index)

--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -184,7 +184,8 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
   end
 
   def handle_info(
-        {ref, %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: false}},
+        {ref,
+         %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: false}},
         %__MODULE__{
           bound_interval: bound_interval,
           task: %Task{ref: ref}
@@ -228,7 +229,8 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
   end
 
   def handle_info(
-        {ref, %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: true}},
+        {ref,
+         %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: true}},
         %__MODULE__{
           task: %Task{ref: ref}
         } = state

--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -194,20 +194,22 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
     new_bound_interval =
       case missing_block_count do
         0 ->
-          Logger.info(fn -> ["Index already caught up in ", to_string(first_block_number), "-0."] end)
+          Logger.info(fn -> "Index already caught up." end, first_block_number: first_block_number, last_block_number: 0)
 
           BoundInterval.increase(bound_interval)
 
         _ ->
-          Logger.info(fn ->
-            [
-              "Index had to catch up ",
-              to_string(missing_block_count),
-              " blocks in ",
-              to_string(first_block_number),
-              "-0."
-            ]
-          end)
+          Logger.info(
+            fn ->
+              [
+                "Index had to catch up ",
+                to_string(missing_block_count),
+                " blocks."
+              ]
+            end,
+            first_block_number: first_block_number,
+            last_block_number: 0
+          )
 
           BoundInterval.decrease(bound_interval)
       end
@@ -234,15 +236,17 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
       when is_integer(missing_block_count) do
     Process.demonitor(ref, [:flush])
 
-    Logger.info(fn ->
-      [
-        "Index had to catch up ",
-        to_string(missing_block_count),
-        " blocks in ",
-        to_string(first_block_number),
-        "-0, but the sequence was shrunk to save memory, so retrying immediately."
-      ]
-    end)
+    Logger.info(
+      fn ->
+        [
+          "Index had to catch up ",
+          to_string(missing_block_count),
+          " blocks, but the sequence was shrunk to save memory, so retrying immediately."
+        ]
+      end,
+      first_block_number: first_block_number,
+      last_block_number: 0
+    )
 
     send(self(), :catchup_index)
 

--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -185,7 +185,7 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
 
   def handle_info(
         {ref,
-         %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: false}},
+         %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: false = shrunk}},
         %__MODULE__{
           bound_interval: bound_interval,
           task: %Task{ref: ref}
@@ -198,7 +198,8 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
           Logger.info("Index already caught up.",
             first_block_number: first_block_number,
             last_block_number: 0,
-            missing_block_count: 0
+            missing_block_count: 0,
+            shrunk: shrunk
           )
 
           BoundInterval.increase(bound_interval)
@@ -208,7 +209,8 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
             "Index had to catch up.",
             first_block_number: first_block_number,
             last_block_number: 0,
-            missing_block_count: missing_block_count
+            missing_block_count: missing_block_count,
+            shrunk: shrunk
           )
 
           BoundInterval.decrease(bound_interval)
@@ -229,7 +231,7 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
 
   def handle_info(
         {ref,
-         %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: true}},
+         %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: true = shrunk}},
         %__MODULE__{
           task: %Task{ref: ref}
         } = state
@@ -241,7 +243,8 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
       "Index had to catch up, but the sequence was shrunk to save memory, so retrying immediately.",
       first_block_number: first_block_number,
       last_block_number: 0,
-      missing_block_count: missing_block_count
+      missing_block_count: missing_block_count,
+      shrunk: shrunk
     )
 
     send(self(), :catchup_index)

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -187,9 +187,12 @@ defmodule Indexer.Block.Catchup.Fetcher do
         {:ok, inserted: inserted}
 
       {:error, {step, reason}} = error ->
-        Logger.error(fn ->
-          ["failed to fetch ", to_string(step), ": ", inspect(reason), ". Retrying."]
-        end)
+        Logger.error(
+          fn ->
+            ["failed to fetch: ", inspect(reason), ". Retrying."]
+          end,
+          step: step
+        )
 
         push_back(sequence, range)
 
@@ -205,9 +208,12 @@ defmodule Indexer.Block.Catchup.Fetcher do
         error
 
       {:error, {step, failed_value, _changes_so_far}} = error ->
-        Logger.error(fn ->
-          ["failed to insert during ", to_string(step), ": ", inspect(failed_value), ". Retrying."]
-        end)
+        Logger.error(
+          fn ->
+            ["failed to insert: ", inspect(failed_value), ". Retrying."]
+          end,
+          step: step
+        )
 
         push_back(sequence, range)
 

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -82,9 +82,10 @@ defmodule Indexer.Block.Catchup.Fetcher do
           |> Stream.map(&Enum.count/1)
           |> Enum.sum()
 
-        Logger.debug(fn ->
-          [to_string(missing_block_count), " missed blocks in ", to_string(range_count), " ranges"]
-        end)
+        Logger.debug(fn -> "Missed blocks in ranges." end,
+          missing_block_range_count: range_count,
+          missing_block_count: missing_block_count
+        )
 
         shrunk =
           case missing_block_count do

--- a/apps/indexer/lib/indexer/block/fetcher/receipts.ex
+++ b/apps/indexer/lib/indexer/block/fetcher/receipts.ex
@@ -13,7 +13,7 @@ defmodule Indexer.Block.Fetcher.Receipts do
         %Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments} = state,
         transaction_params
       ) do
-    Logger.debug(fn -> "fetching #{length(transaction_params)} transaction receipts" end)
+    Logger.debug("fetching transaction receipts", count: Enum.count(transaction_params))
     stream_opts = [max_concurrency: state.receipts_concurrency, timeout: :infinity]
 
     transaction_params

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -159,15 +159,19 @@ defmodule Indexer.Block.Realtime.Fetcher do
 
   @decorate trace(name: "fetch", resource: "Indexer.Block.Realtime.Fetcher.fetch_and_import_block/3", tracer: Tracer)
   def fetch_and_import_block(block_number_to_fetch, block_fetcher, reorg?, retry \\ 3) do
-    Indexer.Logger.metadata(fn ->
-    if reorg? do
-      # give previous fetch attempt (for same block number) a chance to finish
-      # before fetching again, to reduce block consensus mistakes
-      :timer.sleep(@reorg_delay)
-    end
+    Indexer.Logger.metadata(
+      fn ->
+        if reorg? do
+          # give previous fetch attempt (for same block number) a chance to finish
+          # before fetching again, to reduce block consensus mistakes
+          :timer.sleep(@reorg_delay)
+        end
 
-    do_fetch_and_import_block(block_number_to_fetch, block_fetcher, retry)
-    end, fetcher: :block_realtime, block_number: block_number_to_fetch)
+        do_fetch_and_import_block(block_number_to_fetch, block_fetcher, retry)
+      end,
+      fetcher: :block_realtime,
+      block_number: block_number_to_fetch
+    )
   end
 
   @decorate span(tracer: Tracer)

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -195,15 +195,16 @@ defmodule Indexer.Block.Realtime.Fetcher do
         end)
 
       {:error, {step, reason}} ->
-        Logger.error(fn ->
-          [
-            "failed to fetch ",
-            to_string(step),
-            ": ",
-            inspect(reason),
-            ".  Block will be retried by catchup indexer."
-          ]
-        end)
+        Logger.error(
+          fn ->
+            [
+              "failed to fetch: ",
+              inspect(reason),
+              ".  Block will be retried by catchup indexer."
+            ]
+          end,
+          step: step
+        )
 
       {:error, [%Changeset{} | _] = changesets} ->
         params = %{
@@ -226,15 +227,16 @@ defmodule Indexer.Block.Realtime.Fetcher do
         end
 
       {:error, {step, failed_value, _changes_so_far}} ->
-        Logger.error(fn ->
-          [
-            "failed to insert ",
-            to_string(step),
-            ": ",
-            inspect(failed_value),
-            ".  Block will be retried by catchup indexer."
-          ]
-        end)
+        Logger.error(
+          fn ->
+            [
+              "failed to insert: ",
+              inspect(failed_value),
+              ".  Block will be retried by catchup indexer."
+            ]
+          end,
+          step: step
+        )
     end
   end
 

--- a/apps/indexer/lib/indexer/block/uncle/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/uncle/fetcher.ex
@@ -84,9 +84,12 @@ defmodule Indexer.Block.Uncle.Fetcher do
         run_blocks(blocks, block_fetcher, unique_hashes)
 
       {:error, reason} ->
-        Logger.error(fn ->
-          ["failed to fetch: ", inspect(reason)]
-        end, error_count: unique_hash_count)
+        Logger.error(
+          fn ->
+            ["failed to fetch: ", inspect(reason)]
+          end,
+          error_count: unique_hash_count
+        )
 
         {:retry, unique_hashes}
     end
@@ -116,14 +119,10 @@ defmodule Indexer.Block.Uncle.Fetcher do
         retry(errors)
 
       {:error, step, failed_value, _changes_so_far} ->
-        Logger.error(fn ->
-          [
-            "failed to import  in step ",
-            inspect(step),
-            ": ",
-            inspect(failed_value)
-          ]
-        end, error_count: Enum.count(original_entries))
+        Logger.error(fn -> ["failed to import: ", inspect(failed_value)] end,
+          step: step,
+          error_count: Enum.count(original_entries)
+        )
 
         {:retry, original_entries}
     end
@@ -191,12 +190,15 @@ defmodule Indexer.Block.Uncle.Fetcher do
   defp retry(errors) when is_list(errors) do
     retried_entries = errors_to_entries(errors)
 
-    Logger.error(fn ->
-      [
-        "failed to fetch: ",
-        errors_to_iodata(errors)
-      ]
-    end, error_count: Enum.count(retried_entries))
+    Logger.error(
+      fn ->
+        [
+          "failed to fetch: ",
+          errors_to_iodata(errors)
+        ]
+      end,
+      error_count: Enum.count(retried_entries)
+    )
   end
 
   defp errors_to_entries(errors) when is_list(errors) do

--- a/apps/indexer/lib/indexer/block/uncle/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/uncle/fetcher.ex
@@ -86,7 +86,7 @@ defmodule Indexer.Block.Uncle.Fetcher do
       {:error, reason} ->
         Logger.error(fn ->
           ["failed to fetch: ", inspect(reason)]
-        end)
+        end, error_count: unique_hash_count)
 
         {:retry, unique_hashes}
     end
@@ -123,7 +123,7 @@ defmodule Indexer.Block.Uncle.Fetcher do
             ": ",
             inspect(failed_value)
           ]
-        end)
+        end, error_count: Enum.count(original_entries))
 
         {:retry, original_entries}
     end
@@ -193,12 +193,10 @@ defmodule Indexer.Block.Uncle.Fetcher do
 
     Logger.error(fn ->
       [
-        "failed to fetch ",
-        retried_entries |> length() |> to_string(),
-        ": ",
+        "failed to fetch: ",
         errors_to_iodata(errors)
       ]
-    end)
+    end, error_count: Enum.count(retried_entries))
   end
 
   defp errors_to_entries(errors) when is_list(errors) do

--- a/apps/indexer/lib/indexer/coin_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/coin_balance/fetcher.ex
@@ -87,9 +87,12 @@ defmodule Indexer.CoinBalance.Fetcher do
         run_fetched_balances(fetched_balances, unique_entries)
 
       {:error, reason} ->
-        Logger.error(fn ->
-          ["failed to fetch: ", inspect(reason)]
-        end, error_count: unique_entry_count)
+        Logger.error(
+          fn ->
+            ["failed to fetch: ", inspect(reason)]
+          end,
+          error_count: unique_entry_count
+        )
 
         {:retry, unique_entries}
     end
@@ -139,12 +142,15 @@ defmodule Indexer.CoinBalance.Fetcher do
   defp retry(errors) when is_list(errors) do
     retried_entries = fetched_balances_errors_to_entries(errors)
 
-    Logger.error(fn ->
-      [
-        "failed to fetch: ",
-        fetched_balance_errors_to_iodata(errors)
-      ]
-    end, error_count: Enum.count(retried_entries))
+    Logger.error(
+      fn ->
+        [
+          "failed to fetch: ",
+          fetched_balance_errors_to_iodata(errors)
+        ]
+      end,
+      error_count: Enum.count(retried_entries)
+    )
 
     {:retry, retried_entries}
   end

--- a/apps/indexer/lib/indexer/coin_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/coin_balance/fetcher.ex
@@ -89,7 +89,7 @@ defmodule Indexer.CoinBalance.Fetcher do
       {:error, reason} ->
         Logger.error(fn ->
           ["failed to fetch: ", inspect(reason)]
-        end)
+        end, error_count: unique_entry_count)
 
         {:retry, unique_entries}
     end
@@ -141,12 +141,10 @@ defmodule Indexer.CoinBalance.Fetcher do
 
     Logger.error(fn ->
       [
-        "failed to fetch ",
-        retried_entries |> length() |> to_string(),
-        ": ",
+        "failed to fetch: ",
         fetched_balance_errors_to_iodata(errors)
       ]
-    end)
+    end, error_count: Enum.count(retried_entries))
 
     {:retry, retried_entries}
   end

--- a/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
@@ -138,14 +138,14 @@ defmodule Indexer.InternalTransaction.Fetcher do
                 ": ",
                 inspect(reason)
               ]
-            end)
+            end, error_count: unique_entries_count)
 
             # re-queue the de-duped entries
             {:retry, unique_entries}
         end
 
       {:error, reason} ->
-        Logger.error(fn -> ["failed to fetch internal transactions for transactions: ", inspect(reason)] end)
+        Logger.error(fn -> ["failed to fetch internal transactions for transactions: ", inspect(reason)] end, error_count: unique_entries_count)
 
         # re-queue the de-duped entries
         {:retry, unique_entries}

--- a/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
@@ -131,21 +131,25 @@ defmodule Indexer.InternalTransaction.Fetcher do
           })
         else
           {:error, step, reason, _changes_so_far} ->
-            Logger.error(fn ->
-              [
-                "failed to import internal transactions for transactions at ",
-                to_string(step),
-                ": ",
-                inspect(reason)
-              ]
-            end, error_count: unique_entries_count)
+            Logger.error(
+              fn ->
+                [
+                  "failed to import internal transactions for transactions: ",
+                  inspect(reason)
+                ]
+              end,
+              step: step,
+              error_count: unique_entries_count
+            )
 
             # re-queue the de-duped entries
             {:retry, unique_entries}
         end
 
       {:error, reason} ->
-        Logger.error(fn -> ["failed to fetch internal transactions for transactions: ", inspect(reason)] end, error_count: unique_entries_count)
+        Logger.error(fn -> ["failed to fetch internal transactions for transactions: ", inspect(reason)] end,
+          error_count: unique_entries_count
+        )
 
         # re-queue the de-duped entries
         {:retry, unique_entries}

--- a/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
@@ -103,7 +103,10 @@ defmodule Indexer.InternalTransaction.Fetcher do
   def run(entries, json_rpc_named_arguments) do
     unique_entries = unique_entries(entries)
 
-    Logger.debug(fn -> "fetching internal transactions for #{length(unique_entries)} transactions" end)
+    unique_entries_count = Enum.count(unique_entries)
+    Logger.metadata(count: unique_entries_count)
+
+    Logger.debug("fetching internal transactions for transactions")
 
     unique_entries
     |> Enum.map(&params/1)
@@ -130,9 +133,7 @@ defmodule Indexer.InternalTransaction.Fetcher do
           {:error, step, reason, _changes_so_far} ->
             Logger.error(fn ->
               [
-                "failed to import internal transactions for ",
-                to_string(length(entries)),
-                " transactions at ",
+                "failed to import internal transactions for transactions at ",
                 to_string(step),
                 ": ",
                 inspect(reason)
@@ -144,9 +145,7 @@ defmodule Indexer.InternalTransaction.Fetcher do
         end
 
       {:error, reason} ->
-        Logger.error(fn ->
-          "failed to fetch internal transactions for #{length(entries)} transactions: #{inspect(reason)}"
-        end)
+        Logger.error(fn -> ["failed to fetch internal transactions for transactions: ", inspect(reason)] end)
 
         # re-queue the de-duped entries
         {:retry, unique_entries}

--- a/apps/indexer/lib/indexer/logger.ex
+++ b/apps/indexer/lib/indexer/logger.ex
@@ -1,7 +1,21 @@
 defmodule Indexer.Logger do
   @moduledoc """
-  Helpers for formatting `Logger` data as `t:iodata/0`.
+  Helpers for `Logger`.
   """
+
+  @doc """
+  Sets `keyword` in `Logger.metadata/1` around `fun`.
+  """
+  def metadata(fun, keyword) when is_function(fun, 0) and is_list(keyword) do
+    metadata_before = Logger.metadata()
+
+    try do
+      Logger.metadata(keyword)
+      fun.()
+    after
+      Logger.reset_metadata(metadata_before)
+    end
+  end
 
   @doc """
   The PID and its registered name (if it has one) as `t:iodata/0`.

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -117,7 +117,9 @@ defmodule Indexer.TokenBalance.Fetcher do
         :ok
 
       {:error, reason} ->
-        Logger.debug(fn -> ["failed to import token balances: ", inspect(reason)] end, error_count: Enum.count(token_balances_params))
+        Logger.debug(fn -> ["failed to import token balances: ", inspect(reason)] end,
+          error_count: Enum.count(token_balances_params)
+        )
 
         :error
     end

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -117,7 +117,7 @@ defmodule Indexer.TokenBalance.Fetcher do
         :ok
 
       {:error, reason} ->
-        Logger.debug(fn -> "failed to import #{length(token_balances_params)} token balances, #{inspect(reason)}" end)
+        Logger.debug(fn -> ["failed to import token balances: ", inspect(reason)] end, error_count: Enum.count(token_balances_params))
 
         :error
     end

--- a/apps/indexer/lib/indexer/token_balance/fetcher.ex
+++ b/apps/indexer/lib/indexer/token_balance/fetcher.ex
@@ -93,10 +93,11 @@ defmodule Indexer.TokenBalance.Fetcher do
   end
 
   def fetch_from_blockchain(params_list) do
-    {:ok, token_balances} =
-      params_list
-      |> Enum.filter(&(&1.retries_count <= @max_retries))
-      |> TokenBalances.fetch_token_balances_from_blockchain()
+    retryable_params_list = Enum.filter(params_list, &(&1.retries_count <= @max_retries))
+
+    Logger.metadata(count: Enum.count(retryable_params_list))
+
+    {:ok, token_balances} = TokenBalances.fetch_token_balances_from_blockchain(retryable_params_list)
 
     token_balances
   end

--- a/apps/indexer/lib/indexer/token_balances.ex
+++ b/apps/indexer/lib/indexer/token_balances.ex
@@ -34,7 +34,7 @@ defmodule Indexer.TokenBalances do
 
   @decorate span(tracer: Tracer)
   def fetch_token_balances_from_blockchain(token_balances, opts \\ []) do
-    Logger.debug(fn -> "fetching #{Enum.count(token_balances)} token balances" end)
+    Logger.debug("fetching token balances", count: Enum.count(token_balances))
 
     task_timeout = Keyword.get(opts, :timeout, @task_timeout)
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,19 +32,19 @@ config :logger,
 config :logger, :console,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id)a
+  metadata: ~w(application fetcher request_id block_number)a
 
 config :logger, :ecto,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id)a,
+  metadata: ~w(application fetcher request_id block_number)a,
   metadata_filter: [application: :ecto]
 
 config :logger, :error,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
   level: :error,
-  metadata: ~w(application fetcher request_id)a
+  metadata: ~w(application fetcher request_id block_number)a
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,20 +32,25 @@ config :logger,
 config :logger, :console,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a
+  metadata:
+    ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
+       block_number step count error_count)a
 
 config :logger, :ecto,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
-    ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a,
+    ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
+       block_number step count error_count)a,
   metadata_filter: [application: :ecto]
 
 config :logger, :error,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
   level: :error,
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a
+  metadata:
+    ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
+       block_number step count error_count)a
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,19 +32,19 @@ config :logger,
 config :logger, :console,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a
 
 config :logger, :ecto,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a,
   metadata_filter: [application: :ecto]
 
 config :logger, :error,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
   level: :error,
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,19 +32,19 @@ config :logger,
 config :logger, :console,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id block_number)a
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a
 
 config :logger, :ecto,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id block_number)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a,
   metadata_filter: [application: :ecto]
 
 config :logger, :error,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
   level: :error,
-  metadata: ~w(application fetcher request_id block_number)a
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number)a
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,19 +32,19 @@ config :logger,
 config :logger, :console,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a
 
 config :logger, :ecto,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a,
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a,
   metadata_filter: [application: :ecto]
 
 config :logger, :error,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
   level: :error,
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count)a
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -34,14 +34,14 @@ config :logger, :console,
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count)a
+       block_number step count error_count shrunk)a
 
 config :logger, :ecto,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count)a,
+       block_number step count error_count shrunk)a,
   metadata_filter: [application: :ecto]
 
 config :logger, :error,
@@ -50,7 +50,7 @@ config :logger, :error,
   level: :error,
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count)a
+       block_number step count error_count shrunk)a
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,19 +32,20 @@ config :logger,
 config :logger, :console,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a
 
 config :logger, :ecto,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a,
+  metadata:
+    ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a,
   metadata_filter: [application: :ecto]
 
 config :logger, :error,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
   level: :error,
-  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number count error_count)a
+  metadata: ~w(application fetcher request_id first_block_number last_block_number block_number step count error_count)a
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.


### PR DESCRIPTION
Extracted from #1185

## Changelog

### Enhancements
* Move chartable data out of human-readable prose and into logger metadata for easier extraction by log analysis tools.
    * `block_number` - the block number being fetched by the realtime indexer
    * `count` and `error_count` - the number of entries being fetched and those of count that had errors.
    * `first_block_number` and `last_block_number` - numbers in `first_block_number..last_block_number` search range for catchup block fetcher to find missing blocks.
   * `missing_block_range_count` - the number of ranges found in the search range.  More ranges for the same `missing_block_count` indicates the indexer is leaving more holes.
   * `missing_block_count` - the total number of missing blocks found in the search range for the catchup block fetcher.
   * `shrunk` - whether the sequence was shrunk for the catch block fetcher.
   * `step` - the step of the import that failed