### PR TITLE
Increase DB transaction timeout to account for Eth Mainnet performance

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/channels/address_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/address_channel_test.exs
@@ -17,7 +17,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
     Notifier.handle_event({:chain_event, :addresses, :realtime, [address]})
 
-    assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "count", payload: %{count: _}}, 5_000
+    assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "count", payload: %{count: _}}, :timer.seconds(5)
   end
 
   describe "user subscribed to address" do
@@ -36,7 +36,9 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
       Notifier.handle_event({:chain_event, :addresses, :realtime, [address_with_balance]})
 
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "balance_update", payload: payload}, 5_000
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "balance_update", payload: payload},
+                     :timer.seconds(5)
+
       assert payload.address.hash == address_with_balance.hash
     end
 
@@ -54,7 +56,9 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
       Notifier.handle_event({:chain_event, :transactions, :realtime, [pending.hash]})
 
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "pending_transaction", payload: payload}, 5_000
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "pending_transaction", payload: payload},
+                     :timer.seconds(5)
+
       assert payload.address.hash == address.hash
       assert payload.transaction.hash == pending.hash
     end
@@ -67,7 +71,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
       Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction.hash]})
 
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload}, 5_000
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload}, :timer.seconds(5)
       assert payload.address.hash == address.hash
       assert payload.transaction.hash == transaction.hash
     end
@@ -80,7 +84,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
       Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction.hash]})
 
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload}, 5_000
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload}, :timer.seconds(5)
       assert payload.address.hash == address.hash
       assert payload.transaction.hash == transaction.hash
     end
@@ -93,7 +97,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
       Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction.hash]})
 
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload}, 5_000
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload}, :timer.seconds(5)
       assert payload.address.hash == address.hash
       assert payload.transaction.hash == transaction.hash
 
@@ -118,7 +122,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
                          internal_transaction: %{transaction_hash: transaction_hash, index: index}
                        }
                      },
-                     5_000
+                     :timer.seconds(5)
 
       assert address_hash == address.hash
       assert {transaction_hash, index} == {internal_transaction.transaction_hash, internal_transaction.index}
@@ -142,7 +146,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
                          internal_transaction: %{transaction_hash: transaction_hash, index: index}
                        }
                      },
-                     5_000
+                     :timer.seconds(5)
 
       assert address_hash == address.hash
       assert {transaction_hash, index} == {internal_transaction.transaction_hash, internal_transaction.index}
@@ -170,7 +174,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
                          internal_transaction: %{transaction_hash: transaction_hash, index: index}
                        }
                      },
-                     5_000
+                     :timer.seconds(5)
 
       assert address_hash == address.hash
       assert {transaction_hash, index} == {internal_transaction.transaction_hash, internal_transaction.index}

--- a/apps/block_scout_web/test/block_scout_web/channels/block_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/block_channel_test.exs
@@ -15,7 +15,7 @@ defmodule BlockScoutWeb.BlockChannelTest do
       %Phoenix.Socket.Broadcast{topic: ^topic, event: "new_block", payload: %{block: _}} ->
         assert true
     after
-      5_000 ->
+      :timer.seconds(5) ->
         assert false, "Expected message received nothing."
     end
   end
@@ -30,7 +30,7 @@ defmodule BlockScoutWeb.BlockChannelTest do
       %Phoenix.Socket.Broadcast{topic: ^topic, event: "index_status", payload: %{}} ->
         assert true
     after
-      5_000 ->
+      :timer.seconds(5) ->
         assert false, "Expected message received nothing."
     end
   end

--- a/apps/block_scout_web/test/block_scout_web/channels/exchange_rate_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/exchange_rate_channel_test.exs
@@ -52,7 +52,7 @@ defmodule BlockScoutWeb.ExchangeRateChannelTest do
           assert payload.exchange_rate == token
           assert payload.market_history_data == []
       after
-        5_000 ->
+        :timer.seconds(5) ->
           assert false, "Expected message received nothing."
       end
     end
@@ -84,7 +84,7 @@ defmodule BlockScoutWeb.ExchangeRateChannelTest do
           assert payload.exchange_rate == token
           assert payload.market_history_data == records
       after
