### PR TITLE
Convert DBConnection.ConnectionError tcp recv: closed to {:error, :timeout}

### DIFF
--- a/apps/explorer/lib/explorer/repo.ex
+++ b/apps/explorer/lib/explorer/repo.ex
@@ -54,6 +54,9 @@ defmodule Explorer.Repo do
                 to_string(kind),
                 " using options because of error.\n",
                 "\n",
+                "Chunk Size: ",
+                chunk |> length() |> to_string(),
+                "\n",
                 "Chunk:\n",
                 "\n",
                 inspect(chunk, limit: :infinity, printable_limit: :infinity),
@@ -66,7 +69,7 @@ defmodule Explorer.Repo do
                 "\n",
                 "Exception:\n",
                 "\n",
-                Exception.format(:error, exception)
+                Exception.format(:error, exception, __STACKTRACE__)
               ]
             end)
 

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -187,10 +187,15 @@ defmodule Indexer.Block.Catchup.Fetcher do
 
         {:ok, inserted: inserted}
 
-      {:error, {:import, [%Changeset{} | _] = changesets}} = error ->
-        Logger.error(fn ->
-          ["failed to validate: ", inspect(changesets), ". Retrying."]
-        end)
+      {:error, {:import = step, [%Changeset{} | _] = changesets}} = error ->
+        Logger.error(fn -> ["failed to validate: ", inspect(changesets), ". Retrying."] end, step: step)
+
+        push_back(sequence, range)
+
+        error
+
+      {:error, {:import = step, reason}} = error ->
+        Logger.error(fn -> [inspect(reason), ". Retrying."] end, step: step)
 
         push_back(sequence, range)
 

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -198,7 +198,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
           ]
         end)
 
-      {:error, {:import, [%Changeset{} | _] = changesets}} ->
+      {:error, {:import = step, [%Changeset{} | _] = changesets}} ->
         params = %{
           changesets: changesets,
           block_number_to_fetch: block_number_to_fetch,
@@ -207,16 +207,22 @@ defmodule Indexer.Block.Realtime.Fetcher do
         }
 
         if retry_fetch_and_import_block(params) == :ignore do
-          Logger.error(fn ->
-            [
-              "failed to validate for block ",
-              to_string(block_number_to_fetch),
-              ": ",
-              inspect(changesets),
-              ".  Block will be retried by catchup indexer."
-            ]
-          end)
+          Logger.error(
+            fn ->
+              [
+                "failed to validate for block ",
+                to_string(block_number_to_fetch),
+                ": ",
+                inspect(changesets),
+                ".  Block will be retried by catchup indexer."
+              ]
+            end,
+            step: step
+          )
         end
+
+      {:error, {:import = step, reason}} ->
+        Logger.error(fn -> inspect(reason) end, step: step)
 
       {:error, {step, reason}} ->
         Logger.error(

--- a/apps/indexer/lib/indexer/block/uncle/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/uncle/fetcher.ex
@@ -8,6 +8,7 @@ defmodule Indexer.Block.Uncle.Fetcher do
 
   require Logger
 
+  alias Ecto.Changeset
   alias EthereumJSONRPC.Blocks
   alias Explorer.Chain
   alias Explorer.Chain.Hash
@@ -117,6 +118,16 @@ defmodule Indexer.Block.Uncle.Fetcher do
          }) do
       {:ok, _} ->
         retry(errors)
