### PR TITLE
Make insert_address_current_token_balances_in_batches only insert new

### DIFF
--- a/apps/explorer/priv/repo/migrations/scripts/insert_address_current_token_balances_in_batches.sql
+++ b/apps/explorer/priv/repo/migrations/scripts/insert_address_current_token_balances_in_batches.sql
@@ -1,69 +1,133 @@
 DO $$
 DECLARE
-   row_count integer := 1;
-   batch_size  integer := 50000; -- HOW MANY ITEMS WILL BE UPDATED AT TIME
-   iterator  integer := batch_size;
-   affected integer;
+  total_count         integer                     := 0;
+  completed_count     integer                     := 0;
+  remaining_count     integer                     := 0;
+  batch_size          integer                     := 50000; -- HOW MANY ITEMS WILL BE UPDATED AT TIME
+  iterator            integer                     := batch_size;
+  updated_count       integer;
+  deleted_count       integer;
+  start_time          TIMESTAMP WITHOUT TIME ZONE := clock_timestamp();
+  end_time            TIMESTAMP WITHOUT TIME ZONE;
+  elapsed_time        INTERVAL;
+  temp_start_time     TIMESTAMP WITHOUT TIME ZONE;
+  temp_end_time       TIMESTAMP WITHOUT TIME ZONE;
+  temp_elapsed_time   INTERVAL;
+  insert_start_time   TIMESTAMP WITHOUT TIME ZONE;
+  insert_end_time     TIMESTAMP WITHOUT TIME ZONE;
+  insert_elapsed_time INTERVAL;
+  per_row             INTERVAL;
 BEGIN
-  DROP TABLE IF EXISTS current_token_balance_temp;
-  -- CREATES TEMP TABLE TO STORE TOKEN BALANCES TO BE UPDATED
-  CREATE TEMP TABLE current_token_balance_temp(
-    address_hash bytea NOT NULL,
-    block_number bigint NOT NULL,
-    token_contract_address_hash bytea NOT NULL,
-    value numeric,
-    value_fetched_at timestamp without time zone,
-    inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    row_number integer
-  );
-  INSERT INTO current_token_balance_temp
-  SELECT DISTINCT ON (address_hash, token_contract_address_hash)
-    address_hash,
-    block_number,
-    token_contract_address_hash,
-    value,
-    value_fetched_at,
-    inserted_at,
-    updated_at,
-    ROW_NUMBER () OVER ()
-  FROM address_token_balances
-  WHERE value IS NOT NULL
-  ORDER BY address_hash, token_contract_address_hash, block_number DESC;
+  RAISE NOTICE 'Started at %', start_time;
 
-  row_count := (SELECT count(*) FROM current_token_balance_temp);
-  RAISE NOTICE '% items to be updated', row_count;
+  temp_start_time := clock_timestamp();
+
+  DROP TABLE IF EXISTS address_token_balances_without_required_current;
+  CREATE TEMP TABLE address_token_balances_without_required_current(
+    token_contract_address_hash bytea NOT NULL,
+    address_hash bytea NOT NULL,
+    row_number integer NOT NULL
+  );
+
+  INSERT INTO address_token_balances_without_required_current
+  SELECT token_contract_address_hash,
+         address_hash,
+         ROW_NUMBER() OVER ()
+  FROM (
+      SELECT DISTINCT token_contract_address_hash,
+                      address_hash
+      FROM address_token_balances
+      WHERE value IS NOT NULL
+      EXCEPT
+      SELECT token_contract_address_hash,
+             address_hash
+      FROM address_current_token_balances
+    ) AS diff
+  ORDER BY address_hash,
+           token_contract_address_hash DESC;
+
+  temp_end_time := clock_timestamp();
+  temp_elapsed_time := temp_end_time - temp_start_time;
+  total_count := (SELECT COUNT(*) FROM address_token_balances_without_required_current);
+
+  RAISE NOTICE 'address_token_balances_without_required_current TEMP table filled in %', temp_elapsed_time;
+
+  remaining_count := total_count;
+
+  RAISE NOTICE '% address_current_token_balances to be inserted', remaining_count;
+
+  insert_start_time := clock_timestamp();
 
   -- ITERATES THROUGH THE ITEMS UNTIL THE TEMP TABLE IS EMPTY
