### PR TITLE
Handle new blocks older than last block

### DIFF
--- a/apps/block_scout_web/assets/__tests__/pages/blocks.js
+++ b/apps/block_scout_web/assets/__tests__/pages/blocks.js
@@ -103,6 +103,27 @@ describe('RECEIVED_NEW_BLOCK', () => {
         '<div data-block-number="4"></div>'
     ])
   })
+  test('replaces duplicated block older than last one', () => {
+    const state = Object.assign({}, initialState, {
+      items: [
+        '<div data-block-number="5"></div>',
+        '<div data-block-number="4"></div>'
+      ],
+      blockType: 'block'
+    })
+    const action = {
+      type: 'RECEIVED_NEW_BLOCK',
+      msg: {
+        blockHtml: '<div data-block-number="4" class="new"></div>',
+      }
+    }
+    const output = reducer(state, action)
+
+    expect(output.items).toEqual([
+        '<div data-block-number="5"></div>',
+        '<div data-block-number="4" class="new"></div>'
+    ])
+  })
   test('skips if new block height is lower than lowest on page', () => {
     const state = Object.assign({}, initialState, {
       items: [

--- a/apps/block_scout_web/assets/js/pages/blocks.js
+++ b/apps/block_scout_web/assets/js/pages/blocks.js
@@ -56,14 +56,15 @@ function withMissingBlocks (reducer) {
 
     if (result.items.length < 2) return result
 
-    const maxBlock = getBlockNumber(_.first(result.items))
-    const minBlock = getBlockNumber(_.last(result.items))
-
     const blockNumbersToItems = result.items.reduce((acc, item) => {
       const blockNumber = getBlockNumber(item)
       acc[blockNumber] = acc[blockNumber] || item
       return acc
     }, {})
+
+    const blockNumbers = _(blockNumbersToItems).keys().map(x => parseInt(x, 10)).value()
+    const minBlock = _.min(blockNumbers)
+    const maxBlock = _.max(blockNumbers)
 
     return Object.assign({}, result, {
       items: _.rangeRight(minBlock, maxBlock + 1)


### PR DESCRIPTION
Closes #1204.

Before this PR, the last block was assumed to be the newest, but this was causing issues when a new block was added that was older than the last block.

To reproduce this situation:

1. Start the app with the indexer enabled.
2. Go to the blocks page.
3. Disable the indexer (`Application.stop(:indexer)`)
4. Wait for some new blocks to appear in the indexed chain.
5. Re-enable the indexer (`Application.ensure_started(:indexer)`)

A gap filled with placeholders should appear. Later, one of these placeholders may be received. When this happens, it should be replaced without removing the blocks that are after it.