### PR TITLE
Add Chain Consensus Logging

### DIFF
--- a/apps/indexer/lib/indexer/block/realtime/consensus_ensurer.ex
+++ b/apps/indexer/lib/indexer/block/realtime/consensus_ensurer.ex
@@ -22,7 +22,8 @@ defmodule Indexer.Block.Realtime.ConsensusEnsurer do
             "). A reorg initiated."
           ]
         end)
-        #trigger refetch if consensus=false or block was not found
+
+        # trigger refetch if consensus=false or block was not found
         Fetcher.fetch_and_import_block(number, block_fetcher, true)
     end
 

--- a/apps/indexer/lib/indexer/block/realtime/consensus_ensurer.ex
+++ b/apps/indexer/lib/indexer/block/realtime/consensus_ensurer.ex
@@ -3,6 +3,7 @@ defmodule Indexer.Block.Realtime.ConsensusEnsurer do
   Triggers a refetch if a given block doesn't have consensus.
 
   """
+  require Logger
 
   alias Explorer.Chain
   alias Explorer.Chain.Hash
@@ -14,7 +15,14 @@ defmodule Indexer.Block.Realtime.ConsensusEnsurer do
         :ignore
 
       _ ->
-        # trigger refetch if consensus=false or block was not found
+        Logger.info(fn ->
+          [
+            "refetch from consensus was found on block (",
+            to_string(number),
+            "). A reorg initiated."
+          ]
+        end)
+        #trigger refetch if consensus=false or block was not found
         Fetcher.fetch_and_import_block(number, block_fetcher, true)
     end
 


### PR DESCRIPTION
## Motivation

A bug has been noticed on `sokol`, `core`, and `xdai` where a massive number of blocks are being refetched multiple times. After running tests with the logging in this PR it is confirmed that we are reporting that reorgs are taking place. 

Now we have to determine whether these reorgs are actually happening or there is a bug in our reorg logic.

## Changelog
* Adds info log when we refetch a block due to a reorg.
