### PR TITLE
fix: don't reload every page

### DIFF
--- a/apps/block_scout_web/assets/js/lib/smart_contract/read_only_functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/read_only_functions.js
@@ -48,4 +48,6 @@ const readFunction = (element) => {
 
 const container = $('[data-smart-contract-functions]')
 
-loadFunctions(container)
+if (container.length) {
+  loadFunctions(container)
+}


### PR DESCRIPTION
## Motivation

For obvious reasons, we don't want to re-request every page we visit. This will also most likely offer at least a modest performance boost.

## Changelog

### Bug Fixes

* if no `data-smart-contract-functions` elements were found, then
the loadFunctions function would do `$.get(null, {hash: null})`
(or maybe its `undefined`, doesn't matter), which would just result
in refetching the current page again.
