### PR TITLE
Don't log when queue is unavailable in Indexer.Block.InvalidConsensus.Worker

### DIFF
--- a/apps/indexer/lib/indexer/block/invalid_consensus/worker.ex
+++ b/apps/indexer/lib/indexer/block/invalid_consensus/worker.ex
@@ -77,7 +77,10 @@ defmodule Indexer.Block.InvalidConsensus.Worker do
   end
 
   def handle_info({ref, {:error, reason}}, %{task_ref: ref, retry_interval: millis} = state) do
-    Logger.error(fn -> inspect(reason) end)
+    case reason do
+      :queue_unavailable -> :ok
+      _ -> Logger.error(fn -> inspect(reason) end)
+    end
 
     Process.demonitor(ref, [:flush])
     Process.send_after(self(), :push_front_blocks, millis)

--- a/apps/indexer/lib/indexer/token_transfer/uncataloged/worker.ex
+++ b/apps/indexer/lib/indexer/token_transfer/uncataloged/worker.ex
@@ -76,7 +76,10 @@ defmodule Indexer.TokenTransfer.Uncataloged.Worker do
   end
 
   def handle_info({ref, {:error, reason}}, %{task_ref: ref, retry_interval: millis} = state) do
-    Logger.error(fn -> inspect(reason) end)
+    case reason do
+      :queue_unavailable -> :ok
+      _ -> Logger.error(fn -> inspect(reason) end)
+    end
 
     Process.demonitor(ref, [:flush])
     Process.send_after(self(), :push_front_blocks, millis)


### PR DESCRIPTION
Fixes #1223

## Changelog

### Bug Fixes
*  For large chains like ETH Mainnet, it is fairly common for the catchup fetcher to take a long time to calculate the missing block numbers and start the named Sequence used by `push_front(block)`.  Since this is normal and not exceptional, `InvalidConsensus.Worker` shouldn't log this and retry silently.