### PR TITLE
feat: render addresses according to eip-55

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
@@ -5,7 +5,7 @@
     <%= if assigns[:truncate] do %>
       <%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %>
     <% else %>
-      <span class="d-none d-md-none d-lg-inline"><%= @address.hash %></span>
+      <span class="d-none d-md-none d-lg-inline"><%= @address %></span>
       <span class="d-md-inline-block d-lg-none"><%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %></span>
     <% end %>
   <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
@@ -1,6 +1,6 @@
-<span class="<%= if @contract do %>contract-address<% end %>" data-address-hash="<%= @address.hash %>">
+<span class="<%= if @contract do %>contract-address<% end %>" data-address-hash="<%= @address %>">
   <%= if name = primary_name(@address) do %>
-     <span data-toggle="tooltip" data-placement="top" title="<%= @address.hash %>"><%= name %> (<%= short_hash(@address) %>...)</span>
+     <span data-toggle="tooltip" data-placement="top" title="<%= @address %>"><%= name %> (<%= short_hash(@address) %>...)</span>
   <% else %>
     <%= if assigns[:truncate] do %>
       <%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -23,7 +23,7 @@
             <% end %>
           </div>
           <h1 class="card-title"><%= address_title(@address) %> <%= gettext "Details" %> </h1>
-          <h3 class="<%= if BlockScoutWeb.AddressView.contract?(@address) do %>contract-address<% end %>" data-test="address_detail_hash"><%= @address.hash %></h3>
+          <h3 class="<%= if BlockScoutWeb.AddressView.contract?(@address) do %>contract-address<% end %>" data-test="address_detail_hash"><%= @address %></h3>
           <div class="d-flex flex-column flex-lg-row justify-content-start text-muted">
             <%= if address_name = primary_name(@address) do %>
               <strong class="mr-4 mb-2 text-primary"><%= address_name %></strong>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -1,4 +1,4 @@
-<section class="address-overview" data-page="address-details" data-page-address-hash="<%= @address %>">
+<section class="address-overview" data-page="address-details" data-page-address-hash="<%= @address.hash %>">
   <div class="row">
     <div class="card-section col-md-12 col-lg-8">
       <div class="card">

--- a/apps/block_scout_web/lib/phoenix/html/safe.ex
+++ b/apps/block_scout_web/lib/phoenix/html/safe.ex
@@ -1,7 +1,13 @@
 alias Explorer.Chain
 alias Explorer.Chain.{Address, Block, Data, Hash, Transaction}
 
-defimpl Phoenix.HTML.Safe, for: [Address, Transaction] do
+defimpl Phoenix.HTML.Safe, for: Address do
+  def to_iodata(%@for{} = address) do
+    @for.checksum(address, true)
+  end
+end
+
+defimpl Phoenix.HTML.Safe, for: Transaction do
   def to_iodata(%@for{hash: hash}) do
     @protocol.to_iodata(hash)
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
@@ -405,7 +405,7 @@ defmodule BlockScoutWeb.API.RPC.TransactionControllerTest do
         "gasUsed" => "#{transaction.gas_used}",
         "logs" => [
           %{
-            "address" => "#{address}",
+            "address" => "#{address.hash}",
             "data" => "#{log.data}",
             "topics" => ["first topic", "second topic", nil, nil]
           }

--- a/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
@@ -31,8 +31,8 @@ defmodule BlockScoutWeb.AddressPage do
     css("[data-number-of-tokens-by-type='#{type}']", text: text)
   end
 
-  def address(%Address{hash: hash}) do
-    css("[data-address-hash='#{hash}']", text: to_string(hash))
+  def address(%Address{} = address) do
+    css("[data-address-hash='#{address}']", text: to_string(address))
   end
 
   def contract_creator do

--- a/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/address_page.ex
@@ -79,8 +79,8 @@ defmodule BlockScoutWeb.AddressPage do
     css("[data-address-hash='#{hash}']", text: to_string(hash))
   end
 
-  def detail_hash(%Address{hash: address_hash}) do
-    css("[data-test='address_detail_hash']", text: to_string(address_hash))
+  def detail_hash(address) do
+    css("[data-test='address_detail_hash']", text: to_string(address))
   end
 
   def internal_transaction(%InternalTransaction{transaction_hash: transaction_hash, index: index}) do
@@ -99,9 +99,11 @@ defmodule BlockScoutWeb.AddressPage do
         %InternalTransaction{transaction_hash: transaction_hash, index: index, from_address_hash: address_hash},
         :from
       ) do
