### PR TITLE
Fix test warning db connection error

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/features/viewing_blocks_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_blocks_test.exs
@@ -1,5 +1,5 @@
 defmodule BlockScoutWeb.ViewingBlocksTest do
-  use BlockScoutWeb.FeatureCase, async: true
+  use BlockScoutWeb.FeatureCase, async: false
 
   alias BlockScoutWeb.{BlockListPage, BlockPage}
   alias Explorer.Chain.Block

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_transactions_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_transactions_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.ViewingTransactionsTest do
   @moduledoc false
 
-  use BlockScoutWeb.FeatureCase, async: true
+  use BlockScoutWeb.FeatureCase, async: false
 
   alias BlockScoutWeb.{AddressPage, TransactionListPage, TransactionLogsPage, TransactionPage}
   alias Explorer.Chain.Wei

--- a/apps/block_scout_web/test/support/feature_case.ex
+++ b/apps/block_scout_web/test/support/feature_case.ex
@@ -20,8 +20,12 @@ defmodule BlockScoutWeb.FeatureCase do
     end
   end
 
-  setup do
+  setup tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Explorer.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(Explorer.Repo, {:shared, self()})
+    end
 
     metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(Explorer.Repo, self())
     {:ok, session} = Wallaby.start_session(metadata: metadata)


### PR DESCRIPTION
## Motivation

There are some warnings/errors when we try to run the blockscout_web test suit, and it happens because there are some tests that need to be `async:false` and also there is a config missing in the `test/support/feature_case.ex`, so it shares the connection when it is needed.

Error example:

```
** (DBConnection.OwnershipError) cannot find ownership process for #PID<0.1089.0>.

When using ownership, you must manage connections in one
of the four ways:

* By explicitly checking out a connection
* By explicitly allowing a spawned process
* By running the pool in shared mode
* By using :caller option with allowed process

The first two options require every new process to explicitly
check a connection out or be allowed by calling checkout or
allow respectively.

The third option requires a {:shared, pid} mode to be set.
If using shared mode in tests, make sure your tests are not
async.

The fourth option requires [caller: pid] to be used when
checking out a connection from the pool. The caller process
should already be allowed on a connection.

If you are reading this error, it means you have not done one
of the steps above or that the owner process has crashed.

See Ecto.Adapters.SQL.Sandbox docs for more information.
        (ecto_sql) lib/ecto/adapters/sql.ex:601: Ecto.Adapters.SQL.raise_sql_call_error/1
        (ecto_sql) lib/ecto/adapters/sql.ex:537: Ecto.Adapters.SQL.execute/5
        (ecto) lib/ecto/repo/queryable.ex:147: Ecto.Repo.Queryable.execute/4
        (ecto) lib/ecto/repo/queryable.ex:18: Ecto.Repo.Queryable.all/3
        (ecto) lib/ecto/repo/queryable.ex:66: Ecto.Repo.Queryable.one/3
        (explorer) lib/explorer/chain.ex:618: Explorer.Chain.hash_to_address/1
        (block_scout_web) lib/block_scout_web/channels/reward_channel.ex:16: BlockScoutWeb.RewardChannel.join/3
        (phoenix) lib/phoenix/channel/server.ex:188: Phoenix.Channel.Server.init/1
        (stdlib) gen_server.erl:374: :gen_server.init_it/2
        (stdlib) gen_server.erl:342: :gen_server.init_it/6
        (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

## Changelog

### Bug Fixes
* Include config for sandbox mode when `async:false`

