### PR TITLE
Uncataloged.Worker issue with nil block numbers

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1959,6 +1959,7 @@ defmodule Explorer.Chain do
         on: tf.transaction_hash == l.transaction_hash and tf.log_index == l.index,
         where: l.first_topic == unquote(TokenTransfer.constant()),
         where: is_nil(tf.transaction_hash) and is_nil(tf.log_index),
+        where: not is_nil(t.block_number),
         select: t.block_number,
         distinct: t.block_number
       )

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -3131,9 +3131,21 @@ defmodule Explorer.ChainTest do
 
   describe "uncataloged_token_transfer_block_numbers/0" do
     test "returns a list of block numbers" do
-      log = insert(:token_transfer_log)
-      block_number = log.transaction.block_number
+      block = insert(:block)
+      transaction = :transaction |> insert() |> with_block(block)
+      insert(:log, first_topic: TokenTransfer.constant(), transaction: transaction)
+
+      block_number = block.number
+
       assert {:ok, [^block_number]} = Chain.uncataloged_token_transfer_block_numbers()
+      assert is_integer(block_number)
+    end
+
+    test "ignores nil block numbers" do
+      log = insert(:token_transfer_log)
+
+      assert is_nil(log.transaction.block_number)
+      assert {:ok, []} = Chain.uncataloged_token_transfer_block_numbers()
     end
   end
 

--- a/apps/indexer/test/indexer/token_transfer/uncataloged/worker_test.exs
+++ b/apps/indexer/test/indexer/token_transfer/uncataloged/worker_test.exs
@@ -1,6 +1,7 @@
 defmodule Indexer.TokenTransfer.Uncataloged.WorkerTest do
   use Explorer.DataCase
 
+  alias Explorer.Chain.TokenTransfer
   alias Indexer.Sequence
   alias Indexer.TokenTransfer.Uncataloged.{Worker, TaskSupervisor}
 
@@ -28,8 +29,11 @@ defmodule Indexer.TokenTransfer.Uncataloged.WorkerTest do
     end
 
     test "sends message to self when uncataloged token transfers are found" do
-      log = insert(:token_transfer_log)
-      block_number = log.transaction.block_number
+      block = insert(:block)
+      transaction = :transaction |> insert() |> with_block(block)
+      insert(:log, first_topic: TokenTransfer.constant(), transaction: transaction)
+
+      block_number = block.number
 
       expected_state = %{task_ref: nil, block_numbers: [block_number], retry_interval: 1}
       state = %{task_ref: nil, block_numbers: [], retry_interval: 1}


### PR DESCRIPTION
Resolves: https://github.com/poanetwork/blockscout/issues/1227

## Motivation

* We noticed the `Uncataloged.Worker` is stuck on Kovan because it can't
enqueue a block number with nil value for the catchup indexer to index.
You can see the error from the logs on issue 1227

## Bug Fixes
* Editing `Chain.uncataloged_token_transfer_block_numbers/0` to
ignore transactions with nil block number.
* Improving tests for the function mentioned above to account for this
scenario (transaction with nil block number).