### PR TITLE
Use reraise and __STACKTRACE__ to reraise safe_insert_all errors

### DIFF
--- a/apps/explorer/lib/explorer/repo.ex
+++ b/apps/explorer/lib/explorer/repo.ex
@@ -57,7 +57,7 @@ defmodule Explorer.Repo do
             Logger.configure(truncate: old_truncate)
 
             # reraise to kill caller
-            raise exception
+            reraise exception, __STACKTRACE__
         end
 
       if returning do


### PR DESCRIPTION
Fixes #1238

## Changelog
### Enhancements
* Use `reraise` and `__STACKTRACE__` as `reraise` is the current accepted idiom for reraising, not `raise` alone as it preserves the original stacktrace.