### PR TITLE
Don't log errors when uncles aren't found

### DIFF
--- a/apps/indexer/lib/indexer/block/uncle/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/uncle/fetcher.ex
@@ -189,18 +189,29 @@ defmodule Indexer.Block.Uncle.Fetcher do
 
   defp retry(errors) when is_list(errors) do
     retried_entries = errors_to_entries(errors)
+    loggable_errors = loggable_errors(errors)
+    loggable_error_count = Enum.count(loggable_errors)
 
-    Logger.error(
-      fn ->
-        [
-          "failed to fetch: ",
-          errors_to_iodata(errors)
-        ]
-      end,
-      error_count: Enum.count(retried_entries)
-    )
+    unless loggable_error_count == 0 do
+      Logger.error(
+        fn ->
+          [
+            "failed to fetch: ",
+            errors_to_iodata(loggable_errors)
+          ]
+        end,
+        error_count: loggable_error_count
+      )
+    end
 
     {:retry, retried_entries}
+  end
+
+  defp loggable_errors(errors) when is_list(errors) do
+    Enum.filter(errors, fn
+      %{code: 404, message: "Not Found"} -> false
+      _ -> true
+    end)
   end
 
   defp errors_to_entries(errors) when is_list(errors) do

--- a/apps/indexer/lib/indexer/block/uncle/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/uncle/fetcher.ex
@@ -199,6 +199,8 @@ defmodule Indexer.Block.Uncle.Fetcher do
       end,
       error_count: Enum.count(retried_entries)
     )
+
+    {:retry, retried_entries}
   end
 
   defp errors_to_entries(errors) when is_list(errors) do


### PR DESCRIPTION
Fixes #1221

## Changelog

### Bug Fixes
* `Indexer.Block.Uncle.Fetcher.retry/1` when there are errors did not actually retry the calculated `retried_errors` and instead only logged them.  This didn't cause an unused variable warning because
`retried_errors` is used in the Logger metadata.  The `Task` for the `run/2` callback did not error because `Logger.error` returns `:ok`.  This bug was introduced in https://github.com/poanetwork/blockscout/commit/d43a8c61333781185c4f5b349980626bd3e17cbe when partial retry support was added.

    To fix this problem, `{:retry, retried_errors}` need to be returned after the `Logger.error` call.
*  Don't log errors when uncles aren't found.  It happens too often to be worth treating as an error as we should only log things that are exceptional and need human attention as errors.