### PR TITLE
feat: decoding candidates for calls to unverified contracts

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_decoded_input.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_decoded_input.html.eex
@@ -3,9 +3,9 @@
     <h1 class="card-title"><%= gettext "Input" %> </h1>
     <!-- Input -->
     <%= case @decoded_input_data do %>
-    <% {:error, :contract_not_verified} -> %>
-    <div class="alert alert-info">
-      <%= gettext "To see decoded input data, the contract must be verified." %>
+    <% {:error, :contract_not_verified, candidates} -> %>
+    <div class="alert alert-danger">
+      <%= gettext "To see accurate decoded input data, the contract must be verified." %>
       <%= case @transaction do %>
         <% %{to_address: %{hash: hash}} -> %>
           <%= gettext "Verify the contract " %><a href="<%= address_verify_contract_path(@conn, :new, hash)%>"><%= gettext "here" %></a>
@@ -13,57 +13,23 @@
           <%= nil %>
       <% end %>
     </div>
+    <%= unless Enum.empty?(candidates) do %>
+      <h3><%= gettext "Potential matches from our contract method database:" %></h3>
+      <%= gettext "IMPORTANT: This information is a best guess based on similar functions from other verified contracts." %>
+      <%= gettext "To have guaranteed accuracy, use the link above to verify the contract's source code." %>
+
+      <%= for {:ok, method_id, text, mapping} <- candidates do %>
+        <hr>
+
+        <%= render(BlockScoutWeb.TransactionView, "_decoded_input_body.html", method_id: method_id, text: text, mapping: mapping) %>
+      <% end %>
+    <% end %>
     <% {:ok, method_id, text, mapping} -> %>
-    <table summary="<%= gettext "Transaction Info" %>" class="table thead-light table-bordered table-responsive transaction-info-table">
-      <tr>
-        <td><%= gettext "Method Id" %></td>
-        <td colspan="3"><code>0x<%= method_id %></code></td>
-      </tr>
-      <tr>
-        <td>Call</td>
-        <td colspan="3"><code><%= text %></code></td>
-      </tr>
-    </table>
-
-    <table summary="<%= gettext "Transaction Inputs" %>" class="table thead-light table-bordered table-responsive">
-      <tr>
-        <th scope="col"></th>
-        <th scope="col"><%= gettext "Name" %></th>
-        <th scope="col"><%= gettext "Type" %></th>
-        <th scope="col"><%= gettext "Data" %></th>
-      <tr>
-        <%= for {name, type, value} <- mapping do %>
-            <tr>
-              <th scope="row">
-                <%= case BlockScoutWeb.ABIEncodedValueView.copy_text(type, value) do %>
-                  <% :error -> %>
-                    <%= nil %>
-                  <% copy_text -> %>
-                    <button type="button" class="copy icon-link" data-toggle="tooltip" data-placement="top" data-clipboard-text="<%= copy_text %>" aria-label="<%= gettext "Copy Value" %>">
-                      <i class="fas fa-clone"></i>
-                    </button>
-                 <% end %>
-              </th>
-              <td><%= name %></td>
-              <td><%= type %></td>
-              <td>
-                <%= case BlockScoutWeb.ABIEncodedValueView.value_html(type, value) do %>
-                  <% :error -> %>
-                    <div class="alert alert-danger">
-                      <%= gettext "Error rendering value" %>
-                    </div>
-                  <% value -> %>
-                    <pre class="transaction-input-text tile"><code><%= value %></code></pre>
-                <% end %>
-
-              </td>
-            </tr>
-            <% end %>
-    </table>
+      <%= render(BlockScoutWeb.TransactionView, "_decoded_input_body.html", method_id: method_id, text: text, mapping: mapping) %>
     <% _ -> %>
         <div class="alert alert-danger">
           <%= gettext "Failed to decode input data." %>
         </div>
-        <% end %>
+    <% end %>
   </div>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex
@@ -1,0 +1,47 @@
+<table summary="<%= gettext "Transaction Info" %>" class="table thead-light table-bordered table-responsive transaction-info-table">
+  <tr>
+  <td><%= gettext "Method Id" %></td>
+  <td colspan="3"><code>0x<%= @method_id %></code></td>
+  </tr>
+  <tr>
+  <td>Call</td>
+  <td colspan="3"><code><%= @text %></code></td>
+  </tr>
+</table>
+
+<%= unless Enum.empty?(@mapping) do %>
+  <table summary="<%= gettext "Transaction Inputs" %>" class="table thead-light table-bordered table-responsive">
+    <tr>
+    <th scope="col"></th>
+    <th scope="col"><%= gettext "Name" %></th>
+    <th scope="col"><%= gettext "Type" %></th>
+    <th scope="col"><%= gettext "Data" %></th>
+    <tr>
+    <%= for {name, type, value} <- @mapping do %>
+      <tr>
+        <th scope="row">
+          <%= case BlockScoutWeb.ABIEncodedValueView.copy_text(type, value) do %>
+            <% :error -> %>
+              <%= nil %>
+            <% copy_text -> %>
+              <button type="button" class="copy icon-link" data-toggle="tooltip" data-placement="top" data-clipboard-text="<%= copy_text %>" aria-label="<%= gettext "Copy Value" %>">
+                <i class="fas fa-clone"></i>
+              </button>
+          <% end %>
+        </th>
+        <td><%= name %></td>
+        <td><%= type %></td>
+        <td>
+          <%= case BlockScoutWeb.ABIEncodedValueView.value_html(type, value) do %>
+            <% :error -> %>
+              <div class="alert alert-danger">
+                <%= gettext "Error rendering value" %>
+              </div>
+            <% value -> %>
+              <pre class="transaction-input-text tile"><code><%= value %></code></pre>
+            <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -350,7 +350,7 @@ msgid "Curl"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:33
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:18
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:60
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:118
 msgid "Data"
@@ -586,7 +586,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:29
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:31
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:16
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:57
 msgid "Name"
 msgstr ""
@@ -1329,29 +1329,28 @@ msgid "Indexed?"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:32
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:58
 msgid "Type"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:19
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:3
 msgid "Method Id"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:8
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:31
 msgid "To see decoded input data, the contract must be verified."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:17
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:1
 msgid "Transaction Info"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:28
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:13
 msgid "Transaction Inputs"
 msgstr ""
 
@@ -1368,17 +1367,17 @@ msgid "here"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:65
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:31
 msgid "Failed to decode input data."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:53
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:38
 msgid "Error rendering value"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:42
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:27
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:69
 msgid "Copy Value"
 msgstr ""
@@ -1514,6 +1513,26 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/views/block_view.ex:64
 msgid "Uncle Reward"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:18
+msgid "IMPORTANT: This information is a best guess based on similar functions from other verified contracts."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:17
+msgid "Potential matches from our contract method database:"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:19
+msgid "To have guaranteed accuracy, use the link above to verify the contract's source code."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:8
+msgid "To see accurate decoded input data, the contract must be verified."
 msgstr ""
 
 #, elixir-format

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -350,7 +350,7 @@ msgid "Curl"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:33
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:18
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:60
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:118
 msgid "Data"
@@ -586,7 +586,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:29
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:31
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:16
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:57
 msgid "Name"
 msgstr ""
@@ -1329,29 +1329,28 @@ msgid "Indexed?"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:32
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:58
 msgid "Type"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:19
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:3
 msgid "Method Id"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:8
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:31
 msgid "To see decoded input data, the contract must be verified."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:17
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:1
 msgid "Transaction Info"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:28
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:13
 msgid "Transaction Inputs"
 msgstr ""
 
@@ -1368,17 +1367,17 @@ msgid "here"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:65
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:31
 msgid "Failed to decode input data."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:53
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:38
 msgid "Error rendering value"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:42
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:27
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:69
 msgid "Copy Value"
 msgstr ""
@@ -1514,6 +1513,26 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/views/block_view.ex:64
 msgid "Uncle Reward"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:18
