### PR TITLE
Store and maintain Explorer.Chain.count_token_holders_from_token_hash in tokens.holder_count

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
@@ -50,7 +50,7 @@ defmodule BlockScoutWeb.Tokens.HolderController do
         "index.html",
         current_path: current_path(conn),
         token: Market.add_price(token),
-        total_token_holders: Chain.count_token_holders_from_token_hash(address_hash),
+        total_token_holders: token.holder_count || Chain.count_token_holders_from_token_hash(address_hash),
         total_token_transfers: Chain.count_token_transfers_from_token_hash(address_hash)
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
@@ -23,7 +23,7 @@ defmodule BlockScoutWeb.Tokens.InventoryController do
         token: Market.add_price(token),
         unique_tokens: unique_tokens_paginated,
         total_token_transfers: Chain.count_token_transfers_from_token_hash(address_hash),
-        total_token_holders: Chain.count_token_holders_from_token_hash(address_hash),
+        total_token_holders: token.holder_count || Chain.count_token_holders_from_token_hash(address_hash),
         next_page_params: unique_tokens_next_page(next_page, unique_tokens_paginated, params)
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/read_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/read_contract_controller.ex
@@ -10,7 +10,7 @@ defmodule BlockScoutWeb.Tokens.ReadContractController do
         conn,
         "index.html",
         token: Market.add_price(token),
-        total_token_transfers: Chain.count_token_transfers_from_token_hash(address_hash),
+        total_token_transfers: token.holder_count || Chain.count_token_transfers_from_token_hash(address_hash),
         total_token_holders: Chain.count_token_holders_from_token_hash(address_hash)
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
@@ -52,7 +52,7 @@ defmodule BlockScoutWeb.Tokens.TransferController do
         current_path: current_path(conn),
         token: Market.add_price(token),
         total_token_transfers: Chain.count_token_transfers_from_token_hash(address_hash),
-        total_token_holders: Chain.count_token_holders_from_token_hash(address_hash)
+        total_token_holders: token.holder_count || Chain.count_token_holders_from_token_hash(address_hash)
       )
     else
       :error ->

--- a/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
@@ -9,7 +9,8 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
 
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.Address.CurrentTokenBalance
-  alias Explorer.Chain.Import
+  alias Explorer.Chain.{Hash, Import}
+  alias Explorer.Chain.Import.Runner.Tokens
 
   @behaviour Import.Runner
 
@@ -17,6 +18,70 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
   @timeout 60_000
 
   @type imported :: [CurrentTokenBalance.t()]
+
+  @spec to_holder_address_hash_set_by_token_contract_address_hash([CurrentTokenBalance.t()]) :: %{
+          token_contract_address_hash => MapSet.t(holder_address_hash)
+        }
+        when token_contract_address_hash: Hash.Address.t(), holder_address_hash: Hash.Address.t()
+  def to_holder_address_hash_set_by_token_contract_address_hash(address_current_token_balances)
+      when is_list(address_current_token_balances) do
+    address_current_token_balances
+    |> Stream.filter(fn %{value: value} -> not is_nil(value) && Decimal.cmp(value, 0) == :gt end)
+    |> Enum.reduce(%{}, fn %{token_contract_address_hash: token_contract_address_hash, address_hash: address_hash},
+                           acc_holder_address_hash_set_by_token_contract_address_hash ->
+      updated_holder_address_hash_set =
+        acc_holder_address_hash_set_by_token_contract_address_hash
+        |> Map.get_lazy(token_contract_address_hash, &MapSet.new/0)
+        |> MapSet.put(address_hash)
+
+      Map.put(
+        acc_holder_address_hash_set_by_token_contract_address_hash,
+        token_contract_address_hash,
+        updated_holder_address_hash_set
+      )
+    end)
+  end
+
+  @spec token_holder_count_deltas(%{deleted: [current_token_balance], inserted: [current_token_balance]}) :: [
+          Tokens.token_holder_count_delta()
+        ]
+        when current_token_balance: %{
+               address_hash: Hash.Address.t(),
+               token_contract_address_hash: Hash.Address.t(),
+               value: Decimal.t()
+             }
+  def token_holder_count_deltas(%{deleted: deleted, inserted: inserted}) when is_list(deleted) and is_list(inserted) do
+    deleted_holder_address_hash_set_by_token_contract_address_hash =
+      to_holder_address_hash_set_by_token_contract_address_hash(deleted)
+
+    inserted_holder_address_hash_set_by_token_contract_address_hash =
+      to_holder_address_hash_set_by_token_contract_address_hash(inserted)
+
+    ordered_token_contract_address_hashes =
+      ordered_token_contract_address_hashes([
+        deleted_holder_address_hash_set_by_token_contract_address_hash,
+        inserted_holder_address_hash_set_by_token_contract_address_hash
+      ])
+
+    Enum.flat_map(ordered_token_contract_address_hashes, fn token_contract_address_hash ->
+      holder_count_delta =
+        holder_count_delta(%{
+          deleted_holder_address_hash_set_by_token_contract_address_hash:
+            deleted_holder_address_hash_set_by_token_contract_address_hash,
+          inserted_holder_address_hash_set_by_token_contract_address_hash:
+            inserted_holder_address_hash_set_by_token_contract_address_hash,
+          token_contract_address_hash: token_contract_address_hash
+        })
+
+      case holder_count_delta do
+        0 ->
+          []
+
+        _ ->
+          [%{contract_address_hash: token_contract_address_hash, delta: holder_count_delta}]
+      end
+    end)
+  end
 
   @impl Import.Runner
   def ecto_schema_module, do: CurrentTokenBalance
@@ -37,17 +102,108 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
     insert_options =
       options
       |> Map.get(option_key(), %{})
-      |> Map.take(~w(on_conflict timeout)a)
+      |> Map.take(~w(timeout)a)
       |> Map.put_new(:timeout, @timeout)
       |> Map.put(:timestamps, timestamps)
 