-  WHILE row_count > 0 LOOP
-    -- INSERT THE TOKEN BALANCES AND RETURNS THE ADDRESS HASH AND TOKEN HASH TO BE DELETED
-    WITH updated_address_current_token_balances AS (
-      INSERT INTO address_current_token_balances (address_hash, block_number, token_contract_address_hash, value, value_fetched_at, inserted_at, updated_at)
-      SELECT
-        address_hash,
-        block_number,
-        token_contract_address_hash,
-        value,
-        value_fetched_at,
-        inserted_at,
-        updated_at
-      FROM current_token_balance_temp
-      WHERE current_token_balance_temp.row_number <= iterator
-      RETURNING address_hash, token_contract_address_hash
-    )
-    DELETE FROM current_token_balance_temp
-    WHERE (address_hash, token_contract_address_hash) IN (select address_hash, token_contract_address_hash from updated_address_current_token_balances);
+  WHILE remaining_count > 0 LOOP
+    INSERT INTO address_current_token_balances (address_hash,
+                                                token_contract_address_hash,
+                                                block_number,
+                                                value,
+                                                value_fetched_at,
+                                                inserted_at,
+                                                updated_at)
+    SELECT address_token_balances_without_required_current.address_hash,
+           address_token_balances_without_required_current.token_contract_address_hash,
+           address_token_blocks.block_number,
+           address_token_balances.value,
+           address_token_balances.value_fetched_at,
+           address_token_balances.inserted_at,
+           address_token_balances.updated_at
+    FROM address_token_balances_without_required_current
+    INNER JOIN (
+        SELECT address_hash,
+               token_contract_address_hash,
+               MAX(block_number) AS block_number
+        FROM address_token_balances
+        GROUP BY address_hash,
+                 token_contract_address_hash
+      ) AS address_token_blocks
+    ON address_token_blocks.address_hash = address_token_balances_without_required_current.address_hash AND
+       address_token_blocks.token_contract_address_hash = address_token_balances_without_required_current.token_contract_address_hash
+    INNER JOIN address_token_balances
+    ON address_token_balances.address_hash = address_token_balances_without_required_current.address_hash AND
+       address_token_balances.token_contract_address_hash = address_token_balances_without_required_current.token_contract_address_hash AND
+       address_token_balances.block_number = address_token_blocks.block_number
+    WHERE address_token_balances_without_required_current.row_number <= iterator
+    ON CONFLICT DO NOTHING;
 
-    GET DIAGNOSTICS affected = ROW_COUNT;
-    RAISE NOTICE '-> % address current token balances updated!', affected;
+    GET DIAGNOSTICS updated_count = ROW_COUNT;
+    RAISE NOTICE '-> % address current token balances inserted.', updated_count;
+
+    DELETE FROM address_token_balances_without_required_current
+    WHERE address_token_balances_without_required_current.row_number <= iterator;
+
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RAISE NOTICE '-> % address token balances without required current removed from queue.', deleted_count;
 
     -- COMMITS THE BATCH UPDATES
     CHECKPOINT;
 
-    -- UPDATES THE COUNTER SO IT DOESN'T TURN INTO AN INFINITE LOOP
-    row_count := (SELECT count(*) FROM current_token_balance_temp);
+    remaining_count := remaining_count - deleted_count;
     iterator := iterator + batch_size;
-    RAISE NOTICE '-> % counter', row_count;
+    RAISE NOTICE '-> % remaining', remaining_count;
     RAISE NOTICE '-> % next batch', iterator;
+    insert_elapsed_time := clock_timestamp() - insert_start_time;
+    completed_count := total_count - remaining_count;
+    per_row := insert_elapsed_time / completed_count;
+    RAISE NOTICE '-> Estimated time until completion: %s', per_row * remaining_count;
   END LOOP;