+    checksum = Address.checksum(address_hash)
+
     css(
       "[data-internal-transaction-transaction-hash='#{transaction_hash}'][data-internal-transaction-index='#{index}']" <>
-        " [data-test='address_hash_link']" <> " [data-address-hash='#{address_hash}']"
+        " [data-test='address_hash_link']" <> " [data-address-hash='#{checksum}']"
     )
   end
 
@@ -134,20 +136,24 @@ defmodule BlockScoutWeb.AddressPage do
   end
 
   def transaction_address_link(%Transaction{hash: hash, from_address_hash: address_hash}, :from) do
-    css("[data-identifier-hash='#{hash}'] [data-test='address_hash_link'] [data-address-hash='#{address_hash}']")
+    checksum = Address.checksum(address_hash)
+
+    css("[data-identifier-hash='#{hash}'] [data-test='address_hash_link'] [data-address-hash='#{checksum}']")
   end
 
   def transaction_address_link(%Transaction{hash: hash, to_address_hash: address_hash}, :to) do
-    css("[data-identifier-hash='#{hash}'] [data-test='address_hash_link'] [data-address-hash='#{address_hash}']")
+    checksum = Address.checksum(address_hash)
+
+    css("[data-identifier-hash='#{hash}'] [data-test='address_hash_link'] [data-address-hash='#{checksum}']")
   end
 
   def transaction_status(%Transaction{hash: transaction_hash}) do
     css("[data-identifier-hash='#{transaction_hash}'] [data-test='transaction_status']")
   end
 
-  def token_transfer(%Transaction{hash: transaction_hash}, %Address{hash: address_hash}, count: count) do
+  def token_transfer(%Transaction{hash: transaction_hash}, %Address{} = address, count: count) do
     css(
-      "[data-identifier-hash='#{transaction_hash}'] [data-test='token_transfer'] [data-address-hash='#{address_hash}']",
+      "[data-identifier-hash='#{transaction_hash}'] [data-test='token_transfer'] [data-address-hash='#{address}']",
       count: count
     )
   end

--- a/apps/block_scout_web/test/block_scout_web/features/pages/block_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/block_page.ex
@@ -5,10 +5,11 @@ defmodule BlockScoutWeb.BlockPage do
 
   import Wallaby.Query, only: [css: 1, css: 2]
 
-  alias Explorer.Chain.{Block, InternalTransaction, Transaction}
+  alias Explorer.Chain.{Address, Block, InternalTransaction, Transaction}
 
   def contract_creation(%InternalTransaction{created_contract_address_hash: hash}) do
-    css("[data-address-hash='#{hash}']")
+    checksum = Address.checksum(hash)
+    css("[data-address-hash='#{checksum}']")
   end
 
   def detail_number(%Block{number: block_number}) do

--- a/apps/block_scout_web/test/block_scout_web/features/pages/chain_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/chain_page.ex
@@ -5,7 +5,7 @@ defmodule BlockScoutWeb.ChainPage do
 
   import Wallaby.Query, only: [css: 1, css: 2]
 
-  alias Explorer.Chain.{Block, Transaction}
+  alias Explorer.Chain.{Address, Block, Transaction}
 
   def block(%Block{number: block_number}) do
     css("[data-block-number='#{block_number}']")
@@ -16,7 +16,8 @@ defmodule BlockScoutWeb.ChainPage do
   end
 
   def contract_creation(%Transaction{created_contract_address_hash: hash}) do
-    css("[data-test='contract-creation'] [data-address-hash='#{hash}']")
+    checksum = Address.checksum(hash)
+    css("[data-test='contract-creation'] [data-address-hash='#{checksum}']")
   end
 
   def place_holder_blocks(count) do

--- a/apps/block_scout_web/test/block_scout_web/features/pages/transaction_logs_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/transaction_logs_page.ex
@@ -6,7 +6,7 @@ defmodule BlockScoutWeb.TransactionLogsPage do
   import Wallaby.Query, only: [css: 1, css: 2]
   import BlockScoutWeb.Router.Helpers, only: [transaction_log_path: 3]
 
