### PR TITLE
Don't use step variable twice

### DIFF
--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -149,7 +149,7 @@ defmodule Indexer.Block.Fetcher do
       {:ok, %{inserted: inserted, errors: blocks_errors ++ beneficiaries_errors}}
     else
       {step, {:error, reason}} -> {:error, {step, reason}}
-      {step, {:error, step, failed_value, changes_so_far}} -> {:error, {step, failed_value, changes_so_far}}
+      {:import, {:error, step, failed_value, changes_so_far}} -> {:error, {step, failed_value, changes_so_far}}
     end
   end
 


### PR DESCRIPTION
## Changelog
### Bug Fixes
* Accidentally used `step` variable twice when the actual error is like `{:import, {:error, import_step, ..., ...}` which would only allow `{:import, {:error, :import, ..., ...}`.