### PR TITLE
Add reward value of a block in the tile and overview section.

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_validation_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_validation_controller.ex
@@ -23,7 +23,8 @@ defmodule BlockScoutWeb.AddressValidationController do
             necessity_by_association: %{
               miner: :required,
               nephews: :optional,
-              transactions: :optional
+              transactions: :optional,
+              rewards: :optional
             }
           ],
           paging_options(params)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_controller.ex
@@ -11,7 +11,8 @@ defmodule BlockScoutWeb.BlockController do
     [
       necessity_by_association: %{
         :transactions => :optional,
-        [miner: :names] => :optional
+        [miner: :names] => :optional,
+        :rewards => :optional
       }
     ]
     |> handle_render(conn, params)
@@ -25,7 +26,8 @@ defmodule BlockScoutWeb.BlockController do
     [
       necessity_by_association: %{
         :transactions => :optional,
-        [miner: :names] => :optional
+        [miner: :names] => :optional,
+        :rewards => :optional
       },
       block_type: "Reorg"
     ]
@@ -37,7 +39,8 @@ defmodule BlockScoutWeb.BlockController do
       necessity_by_association: %{
         :transactions => :optional,
         [miner: :names] => :optional,
-        :nephews => :required
+        :nephews => :required,
+        :rewards => :optional
       },
       block_type: "Uncle"
     ]

--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
@@ -13,7 +13,8 @@ defmodule BlockScoutWeb.BlockTransactionController do
              necessity_by_association: %{
                [miner: :names] => :required,
                :uncles => :optional,
-               :nephews => :optional
+               :nephews => :optional,
+               :rewards => :optional
              }
            ) do
       block_transaction_count = Chain.block_to_transaction_count(block)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
@@ -10,7 +10,7 @@ defmodule BlockScoutWeb.ChainController do
     blocks =
       [paging_options: %PagingOptions{page_size: 4}]
       |> Chain.list_blocks()
-      |> Repo.preload([[miner: :names], :transactions])
+      |> Repo.preload([[miner: :names], :transactions, :rewards])
 
     transaction_estimated_count = Chain.transaction_estimated_count()
 

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -108,7 +108,7 @@ defmodule BlockScoutWeb.Notifier do
   end
 
   defp broadcast_block(block) do
