### PR TITLE
Fix docker build dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-elixir-phoenix:latest
+FROM bitwalker/alpine-elixir-phoenix:1.7.1
 
 RUN apk --no-cache --update add automake libtool inotify-tools autoconf
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitwalker/alpine-elixir-phoenix:1.7.1
 
-RUN apk --no-cache --update add automake libtool inotify-tools autoconf
+RUN apk --no-cache --update add automake libtool inotify-tools autoconf python
 
 EXPOSE 4000
 


### PR DESCRIPTION
closes #1391 

## Fix docker build dependencies

* pin bitwalker/alpine-elixir-phoenix to image version 1.7.1
* install missing python dependency