### PR TITLE
Fix Beneficiaries External 2 on xDAI

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
@@ -171,6 +171,7 @@ defmodule EthereumJSONRPC.Parity.FetchedBeneficiaries do
   # The rewardType "uncle" will show reward for validating an uncle block
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 0, do: :validator
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 1, do: :emission_funds
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 2, do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "block", do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "uncle", do: :uncle
 end


### PR DESCRIPTION
Fixes #1397 

## Motivation
Fixes a small bug detailed in #1397 

## Changelog
* adds reward type `external` at index 2

### Bug Fixes
Fixes no function clause matching in `EthereumJSONRPC.Parity.FetchedBeneficiaries.get_address_type/2`