-    Multi.run(multi, :address_current_token_balances, fn repo, _ ->
-      insert(repo, changes_list, insert_options)
+    timeout = insert_options.timeout
+
+    # order so that row ShareLocks are grabbed in a consistent order
+    ordered_changes_list = Enum.sort_by(changes_list, &{&1.address_hash, &1.token_contract_address_hash})
+
+    multi
+    |> Multi.run(:deleted_address_current_token_balances, fn repo, _ ->
+      deleted_address_current_token_balances(repo, ordered_changes_list, %{timeout: timeout})
+    end)
+    |> Multi.run(:address_current_token_balances, fn repo, _ ->
+      insert(repo, ordered_changes_list, insert_options)
+    end)
+    |> Multi.run(:address_current_token_balances_update_token_holder_counts, fn repo,
+                                                                                %{
+                                                                                  deleted_address_current_token_balances:
+                                                                                    deleted,
+                                                                                  address_current_token_balances:
+                                                                                    inserted
+                                                                                } ->
+      token_holder_count_deltas = token_holder_count_deltas(%{deleted: deleted, inserted: inserted})
+
+      Tokens.update_holder_counts_with_deltas(
+        repo,
+        token_holder_count_deltas,
+        insert_options
+      )
     end)
   end
 
   @impl Import.Runner
   def timeout, do: @timeout
+
+  @spec deleted_address_current_token_balances(Repo.t(), [map()], %{timeout: timeout()}) ::
+          {:ok, [CurrentTokenBalance.t()]}
+  defp deleted_address_current_token_balances(_, [], _), do: {:ok, []}
+
+  defp deleted_address_current_token_balances(repo, changes_list, %{timeout: timeout})
+       when is_atom(repo) and is_list(changes_list) do
+    initial_query =
+      from(current_token_balance in CurrentTokenBalance,
+        select:
+          map(current_token_balance, [
+            :address_hash,
+            :token_contract_address_hash,
+            # to determine if a holder for `update_token_holder_counts`
+            :value
+          ]),
+        # to maintain order of lock for `address_current_token_balances`
+        lock: "FOR UPDATE"
+      )
+
+    final_query =
+      Enum.reduce(changes_list, initial_query, fn %{
+                                                    address_hash: address_hash,
+                                                    token_contract_address_hash: token_contract_address_hash,
+                                                    block_number: block_number
+                                                  },
+                                                  acc_query ->
+        from(current_token_balance in acc_query,
+          or_where:
+            current_token_balance.address_hash == ^address_hash and
+              current_token_balance.token_contract_address_hash == ^token_contract_address_hash and
+              current_token_balance.block_number < ^block_number
+        )
+      end)
+
+    {:ok, repo.all(final_query, timeout: timeout)}
+  end
+
+  defp holder_count_delta(%{
+         deleted_holder_address_hash_set_by_token_contract_address_hash:
+           deleted_holder_address_hash_set_by_token_contract_address_hash,
+         inserted_holder_address_hash_set_by_token_contract_address_hash:
+           inserted_holder_address_hash_set_by_token_contract_address_hash,
+         token_contract_address_hash: token_contract_address_hash
+       }) do
+    case {deleted_holder_address_hash_set_by_token_contract_address_hash[token_contract_address_hash],
+          inserted_holder_address_hash_set_by_token_contract_address_hash[token_contract_address_hash]} do
+      {deleted_holder_address_hash_set, nil} ->
+        -1 * Enum.count(deleted_holder_address_hash_set)
+
+      {nil, inserted_holder_address_hash_set} ->
+        Enum.count(inserted_holder_address_hash_set)
+
+      {deleted_holder_address_hash_set, inserted_holder_address_hash_set} ->
+        inserted_holder_address_hash_count =
+          inserted_holder_address_hash_set
+          |> MapSet.difference(deleted_holder_address_hash_set)
+          |> Enum.count()
+
+        deleted_holder_address_hash_count =
+          deleted_holder_address_hash_set
+          |> MapSet.difference(inserted_holder_address_hash_set)
+          |> Enum.count()
+
+        inserted_holder_address_hash_count - deleted_holder_address_hash_count
+    end
+  end
 
   @spec insert(Repo.t(), [map()], %{
           optional(:on_conflict) => Import.Runner.on_conflict(),
@@ -56,24 +212,20 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
         }) ::
           {:ok, [CurrentTokenBalance.t()]}
           | {:error, [Changeset.t()]}
-  def insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options)
-      when is_atom(repo) and is_list(changes_list) do
+  defp insert(repo, ordered_changes_list, %{timeout: timeout, timestamps: timestamps} = options)
+       when is_atom(repo) and is_list(ordered_changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
-    # order so that row ShareLocks are grabbed in a consistent order
-    ordered_changes_list = Enum.sort_by(changes_list, &{&1.address_hash, &1.token_contract_address_hash})
-
-    {:ok, _} =
-      Import.insert_changes_list(
-        repo,
-        ordered_changes_list,
-        conflict_target: ~w(address_hash token_contract_address_hash)a,
-        on_conflict: on_conflict,
-        for: CurrentTokenBalance,
-        returning: true,
-        timeout: timeout,
-        timestamps: timestamps
-      )
+    Import.insert_changes_list(
+      repo,
+      ordered_changes_list,
+      conflict_target: ~w(address_hash token_contract_address_hash)a,
+      on_conflict: on_conflict,
+      for: CurrentTokenBalance,
+      returning: true,
+      timeout: timeout,
+      timestamps: timestamps
+    )
   end
 
   defp default_on_conflict do
@@ -90,5 +242,17 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
       ],
       where: fragment("? < EXCLUDED.block_number", current_token_balance.block_number)
     )
+  end
+
+  defp ordered_token_contract_address_hashes(holder_address_hash_set_by_token_contract_address_hash_list)
+       when is_list(holder_address_hash_set_by_token_contract_address_hash_list) do
+    holder_address_hash_set_by_token_contract_address_hash_list
+    |> Enum.reduce(MapSet.new(), fn holder_address_hash_set_by_token_contract_address_hash, acc ->
+      holder_address_hash_set_by_token_contract_address_hash
+      |> Map.keys()
+      |> MapSet.new()
+      |> MapSet.union(acc)
+    end)
+    |> Enum.sort()
   end
 end

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -12,6 +12,8 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   alias Explorer.Chain.{Address, Block, Hash, Import, InternalTransaction, Transaction}
   alias Explorer.Chain.Block.Reward
   alias Explorer.Chain.Import.Runner
+  alias Explorer.Chain.Import.Runner.Address.CurrentTokenBalances
+  alias Explorer.Chain.Import.Runner.Tokens
 
   @behaviour Runner
 
@@ -80,8 +82,13 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
                                                             } ->
       derive_address_current_token_balances(repo, deleted_address_current_token_balances, insert_options)
     end)