-    preloaded_block = Repo.preload(block, [[miner: :names], :transactions])
+    preloaded_block = Repo.preload(block, [[miner: :names], :transactions, :rewards])
     average_block_time = Chain.average_block_time()
 
     Endpoint.broadcast("blocks:new_block", "new_block", %{

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/_tile.html.eex
@@ -42,6 +42,15 @@
             contract: false %>
         </span>
       </div>
+      <%= if show_reward?(@block.rewards) do %>
+        <div class="text-nowrap text-truncate mt-3 mt-md-0">
+          <!-- validator reward -->
+          <%= gettext "Reward" %>
+          <span class="ml-2">
+            <%= combined_rewards_value(@block) %>
+          </span>
+        </div>
+      <% end %>
     </div>
     <div class="col-md-4 col-lg-3 text-md-right d-flex flex-column align-items-md-end justify-content-md-end mt-3 mt-md-0">
       <!-- Gas Limit -->

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
@@ -65,14 +65,14 @@
             </dl>
 
             <!-- Nonce -->
-            <dl class="row mb-0">
+            <dl class="row">
               <dt class="col-sm-3 text-muted"> <%= gettext "Nonce" %> </dt>
               <dd class="col-sm-9"> <%= to_string(@block.nonce) %> </dd>
             </dl>
 
             <%= if length(@block.uncle_relations) > 0 do %>
               <!-- Uncles -->
-              <dl class="row mt-3 mb-0">
+              <dl class="row mt-3">
                 <dt class="col-sm-3 text-muted"> <%= gettext "Uncles" %> </dt>
                 <dd class="col-sm-9">
                   <%= for {relation, index} <- Enum.with_index(@block.uncle_relations) do %>
@@ -84,6 +84,24 @@
                         to: block_path(@conn, :show, relation.uncle_hash)
                       ) %><%= if index < length(@block.uncle_relations) - 1 do %>,<% end %>
                   <% end %>
+                </dd>
+              </dl>
+            <% end %>
+
+            <!-- Otherwise it will be displayed in its own block -->
+            <%= if show_reward?(@block.rewards) do %>
+              <dl class="row">
+                <dt class="col-sm-3 text-muted"><%= gettext "Gas Used" %></dt>
+                <dd class="col-sm-9">
+                  <%= @block.gas_used |> Cldr.Number.to_string! %>
+                  <span class="text-muted"> (<%= (Decimal.to_integer(@block.gas_used) / Decimal.to_integer(@block.gas_limit)) |> Cldr.Number.to_string!(format: "#.#%") %>) </span>
+                </dt>
+              </dl>
+
+              <dl class="row mb-0">
+                <dt class="col-sm-3 text-muted"><%= gettext "Gas Limit" %></dt>
+                <dd class="col-sm-9">
+                  <%= Cldr.Number.to_string!(@block.gas_limit) %>
                 </dd>
               </dl>
             <% end %>
@@ -112,19 +130,33 @@
         </div>
       </div>
 
-      <!-- Gas -->
+      <!-- Validator Reward or Gas-->
       <div class="card flex-grow-1 ml-0 ml-md-5 ml-lg-0">
         <div class="card-body">
-          <h2 class="card-title"> <%= gettext "Gas Used" %> </h2>
-          <div class="text-right">
-            <!-- Gas Used -->
-            <h3>
-              <%= @block.gas_used |> Cldr.Number.to_string! %>
-              <span class="text-muted"> (<%= (Decimal.to_integer(@block.gas_used) / Decimal.to_integer(@block.gas_limit)) |> Cldr.Number.to_string!(format: "#.#%") %>) </span>
-            </h3>
-            <!-- Gas Limit -->
-            <span class="text-muted"> <%= @block.gas_limit |> Cldr.Number.to_string! %> <%= gettext "Gas Limit" %> </span>
-          </div>
+          <%= if show_reward?(@block.rewards) do %>
+            <h2 class="card-title"> <%= gettext "Block Rewards" %> </h2>
+
+            <%= for block_reward <- @block.rewards do %>
+              <dl class="row">
+                <dt class="col-sm-5 text-muted"><%= block_reward_text(block_reward) %></dt>
+                <dd class="col-sm-7">
+                  <%= format_wei_value(block_reward.reward, :ether) %></dt>
+                </dd>
+              </dl>
+            <% end %>
+          <% else %>
+            <h2 class="card-title"> <%= gettext "Gas Used" %> </h2>
+
+            <div class="text-right">
+              <!-- Gas Used -->
+              <h3>
+                <%= @block.gas_used |> Cldr.Number.to_string! %>
+                <span class="text-muted"> (<%= (Decimal.to_integer(@block.gas_used) / Decimal.to_integer(@block.gas_limit)) |> Cldr.Number.to_string!(format: "#.#%") %>) </span>
+              </h3>
+              <!-- Gas Limit -->
+              <span class="text-muted"> <%= @block.gas_limit |> Cldr.Number.to_string! %> <%= gettext "Gas Limit" %> </span>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/chain/_block.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/chain/_block.html.eex
@@ -18,5 +18,13 @@
         address: @block.miner,
         contract: false %>
     </span>
+
+    <%= if BlockScoutWeb.BlockView.show_reward?(@block.rewards) do %>
+      <span class="text-truncate">
+        <%= gettext "Reward" %>
+
+        <%= BlockScoutWeb.BlockView.combined_rewards_value(@block) %>
+      </span>
+    <% end %>
   </div>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/views/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/block_view.ex
@@ -3,7 +3,9 @@ defmodule BlockScoutWeb.BlockView do
 
   import Math.Enum, only: [mean: 1]
 
+  alias Explorer.Chain
   alias Explorer.Chain.{Block, Wei}
+  alias Explorer.Chain.Block.Reward
 
   @dialyzer :no_match
 
@@ -45,5 +47,26 @@ defmodule BlockScoutWeb.BlockView do
 
   def formatted_timestamp(%Block{timestamp: timestamp}) do
     Timex.format!(timestamp, "%b-%d-%Y %H:%M:%S %p %Z", :strftime)
+  end
+
+  def show_reward?([]), do: false
+  def show_reward?(_), do: true
+
+  def block_reward_text(%Reward{address_type: :validator}) do
+    gettext("Miner Reward")
+  end
+
+  def block_reward_text(%Reward{address_type: :emission_funds}) do
+    gettext("Emission Reward")
+  end
+
+  def block_reward_text(%Reward{address_type: :uncle}) do
+    gettext("Uncle Reward")
+  end
+
+  def combined_rewards_value(block) do
+    block
+    |> Chain.block_combined_rewards()
+    |> format_wei_value(:ether)
   end
 end

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -450,14 +450,16 @@ msgid "Gas"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/_tile.html.eex:48
-#: lib/block_scout_web/templates/block/overview.html.eex:126
+#: lib/block_scout_web/templates/block/_tile.html.eex:57
+#: lib/block_scout_web/templates/block/overview.html.eex:102
+#: lib/block_scout_web/templates/block/overview.html.eex:157
 msgid "Gas Limit"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/_tile.html.eex:53
-#: lib/block_scout_web/templates/block/overview.html.eex:118
+#: lib/block_scout_web/templates/block/_tile.html.eex:62
+#: lib/block_scout_web/templates/block/overview.html.eex:94
+#: lib/block_scout_web/templates/block/overview.html.eex:148
 msgid "Gas Used"
 msgstr ""
 
@@ -467,7 +469,7 @@ msgid "Github"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/block_view.ex:18
+#: lib/block_scout_web/views/block_view.ex:20
 #: lib/block_scout_web/views/wei_helpers.ex:71
 msgid "Gwei"
 msgstr ""
@@ -551,7 +553,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_tile.html.eex:37
-#: lib/block_scout_web/templates/block/overview.html.eex:99
+#: lib/block_scout_web/templates/block/overview.html.eex:117
 #: lib/block_scout_web/templates/chain/_block.html.eex:14
 msgid "Miner"
 msgstr ""
@@ -1165,6 +1167,8 @@ msgid "Delegate Call"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/block/_tile.html.eex:48
+#: lib/block_scout_web/templates/chain/_block.html.eex:24
 #: lib/block_scout_web/views/internal_transaction_view.ex:27
 msgid "Reward"
 msgstr ""
@@ -1501,4 +1505,24 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:19
 msgid "Validator Info"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block/overview.html.eex:137
+msgid "Block Rewards"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_view.ex:60
+msgid "Emission Reward"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_view.ex:56
+msgid "Miner Reward"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_view.ex:64
+msgid "Uncle Reward"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -450,14 +450,16 @@ msgid "Gas"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/_tile.html.eex:48
-#: lib/block_scout_web/templates/block/overview.html.eex:126
+#: lib/block_scout_web/templates/block/_tile.html.eex:57
+#: lib/block_scout_web/templates/block/overview.html.eex:102
+#: lib/block_scout_web/templates/block/overview.html.eex:157
 msgid "Gas Limit"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/_tile.html.eex:53
-#: lib/block_scout_web/templates/block/overview.html.eex:118
+#: lib/block_scout_web/templates/block/_tile.html.eex:62
+#: lib/block_scout_web/templates/block/overview.html.eex:94
+#: lib/block_scout_web/templates/block/overview.html.eex:148
 msgid "Gas Used"
 msgstr ""
 
@@ -467,7 +469,7 @@ msgid "Github"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/block_view.ex:18
+#: lib/block_scout_web/views/block_view.ex:20
 #: lib/block_scout_web/views/wei_helpers.ex:71
 msgid "Gwei"
 msgstr ""
@@ -551,7 +553,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_tile.html.eex:37
-#: lib/block_scout_web/templates/block/overview.html.eex:99
+#: lib/block_scout_web/templates/block/overview.html.eex:117
 #: lib/block_scout_web/templates/chain/_block.html.eex:14
 msgid "Miner"
 msgstr ""
@@ -1165,6 +1167,8 @@ msgid "Delegate Call"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/block/_tile.html.eex:48
+#: lib/block_scout_web/templates/chain/_block.html.eex:24
 #: lib/block_scout_web/views/internal_transaction_view.ex:27
 msgid "Reward"
 msgstr ""
@@ -1501,4 +1505,24 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:19
 msgid "Validator Info"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block/overview.html.eex:137
+msgid "Block Rewards"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_view.ex:60
+msgid "Emission Reward"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_view.ex:56
+msgid "Miner Reward"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_view.ex:64
+msgid "Uncle Reward"
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/views/block_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/block_view_test.exs
@@ -47,4 +47,51 @@ defmodule BlockScoutWeb.BlockViewTest do
                BlockView.formatted_timestamp(block)
     end
   end
+
+  describe "show_reward?/1" do
+    test "returns false when list of rewards is empty" do
+      assert BlockView.show_reward?([]) == false
+    end
+
+    test "returns true when list of rewards is not empty" do
+      block = insert(:block)
+      validator = insert(:reward, address_hash: block.miner_hash, block_hash: block.hash, address_type: :validator)
+
+      assert BlockView.show_reward?([validator]) == true
+    end
+  end
+
+  describe "combined_rewards_value/1" do
+    test "returns all the reward values summed up and formatted into a String" do
+      block = insert(:block)
+
+      insert(
+        :reward,
+        address_hash: block.miner_hash,
+        block_hash: block.hash,
+        address_type: :validator,
+        reward: Decimal.new(1_000_000_000_000_000_000)
+      )
+
+      insert(
+        :reward,
+        address_hash: block.miner_hash,
+        block_hash: block.hash,
+        address_type: :emission_funds,
+        reward: Decimal.new(1_000_000_000_000_000_000)
+      )
+
+      insert(
+        :reward,
+        address_hash: block.miner_hash,
+        block_hash: block.hash,
+        address_type: :uncle,
+        reward: Decimal.new(1_000_042_000_000_000_000)
+      )
+
+      block = Repo.preload(block, :rewards)
+
+      assert BlockView.combined_rewards_value(block) == "3.000042 POA"
+    end
+  end
 end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2156,4 +2156,24 @@ defmodule Explorer.Chain do
 
     Repo.all(query, timeout: :infinity)
   end
+
+  @doc """
+  Combined block reward from all the fees.
+  """
+  @spec block_combined_rewards(Block.t()) :: Wei.t()
+  def block_combined_rewards(block) do
+    {:ok, value} =
+      block.rewards
+      |> Enum.reduce(
+        0,
+        fn block_reward, acc ->
+          {:ok, decimal} = Wei.dump(block_reward.reward)
+
+          Decimal.add(decimal, acc)
+        end
+      )
+      |> Wei.cast()
+
+    value
+  end
 end

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -7,7 +7,8 @@ defmodule Explorer.Chain.Block do
 
   use Explorer.Schema
 
-  alias Explorer.Chain.{Address, Block.SecondDegreeRelation, Gas, Hash, Transaction}
+  alias Explorer.Chain.{Address, Gas, Hash, Transaction}
+  alias Explorer.Chain.Block.{Reward, SecondDegreeRelation}
 
   @required_attrs ~w(consensus difficulty gas_limit gas_used hash miner_hash nonce number parent_hash size timestamp
                      total_difficulty)a
@@ -87,6 +88,8 @@ defmodule Explorer.Chain.Block do
     has_many(:uncles, through: [:uncle_relations, :uncle])
 
     has_many(:transactions, Transaction)
+
+    has_many(:rewards, Reward, foreign_key: :block_hash)
   end
 
   def changeset(%__MODULE__{} = block, attrs) do

--- a/apps/explorer/lib/explorer/chain/block/reward.ex
+++ b/apps/explorer/lib/explorer/chain/block/reward.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Chain.Block.Reward do
   use Explorer.Schema
 
   alias Explorer.Chain.Block.Reward.AddressType
-  alias Explorer.Chain.{Hash, Wei}
+  alias Explorer.Chain.{Address, Block, Hash, Wei}
 
   @required_attrs ~w(address_hash address_type block_hash reward)a
 
@@ -19,18 +19,34 @@ defmodule Explorer.Chain.Block.Reward do
   * `:reward` - Total block reward
   """
   @type t :: %__MODULE__{
+          address: %Ecto.Association.NotLoaded{} | Address.t() | nil,
           address_hash: Hash.Address.t(),
           address_type: AddressType.t(),
+          block: %Ecto.Association.NotLoaded{} | Block.t() | nil,
           block_hash: Hash.Full.t(),
           reward: Wei.t()
         }
 
   @primary_key false
   schema "block_rewards" do
-    field(:address_hash, Hash.Address)
     field(:address_type, AddressType)
-    field(:block_hash, Hash.Full)
     field(:reward, Wei)
+
+    belongs_to(
+      :address,
+      Address,
+      foreign_key: :address_hash,
+      references: :hash,
+      type: Hash.Address
+    )
+
+    belongs_to(
+      :block,
+      Block,
+      foreign_key: :block_hash,
+      references: :hash,
+      type: Hash.Full
+    )
 
     timestamps()
   end

--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -101,7 +101,7 @@ defmodule Explorer.Mixfile do
         github: "deadtrickster/prometheus-ecto", ref: "650a403183f6a2fb6b682d7fbcba8bf9d24fe1e4"
       },
       # bypass optional dependency
-      {:plug_cowboy, "~> 1.0", only: :test},
+      {:plug_cowboy, "~> 1.0", only: [:dev, :test]},
       {:sobelow, ">= 0.7.0", only: [:dev, :test], runtime: false},
       # Tracing
       {:spandex, github: "spandex-project/spandex", branch: "allow-setting-trace-key", override: true},

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -9,7 +9,7 @@ defmodule Explorer.Factory do
   alias Comeonin.Bcrypt
   alias Explorer.Accounts.{User, UserContact}
   alias Explorer.Admin.Administrator
-  alias Explorer.Chain.Block.{EmissionReward, Range}
+  alias Explorer.Chain.Block.{EmissionReward, Range, Reward}
 
   alias Explorer.Chain.{
     Address,
@@ -422,6 +422,15 @@ defmodule Explorer.Factory do
     %EmissionReward{
       block_range: %Range{from: lower, to: upper},
       reward: reward
+    }
+  end
+
+  def reward_factory do
+    %Reward{
+      address_hash: build(:address).hash,
+      address_type: :validator,
+      block_hash: build(:block).hash,
+      reward: Decimal.new(3)
     }
   end
 


### PR DESCRIPTION
Resolves #23

## Motivation

Displays the reward value in the block tile at the home page, block details page and the address block validated page.

In the tile shows the combined reward value, and at the block details page shows the reward value detail.

<img width="1126" alt="screen shot 2018-12-19 at 12 13 47" src="https://user-images.githubusercontent.com/840531/50225406-92362100-0387-11e9-808f-733d1e562098.png">

<img width="1136" alt="screen shot 2018-12-19 at 12 12 41" src="https://user-images.githubusercontent.com/840531/50225359-6f0b7180-0387-11e9-9c59-566cb20c19e4.png">

<img width="1088" alt="screen shot 2018-12-19 at 12 12 33" src="https://user-images.githubusercontent.com/840531/50225366-76327f80-0387-11e9-8a22-1f702dc22bbf.png">

## Changelog

### Bug Fixes
* Add `:dev` dependency to `plug_cowboy` at the `explorer`, so `iex` can start.