-  alias Explorer.Chain.{Address, Transaction}
+  alias Explorer.Chain.Transaction
   alias BlockScoutWeb.Endpoint
 
   def logs(count: count) do
@@ -17,7 +17,7 @@ defmodule BlockScoutWeb.TransactionLogsPage do
     visit(session, transaction_log_path(Endpoint, :index, transaction))
   end
 
-  def click_address(session, %Address{hash: address_hash}) do
-    click(session, css("[data-test='log_address_link'][data-address-hash='#{address_hash}']"))
+  def click_address(session, address) do
+    click(session, css("[data-test='log_address_link'][data-address-hash='#{address}']"))
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
@@ -334,19 +334,19 @@ defmodule BlockScoutWeb.AddressViewTest do
       smart_contract = build(:smart_contract, name: "POA")
       address = build(:address, smart_contract: smart_contract)
 
-      assert AddressView.address_page_title(address) == "POA (#{address.hash})"
+      assert AddressView.address_page_title(address) == "POA (#{address})"
     end
 
     test "uses the string 'Contract' when it's a contract" do
       address = build(:contract_address, smart_contract: nil)
 
-      assert AddressView.address_page_title(address) == "Contract #{address.hash}"
+      assert AddressView.address_page_title(address) == "Contract #{address}"
     end
 
     test "uses the address hash when it is not a contract" do
       address = build(:address, smart_contract: nil)
 
-      assert AddressView.address_page_title(address) == "#{address.hash}"
+      assert AddressView.address_page_title(address) == "#{address}"
     end
   end
 end

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -85,8 +85,17 @@ defmodule Explorer.Chain.Address do
     |> unique_constraint(:hash)
   end
 
-  def checksum(%__MODULE__{hash: hash}, iodata? \\ false) do
-    "0x" <> string_hash = to_string(hash)
+  def checksum(address_or_hash, iodata? \\ false)
+
+  def checksum(%__MODULE__{hash: hash}, iodata?) do
+    checksum(hash, iodata?)
+  end
+
+  def checksum(hash, iodata?) do
+    string_hash =
+      hash
+      |> to_string()
+      |> String.trim_leading("0x")
 
     match_byte_stream = stream_every_four_bytes_of_sha256(string_hash)
 

--- a/apps/explorer/test/explorer/chain/address_test.exs
+++ b/apps/explorer/test/explorer/chain/address_test.exs
@@ -26,4 +26,18 @@ defmodule Explorer.Chain.AddressTest do
       assert Repo.one(Address.count_with_fetched_coin_balance()) == 2
     end
   end
+
+  describe "Phoenix.HTML.Safe.to_iodata/1" do
+    defp str(value) do
+      to_string(insert(:address, hash: value))
+    end
+
+    test "returns the checksum formatted address" do
+      assert str("0xdf9aac76b722b08511a4c561607a9bf3afa62e49") == "0xDF9AaC76b722B08511A4C561607A9bf3AfA62E49"
+      assert str("0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed") == "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"
+      assert str("0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359") == "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
+      assert str("0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb") == "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"
+      assert str("0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb") == "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"
+    end
+  end
 end

--- a/apps/indexer/test/indexer_test.exs
+++ b/apps/indexer/test/indexer_test.exs
@@ -1,7 +1,5 @@
 defmodule IndexerTest do
   use Explorer.DataCase, async: true
 
-  import Explorer.Factory
-
   doctest Indexer
 end


### PR DESCRIPTION
Resolves #1125

## Motivation

* To be consistent with other explorers, and make copying addresses from blockscout as safe as possible, we display the checksum formatted version of addresses wherever we show addresses. The specification itself can be found here: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md#specification

## Changelog

### Enhancements
* Alter the representation of addresses both `to_string/1` and `Phoenix.HTML.Safe.to_iodata/1` to return the checksum formatted address.

![screen shot 2019-01-17 at 3 42 44 pm](https://user-images.githubusercontent.com/5722339/51347598-903aad00-1a6e-11e9-9fa2-c854672c0ac1.png)