-    |> Multi.run(:update_token_holder_counts, fn repo, changes_so_far ->
-      update_token_holder_counts(repo, changes_so_far, insert_options)
+    |> Multi.run(:blocks_update_token_holder_counts, fn repo,
+                                                        %{
+                                                          delete_address_current_token_balances: deleted,
+                                                          derive_address_current_token_balances: inserted
+                                                        } ->
+      deltas = CurrentTokenBalances.token_holder_count_deltas(%{deleted: deleted, inserted: inserted})
+      Tokens.update_holder_counts_with_deltas(repo, deltas, insert_options)
     end)
     |> Multi.run(:delete_rewards, fn repo, _ ->
       delete_rewards(repo, changes_list, insert_options)
@@ -472,166 +479,6 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
       {:ok, derived_address_current_token_balances}
     end
-  end
-
-  # sobelow_skip ["SQL.Query"]
-  defp update_token_holder_counts(repo, changes_so_far, options) when is_map(changes_so_far) do
-    parameters = update_token_holder_counts_parameters(changes_so_far)
-
-    update_token_holder_counts(repo, parameters, options)
-  end
-
-  defp update_token_holder_counts(_, [], _), do: {:ok, []}
-
-  defp update_token_holder_counts(repo, parameters, %{timeout: timeout}) do
-    update_sql = update_token_holder_counts_sql(parameters)
-
-    with {:ok, %Postgrex.Result{columns: ["contract_address_hash", "holder_count"], command: :update, rows: rows}} <-
-           SQL.query(repo, update_sql, parameters, timeout: timeout) do
-      update_token_holder_counts =
-        Enum.map(rows, fn [contract_address_hash_bytes, holder_count] ->
-          {:ok, contract_address_hash} = Hash.Address.cast(contract_address_hash_bytes)
-          %{contract_address_hash: contract_address_hash, holder_count: holder_count}
-        end)
-
-      {:ok, update_token_holder_counts}
-    end
-  end
-
-  defp update_token_holder_counts_parameters(%{
-         delete_address_current_token_balances: deleted_address_current_token_balances,
-         derive_address_current_token_balances: derived_address_current_token_balances
-       }) do
-    previous_holder_address_hash_set_by_token_contract_address_hash =
-      address_current_token_balances_to_holder_address_hash_set_by_token_contract_address_hash(
-        deleted_address_current_token_balances
-      )
-
-    current_holder_address_hash_set_by_token_contract_address_hash =
-      address_current_token_balances_to_holder_address_hash_set_by_token_contract_address_hash(
-        derived_address_current_token_balances
-      )
-
-    ordered_token_contract_address_hashes =
-      ordered_token_contract_address_hashes([
-        previous_holder_address_hash_set_by_token_contract_address_hash,
-        current_holder_address_hash_set_by_token_contract_address_hash
-      ])
-
-    Enum.flat_map(ordered_token_contract_address_hashes, fn token_contract_address_hash ->
-      holder_count_delta =
-        holder_count_delta(%{
-          previous_holder_address_hash_set_by_token_contract_address_hash:
-            previous_holder_address_hash_set_by_token_contract_address_hash,
-          current_holder_address_hash_set_by_token_contract_address_hash:
-            current_holder_address_hash_set_by_token_contract_address_hash,
-          token_contract_address_hash: token_contract_address_hash
-        })
-
-      case holder_count_delta do
-        0 ->
-          []
-
-        _ ->
-          {:ok, token_contract_address_hash_bytes} = Hash.Address.dump(token_contract_address_hash)
-          [token_contract_address_hash_bytes, holder_count_delta]
-      end
-    end)
-  end
-
-  defp ordered_token_contract_address_hashes(holder_address_hash_set_by_token_contract_address_hash_list)
-       when is_list(holder_address_hash_set_by_token_contract_address_hash_list) do
-    holder_address_hash_set_by_token_contract_address_hash_list
-    |> Enum.reduce(MapSet.new(), fn holder_address_hash_set_by_token_contract_address_hash, acc ->
-      holder_address_hash_set_by_token_contract_address_hash
-      |> Map.keys()
-      |> MapSet.new()
-      |> MapSet.union(acc)
-    end)
-    |> Enum.sort()
-  end
-
-  defp holder_count_delta(%{
-         previous_holder_address_hash_set_by_token_contract_address_hash:
-           previous_holder_address_hash_set_by_token_contract_address_hash,
-         current_holder_address_hash_set_by_token_contract_address_hash:
-           current_holder_address_hash_set_by_token_contract_address_hash,
-         token_contract_address_hash: token_contract_address_hash
-       }) do
-    case {previous_holder_address_hash_set_by_token_contract_address_hash[token_contract_address_hash],
-          current_holder_address_hash_set_by_token_contract_address_hash[token_contract_address_hash]} do
-      {previous_holder_address_hash_set, nil} ->
-        -1 * Enum.count(previous_holder_address_hash_set)
-
-      {nil, current_holder_address_hash_set} ->
-        Enum.count(current_holder_address_hash_set)
-
-      {previous_holder_address_hash_set, current_holder_address_hash_set} ->
-        added_holder_address_hash_count =
-          current_holder_address_hash_set
-          |> MapSet.difference(previous_holder_address_hash_set)
-          |> Enum.count()
-
-        removed_holder_address_hash_count =
-          previous_holder_address_hash_set
-          |> MapSet.difference(current_holder_address_hash_set)
-          |> Enum.count()
-
-        added_holder_address_hash_count - removed_holder_address_hash_count
-    end
-  end
-
-  defp update_token_holder_counts_sql(parameters) when is_list(parameters) do
-    parameters
-    |> Enum.count()
-    |> div(2)
-    |> update_token_holder_counts_sql()
-  end
-
-  defp update_token_holder_counts_sql(row_count) when is_integer(row_count) do
-    parameters_sql = update_token_holder_counts_parameters_sql(row_count)
-
-    """
-    UPDATE tokens
-    SET holder_count = holder_count + holder_counts.delta
-    FROM (
-        VALUES
-          #{parameters_sql}
-      ) AS holder_counts(contract_address_hash, delta)
-    WHERE tokens.contract_address_hash = holder_counts.contract_address_hash AND
-          holder_count IS NOT NULL
-    RETURNING tokens.contract_address_hash, tokens.holder_count
-    """
-  end
-
-  defp update_token_holder_counts_parameters_sql(row_count) when is_integer(row_count) do
-    Enum.map_join(0..(row_count - 1), ",\n      ", fn i ->
-      contract_address_hash_parameter_number = 2 * i + 1
-      holder_count_number = contract_address_hash_parameter_number + 1
-
-      "($#{contract_address_hash_parameter_number}::bytea, $#{holder_count_number}::bigint)"
-    end)
-  end
-
-  defp address_current_token_balances_to_holder_address_hash_set_by_token_contract_address_hash(
-         address_current_token_balances
-       )
-       when is_list(address_current_token_balances) do
-    address_current_token_balances
-    |> Stream.filter(fn %{value: value} -> Decimal.cmp(value, 0) == :gt end)
-    |> Enum.reduce(%{}, fn %{token_contract_address_hash: token_contract_address_hash, address_hash: address_hash},
-                           acc_holder_address_hash_set_by_token_contract_address_hash ->
-      updated_holder_address_hash_set =
-        acc_holder_address_hash_set_by_token_contract_address_hash
-        |> Map.get_lazy(token_contract_address_hash, &MapSet.new/0)
-        |> MapSet.put(address_hash)
-
-      Map.put(
-        acc_holder_address_hash_set_by_token_contract_address_hash,
-        token_contract_address_hash,
-        updated_holder_address_hash_set
-      )
-    end)
   end
 
   # `block_rewards` are linked to `blocks.hash`, but fetched by `blocks.number`, so when a block with the same number is

--- a/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
@@ -7,8 +7,9 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
 
   import Ecto.Query, only: [from: 2]
 
+  alias Ecto.Adapters.SQL
   alias Ecto.{Multi, Repo}
-  alias Explorer.Chain.{Import, Token}
+  alias Explorer.Chain.{Hash, Import, Token}
 
   @behaviour Import.Runner
 
@@ -16,6 +17,16 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
   @timeout 60_000
 
   @type imported :: [Token.t()]
+
+  @type token_holder_count_delta :: %{contract_address_hash: Hash.Address.t(), delta: neg_integer() | pos_integer()}
+  @type holder_count :: non_neg_integer()
+  @type token_holder_count :: %{contract_address_hash: Hash.Address.t(), count: holder_count()}
+
+  def update_holder_counts_with_deltas(repo, token_holder_count_deltas, options) do
+    parameters = token_holder_count_deltas_to_parameters(token_holder_count_deltas)
+
+    update_holder_counts_with_parameters(repo, parameters, options)
+  end
 
   @impl Import.Runner
   def ecto_schema_module, do: Token
@@ -98,5 +109,70 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
           token.cataloged
         )
     )
