### PR TITLE
Allow block numbers to exceed missing block search range by > 1

### DIFF
--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2191,6 +2191,117 @@ defmodule Explorer.ChainTest do
     end
   end
 
+  describe "missing_block_number_ranges/1" do
+    # 0000
+    test "0..0 without blocks" do
+      assert Chain.missing_block_number_ranges(0..0) == [0..0]
+    end
+
+    # 0001
+    test "0..0 with block 3" do
+      insert(:block, number: 3)
+
+      assert Chain.missing_block_number_ranges(0..0) == [0..0]
+    end
+
+    # 0010
+    test "0..0 with block 2" do
+      insert(:block, number: 2)
+
+      assert Chain.missing_block_number_ranges(0..0) == [0..0]
+    end
+
+    # 0011
+    test "0..0 with blocks 2,3" do
+      Enum.each([2, 3], &insert(:block, number: &1))
+
+      assert Chain.missing_block_number_ranges(0..0) == [0..0]
+    end
+
+    # 0100
+    test "0..0 with block 1" do
+      insert(:block, number: 1)
+
+      assert Chain.missing_block_number_ranges(0..0) == [0..0]
+    end
+
+    # 0101
+    test "0..0 with blocks 1,3" do
+      Enum.each([1, 3], &insert(:block, number: &1))
+
+      assert Chain.missing_block_number_ranges(0..0) == [0..0]
+    end
+
+    # 0111
+    test "0..0 with blocks 1..3" do
+      Enum.each(1..3, &insert(:block, number: &1))
+
+      assert Chain.missing_block_number_ranges(0..0) == [0..0]
+    end
+
+    # 1000
+    test "0..0 with block 0" do
+      insert(:block, number: 0)
+
+      assert Chain.missing_block_number_ranges(0..0) == []
+    end
+
+    # 1001
+    test "0..0 with blocks 0,3" do
+      Enum.each([0, 3], &insert(:block, number: &1))
+
+      assert Chain.missing_block_number_ranges(0..0) == []
+    end
+
+    # 1010
+    test "0..0 with blocks 0,2" do
+      Enum.each([0, 2], &insert(:block, number: &1))
+
+      assert Chain.missing_block_number_ranges(0..0) == []
+    end
+
+    # 1011
+    test "0..0 with blocks 0,2,3" do
+      Enum.each([0, 2, 3], &insert(:block, number: &1))
+
+      assert Chain.missing_block_number_ranges(0..0) == []
+    end
+
+    # 1100
+    test "0..0 with blocks 0..1" do
+      Enum.each(0..1, &insert(:block, number: &1))
+
+      assert Chain.missing_block_number_ranges(0..0) == []
+    end
+
+    # 1101
+    test "0..0 with blocks 0,1,3" do
+      Enum.each([0, 1, 3], &insert(:block, number: &1))
+
+      assert Chain.missing_block_number_ranges(0..0) == []
+    end
+
+    # 1110
+    test "0..0 with blocks 0..2" do
+      Enum.each(0..2, &insert(:block, number: &1))
+
+      assert Chain.missing_block_number_ranges(0..0) == []
+    end
+
+    # 1111
+    test "0..0 with blocks 0..3" do
+      Enum.each(0..2, &insert(:block, number: &1))
+
+      assert Chain.missing_block_number_ranges(0..0) == []
+    end
+
+    test "0..2 with block 1" do
+      insert(:block, number: 1)
+
+      assert Chain.missing_block_number_ranges(0..2) == [0..0, 2..2]
+    end
+  end
+
   describe "recent_collated_transactions/1" do
     test "with no collated transactions it returns an empty list" do
       assert [] == Explorer.Chain.recent_collated_transactions()


### PR DESCRIPTION
Fixes #1266

## Changelog

### Enhancements
* Regression test for #1266

### Bug Fixes
* Allow block numbers to exceed missing block search range by > 1.

  #1266 was triggered when the recorded block number exceeded the reported max block number as can happen temporary when the node that gives the latest block number is farther behind than the node that gave the block data.

  The previous `Explorer.Chain.missing_block_number_ranges` query added in #1230 did not account for the max block number in the database exceeding the range max.  When this occurs, an errant range was produced by the #1230 query because it chose the greatest of the range and the max block when trying to find the end point for the gap search.

  The testing did not catch #1266 because the doctests only used block numbers that exceeded the search range, by 1 and the bug did not show up until it was 2 or more.

  The new query is split into 4 subqueries:
  1. missing prefix when range min < min(block.number)
  2. missing infix when the blocks aren't in the range at all
  3. missing suffix when max(block.number) < range max
  4. gaps between existent block numbers

  This version is also more efficient as there is only a single sort of the outer `UNION ALL` result instead of a sort of real blocks and fake end points for the range and the outer sort as seen below. 

  ![screen shot 2018-12-20 at 7 26 53 pm](https://user-images.githubusercontent.com/298259/50323936-d0bffe80-04a1-11e9-893f-379f50753046.png)

  It is able to move the `UNION ALL` up because it doesn't need to produce fake end cap blocks.  This positioning of the `UNION ALL` and `ORDER BY` on the outermost query allows for all 4 queries to use `one_consensus_block_at_height` index and either a limit (for `min`/`max`) or a window aggregate (for `lag`), which has minimal, single row cost.
  ![screen shot 2018-12-20 at 9 21 37 pm](https://user-images.githubusercontent.com/298259/50323923-b9811100-04a1-11e9-9165-db5ddf416138.png)

