### PR TITLE
Label all steps in Block.Fetcher implementations

### DIFF
--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -83,8 +83,7 @@ defmodule Indexer.Block.Fetcher do
   @spec fetch_and_import_range(t, Range.t()) ::
           {:ok, %{inserted: %{}, errors: [EthereumJSONRPC.Transport.error()]}}
           | {:error,
-             {step :: atom(), reason :: term()}
-             | [%Ecto.Changeset{}]
+             {step :: atom(), reason :: [%Ecto.Changeset{}] | term()}
              | {step :: atom(), failed_value :: term(), changes_so_far :: term()}}
   def fetch_and_import_range(
         %__MODULE__{
@@ -150,8 +149,6 @@ defmodule Indexer.Block.Fetcher do
       {:ok, %{inserted: inserted, errors: blocks_errors ++ beneficiaries_errors}}
     else
       {step, {:error, reason}} -> {:error, {step, reason}}
-      {:error, :timeout} = error -> error
-      {:error, changesets} = error when is_list(changesets) -> error
       {:error, step, failed_value, changes_so_far} -> {:error, {step, failed_value, changes_so_far}}
     end
   end

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -97,22 +97,26 @@ defmodule Indexer.Block.Realtime.Fetcher do
           transactions: %{params: transactions_params}
         } = options
       ) do
-    with {:ok,
-          %{
-            addresses_params: internal_transactions_addresses_params,
-            internal_transactions_params: internal_transactions_params
-          }} <-
-           internal_transactions(block_fetcher, %{
-             addresses_params: addresses_params,
-             transactions_params: transactions_params
-           }),
-         {:ok, %{addresses_params: balances_addresses_params, balances_params: balances_params}} <-
-           balances(block_fetcher, %{
-             address_hash_to_block_number: address_hash_to_block_number,
+    with {:internal_transactions,
+          {:ok,
+           %{
              addresses_params: internal_transactions_addresses_params,
-             balances_params: address_coin_balances_params
-           }),
-         {:ok, address_token_balances} <- fetch_token_balances(address_token_balances_params),
+             internal_transactions_params: internal_transactions_params
+           }}} <-
+           {:internal_transactions,
+            internal_transactions(block_fetcher, %{
+              addresses_params: addresses_params,
+              transactions_params: transactions_params
+            })},
+         {:balances, {:ok, %{addresses_params: balances_addresses_params, balances_params: balances_params}}} <-
+           {:balances,
+            balances(block_fetcher, %{
+              address_hash_to_block_number: address_hash_to_block_number,
+              addresses_params: internal_transactions_addresses_params,
+              balances_params: address_coin_balances_params
+            })},
+         {:address_token_balances, {:ok, address_token_balances}} <-
+           {:address_token_balances, fetch_token_balances(address_token_balances_params)},
          chain_import_options =
            options
            |> Map.drop(@import_options)
@@ -122,7 +126,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
            |> put_in([Access.key(:address_current_token_balances, %{}), :params], address_token_balances)
            |> put_in([Access.key(:address_token_balances), :params], address_token_balances)
            |> put_in([Access.key(:internal_transactions, %{}), :params], internal_transactions_params),
-         {:ok, imported} = ok <- Chain.import(chain_import_options) do
+         {:import, {:ok, imported} = ok} <- {:import, Chain.import(chain_import_options)} do
       async_import_remaining_block_data(imported)
       ok
     end
@@ -194,19 +198,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
           ]
         end)
 
-      {:error, {step, reason}} ->
-        Logger.error(
-          fn ->
-            [
-              "failed to fetch: ",
-              inspect(reason),
-              ".  Block will be retried by catchup indexer."
-            ]
-          end,
-          step: step
-        )
-
-      {:error, [%Changeset{} | _] = changesets} ->
+      {:error, {:import, [%Changeset{} | _] = changesets}} ->
         params = %{
           changesets: changesets,
           block_number_to_fetch: block_number_to_fetch,
@@ -225,6 +217,18 @@ defmodule Indexer.Block.Realtime.Fetcher do
             ]
           end)
         end
+
+      {:error, {step, reason}} ->
+        Logger.error(
+          fn ->
+            [
+              "failed to fetch: ",
+              inspect(reason),
+              ".  Block will be retried by catchup indexer."
+            ]
+          end,
+          step: step
+        )
 
       {:error, {step, failed_value, _changes_so_far}} ->
         Logger.error(


### PR DESCRIPTION
Fixes #1232

Port from #1185.

## Changelog
### Bug Fixes
* `{:error, :timeout}` should have been caught, but additionally, it should never have been allowed to propagate out unassigned to a step as it is not possible to track the timeout to a specific fetch.