+
+  end_time := clock_timestamp();
+  insert_end_time := end_time;
+  insert_elapsed_time = insert_end_time - insert_start_time;
+
+  IF total_count > 0 THEN
+    per_row := insert_elapsed_time / total_count;
+  ELSE
+    per_row := 0;
+  END IF;
+
+  RAISE NOTICE 'address_current_token_balances updated in % (% per row)', insert_elapsed_time, per_row;
+
+  elapsed_time := end_time - start_time;
+
+  RAISE NOTICE 'Ended at %s', end_time;
+  RAISE NOTICE 'Elapsed time: %', elapsed_time;
 END $$;


### PR DESCRIPTION
Fixes #1345

## Test Resources

### `missing_count.sql`

The number of `address_current_token_balances` that are missing because of the cause of #1345.

```sql
SELECT COUNT(*)
FROM (
       SELECT DISTINCT token_contract_address_hash,
                       address_hash
       FROM address_token_balances
            EXCEPT
       SELECT token_contract_address_hash,
              address_hash
       FROM address_current_token_balances
     ) AS address_token_balances_without_current
INNER JOIN address_token_balances
USING (token_contract_address_hash, address_hash)
WHERE value IS NOT NULL
```

### `missing.sql`

The `(token_contract_address_hash, addres_hash)` pairs that are missing a `address_current_token_balances` because of the cause of #1345.

```sql
SELECT address_token_balances.token_contract_address_hash,
       address_token_balances.address_hash
FROM (
       SELECT DISTINCT token_contract_address_hash,
                       address_hash
       FROM address_token_balances
            EXCEPT
       SELECT token_contract_address_hash,
              address_hash
       FROM address_current_token_balances
     ) AS address_token_balances_without_current
INNER JOIN address_token_balances
USING (token_contract_address_hash, address_hash)
WHERE value IS NOT NULL
```

### `poison.sql`

```sql
DELETE FROM address_current_token_balances
USING (
    SELECT *
    FROM address_current_token_balances
    LIMIT 500
  ) AS poisoned
WHERE address_current_token_balances.address_hash = poisoned.address_hash AND
      address_current_token_balances.token_contract_address_hash = poisoned.token_contract_address_hash
```

## Test Plan

1. Run against Eth Mainnet.
2. Shutdown the indexer.
3. Confirm cause of #1345 no longer exists by running `missing_count.sql` from Test Resources and **VERIFY:** count of `0`.
4. Create some missing `address_current_token_balances` to replicate Eth Mainnet prod's fault by running `poison.sql`.
5. Check that rows where poisoned.  Run `missing_count.sql`.  **VERIFY:**  count of`500`.
6. Run `insert_address_current_token_balances_in_batches`.  **VERIFY** It shows `500` rows needing inserts.
    ```
     500 address_current_token_balances to be inserted
    ```
7 Run `insert_address_current_token_balances_in_batches` again.  **VERIFY** it shows `0` rows needing inserts.  
  ```
   0 address_current_token_balances to be inserted
   ```
   This proves `insert_address_current_token_balances_in_batches` is now safe to run repeatedly.

## Changelog
### Enhancements
* `insert_address_current_token_balances_in_batches` is rewritten to follow the convention from the new scripts like `update_new_tokens_holder_count_in_batches`, which include more logging with timing informations and estimates.

### Bug Fixes
* The previous version of `insert_address_current_token_balances_in_batches` could only be run
once because it assumed that `address_current_token_balances` rows did not exist.  I could have added an `ON CONFLICT` to to allow `insert_address_current`insert_address_current` to be rerun, but that would have attempted to rebuild the whole table, which would be very costly as the the complex join and aggregate calculations would need to be done for all rows even if they eventually conflict and we do `ON CONFLICT DO NOTHING`.  

  Instead, `insert_address_current_token_balances_in_batches` searched for `address_token_balances` with `(address_hash, token_contract_address_hash)` pairs that should have an `address_current_token_balance` because the `address_token_balances` `value` is non-`NULL`.  From this set of `address_token_balances_requiring_current`, the set of `address_current_token_balances` is removed, leaving only those `address_token_balances_without_required_current`, which are those affected by #1345.

  
## Upgrading

1. Run the new version of `insert_address_current_token_balances_in_batches`.  It should show so number of `address_current_token_balances` missing:
    ```
     N address_current_token_balances to be inserted
    ```
    * Let @KronicDeth if the estimates or run time is multiple days as the script may require optimization then.