### PR TITLE
Log timeout in PendingTransaction fetcher instead of crashing

### DIFF
--- a/apps/indexer/lib/indexer/pending_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/pending_transaction/fetcher.ex
@@ -120,6 +120,11 @@ defmodule Indexer.PendingTransaction.Fetcher do
 
       :ignore ->
         :ok
+
+      {:error, :timeout} ->
+        Logger.error("timeout")
+
+        :ok
     end
   end
 end


### PR DESCRIPTION
Fixes #1216

## Changelog
### Bug Fixes
* Log timeout in `PendingTransaction` fetcher instead of crashing