### PR TITLE
Add `conflict_target` and `on_conflict` to `Indexer.Block.UncatalogedRewards.Importer.insert_reward_group`

### DIFF
--- a/apps/indexer/lib/indexer/block/uncataloged_rewards/importer.ex
+++ b/apps/indexer/lib/indexer/block/uncataloged_rewards/importer.ex
@@ -100,7 +100,10 @@ defmodule Indexer.Block.UncatalogedRewards.Importer do
   defp insert_reward_group(rewards) do
     rewards
     |> Enum.reduce({Multi.new(), 0}, fn changeset, {multi, index} ->
-      {Multi.insert(multi, "insert_#{index}", changeset), index + 1}
+      {Multi.insert(multi, "insert_#{index}", changeset,
+         conflict_target: ~w(address_hash address_type block_hash),
+         on_conflict: {:replace, [:reward]}
+       ), index + 1}
     end)
     |> elem(0)
     |> Explorer.Repo.transaction()


### PR DESCRIPTION
Fixes #1297

## Changelog

### Enhancements
* Regression test for #1297

### Bug Fixes
* Add `conflict_target` and `on_conflict` to `Indexer.Block.UncatalogedRewards.Importer.insert_reward_group`.
* Fix `assert` in `Indexer.Block.UncatalogedRewards.ImporterTest`.  Unused variable warning was an indication that the `assert` was rebinding the variable and `^` was missing.  Rewritten to inline the expected value for better error message from `assert`.