+
+      {:error, {:import = step, [%Changeset{} | _] = changesets}} ->
+        Logger.error(fn -> ["Failed to validate: ", inspect(changesets)] end, step: step)
+
+        {:retry, original_entries}
+
+      {:error, {:import = step, reason}} ->
+        Logger.error(fn -> inspect(reason) end, step: step)
+
+        {:retry, original_entries}
 
       {:error, step, failed_value, _changes_so_far} ->
         Logger.error(fn -> ["failed to import: ", inspect(failed_value)] end,


### PR DESCRIPTION
Resolves #1251

## Before

```
2018-12-17T14:52:29.991 application=db_connection [error] Postgrex.Protocol (#PID<0.994.0>) disconnected: ** (DBConnection.ConnectionError) client #PID<0.2264.0> timed out because it queued and checked out the connection for longer than 120000ms
2018-12-17T14:52:30.023 application=explorer fetcher=block_catchup first_block_number=6905195 last_block_number=6905191 [error] Could not insert all of chunk into Elixir.Explorer.Chain.Address.TokenBalance using options because of error.

Chunk:

[...]

Options:

[...]

Exception:

** (DBConnection.ConnectionError) tcp recv: closed (the connection was closed by the pool, possibly due to a timeout or because the pool has been terminated)
2018-12-17T14:52:30.026 application=indexer fetcher=block_catchup first_block_number=6905195 last_block_number=6905191 [error] ** (DBConnection.ConnectionError) tcp recv: closed (the connection was closed by the pool, possibly due to a timeout or because the pool has been terminated)
    (explorer) lib/explorer/repo.ex:76: anonymous fn/5 in Explorer.Repo.safe_insert_all/3
    (elixir) lib/enum.ex:1925: Enum."-reduce/3-lists^foldl/2-0-"/3
    (explorer) lib/explorer/chain/import.ex:301: Explorer.Chain.Import.insert_changes_list/3
    (explorer) lib/explorer/chain/import/runner/address/token_balances.ex:66: Explorer.Chain.Import.Runner.Address.TokenBalances.insert/3
    (ecto) lib/ecto/multi.ex:580: Ecto.Multi.apply_operation/5
    (elixir) lib/enum.ex:1925: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto) lib/ecto/multi.ex:564: anonymous fn/5 in Ecto.Multi.apply_operations/5
    (ecto_sql) lib/ecto/adapters/sql.ex:798: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
    (db_connection) lib/db_connection.ex:1349: DBConnection.run_transaction/4
    (ecto) lib/ecto/repo/transaction.ex:16: Ecto.Repo.Transaction.transaction/3
    (stdlib) timer.erl:197: :timer.tc/3
    (explorer) lib/explorer/repo.ex:21: anonymous fn/2 in Explorer.Repo.logged_transaction/2
    (explorer) lib/explorer/logger.ex:14: Explorer.Logger.metadata/2
    (explorer) lib/explorer/chain/import.ex:332: anonymous fn/3 in Explorer.Chain.Import.import_transactions/2
    (elixir) lib/enum.ex:3281: Enumerable.List.reduce/3
    (elixir) lib/enum.ex:1968: Enum.reduce_while/3
    (explorer) lib/explorer/logger.ex:14: Explorer.Logger.metadata/2
    (explorer) lib/explorer/chain/import.ex:124: Explorer.Chain.Import.all/1
    (indexer) lib/indexer/block/catchup/fetcher.ex:120: Indexer.Block.Catchup.Fetcher.import/2
    (indexer) lib/indexer/block/fetcher.ex:134: Indexer.Block.Fetcher.fetch_and_import_range/2


Retrying
```

## After

```
2018-12-18T09:17:43.078 application=db_connection [error] Postgrex.Protocol (#PID<0.1013.0>) disconnected: ** (DBConnection.ConnectionError) client #PID<0.2851.0> timed out because it queued and checked out the connection for longer than 120000ms
2018-12-18T09:17:43.419 application=explorer fetcher=block_catchup first_block_number=6909638 last_block_number=6909634 [error] Could not insert all of chunk into Elixir.Explorer.Chain.Transaction using options because of error.

Chunk Size: 237
Chunk:

[....]

Options:

[...]

Exception:

** (DBConnection.ConnectionError) tcp recv: closed (the connection was closed by the pool, possibly due to a timeout or because the pool has been terminated)
    (ecto_sql) lib/ecto/adapters/sql.ex:604: Ecto.Adapters.SQL.raise_sql_call_error/1
    (ecto_sql) lib/ecto/adapters/sql.ex:513: Ecto.Adapters.SQL.insert_all/8
    (ecto) lib/ecto/repo/schema.ex:56: Ecto.Repo.Schema.do_insert_all/6
    (explorer) lib/explorer/repo.ex:45: anonymous fn/5 in Explorer.Repo.safe_insert_all/3
    (elixir) lib/enum.ex:1925: Enum."-reduce/3-lists^foldl/2-0-"/3
    (explorer) lib/explorer/chain/import.ex:301: Explorer.Chain.Import.insert_changes_list/3
    (explorer) lib/explorer/chain/import/runner/transactions.ex:64: Explorer.Chain.Import.Runner.Transactions.insert/3
    (ecto) lib/ecto/multi.ex:580: Ecto.Multi.apply_operation/5
    (elixir) lib/enum.ex:1925: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto) lib/ecto/multi.ex:564: anonymous fn/5 in Ecto.Multi.apply_operations/5
    (ecto_sql) lib/ecto/adapters/sql.ex:798: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
    (db_connection) lib/db_connection.ex:1349: DBConnection.run_transaction/4
    (ecto) lib/ecto/repo/transaction.ex:16: Ecto.Repo.Transaction.transaction/3
    (stdlib) timer.erl:197: :timer.tc/3
    (explorer) lib/explorer/repo.ex:21: anonymous fn/2 in Explorer.Repo.logged_transaction/2
    (explorer) lib/explorer/logger.ex:14: Explorer.Logger.metadata/2
    (explorer) lib/explorer/chain/import.ex:332: anonymous fn/3 in Explorer.Chain.Import.import_transactions/2
    (elixir) lib/enum.ex:3281: Enumerable.List.reduce/3
    (elixir) lib/enum.ex:1968: Enum.reduce_while/3
    (explorer) lib/explorer/chain/import.ex:331: Explorer.Chain.Import.import_transactions/2

2018-12-18T09:17:43.424 application=indexer fetcher=block_catchup first_block_number=6909638 last_block_number=6909634 step=import [error] :timeout. Retrying.
```

## Changelog

### Enhancements
* Convert `DBConnection.ConnectionError` `tcp recv: closed` to `{:error, :timeout}`
* Add Chunk Size to `Explorer.Repo.safe_insert_all` log message as we often want some idea of how much data was being inserted to gauge if batch size needs to be adjusted.

### Bug Fixes
* Stacktrace is included in `Explorer.Repo.safe_insert_all` error now so the stacktrace is not split from the rest of the information as that could allow other messages to be interleaved.