-        5_000 ->
+        :timer.seconds(5) ->
           assert false, "Expected message received nothing."
       end
     end

--- a/apps/block_scout_web/test/block_scout_web/channels/transaction_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/transaction_channel_test.exs
@@ -19,7 +19,7 @@ defmodule BlockScoutWeb.TransactionChannelTest do
       %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload} ->
         assert payload.transaction.hash == transaction.hash
     after
-      5_000 ->
+      :timer.seconds(5) ->
         assert false, "Expected message received nothing."
     end
   end
@@ -36,7 +36,7 @@ defmodule BlockScoutWeb.TransactionChannelTest do
       %Phoenix.Socket.Broadcast{topic: ^topic, event: "pending_transaction", payload: payload} ->
         assert payload.transaction.hash == pending.hash
     after
-      5_000 ->
+      :timer.seconds(5) ->
         assert false, "Expected message received nothing."
     end
   end
@@ -56,7 +56,7 @@ defmodule BlockScoutWeb.TransactionChannelTest do
       %Phoenix.Socket.Broadcast{topic: ^topic, event: "collated", payload: %{}} ->
         assert true
     after
-      5_000 ->
+      :timer.seconds(5) ->
         assert false, "Expected message received nothing."
     end
   end

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -21,7 +21,7 @@ config :explorer, Explorer.Counters.BlockValidationCounter, enabled: true, enabl
 
 config :explorer, Explorer.ExchangeRates, enabled: true, store: :ets
 
-config :explorer, Explorer.Integrations.EctoLogger, query_time_ms_threshold: 2_000
+config :explorer, Explorer.Integrations.EctoLogger, query_time_ms_threshold: :timer.seconds(2)
 
 config :explorer, Explorer.Market.History.Cataloger, enabled: true
 

--- a/apps/explorer/config/dev.exs
+++ b/apps/explorer/config/dev.exs
@@ -5,7 +5,7 @@ config :explorer, Explorer.Repo,
   database: "explorer_dev",
   hostname: "localhost",
   pool_size: 20,
-  timeout: 80_000
+  timeout: :timer.seconds(80)
 
 config :explorer, Explorer.Tracer, env: "dev", disabled?: true
 

--- a/apps/explorer/config/dev/ganache.exs
+++ b/apps/explorer/config/dev/ganache.exs
@@ -6,7 +6,7 @@ config :explorer,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:7545",
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Ganache
   ],

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -6,7 +6,7 @@ config :explorer,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth
   ],

--- a/apps/explorer/config/dev/parity.exs
+++ b/apps/explorer/config/dev/parity.exs
@@ -11,7 +11,7 @@ config :explorer,
         eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Parity
   ],

--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -6,7 +6,7 @@ config :explorer, Explorer.Repo,
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
   ssl: String.equivalent?(System.get_env("ECTO_USE_SSL") || "true", "true"),
   prepare: :unnamed,
-  timeout: 60_000
+  timeout: :timer.seconds(60)
 
 config :explorer, Explorer.Tracer, env: "production", disabled?: true
 

--- a/apps/explorer/config/prod/ganache.exs
+++ b/apps/explorer/config/prod/ganache.exs
@@ -6,7 +6,7 @@ config :explorer,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:7545",
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Ganache
   ],

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -6,7 +6,7 @@ config :explorer,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth
   ],

--- a/apps/explorer/config/prod/parity.exs
+++ b/apps/explorer/config/prod/parity.exs
@@ -11,7 +11,7 @@ config :explorer,
         eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Parity
   ],

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -9,7 +9,7 @@ config :explorer, Explorer.Repo,
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox,
   # Default of `5_000` was too low for `BlockFetcher` test
-  ownership_timeout: 60_000
+  ownership_timeout: :timer.minutes(1)
 
 config :explorer, Explorer.ExchangeRates, enabled: false, store: :ets
 

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -60,7 +60,7 @@ defmodule Explorer.Chain.Import do
   @type timestamps :: %{inserted_at: DateTime.t(), updated_at: DateTime.t()}
 
   # milliseconds