+  end
+
+  defp token_holder_count_deltas_to_parameters(token_holder_count_deltas) when is_list(token_holder_count_deltas) do
+    Enum.flat_map(token_holder_count_deltas, fn
+      %{contract_address_hash: contract_address_hash, delta: delta} ->
+        {:ok, contract_address_hash_bytes} = Hash.Address.dump(contract_address_hash)
+        [contract_address_hash_bytes, delta]
+    end)
+  end
+
+  defp update_holder_counts_with_parameters(_, [], _), do: {:ok, []}
+
+  # sobelow_skip ["SQL.Query"]
+  defp update_holder_counts_with_parameters(repo, parameters, %{timeout: timeout, timestamps: %{updated_at: updated_at}})
+       when is_list(parameters) do
+    update_sql = update_holder_counts_sql(parameters)
+
+    with {:ok, %Postgrex.Result{columns: ["contract_address_hash", "holder_count"], command: :update, rows: rows}} <-
+           SQL.query(repo, update_sql, [updated_at | parameters], timeout: timeout) do
+      update_token_holder_counts =
+        Enum.map(rows, fn [contract_address_hash_bytes, holder_count] ->
+          {:ok, contract_address_hash} = Hash.Address.cast(contract_address_hash_bytes)
+          %{contract_address_hash: contract_address_hash, holder_count: holder_count}
+        end)
+
+      {:ok, update_token_holder_counts}
+    end
+  end
+
+  defp update_holder_counts_sql(parameters) when is_list(parameters) do
+    parameters
+    |> Enum.count()
+    |> div(2)
+    |> update_holder_counts_sql()
+  end
+
+  defp update_holder_counts_sql(row_count) when is_integer(row_count) do
+    parameters_sql =
+      update_holder_counts_parameters_sql(
+        row_count,
+        # skip $1 as it is used for the common `updated_at` timestamp
+        2
+      )
+
+    """
+    UPDATE tokens
+    SET holder_count = holder_count + holder_counts.delta,
+        updated_at = $1
+    FROM (
+        VALUES
+          #{parameters_sql}
+      ) AS holder_counts(contract_address_hash, delta)
+    WHERE tokens.contract_address_hash = holder_counts.contract_address_hash AND
+          holder_count IS NOT NULL
+    RETURNING tokens.contract_address_hash, tokens.holder_count
+    """
+  end
+
+  defp update_holder_counts_parameters_sql(row_count, start) when is_integer(row_count) do
+    Enum.map_join(0..(row_count - 1), ",\n      ", fn i ->
+      contract_address_hash_parameter_number = 2 * i + start
+      holder_count_number = contract_address_hash_parameter_number + 1
+
+      "($#{contract_address_hash_parameter_number}::bytea, $#{holder_count_number}::bigint)"
+    end)
   end
 end

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -25,14 +25,16 @@ defmodule Explorer.Chain.Token do
   alias Explorer.Chain.{Address, Hash, Token}
 
   @typedoc """
-  * `:name` - Name of the token
-  * `:symbol` - Trading symbol of the token
-  * `:total_supply` - The total supply of the token
-  * `:decimals` - Number of decimal places the token can be subdivided to
-  * `:type` - Type of token
-  * `:calatoged` - Flag for if token information has been cataloged
-  * `:contract_address` - The `t:Address.t/0` of the token's contract
-  * `:contract_address_hash` - Address hash foreign key
+  * `name` - Name of the token
+  * `symbol` - Trading symbol of the token
+  * `total_supply` - The total supply of the token
+  * `decimals` - Number of decimal places the token can be subdivided to
+  * `type` - Type of token
+  * `calatoged` - Flag for if token information has been cataloged
+  * `contract_address` - The `t:Address.t/0` of the token's contract
+  * `contract_address_hash` - Address hash foreign key
+  * `holder_count` - the number of `t:Explorer.Chain.Address.t/0` (except the burn address) that have a
+    `t:Explorer.Chain.CurrentTokenBalance.t/0` `value > 0`.  Can be `nil` when data not migrated.
   """
   @type t :: %Token{
           name: String.t(),
@@ -42,7 +44,8 @@ defmodule Explorer.Chain.Token do
           type: String.t(),
           cataloged: boolean(),
           contract_address: %Ecto.Association.NotLoaded{} | Address.t(),
-          contract_address_hash: Hash.Address.t()
+          contract_address_hash: Hash.Address.t(),
+          holder_count: non_neg_integer() | nil
         }
 
   @primary_key false
@@ -53,6 +56,7 @@ defmodule Explorer.Chain.Token do
     field(:decimals, :decimal)
     field(:type, :string)
     field(:cataloged, :boolean)
+    field(:holder_count, :integer)
 
     belongs_to(
       :contract_address,

--- a/apps/explorer/priv/repo/migrations/20190114204640_add_tokens_holder_count.exs
+++ b/apps/explorer/priv/repo/migrations/20190114204640_add_tokens_holder_count.exs
@@ -1,0 +1,10 @@
+defmodule Explorer.Repo.Migrations.AddTokensHolderCount do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tokens) do
+      # `NULL` so it can be filled in in the background while upgrading
+      add(:holder_count, :integer, null: true)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/scripts/update_new_tokens_holder_count_in_batches.sql
+++ b/apps/explorer/priv/repo/migrations/scripts/update_new_tokens_holder_count_in_batches.sql
@@ -1,0 +1,95 @@
+DO $$
+  DECLARE
+    total_count         integer                     := 0;
+    completed_count     integer                     := 0;
+    remaining_count     integer                     := 0;
+    -- Eth Mainnet has ~80000 tokens and the old ETs way took ~90 minutes so approximate 1000 tokens per minute and
+    -- make each batch take approximately 1 minute
+    batch_size          integer                     := 1000;
+    iterator            integer                     := batch_size;
+    updated_count       integer;
+    deleted_count       integer;
+    start_time          TIMESTAMP WITHOUT TIME ZONE := clock_timestamp();
+    end_time            TIMESTAMP WITHOUT TIME ZONE;
+    elapsed_time        INTERVAL;
+    temp_start_time     TIMESTAMP WITHOUT TIME ZONE;
+    temp_end_time       TIMESTAMP WITHOUT TIME ZONE;
+    temp_elapsed_time   INTERVAL;
+    update_start_time   TIMESTAMP WITHOUT TIME ZONE;
+    update_end_time     TIMESTAMP WITHOUT TIME ZONE;
+    update_elapsed_time INTERVAL;
+    per_row             INTERVAL;
+  BEGIN
+    RAISE NOTICE 'Started at %', start_time;
+
+    temp_start_time := clock_timestamp();
+
+    DROP TABLE IF EXISTS tokens_without_holder_count;
+    CREATE TEMP TABLE tokens_without_holder_count
+    (
+      contract_address_hash bytea NOT NULL,
+      row_number integer NOT NULL
+    );
+
+    INSERT INTO tokens_without_holder_count
+    SELECT tokens.contract_address_hash,
+           ROW_NUMBER() OVER ()
+    FROM tokens
+    WHERE tokens.holder_count IS NULL;
+
+    temp_end_time := clock_timestamp();
+    temp_elapsed_time := temp_end_time - temp_start_time;
+    total_count := (SELECT COUNT(*) FROM tokens_without_holder_count);
+
+    RAISE NOTICE 'tokens_without_holder_count TEMP table filled in %', temp_elapsed_time;
+
+    remaining_count := total_count;
+
+    RAISE NOTICE '% tokens to be updated', remaining_count;
+
+    update_start_time := clock_timestamp();
+
+    WHILE remaining_count > 0
+      LOOP
+        UPDATE tokens
+        SET holder_count = (
+                SELECT COUNT(*)
+                FROM address_current_token_balances
+                WHERE address_current_token_balances.token_contract_address_hash = tokens.contract_address_hash AND
+                      address_current_token_balances.address_hash != '\x0000000000000000000000000000000000000000' AND
+                      address_current_token_balances.value > 0
+              )
+        FROM tokens_without_holder_count
+        WHERE tokens_without_holder_count.row_number <= iterator AND
+              tokens_without_holder_count.contract_address_hash = tokens.contract_address_hash AND
+              tokens.holder_count IS NULL;
+
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+        RAISE NOTICE '-> % token holder counts updated.', updated_count;
+
+        DELETE
+        FROM tokens_without_holder_count
+        WHERE tokens_without_holder_count.row_number <= iterator;
+
+        GET DIAGNOSTICS deleted_count = ROW_COUNT;
+        RAISE NOTICE '-> % tokens without holder count removed from queue.', deleted_count;
+
+        -- COMMITS THE BATCH UPDATES
+        CHECKPOINT;
+
+        remaining_count := remaining_count - deleted_count;
+        iterator := iterator + batch_size;
+        RAISE NOTICE '-> % remaining', remaining_count;
+        RAISE NOTICE '-> % next batch', iterator;
+        update_elapsed_time := clock_timestamp() - update_start_time;
+        completed_count := total_count - remaining_count;
+        per_row := update_elapsed_time / completed_count;
+        RAISE NOTICE '-> Estimated time until completion: %s', per_row * remaining_count;
+      END LOOP;
+
+    end_time := clock_timestamp();
+    elapsed_time := end_time - start_time;
+
+    RAISE NOTICE 'Ended at %s', end_time;
+    RAISE NOTICE 'Elapsed time: %', elapsed_time;
+END $$;

