### PR TITLE
Add HTTPS Upgrade to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ The [development stack page](https://github.com/poanetwork/blockscout/wiki/Devel
 
   8. Update your JSON RPC Endpoint in `apps/explorer/config/dev/` and `apps/indexer/config/dev/`
   For the `variant` chosen in step 7, enter the correct information for the corresponding JSON RPC Endpoint in `parity.exs`, `geth.exs`, or `ganache.exs`
+  
+  9. Enable HTTPS in development. The Phoenix server only runs with HTTPS now.
+     * `cd apps/block_scout_web`
+     * `mix phx.gen.cert blockscout blockscout.local`
+     * Add blockscout and blockscout.local to your `/etc/hosts`
+     ```
+        127.0.0.1       localhost blockscout blockscout.local
+        255.255.255.255 broadcasthost
+        ::1             localhost blockscout blockscout.local
+      ```
+      * If using Chrome, Enable `chrome://flags/#allow-insecure-localhost`.
 
   9. Start Phoenix Server.  
   `mix phx.server`


### PR DESCRIPTION
Fixes #1373 

## Motivation

With the upgrade to `HTTP/2`, the Phoenix server only runs in `HTTPS` in development. This README edit provides instructions to upgrade the development environment.

## Changelog

- add instructions to the README to upgrade to `HTTPS`

