### PR TITLE
Guard against nil in Parity.Trace.Action input

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/trace/action.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/trace/action.ex
@@ -44,8 +44,8 @@ defmodule EthereumJSONRPC.Parity.Trace.Action do
     Enum.into(action, %{}, &entry_to_elixir/1)
   end
 
-  defp entry_to_elixir({key, _} = entry)
-       when key in ~w(address callType from init input refundAddress to),
+  defp entry_to_elixir({key, value} = entry)
+       when key in ~w(address callType from init input refundAddress to) and is_binary(value),
        do: entry
 
   defp entry_to_elixir({key, quantity}) when key in ~w(balance gas value) do


### PR DESCRIPTION
Resolves #1115

## Changelog

### Enhancements
* Guard against `nil` in `Parity.Trace.Action` input.