--- a/apps/explorer/test/explorer/chain/import/runner/address/current_token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/address/current_token_balances_test.exs
@@ -1,34 +1,61 @@
 defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
   use Explorer.DataCase
 
+  import Explorer.Chain.Import.RunnerCase, only: [insert_token_balance: 1, update_holder_count!: 2]
+
+  alias Ecto.Multi
+  alias Explorer.Chain.{Address, Token}
   alias Explorer.Chain.Address.CurrentTokenBalance
   alias Explorer.Chain.Import.Runner.Address.CurrentTokenBalances
   alias Explorer.Repo
 
-  describe "insert/2" do
+  describe "run/2" do
     setup do
-      address = insert(:address, hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca")
-      token = insert(:token)
+      address = insert(:address)
+      token = insert(:token, holder_count: 0)
 
-      insert_options = %{
+      options = %{
         timeout: :infinity,
         timestamps: %{inserted_at: DateTime.utc_now(), updated_at: DateTime.utc_now()}
       }
 
-      %{address: address, token: token, insert_options: insert_options}
+      %{address: address, token: token, options: options}
     end
 
-    test "inserts in the current token balances", %{address: address, token: token, insert_options: insert_options} do
-      changes = [
-        %{
-          address_hash: address.hash,
-          block_number: 1,
-          token_contract_address_hash: token.contract_address_hash,
-          value: Decimal.new(100)
-        }
-      ]
+    test "inserts in the current token balances", %{
+      address: %Address{hash: address_hash},
+      token: %Token{contract_address_hash: token_contract_address_hash},
+      options: options
+    } do
+      value = Decimal.new(100)
+      block_number = 1
 
-      CurrentTokenBalances.insert(Repo, changes, insert_options)
+      assert {:ok,
+              %{
+                address_current_token_balances: [
+                  %Explorer.Chain.Address.CurrentTokenBalance{
+                    address_hash: ^address_hash,
+                    block_number: ^block_number,
+                    token_contract_address_hash: ^token_contract_address_hash,
+                    value: ^value
+                  }
+                ],
+                address_current_token_balances_update_token_holder_counts: [
+                  %{
+                    contract_address_hash: ^token_contract_address_hash,
+                    holder_count: 1
+                  }
+                ]
+              }} =
+               run_changes(
+                 %{
+                   address_hash: address_hash,
+                   block_number: block_number,
+                   token_contract_address_hash: token_contract_address_hash,
+                   value: value
+                 },
+                 options
+               )
 
       current_token_balances =
         CurrentTokenBalance
@@ -41,7 +68,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
     test "updates when the new block number is greater", %{
       address: address,
       token: token,
-      insert_options: insert_options
+      options: options
     } do
       insert(
         :address_current_token_balance,
@@ -51,16 +78,15 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
         value: 100
       )
 
-      changes = [
+      run_changes(
         %{
           address_hash: address.hash,
           block_number: 2,
           token_contract_address_hash: token.contract_address_hash,
           value: Decimal.new(200)
-        }
-      ]
-
-      CurrentTokenBalances.insert(Repo, changes, insert_options)
+        },
+        options
+      )
 
       current_token_balance = Repo.get_by(CurrentTokenBalance, address_hash: address.hash)
 
@@ -69,33 +95,211 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
     end
 
     test "ignores when the new block number is lesser", %{
-      address: address,
-      token: token,
-      insert_options: insert_options
+      address: %Address{hash: address_hash} = address,
+      token: %Token{contract_address_hash: token_contract_address_hash},
+      options: options
     } do
       insert(
         :address_current_token_balance,
         address: address,
         block_number: 2,
-        token_contract_address_hash: token.contract_address_hash,
+        token_contract_address_hash: token_contract_address_hash,
         value: 200
       )
 
-      changes = [
-        %{
-          address_hash: address.hash,
-          block_number: 1,
-          token_contract_address_hash: token.contract_address_hash,
-          value: Decimal.new(100)
-        }
-      ]
+      update_holder_count!(token_contract_address_hash, 1)
 
-      CurrentTokenBalances.insert(Repo, changes, insert_options)
+      assert {:ok, %{address_current_token_balances: [], address_current_token_balances_update_token_holder_counts: []}} =
+               run_changes(
+                 %{
+                   address_hash: address_hash,
+                   token_contract_address_hash: token_contract_address_hash,
+                   block_number: 1,
+                   value: Decimal.new(100)
+                 },
+                 options
+               )
 
-      current_token_balance = Repo.get_by(CurrentTokenBalance, address_hash: address.hash)
+      current_token_balance = Repo.get_by(CurrentTokenBalance, address_hash: address_hash)
 
       assert current_token_balance.block_number == 2
       assert current_token_balance.value == Decimal.new(200)
     end
+
+    test "a non-holder updating to a holder increases the holder_count", %{
+      address: %Address{hash: address_hash} = address,
+      token: %Token{contract_address_hash: token_contract_address_hash},
+      options: options
+    } do
+      previous_block_number = 1
+
+      insert_token_balance(%{
+        address: address,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: previous_block_number,
+        value: 0
+      })
+
+      block_number = previous_block_number + 1
+      value = Decimal.new(1)
+
+      assert {:ok,
+              %{
+                address_current_token_balances: [
+                  %Explorer.Chain.Address.CurrentTokenBalance{
+                    address_hash: ^address_hash,
+                    block_number: ^block_number,
+                    token_contract_address_hash: ^token_contract_address_hash,
+                    value: ^value
+                  }
+                ],
+                address_current_token_balances_update_token_holder_counts: [
+                  %{
+                    contract_address_hash: ^token_contract_address_hash,
+                    holder_count: 1
+                  }
+                ]
+              }} =
+               run_changes(
+                 %{
+                   address_hash: address_hash,
+                   token_contract_address_hash: token_contract_address_hash,
+                   block_number: block_number,
+                   value: value
+                 },
+                 options
+               )
+    end
+
+    test "a holder updating to a non-holder decreases the holder_count", %{
+      address: %Address{hash: address_hash} = address,
+      token: %Token{contract_address_hash: token_contract_address_hash},
+      options: options
+    } do
+      previous_block_number = 1
+
+      insert_token_balance(%{
+        address: address,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: previous_block_number,
+        value: 1
+      })
+
+      update_holder_count!(token_contract_address_hash, 1)
+
+      block_number = previous_block_number + 1
+      value = Decimal.new(0)
+
+      assert {:ok,
+              %{
+                address_current_token_balances: [
+                  %Explorer.Chain.Address.CurrentTokenBalance{
+                    address_hash: ^address_hash,
+                    block_number: ^block_number,
+                    token_contract_address_hash: ^token_contract_address_hash,
+                    value: ^value
+                  }
+                ],
+                address_current_token_balances_update_token_holder_counts: [
+                  %{contract_address_hash: ^token_contract_address_hash, holder_count: 0}
+                ]
+              }} =
+               run_changes(
+                 %{
+                   address_hash: address_hash,
+                   token_contract_address_hash: token_contract_address_hash,
+                   block_number: block_number,
+                   value: value
+                 },
+                 options
+               )
+    end
+
+    test "a non-holder becoming and a holder becoming while a holder becomes a non-holder cancels out and holder_count does not change",
+         %{
+           address: %Address{hash: non_holder_becomes_holder_address_hash} = non_holder_becomes_holder_address,
+           token: %Token{contract_address_hash: token_contract_address_hash},
+           options: options
+         } do
+      previous_block_number = 1
+
+      insert_token_balance(%{
+        address: non_holder_becomes_holder_address,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: previous_block_number,
+        value: 0
+      })
+
+      %Address{hash: holder_becomes_non_holder_address_hash} = holder_becomes_non_holder_address = insert(:address)
+
+      insert_token_balance(%{
+        address: holder_becomes_non_holder_address,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: previous_block_number,
+        value: 1
+      })
+
+      update_holder_count!(token_contract_address_hash, 1)
+
+      block_number = previous_block_number + 1
+      non_holder_becomes_holder_value = Decimal.new(1)
+      holder_becomes_non_holder_value = Decimal.new(0)
+
+      assert {:ok,
+              %{
+                deleted_address_current_token_balances: [
+                  %{
+                    address_hash: ^non_holder_becomes_holder_address_hash,
+                    token_contract_address_hash: ^token_contract_address_hash
+                  },
+                  %{
+                    address_hash: ^holder_becomes_non_holder_address_hash,
+                    token_contract_address_hash: ^token_contract_address_hash
+                  }
+                ],
+                address_current_token_balances: [
+                  %{
+                    address_hash: ^non_holder_becomes_holder_address_hash,
+                    token_contract_address_hash: ^token_contract_address_hash,
+                    block_number: ^block_number,
+                    value: ^non_holder_becomes_holder_value
+                  },
+                  %{
+                    address_hash: ^holder_becomes_non_holder_address_hash,
+                    token_contract_address_hash: ^token_contract_address_hash,
+                    block_number: ^block_number,
+                    value: ^holder_becomes_non_holder_value
+                  }
+                ],
+                address_current_token_balances_update_token_holder_counts: []
+              }} =
+               run_changes_list(
+                 [
+                   %{
+                     address_hash: non_holder_becomes_holder_address_hash,
+                     token_contract_address_hash: token_contract_address_hash,
+                     block_number: block_number,
+                     value: non_holder_becomes_holder_value
+                   },
+                   %{
+                     address_hash: holder_becomes_non_holder_address_hash,
+                     token_contract_address_hash: token_contract_address_hash,
+                     block_number: block_number,
+                     value: holder_becomes_non_holder_value
+                   }
+                 ],
+                 options
+               )
+    end
+  end
+
+  defp run_changes(changes, options) when is_map(changes) do
+    run_changes_list([changes], options)
+  end
+
+  defp run_changes_list(changes_list, options) when is_list(changes_list) do
+    Multi.new()
+    |> CurrentTokenBalances.run(changes_list, options)
+    |> Repo.transaction()
   end
 end

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -5,7 +5,7 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
   alias Ecto.Multi
   alias Explorer.Chain.Import.Runner.{Blocks, Transaction}
-  alias Explorer.Chain.{Address, Block, Transaction}
+  alias Explorer.Chain.{Address, Block, Token, Transaction}
   alias Explorer.Repo
 
   describe "run/1" do
@@ -78,14 +78,9 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
     end
 
     test "delete_address_current_token_balances deletes rows with matching block number when consensus is true",
-         %{consensus_block: %Block{hash: block_hash, miner_hash: miner_hash, number: block_number}, options: options} do
+         %{consensus_block: %Block{number: block_number} = block, options: options} do
       %Address.CurrentTokenBalance{address_hash: address_hash, token_contract_address_hash: token_contract_address_hash} =
         insert(:address_current_token_balance, block_number: block_number)
-
-      block_params = params_for(:block, hash: block_hash, miner_hash: miner_hash, number: block_number, consensus: true)
-
-      %Ecto.Changeset{valid?: true, changes: block_changes} = Block.changeset(%Block{}, block_params)
-      changes_list = [block_changes]
 
       assert count(Address.CurrentTokenBalance) == 1
 
@@ -94,23 +89,14 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
                 delete_address_current_token_balances: [
                   %{address_hash: ^address_hash, token_contract_address_hash: ^token_contract_address_hash}
                 ]
-              }} =
-               Multi.new()
-               |> Blocks.run(changes_list, options)
-               |> Repo.transaction()
+              }} = run_block_consensus_change(block, true, options)
 
       assert count(Address.CurrentTokenBalance) == 0
     end
 
     test "delete_address_current_token_balances does not delete rows with matching block number when consensus is false",
