### PR TITLE
fix: poll on import completion and only new blocks

### DIFF
--- a/apps/explorer/lib/explorer/counters/average_block_time.ex
+++ b/apps/explorer/lib/explorer/counters/average_block_time.ex
@@ -64,13 +64,17 @@ defmodule Explorer.Counters.AverageBlockTime do
 
   # This is pretty naive, but we'll only ever be sorting 100 dates so I don't think
   # complex logic is really necessary here.
-  defp add_block(%{timestamps: timestamps} = state, block) do
-    timestamps =
-      [block | timestamps]
-      |> Enum.sort_by(fn {number, _} -> number end, &Kernel.>/2)
-      |> Enum.take(100)
+  defp add_block(%{timestamps: timestamps} = state, {new_number, _} = block) do
+    if Enum.any?(timestamps, fn {number, _} -> number == new_number end) do
+      state
+    else
+      timestamps =
+        [block | timestamps]
+        |> Enum.sort_by(fn {number, _} -> number end, &Kernel.>/2)
+        |> Enum.take(100)
 
-    %{state | timestamps: timestamps, average: average_distance(timestamps)}
+      %{state | timestamps: timestamps, average: average_distance(timestamps)}
+    end
   end
 
   defp average_distance([]), do: Duration.from_milliseconds(0)

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -88,12 +88,12 @@ defmodule Indexer.Block.Realtime.Fetcher do
     new_timer = schedule_polling()
 
     {:noreply,
-    %{
-      state
-      | previous_number: number,
-        max_number_seen: new_max_number,
-        timer: new_timer
-    }}
+     %{
+       state
+       | previous_number: number,
+         max_number_seen: new_max_number,
+         timer: new_timer
+     }}
   end
 
   @impl GenServer

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -15,15 +15,15 @@ defmodule Indexer.Block.Realtime.Fetcher do
   alias Ecto.Changeset
   alias EthereumJSONRPC.{FetchedBalances, Subscription}
   alias Explorer.Chain
+  alias Explorer.Counters.AverageBlockTime
   alias Indexer.{AddressExtraction, Block, TokenBalances, Tracer}
   alias Indexer.Block.Realtime.{ConsensusEnsurer, TaskSupervisor}
-
-  @polling_period 2_000
+  alias Timex.Duration
 
   @behaviour Block.Fetcher
 
   @enforce_keys ~w(block_fetcher)a
-  defstruct ~w(block_fetcher subscription previous_number max_number_seen)a
+  defstruct ~w(block_fetcher subscription previous_number max_number_seen timer)a
 
   @type t :: %__MODULE__{
           block_fetcher: %Block.Fetcher{
@@ -54,13 +54,14 @@ defmodule Indexer.Block.Realtime.Fetcher do
   @impl GenServer
   def handle_continue({:init, subscribe_named_arguments}, %__MODULE__{subscription: nil} = state)
       when is_list(subscribe_named_arguments) do
-
     case EthereumJSONRPC.subscribe("newHeads", subscribe_named_arguments) do
       {:ok, subscription} ->
-        schedule_polling()
+        timer = schedule_polling()
 
-        {:noreply, %__MODULE__{state | subscription: subscription}}
-      {:error, reason} -> {:stop, reason, state}
+        {:noreply, %__MODULE__{state | subscription: subscription, timer: timer}}
+
+      {:error, reason} ->
+        {:stop, reason, state}
     end
   end
 
@@ -71,24 +72,28 @@ defmodule Indexer.Block.Realtime.Fetcher do
           block_fetcher: %Block.Fetcher{} = block_fetcher,
           subscription: %Subscription{} = subscription,
           previous_number: previous_number,
-          max_number_seen: max_number_seen
+          max_number_seen: max_number_seen,
+          timer: timer
         } = state
       )
       when is_binary(quantity) do
     number = quantity_to_integer(quantity)
-
     # Subscriptions don't support getting all the blocks and transactions data,
     # so we need to go back and get the full block
     start_fetch_and_import(number, block_fetcher, previous_number, max_number_seen)
 
     new_max_number = new_max_number(number, max_number_seen)
 
+    :timer.cancel(timer)
+    new_timer = schedule_polling()
+
     {:noreply,
-     %{
-       state
-       | previous_number: number,
-         max_number_seen: new_max_number
-     }}
+    %{
+      state
+      | previous_number: number,
+        max_number_seen: new_max_number,
+        timer: new_timer
+    }}
   end
 
   @impl GenServer
@@ -102,21 +107,23 @@ defmodule Indexer.Block.Realtime.Fetcher do
       ) do
     {number, new_max_number} =
       case EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments) do
-        {:ok, number} when number > max_number_seen ->
-          start_fetch_and_import(number, block_fetcher, previous_number, max_number_seen)
+        {:ok, number} when is_nil(max_number_seen) or number > max_number_seen ->
+          start_fetch_and_import(number, block_fetcher, previous_number, number)
 
           {max_number_seen, number}
-        {:error, _} ->
+
+        _ ->
           {previous_number, max_number_seen}
       end
 
-    schedule_polling()
+    timer = schedule_polling()
 
     {:noreply,
      %{
        state
        | previous_number: number,
-         max_number_seen: new_max_number
+         max_number_seen: new_max_number,
+         timer: timer
      }}
   end
 
@@ -125,7 +132,13 @@ defmodule Indexer.Block.Realtime.Fetcher do
   defp new_max_number(number, max_number_seen), do: max(number, max_number_seen)
 
   defp schedule_polling do
-    Process.send_after(self(), :poll_latest_block_number, @polling_period)
+    polling_period =
+      case AverageBlockTime.average_block_time() do
+        {:error, :disabled} -> 2_000
+        block_time -> round(Duration.to_milliseconds(block_time) * 2)
+      end
+
+    Process.send_after(self(), :poll_latest_block_number, polling_period)
   end
 
   @import_options ~w(address_hash_to_fetched_balance_block_number)a


### PR DESCRIPTION
## Motivation

Polling is swamping the db connections and also is causing us to reimport new blocks multiple times.

## Changelog

### Bug Fixes
* Only schedule the next poll after the import of one poll is completed.
* Only import blocks that are new
* reschedule polling if we get a new head
* Change poll time to be 2 * average_block_time
* When we get a block in the avereage_block_time server, we don't do anything if we already have that block number. 