### PR TITLE
Include import_id and transaction_id in logger metadata

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -50,7 +50,7 @@ config :logger, :block_scout_web,
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count shrunk)a,
+       block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :block_scout_web]
 
 config :spandex_phoenix, tracer: BlockScoutWeb.Tracer

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -19,7 +19,7 @@ config :logger, :ethereum_jsonrpc,
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count shrunk)a,
+       block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :ethereum_jsonrpc]
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -58,7 +58,7 @@ config :logger, :explorer,
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count shrunk)a,
+       block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :explorer]
 
 config :spandex_ecto, SpandexEcto.EctoLogger,

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -21,7 +21,7 @@ config :logger, :indexer,
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count shrunk)a,
+       block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :indexer]
 
 # Import environment specific config. This must remain at the bottom

--- a/config/config.exs
+++ b/config/config.exs
@@ -34,14 +34,14 @@ config :logger, :console,
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count shrunk)a
+       block_number step count error_count shrunk import_id transaction_id)a
 
 config :logger, :ecto,
   # Use same format for all loggers, even though the level should only ever be `:error` for `:error` backend
   format: "$dateT$time $metadata[$level] $message\n",
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count shrunk)a,
+       block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :ecto]
 
 config :logger, :error,
@@ -50,7 +50,7 @@ config :logger, :error,
   level: :error,
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count shrunk)a
+       block_number step count error_count shrunk import_id transaction_id)a
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.


### PR DESCRIPTION


## Changelog
### Bug Fixes
* When `import_id` and `transaction_id` was added in `Logger` calls in #1242, they were not added to the `:metadata` allowed to be shown and so weren't appearing in the logs.

   You can use the `import_id` key to see all DB transactions and queries used in one `Explorer.Chain.import` call.   This allows to calculate the elapsed time and how much each query is taking of that time.