-  @transaction_timeout 240_000
+  @transaction_timeout :timer.minutes(4)
 
   @imported_table_rows @runners
                        |> Stream.map(&Map.put(&1.imported_table_row(), :key, &1.option_key()))

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -60,7 +60,7 @@ defmodule Explorer.Chain.Import do
   @type timestamps :: %{inserted_at: DateTime.t(), updated_at: DateTime.t()}
 
   # milliseconds
-  @transaction_timeout 120_000
+  @transaction_timeout 240_000
 
   @imported_table_rows @runners
                        |> Stream.map(&Map.put(&1.imported_table_row(), :key, &1.option_key()))

--- a/apps/indexer/config/dev/ganache.exs
+++ b/apps/indexer/config/dev/ganache.exs
@@ -1,13 +1,13 @@
 use Mix.Config
 
 config :indexer,
-  block_interval: 5_000,
+  block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:7545",
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Ganache
   ],

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -1,13 +1,13 @@
 use Mix.Config
 
 config :indexer,
-  block_interval: 5_000,
+  block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth
   ],

--- a/apps/indexer/config/dev/parity.exs
+++ b/apps/indexer/config/dev/parity.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :indexer,
-  block_interval: 5_000,
+  block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
@@ -12,7 +12,7 @@ config :indexer,
         trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Parity
   ],

--- a/apps/indexer/config/prod/ganache.exs
+++ b/apps/indexer/config/prod/ganache.exs
@@ -1,13 +1,13 @@
 use Mix.Config
 
 config :indexer,
-  block_interval: 5_000,
+  block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:7545",
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Ganache
   ],

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -1,13 +1,13 @@
 use Mix.Config
 
 config :indexer,
-  block_interval: 5_000,
+  block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth
   ],

--- a/apps/indexer/config/prod/parity.exs
+++ b/apps/indexer/config/prod/parity.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :indexer,
-  block_interval: 5_000,
+  block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
@@ -12,7 +12,7 @@ config :indexer,
         trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
-      http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Parity
   ],

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -611,7 +611,7 @@ defmodule Indexer.Block.FetcherTest do
   end
 
   defp wait_for_tasks(buffered_task) do
-    wait_until(10_000, fn ->
+    wait_until(:timer.seconds(10), fn ->
       counts = BufferedTask.debug_count(buffered_task)
       counts.buffer == 0 and counts.tasks == 0
     end)

--- a/apps/indexer/test/indexer/sequence_test.exs
+++ b/apps/indexer/test/indexer/sequence_test.exs
@@ -16,7 +16,7 @@ defmodule Indexer.SequenceTest do
       {child_pid, child_ref} =
         spawn_monitor(fn ->
           Sequence.start_link(first: 1, step: -1)
-          Process.sleep(5_000)
+          Process.sleep(:timer.seconds(5))
         end)
 
       assert_receive {:DOWN, ^child_ref, :process, ^child_pid,
@@ -27,7 +27,7 @@ defmodule Indexer.SequenceTest do
       {child_pid, child_ref} =
         spawn_monitor(fn ->
           Sequence.start_link(step: -1)
-          Process.sleep(5_000)
+          Process.sleep(:timer.seconds(5))
         end)
 
       assert_receive {:DOWN, ^child_ref, :process, ^child_pid, "either :ranges or :first must be set"}
@@ -47,7 +47,7 @@ defmodule Indexer.SequenceTest do
       {child_pid, child_ref} =
         spawn_monitor(fn ->
           Sequence.start_link(ranges: [1..0], first: 1, step: -1)
-          Process.sleep(5_000)
+          Process.sleep(:timer.seconds(5))
         end)
 
       assert_receive {:DOWN, ^child_ref, :process, ^child_pid,


### PR DESCRIPTION
## Changelog

### Enhancements
* Use `:timer` functions to make timeout values clearer

### Bug Fixes
*  Increase DB transaction timeout to 4 minutes.  This prevents DB timeouts against Eth Mainnet for stretches of 20 minutes when testing with block concurrency of 5 and block batch size of 5 while production is simultaneously running at 12x12.