### PR TITLE
fix: add height for footer logo

### DIFF
--- a/apps/block_scout_web/assets/css/components/_footer.scss
+++ b/apps/block_scout_web/assets/css/components/_footer.scss
@@ -15,6 +15,10 @@ $footer-text-color: rgba($white, 0.7);
   }
 }
 
+.footer-logo {
+  height: 2rem;
+}
+
 .footer-social-icons {
   // float: right;
   padding-top: 0.5em;
@@ -36,12 +40,12 @@ $footer-text-color: rgba($white, 0.7);
   padding-top: 1em;
 
   h3 {
-    margin-bottom: 0em;
+    margin-bottom: 0;
     // text-align: center;
   }
 
   hr {
-    margin-top: 0em;
+    margin-top: 0;
     margin-bottom: 1em;
     border: 0;
     height: 0;


### PR DESCRIPTION
## Motivation

The footer will scale to the size of the image without this. This keeps it to a good size for the footer logo.

Wrong:

![screen shot 2019-01-17 at 12 36 41 pm](https://user-images.githubusercontent.com/5722339/51337241-90c64a00-1a54-11e9-9d0f-7e65475628d4.png)


Fixed: 

![screen shot 2019-01-17 at 12 36 10 pm](https://user-images.githubusercontent.com/5722339/51337208-81470100-1a54-11e9-8571-55a524ad6cea.png)
