### PR TITLE
Dockerfile: conditionally change coin name in gettext via environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,9 @@ RUN mix do deps.get, deps.compile
 
 ADD . .
 
+ARG COIN
+RUN if [ "$COIN" != "" ]; then sed -i s/"POA"/"${COIN}"/g apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po; fi
+
 # Run forderground build and phoenix digest
 RUN mix compile
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -53,7 +53,7 @@ ifdef HAS_BLOCKSCOUT_IMAGE
 	@echo "==> Image exist. Using $(DOCKER_IMAGE)"
 else
 	@echo "==> No image found trying to build one..."
-	@docker build -f ./Dockerfile -t $(DOCKER_IMAGE) ../
+	@docker build --build-arg COIN="$(COIN)" -f ./Dockerfile -t $(DOCKER_IMAGE) ../
 endif
 
 migrate: build postgres


### PR DESCRIPTION
relates-to: #1387 

## Allow image creation with custom coin currency symbol / name

* Dockerfile: conditionally change coin name in gettext via environment

Note: This bakes the requested coin symbol into the docker image, rather than the default, "POA".  As some of the other environment variables can be changed between runs of the same image, changing the COIN variable will not change the coin name baked into an existing image.  To make such a change take effect after an image has already been built, simply `docker image remove blockscout_prod` before re-running `make start` to rebuild.