-         %{consensus_block: %Block{hash: block_hash, miner_hash: miner_hash, number: block_number}, options: options} do
+         %{consensus_block: %Block{number: block_number} = block, options: options} do
       %Address.CurrentTokenBalance{} = insert(:address_current_token_balance, block_number: block_number)
-
-      block_params =
-        params_for(:block, hash: block_hash, miner_hash: miner_hash, number: block_number, consensus: false)
-
-      %Ecto.Changeset{valid?: true, changes: block_changes} = Block.changeset(%Block{}, block_params)
-      changes_list = [block_changes]
 
       count = 1
 
@@ -119,59 +105,30 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
       assert {:ok,
               %{
                 delete_address_current_token_balances: []
-              }} =
-               Multi.new()
-               |> Blocks.run(changes_list, options)
-               |> Repo.transaction()
+              }} = run_block_consensus_change(block, false, options)
 
       assert count(Address.CurrentTokenBalance) == count
     end
 
     test "derive_address_current_token_balances inserts rows if there is an address_token_balance left for the rows deleted by delete_address_current_token_balances",
-         %{consensus_block: %Block{hash: block_hash, miner_hash: miner_hash, number: block_number}, options: options} do
-      %Address.TokenBalance{
-        address_hash: address_hash,
-        token_contract_address_hash: token_contract_address_hash,
-        value: previous_value,
-        block_number: previous_block_number
-      } = insert(:token_balance, block_number: block_number - 1)
+         %{consensus_block: %Block{number: block_number} = block, options: options} do
+      token = insert(:token)
+      token_contract_address_hash = token.contract_address_hash
 
