### PR TITLE
Missed error pattern change in #1233

### DIFF
--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -149,7 +149,7 @@ defmodule Indexer.Block.Fetcher do
       {:ok, %{inserted: inserted, errors: blocks_errors ++ beneficiaries_errors}}
     else
       {step, {:error, reason}} -> {:error, {step, reason}}
-      {:error, step, failed_value, changes_so_far} -> {:error, {step, failed_value, changes_so_far}}
+      {step, {:error, step, failed_value, changes_so_far}} -> {:error, {step, failed_value, changes_so_far}}
     end
   end
 


### PR DESCRIPTION
Fixes

```
2018-12-17T13:55:29.652 application=indexer fetcher=block_catchup first_block_number=6561714 last_block_number=6561714 [error] ** (WithClauseError) no with clause matching: {:import, {:error, :derive_transaction_forks, %Postgrex.Error{connection_id: 16967, message: nil, 
```

## Changelog

### Bug Fixes
* Missed error pattern change in #1233
