### PR TITLE
Order derive_tranactions_forks SELECT to match transaction inserts

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -129,7 +129,10 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
           transaction.hash,
           type(^inserted_at, transaction.inserted_at),
           type(^updated_at, transaction.updated_at)
-        ]
+        ],
+        # order so that row ShareLocks are grabbed in a consistent order with
+        # `Explorer.Chain.Import.Runner.Transactions.insert`
+        order_by: transaction.hash
       )
 
     {select_sql, parameters} = SQL.to_sql(:all, repo, query)


### PR DESCRIPTION
Fixes #1311

## Changelog

### Bug Fixes
* Prevent deadlocks due to order in the `SELECT transaction` for `Explorer.Chain.Import.Runner.Blocks.derived_transaction_forks` differing from order in `Explorer.Chain.Import.Runner.Transactions.insert` by sorting both by hash ascending.