-      address = Repo.get(Address, address_hash)
+      %Address{hash: address_hash} =
+        insert_address_with_token_balances(%{
+          previous: %{value: 1},
+          current: %{block_number: block_number, value: 2},
+          token_contract_address_hash: token_contract_address_hash
+        })
 
-      %Address.TokenBalance{
-        address_hash: ^address_hash,
-        token_contract_address_hash: ^token_contract_address_hash,
-        value: current_value,
-        block_number: ^block_number
-      } =
-        insert(:token_balance,
-          address: address,
-          token_contract_address_hash: token_contract_address_hash,
-          block_number: block_number
-        )
-
-      refute current_value == previous_value
-
-      %Address.CurrentTokenBalance{
-        address_hash: ^address_hash,
-        token_contract_address_hash: ^token_contract_address_hash,
-        block_number: ^block_number,
-        value: ^current_value
-      } =
-        insert(:address_current_token_balance,
-          address: address,
-          token_contract_address_hash: token_contract_address_hash,
-          block_number: block_number,
-          value: current_value
-        )
-
-      block_params = params_for(:block, hash: block_hash, miner_hash: miner_hash, number: block_number, consensus: true)
-
-      %Ecto.Changeset{valid?: true, changes: block_changes} = Block.changeset(%Block{}, block_params)
-      changes_list = [block_changes]
+      # Token must exist with non-`nil` `holder_count` for `update_token_holder_counts` to update
+      update_holder_count!(token_contract_address_hash, 1)
 
       assert count(Address.TokenBalance) == 2
       assert count(Address.CurrentTokenBalance) == 1
+
+      previous_block_number = block_number - 1
 
       assert {:ok,
               %{
@@ -194,14 +151,15 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
                     token_contract_address_hash: ^token_contract_address_hash,
                     block_number: ^previous_block_number
                   }
-                ]
-              }} =
-               Multi.new()
-               |> Blocks.run(changes_list, options)
-               |> Repo.transaction()
+                ],
+                # no updates because it both deletes and derives a holder
+                update_token_holder_counts: []
+              }} = run_block_consensus_change(block, true, options)
 
       assert count(Address.TokenBalance) == 1
       assert count(Address.CurrentTokenBalance) == 1
+
+      previous_value = Decimal.new(1)
 
       assert %Address.CurrentTokenBalance{block_number: ^previous_block_number, value: ^previous_value} =
                Repo.get_by(Address.CurrentTokenBalance,
@@ -209,9 +167,193 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
                  token_contract_address_hash: token_contract_address_hash
                )
     end
+
+    test "a non-holder reverting to a holder increases the holder_count",
+         %{consensus_block: %Block{hash: block_hash, miner_hash: miner_hash, number: block_number}, options: options} do
+      token = insert(:token)
+      token_contract_address_hash = token.contract_address_hash
+
+      non_holder_reverts_to_holder(%{
+        current: %{block_number: block_number},
+        token_contract_address_hash: token_contract_address_hash
+      })
+
+      # Token must exist with non-`nil` `holder_count` for `update_token_holder_counts` to update
+      update_holder_count!(token_contract_address_hash, 0)
+
+      block_params = params_for(:block, hash: block_hash, miner_hash: miner_hash, number: block_number, consensus: true)
+
+      %Ecto.Changeset{valid?: true, changes: block_changes} = Block.changeset(%Block{}, block_params)
+      changes_list = [block_changes]
+
+      assert {:ok,
+              %{
+                update_token_holder_counts: [
+                  %{
+                    contract_address_hash: ^token_contract_address_hash,
+                    holder_count: 1
+                  }
+                ]
+              }} =
+               Multi.new()
+               |> Blocks.run(changes_list, options)
+               |> Repo.transaction()
+    end
+
+    test "a holder reverting to a non-holder decreases the holder_count",
+         %{consensus_block: %Block{hash: block_hash, miner_hash: miner_hash, number: block_number}, options: options} do
+      token = insert(:token)
+      token_contract_address_hash = token.contract_address_hash
+
+      holder_reverts_to_non_holder(%{
+        current: %{block_number: block_number},
+        token_contract_address_hash: token_contract_address_hash
+      })
+
+      # Token must exist with non-`nil` `holder_count` for `update_token_holder_counts` to update
+      update_holder_count!(token_contract_address_hash, 1)
+
+      block_params = params_for(:block, hash: block_hash, miner_hash: miner_hash, number: block_number, consensus: true)
+
+      %Ecto.Changeset{valid?: true, changes: block_changes} = Block.changeset(%Block{}, block_params)
+      changes_list = [block_changes]
+
+      assert {:ok,
+              %{
+                update_token_holder_counts: [
+                  %{
+                    contract_address_hash: ^token_contract_address_hash,
+                    holder_count: 0
+                  }
+                ]
+              }} =
+               Multi.new()
+               |> Blocks.run(changes_list, options)
+               |> Repo.transaction()
+    end
+
+    test "a non-holder becoming and a holder becoming while a holder becomes a non-holder cancels out and holder_count does not change",
+         %{consensus_block: %Block{number: block_number} = block, options: options} do
+      token = insert(:token)
+      token_contract_address_hash = token.contract_address_hash
+
+      non_holder_reverts_to_holder(%{
+        current: %{block_number: block_number},
+        token_contract_address_hash: token_contract_address_hash
+      })
+
+      holder_reverts_to_non_holder(%{
+        current: %{block_number: block_number},
+        token_contract_address_hash: token_contract_address_hash
+      })
+
+      # Token must exist with non-`nil` `holder_count` for `update_token_holder_counts` to update
+      update_holder_count!(token_contract_address_hash, 1)
+
+      assert {:ok,
+              %{
+                # cancels out to no change
+                update_token_holder_counts: []
+              }} = run_block_consensus_change(block, true, options)
+    end
   end
 
   defp count(schema) do
     Repo.one!(select(schema, fragment("COUNT(*)")))
