### PR TITLE
feat: restart on heartbeat timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ _Additional runtime options:_
 *  Run Phoenix Server with real time indexer
 `iex -S mix phx.server`
 
+### Automating Restarts
+
+By default `blockscout` does not restart if it crashes. To enable automated
+restarts, set the environment variable `HEART_COMMAND` to whatever you run to
+start `blockscout`. You can configure the heart beat timeout, which will change
+how long it will wait before considering the application to be unresponsive. At
+that point, it will kill the current blockscout and execute `HEART_COMMAND`.
+By default a crash dump is not written unless you set `ERL_CRASH_DUMP_SECONDS`
+to a positive or negative integer. See the documentation for
+[heart](http://erlang.org/doc/man/heart.html) for more information.
+
 ### BlockScout Visual Interface
 
 ![BlockScout Example](explorer_example.gif)

--- a/rel/vm.args
+++ b/rel/vm.args
@@ -10,7 +10,7 @@
 
 ## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
 ## (Disabled by default..use with caution!)
-##-heart
+-heart
 
 ## Enable kernel poll and a few async threads
 ##+K true


### PR DESCRIPTION
## Motivation

This will keep the explorer running in the case that the entire system crashes.

## Changelog

### Enhancements
Enable the `-heart` option.

## Upgrading

In order for `-heart` to do anything at all, an environment variable called `HEART_COMMAND` must be set. Additional environment variables can be set to configure its behavior, all of which are documented here: http://erlang.org/doc/man/heart.html


Questions:

Do we want to configure any of these by default? We might just want to make it entirely opt in behavior. Many systems rely on letting machines crash (for instance docker/kubernetes based architectures), so adding something like `-heart` would be an unwelcome change to those kinds of architectures.