+msgid "IMPORTANT: This information is a best guess based on similar functions from other verified contracts."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:17
+msgid "Potential matches from our contract method database:"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:19
+msgid "To have guaranteed accuracy, use the link above to verify the contract's source code."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:8
+msgid "To see accurate decoded input data, the contract must be verified."
 msgstr ""
 
 #, elixir-format

--- a/apps/explorer/lib/explorer/chain/contract_method.ex
+++ b/apps/explorer/lib/explorer/chain/contract_method.ex
@@ -1,0 +1,74 @@
+defmodule Explorer.Chain.ContractMethod do
+  @moduledoc """
+  The representation of an individual item from the ABI of a verified smart contract.
+  """
+
+  require Logger
+
+  use Explorer.Schema
+
+  alias Explorer.Chain.{Hash, MethodIdentifier}
+  alias Explorer.Repo
+
+  @type t :: %__MODULE__{
+          identifier: MethodIdentifier.t(),
+          abi: map(),
+          type: String.t()
+        }
+
+  schema "contract_methods" do
+    field(:identifier, MethodIdentifier)
+    field(:abi, :map)
+    field(:type, :string)
+
+    timestamps()
+  end
+
+  def upsert_from_abi(abi, address_hash) do
+    {successes, errors} =
+      abi
+      |> Enum.reject(fn selector ->
+        Map.get(selector, "type") in ["fallback", "constructor"]
+      end)
+      |> Enum.reduce({[], []}, fn selector, {successes, failures} ->
+        case abi_element_to_contract_method(selector) do
+          {:error, message} ->
+            {successes, [message | failures]}
+
+          selector ->
+            {[selector | successes], failures}
+        end
+      end)
+
+    unless Enum.empty?(errors) do
+      Logger.error(fn ->
+        ["Error parsing some abi elements at ", Hash.to_iodata(address_hash), ": ", Enum.intersperse(errors, "\n")]
+      end)
+    end
+
+    Repo.insert_all(__MODULE__, successes, on_conflict: :nothing, conflict_target: [:identifier, :abi])
+  end
+
+  defp abi_element_to_contract_method(element) do
+    case ABI.parse_specification([element], include_events?: true) do
+      [selector] ->
+        now = DateTime.utc_now()
+
+        %{
+          identifier: selector.method_id,
+          abi: element,
+          type: Atom.to_string(selector.type),
+          inserted_at: now,
+          updated_at: now
+        }
+
+      _ ->
+        {:error, "Failed to parse abi row."}
+    end
+  rescue
+    e ->
+      message = Exception.format(:error, e)
+
+      {:error, message}
+  end
+end