+  end
+
+  defp holder_reverts_to_non_holder(%{
+         current: %{block_number: current_block_number},
+         token_contract_address_hash: token_contract_address_hash
+       }) do
+    insert_address_with_token_balances(%{
+      previous: %{value: 0},
+      current: %{block_number: current_block_number, value: 1},
+      token_contract_address_hash: token_contract_address_hash
+    })
+  end
+
+  defp non_holder_reverts_to_holder(%{
+         current: %{block_number: current_block_number},
+         token_contract_address_hash: token_contract_address_hash
+       }) do
+    insert_address_with_token_balances(%{
+      previous: %{value: 1},
+      current: %{block_number: current_block_number, value: 0},
+      token_contract_address_hash: token_contract_address_hash
+    })
+  end
+
+  defp insert_address_with_token_balances(%{
+         previous: %{value: previous_value},
+         current: %{block_number: current_block_number, value: current_value},
+         token_contract_address_hash: token_contract_address_hash
+       }) do
+    %Address.TokenBalance{
+      address_hash: address_hash,
+      token_contract_address_hash: ^token_contract_address_hash
+    } =
+      insert(:token_balance,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: current_block_number - 1,
+        value: previous_value
+      )
+
+    address = Repo.get(Address, address_hash)
+
+    %Address.TokenBalance{
+      address_hash: ^address_hash,
+      token_contract_address_hash: ^token_contract_address_hash,
+      block_number: ^current_block_number,
+      value: holder_current_value
+    } =
+      insert(:token_balance,
+        address: address,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: current_block_number,
+        value: current_value
+      )
+
+    %Address.CurrentTokenBalance{
+      address_hash: ^address_hash,
+      token_contract_address_hash: ^token_contract_address_hash,
+      block_number: ^current_block_number,
+      value: ^holder_current_value
+    } =
+      insert(:address_current_token_balance,
+        address: address,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: current_block_number,
+        value: holder_current_value
+      )
+
+    address
+  end
+
+  defp run_block_consensus_change(
+         %Block{hash: block_hash, miner_hash: miner_hash, number: block_number},
+         consensus,
+         options
+       ) do
+    block_params =
+      params_for(:block, hash: block_hash, miner_hash: miner_hash, number: block_number, consensus: consensus)
+
+    %Ecto.Changeset{valid?: true, changes: block_changes} = Block.changeset(%Block{}, block_params)
+    changes_list = [block_changes]
+
+    Multi.new()
+    |> Blocks.run(changes_list, options)
+    |> Repo.transaction()
+  end
+
+  defp update_holder_count!(contract_address_hash, holder_count) do
+    {1, [%{holder_count: ^holder_count}]} =
+      Repo.update_all(
+        from(token in Token,
+          where: token.contract_address_hash == ^contract_address_hash,
+          select: map(token, [:holder_count])
+        ),
+        set: [holder_count: holder_count]
+      )
   end
 end

--- a/apps/explorer/test/support/chain/import/runner_case.ex
+++ b/apps/explorer/test/support/chain/import/runner_case.ex
@@ -1,0 +1,78 @@
+defmodule Explorer.Chain.Import.RunnerCase do
+  import Explorer.Factory, only: [insert: 2]
+  import Ecto.Query, only: [from: 2]
+
+  alias Explorer.Chain.{Address, Token}
+  alias Explorer.Repo
+
+  def insert_address_with_token_balances(%{
+        previous: %{value: previous_value},
+        current: %{block_number: current_block_number, value: current_value},
+        token_contract_address_hash: token_contract_address_hash
+      }) do
+    %Address.TokenBalance{
+      address_hash: address_hash,
+      token_contract_address_hash: ^token_contract_address_hash
+    } =
+      insert(:token_balance,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: current_block_number - 1,
+        value: previous_value
+      )
+
+    address = Repo.get(Address, address_hash)
+
+    insert_token_balance(%{
+      address: address,
+      token_contract_address_hash: token_contract_address_hash,
+      block_number: current_block_number,
+      value: current_value
+    })
+
+    address
+  end
+
+  def insert_token_balance(%{
+        address: %Address{hash: address_hash} = address,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: block_number,
+        value: value
+      }) do
+    %Address.TokenBalance{
+      address_hash: ^address_hash,
+      token_contract_address_hash: ^token_contract_address_hash,
+      block_number: ^block_number,
+      value: cast_value
+    } =
+      insert(:token_balance,
+        address: address,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: block_number,
+        value: value
+      )
+
+    %Address.CurrentTokenBalance{
+      address_hash: ^address_hash,
+      token_contract_address_hash: ^token_contract_address_hash,
+      block_number: ^block_number,
+      value: ^cast_value
+    } =
+      insert(:address_current_token_balance,
+        address: address,
+        token_contract_address_hash: token_contract_address_hash,
+        block_number: block_number,
+        value: value
+      )
+  end
+
+  def update_holder_count!(contract_address_hash, holder_count) do
+    {1, [%{holder_count: ^holder_count}]} =
+      Repo.update_all(
+        from(token in Token,
+          where: token.contract_address_hash == ^contract_address_hash,
+          select: map(token, [:holder_count])
+        ),
+        set: [holder_count: holder_count]
+      )
+  end
+end


### PR DESCRIPTION
Fixes #1328

## Changelog

### Bug Fixes
* `Token` `holder_count` stores `Explorer.Chain.count_token_holders_from_token_hash`, so it does not need to be recalculate for all runs.  The `holder_count` is `nil` and must be initialized with a data migration.  Since we know `count_token_holders_from_token_hash` across all tokens takes ~90
minutes the `token.holder_count` will be checked first, but if it is `nil`, `count_token_holders_from_token_hash` will still be called, which means the code can be deployed and the data migrations run in the background without blocking further deploys.
  * When `CurrentTokenBalance`s change due to blocks being reorged in `delete_address_current_token_balances` and `derive_address_current_token_balances`, whether an `address_hash` is a holder can change, which means the token holder_count can change.

  `update_token_holder_counts` checks if there is a net change in holders or does not update for that token.
  * When `CurrentTokenBalance`s are directly changed

    1. Determine which rows will be deleted in `deleted_address_current_token_balances` using same `where` as `on_conflict` for `address_current_token_balances`
    2. Upsert rows using pre-existing `address_current_token_balances`.
    3. Calculate delta of holder count using `deleted_address_current_token_balances` and `address_current_token_balances`.  If the delta is non-zero, update the `tokens.holder_count`.
  * `update_new_tokens_holder_count_in_batches` will `UPDATE` any `tokens` where `holders_count` is `NULL` will have it set using the same query as `Explorer.Chain.count_token_holders_from_token_hash/1`, so after `holders_count` is filled in, it will just be a faster version of `Explorer.Chain.count_token_holders_from_token_hash/1`.  `holder_counts` is updated with deltas by `Explorer.Chain.Import.Runner.{Block, Address.CurrentTokenBalance}` as `address_current_token_balances` is changed in a way that would change `Explorer.Chain.count_token_holders_from_token_hash/1` without the need to run the expensive `COUNT` query again.

## Upgrading

1. Run migrations as normal to give `tokens` `holder_count`, but as `NULL`.
2. Run the code in production
3. While production is up, run `update_new_tokens_holder_count_in_batches.sql` to fill in those `NULL`s.  The slow way using `Explorer.Chain.count_token_holders_from_token_hash/1` will continue to be used while the script runs.
   * Tell @KronicDeth if the estimate is over ≫ 90 minutes.
4. With `NULL`s filled, check that the slow tokens from #1328 are no longer slow/timing out.