### PR TITLE
fix: webpack to production mode and remove devtool

### DIFF
--- a/apps/block_scout_web/assets/webpack.config.js
+++ b/apps/block_scout_web/assets/webpack.config.js
@@ -5,6 +5,8 @@ const glob = require("glob");
 
 function transpileViewScript(file) {
   return {
+    devtool: 'none',
+    mode: 'production',
     entry: file,
     output: {
       filename: file.replace('./js/view_specific/', ''),
@@ -26,6 +28,8 @@ function transpileViewScript(file) {
 
 const appJs =
   {
+    devtool: 'none',
+    mode: 'production',
     entry: './js/app.js',
     output: {
       filename: 'app.js',


### PR DESCRIPTION
* This helps increase page load performance per #1306

## Motivation

Honestly, everything I can find anywhere claims that these should be the defaults. And that you shouldn't really see performance issues when using the devtools to export source maps. But according to lighthouse its at least a 1 second slowdown.

## Changelog

### Enhancements
* Switch webpack to production mode and remove devtools.