--- a/apps/explorer/lib/explorer/chain/method_identifier.ex
+++ b/apps/explorer/lib/explorer/chain/method_identifier.ex
@@ -1,0 +1,38 @@
+defmodule Explorer.Chain.MethodIdentifier do
+  @moduledoc """
+  The first four bytes of the [KECCAK-256](https://en.wikipedia.org/wiki/SHA-3) hash of a contract method or event.
+
+  Represented in the database as a 4 byte integer, decodes into a 4 byte bitstring
+  """
+
+  @behaviour Ecto.Type
+
+  @type t :: binary
+
+  defguard one_byte(value) when 0 <= value and value <= 255
+
+  @impl true
+  def type, do: :integer
+
+  @impl true
+  @spec load(integer) :: {:ok, t()}
+  def load(value) do
+    {:ok, <<value::integer-signed-32>>}
+  end
+
+  @impl true
+  @spec cast(binary) :: {:ok, t()} | :error
+  def cast(<<_::binary-size(4)>> = identifier) do
+    {:ok, identifier}
+  end
+
+  def cast(_), do: :error
+
+  @impl true
+  @spec dump(t()) :: {:ok, integer} | :error
+  def dump(<<num::integer-signed-32>>) do
+    {:ok, num}
+  end
+
+  def dump(_), do: :error
+end

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -8,9 +8,11 @@ defmodule Explorer.Chain.SmartContract do
   http://solidity.readthedocs.io/en/v0.4.24/introduction-to-smart-contracts.html
   """
 
-  alias Explorer.Chain.{Address, Hash}
+  require Logger
 
   use Explorer.Schema
+
+  alias Explorer.Chain.{Address, ContractMethod, Hash}
 
   @type t :: %Explorer.Chain.SmartContract{
           name: String.t(),
@@ -43,6 +45,7 @@ defmodule Explorer.Chain.SmartContract do
     |> cast(attrs, [:name, :compiler_version, :optimization, :contract_source_code, :address_hash, :abi])
     |> validate_required([:name, :compiler_version, :optimization, :contract_source_code, :abi, :address_hash])
     |> unique_constraint(:address_hash)
+    |> prepare_changes(&upsert_contract_methods/1)
   end
 
   def invalid_contract_changeset(%__MODULE__{} = smart_contract, attrs, error) do
@@ -51,6 +54,21 @@ defmodule Explorer.Chain.SmartContract do
     |> validate_required([:name, :compiler_version, :optimization, :address_hash])
     |> add_error(:contract_source_code, error_message(error))
   end
+
+  defp upsert_contract_methods(%Ecto.Changeset{changes: %{abi: abi}} = changeset) do
+    ContractMethod.upsert_from_abi(abi, get_field(changeset, :address_hash))
+
+    changeset
+  rescue
+    exception ->
+      message = Exception.format(:error, exception, __STACKTRACE__)
+
+      Logger.error(fn -> ["Error while upserting contract methods: ", message] end)
+
+      changeset
+  end
+
+  defp upsert_contract_methods(changeset), do: changeset
 
   defp error_message(:compilation), do: "There was an error compiling your contract."
   defp error_message(:generated_bytecode), do: "Bytecode does not match, please try again."

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -14,6 +14,7 @@ defmodule Explorer.Chain.Transaction do
   alias Explorer.Chain.{
     Address,
     Block,
+    ContractMethod,
     Data,
     Gas,
     Hash,
@@ -25,6 +26,8 @@ defmodule Explorer.Chain.Transaction do
   }
 
   alias Explorer.Chain.Transaction.{Fork, Status}
+
+  alias Explorer.Repo
 
   @optional_attrs ~w(block_hash block_number created_contract_address_hash cumulative_gas_used error gas_used index
                      internal_transactions_indexed_at status to_address_hash)a
@@ -423,9 +426,40 @@ defmodule Explorer.Chain.Transaction do
   def decoded_input_data(%__MODULE__{to_address: nil}), do: {:error, :no_to_address}
   def decoded_input_data(%__MODULE__{input: %{bytes: bytes}}) when bytes in [nil, <<>>], do: {:error, :no_input_data}
   def decoded_input_data(%__MODULE__{to_address: %{contract_code: nil}}), do: {:error, :not_a_contract_call}
-  def decoded_input_data(%__MODULE__{to_address: %{smart_contract: nil}}), do: {:error, :contract_not_verified}
+
+  def decoded_input_data(%__MODULE__{
+        to_address: %{smart_contract: nil},
+        input: %{bytes: <<method_id::binary-size(4), _::binary>> = data},
+        hash: hash
+      }) do
+    candidates_query =
+      from(
+        contract_method in ContractMethod,
+        where: contract_method.identifier == ^method_id
+      )
+
+    candidates =
+      candidates_query
+      |> Repo.all()
+      |> Enum.flat_map(fn candidate ->
+        case do_decoded_input_data(data, [candidate.abi], hash) do
+          {:ok, _, _, _} = decoded -> [decoded]
+          _ -> []
+        end
+      end)
+
+    {:error, :contract_not_verified, candidates}
+  end
+
+  def decoded_input_data(%__MODULE__{to_address: %{smart_contract: nil}}) do
+    {:error, :contract_not_verified, []}
+  end
 
   def decoded_input_data(%__MODULE__{input: %{bytes: data}, to_address: %{smart_contract: %{abi: abi}}, hash: hash}) do
+    do_decoded_input_data(data, abi, hash)
+  end
+
+  defp do_decoded_input_data(data, abi, hash) do
     with {:ok, {selector, values}} <- find_and_decode(abi, data, hash),
          {:ok, mapping} <- selector_mapping(selector, values, hash),
          identifier <- Base.encode16(selector.method_id, case: :lower),

--- a/apps/explorer/priv/repo/migrations/20181221145054_add_contract_methods.exs
+++ b/apps/explorer/priv/repo/migrations/20181221145054_add_contract_methods.exs
@@ -1,0 +1,15 @@
+defmodule Explorer.Repo.Migrations.AddContractMethods do
+  use Ecto.Migration
+
+  def change do
+    create table(:contract_methods) do
+      add(:identifier, :integer, null: false)
+      add(:abi, :map, null: false)
+      add(:type, :string, null: false)
+
+      timestamps()
+    end
+
+    create(unique_index(:contract_methods, [:identifier, :abi]))
+  end
+end

--- a/apps/explorer/test/explorer/smart_contract/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/publisher_test.exs
@@ -5,9 +5,9 @@ defmodule Explorer.SmartContract.PublisherTest do
 
   doctest Explorer.SmartContract.Publisher
 
-  alias Explorer.Chain.SmartContract
+  alias Explorer.Chain.{ContractMethod, SmartContract}
+  alias Explorer.{Factory, Repo}
   alias Explorer.SmartContract.Publisher
-  alias Explorer.Factory
 
   describe "publish/2" do
     test "with valid data creates a smart_contract" do
@@ -30,7 +30,29 @@ defmodule Explorer.SmartContract.PublisherTest do
       assert smart_contract.compiler_version == valid_attrs["compiler_version"]
       assert smart_contract.optimization == valid_attrs["optimization"]
       assert smart_contract.contract_source_code == valid_attrs["contract_source_code"]
-      assert smart_contract.abi != nil
+      assert smart_contract.abi == contract_code_info.abi
+    end
+
+    test "corresponding contract_methods are created for the abi" do
+      contract_code_info = Factory.contract_code_info()
+
+      contract_address = insert(:contract_address, contract_code: contract_code_info.bytecode)
+
+      valid_attrs = %{
+        "contract_source_code" => contract_code_info.source_code,
+        "compiler_version" => contract_code_info.version,
+        "name" => contract_code_info.name,
+        "optimization" => contract_code_info.optimized
+      }
+
+      response = Publisher.publish(contract_address.hash, valid_attrs)
+      assert {:ok, %SmartContract{} = smart_contract} = response
+
+      Enum.each(contract_code_info.abi, fn selector ->
+        [parsed] = ABI.parse_specification([selector])
+
+        assert Repo.get_by(ContractMethod, abi: selector, identifier: parsed.method_id)
+      end)
     end
 
     test "with invalid data returns error changeset" do


### PR DESCRIPTION
## Motivation

We'd like to display potential candidates for transaction input decoding. This will mostly help with very common functions that exist on many different contracts. If we find a match by method_id, and can successfully use it to decode the transaction input, we display it in a list of potential transaction input tables.

## Changelog

### Enhancements
* Add decoding candidates for calls to unverified contracts.

## Upgrading

* The following code would fill the `contract_methods` table with any methods on the currently verified contracts.

```
Explorer.Chain.SmartContract
|> Explorer.Repo.all()
|> Enum.map(fn sc ->
  sc
  |> Explorer.Chain.SmartContract.changeset(%{})
  |> Ecto.Changeset.force_change(:abi, sc.abi)
  |> Explorer.Repo.update!()
end)
```

* This PR doesn't add that behavior to logs.
* There isn't much of a focus on design here. We may want to consider alternative ways to render this.

<img width="1218" alt="screen shot 2018-12-21 at 7 56 53 pm" src="https://user-images.githubusercontent.com/5722339/50368944-1fca6a00-055c-11e9-9b39-aa6182000d72.png">
