### PR TITLE
fix receipts for pending transactions

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -258,7 +258,14 @@ defmodule EthereumJSONRPC.Receipt do
 
   defp entry_to_elixir({key, quantity})
        when key in ~w(blockNumber cumulativeGasUsed gasUsed transactionIndex) do
-    {:ok, {key, quantity_to_integer(quantity)}}
+    result =
+      if is_nil(quantity) do
+        nil
+      else
+        quantity_to_integer(quantity)
+      end
+
+    {:ok, {key, result}}
   end
 
   defp entry_to_elixir({"logs" = key, logs}) do

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/receipt_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/receipt_test.exs
@@ -30,4 +30,11 @@ defmodule EthereumJSONRPC.ReceiptTest do
       assert Receipt.to_elixir(%{"status" => nil, "transactionHash" => "0x0"}) == %{"transactionHash" => "0x0"}
     end
   end
+
+  test "leaves nil if blockNumber is nil" do
+    assert Receipt.to_elixir(%{"blockNumber" => nil, "transactionHash" => "0x0"}) == %{
+             "transactionHash" => "0x0",
+             "blockNumber" => nil
+           }
+  end
 end


### PR DESCRIPTION
#1380 
## Motivation

Almost certainly some values in receipts of pending transactions have nil values (for example, `BlockNumber`)

## Changelog

- do not try to convert nil values to an integer in receipts response
