### PR TITLE
 Restrict `Explorer.Chain.Block.get_blocks_without_reward` to consensus

### DIFF
--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -105,7 +105,7 @@ defmodule Explorer.Chain.Block do
       b in query,
       left_join: r in Reward,
       on: [block_hash: b.hash],
-      where: is_nil(r.block_hash)
+      where: is_nil(r.block_hash) and b.consensus == true
     )
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1315,6 +1315,28 @@ defmodule Explorer.ChainTest do
     end
   end
 
+  describe "get_blocks_without_reward/1" do
+    test "includes consensus blocks" do
+      %Block{hash: consensus_hash} = insert(:block, consensus: true)
+
+      assert [%Block{hash: ^consensus_hash}] = Chain.get_blocks_without_reward()
+    end
+
+    test "does not include consensus block that has a reward" do
+      %Block{hash: consensus_hash, miner_hash: miner_hash} = insert(:block, consensus: true)
+      insert(:reward, address_hash: miner_hash, block_hash: consensus_hash)
+
+      assert [] = Chain.get_blocks_without_reward()
+    end
+
+    # https://github.com/poanetwork/blockscout/issues/1310 regression test
+    test "does not include non-consensus blocks" do
+      insert(:block, consensus: false)
+
+      assert [] = Chain.get_blocks_without_reward()
+    end
+  end
+
   describe "get_blocks_validated_by_address/2" do
     test "returns nothing when there are no blocks" do
       address = insert(:address)


### PR DESCRIPTION
Fixes #1310

## Changelog

### Enhancements
* Regression test for #1310
* Switch reward factory to use build association idiom. `ExMachina` works better if we build associations with `build` instead of setting foreign keys.

### Bug Fixes
* Restrict `Explorer.Chain.Block.get_blocks_without_reward` to consensus. 