### PR TITLE
Only query for coin balance when channel connected

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -95,10 +95,8 @@ defmodule BlockScoutWeb.Notifier do
   def handle_event(_), do: nil
 
   defp broadcast_address_coin_balance(%{address_hash: address_hash, block_number: block_number}) do
-    coin_balance = Chain.get_coin_balance(address_hash, block_number)
-
     Endpoint.broadcast("addresses:#{address_hash}", "coin_balance", %{
-      coin_balance: coin_balance
+      block_number: block_number
     })
   end
 


### PR DESCRIPTION
## Changelog

### Bug Fixes
* Normally, it is good idea to only query the database once no matter the number of sockets for a channel, but most addresses don't have listeners, so it is cheaper to not query unless the channel is in use.

  If we start to see popular addresses, [con_cache](https://hex.pm/packages/con_cache) can be used to only do the query once across all connected sockets for the same address.