### PR TITLE
update transactions even if internal transactions are inserted

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -66,7 +66,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         where_forked: where_forked
       })
     end)
-    |> Multi.run(:lose_consenus, fn repo, _ ->
+    |> Multi.run(:lose_consensus, fn repo, _ ->
       lose_consensus(repo, ordered_consensus_block_numbers, insert_options)
     end)
     |> Multi.run(:delete_address_token_balances, fn repo, _ ->

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -51,10 +51,8 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     |> Multi.run(:internal_transactions, fn repo, _ ->
       insert(repo, changes_list, insert_options)
     end)
-    |> Multi.run(:internal_transactions_indexed_at_transactions, fn repo,
-                                                                    %{internal_transactions: internal_transactions}
-                                                                    when is_list(internal_transactions) ->
-      update_transactions(repo, internal_transactions, update_transactions_options)
+    |> Multi.run(:internal_transactions_indexed_at_transactions, fn repo, _ ->
+      update_transactions(repo, changes_list, update_transactions_options)
     end)
   end
 


### PR DESCRIPTION
## Motivation

Initially, internal transactions weren't indexed because of #1337. Now, some transactions don't have `error` and `status` fields from internal transactions because internal transactions from these transactions are already inserted. However `error`, `status` and `internal_transactions_indexed_at` fields in transactions table are updated only for newly created internal transactions.

## Changelog

- update transactions even if internal transactions are inserted
- add regression test