### PR TITLE
fix: import clique genesis blocks

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
@@ -10,7 +10,7 @@
           <!-- Block Height -->
           <h3 data-test="block_detail_number">
             <%= if block_type(@block) == "Block" do %>
-              <%= gettext("Block Height: %{height}", height: @block.number) %>
+              <%= gettext("Block Height: %{height}", height: @block.number) %> <%= if @block.number == 0, do: "- " <> gettext("Genesis Block")%>
             <% else %>
               <%= gettext("%{block_type} Height:", block_type: block_type(@block)) %>
               <%= link(@block, to: block_path(BlockScoutWeb.Endpoint, :show, @block.number)) %>
@@ -37,17 +37,19 @@
             <dd class="col-sm-9"> <%= to_string(@block.hash) %> </dd>
           </dl>
 
-          <!-- Parent Hash -->
-          <dl class="row">
-            <dt class="col-sm-3 text-muted"> <%= gettext "Parent Hash" %> </dt>
-            <dd class="col-sm-9">
-              <%= link(
-                  @block.parent_hash,
-                  class: "block__link",
-                  to: block_path(@conn, :show, @block.number - 1)
-                ) %>
-            </dd>
-          </dl>
+          <%= unless @block.number == 0 do %>
+              <!-- Parent Hash -->
+              <dl class="row">
+                <dt class="col-sm-3 text-muted"> <%= gettext "Parent Hash" %> </dt>
+                <dd class="col-sm-9">
+                  <%= link(
+                      @block.parent_hash,
+                      class: "block__link",
+                      to: block_path(@conn, :show, @block.number - 1)
+                    ) %>
+                </dd>
+              </dl>
+          <% end %>
 
           <!-- Difficulty value -->
           <dl class="row">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -357,7 +357,7 @@ msgid "Details"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:54
+#: lib/block_scout_web/templates/block/overview.html.eex:56
 msgid "Difficulty"
 msgstr ""
 
@@ -437,15 +437,15 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_tile.html.eex:57
-#: lib/block_scout_web/templates/block/overview.html.eex:102
-#: lib/block_scout_web/templates/block/overview.html.eex:157
+#: lib/block_scout_web/templates/block/overview.html.eex:104
+#: lib/block_scout_web/templates/block/overview.html.eex:159
 msgid "Gas Limit"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_tile.html.eex:62
-#: lib/block_scout_web/templates/block/overview.html.eex:94
-#: lib/block_scout_web/templates/block/overview.html.eex:148
+#: lib/block_scout_web/templates/block/overview.html.eex:96
+#: lib/block_scout_web/templates/block/overview.html.eex:150
 msgid "Gas Used"
 msgstr ""
 
@@ -539,7 +539,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_tile.html.eex:37
-#: lib/block_scout_web/templates/block/overview.html.eex:117
+#: lib/block_scout_web/templates/block/overview.html.eex:119
 #: lib/block_scout_web/templates/chain/_block.html.eex:14
 msgid "Miner"
 msgstr ""
@@ -608,7 +608,7 @@ msgid "No"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:69
+#: lib/block_scout_web/templates/block/overview.html.eex:71
 #: lib/block_scout_web/templates/transaction/overview.html.eex:67
 msgid "Nonce"
 msgstr ""
@@ -655,7 +655,7 @@ msgid "Parameters"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:42
+#: lib/block_scout_web/templates/block/overview.html.eex:43
 msgid "Parent Hash"
 msgstr ""
 
@@ -674,7 +674,7 @@ msgid "Pending Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:80
+#: lib/block_scout_web/templates/block/overview.html.eex:82
 msgid "Position %{index}"
 msgstr ""
 
@@ -917,7 +917,7 @@ msgid "Topics"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:63
+#: lib/block_scout_web/templates/block/overview.html.eex:65
 msgid "Total Difficulty"
 msgstr ""
 
@@ -989,7 +989,7 @@ msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:76
+#: lib/block_scout_web/templates/block/overview.html.eex:78
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:23
 msgid "Uncles"
 msgstr ""
@@ -1475,7 +1475,7 @@ msgid "Validator Info"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:137
+#: lib/block_scout_web/templates/block/overview.html.eex:139
 msgid "Block Rewards"
 msgstr ""
 
@@ -1562,4 +1562,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract/index.html.eex:39
 msgid "Copy Source Code"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block/overview.html.eex:13
+msgid "Genesis Block"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -357,7 +357,7 @@ msgid "Details"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:54
+#: lib/block_scout_web/templates/block/overview.html.eex:56
 msgid "Difficulty"
 msgstr ""
 
@@ -437,15 +437,15 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_tile.html.eex:57
-#: lib/block_scout_web/templates/block/overview.html.eex:102
-#: lib/block_scout_web/templates/block/overview.html.eex:157
+#: lib/block_scout_web/templates/block/overview.html.eex:104
+#: lib/block_scout_web/templates/block/overview.html.eex:159
 msgid "Gas Limit"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_tile.html.eex:62
-#: lib/block_scout_web/templates/block/overview.html.eex:94
-#: lib/block_scout_web/templates/block/overview.html.eex:148
+#: lib/block_scout_web/templates/block/overview.html.eex:96
+#: lib/block_scout_web/templates/block/overview.html.eex:150
 msgid "Gas Used"
 msgstr ""
 
@@ -539,7 +539,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_tile.html.eex:37
-#: lib/block_scout_web/templates/block/overview.html.eex:117
+#: lib/block_scout_web/templates/block/overview.html.eex:119
 #: lib/block_scout_web/templates/chain/_block.html.eex:14
 msgid "Miner"
 msgstr ""
@@ -608,7 +608,7 @@ msgid "No"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:69
+#: lib/block_scout_web/templates/block/overview.html.eex:71
 #: lib/block_scout_web/templates/transaction/overview.html.eex:67
 msgid "Nonce"
 msgstr ""
@@ -655,7 +655,7 @@ msgid "Parameters"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:42
+#: lib/block_scout_web/templates/block/overview.html.eex:43
 msgid "Parent Hash"
 msgstr ""
 
@@ -674,7 +674,7 @@ msgid "Pending Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:80
+#: lib/block_scout_web/templates/block/overview.html.eex:82
 msgid "Position %{index}"
 msgstr ""
 
@@ -917,7 +917,7 @@ msgid "Topics"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:63
+#: lib/block_scout_web/templates/block/overview.html.eex:65
 msgid "Total Difficulty"
 msgstr ""
 
@@ -989,7 +989,7 @@ msgid "Twitter"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:76
+#: lib/block_scout_web/templates/block/overview.html.eex:78
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:23
 msgid "Uncles"
 msgstr ""
@@ -1475,7 +1475,7 @@ msgid "Validator Info"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/block/overview.html.eex:137
+#: lib/block_scout_web/templates/block/overview.html.eex:139
 msgid "Block Rewards"
 msgstr ""
 
@@ -1554,7 +1554,7 @@ msgstr ""
 msgid "Copy ABI"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/block_scout_web/templates/address_contract/index.html.eex:65
 msgid "Copy Contract Creation Code"
 msgstr ""
@@ -1562,4 +1562,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract/index.html.eex:39
 msgid "Copy Source Code"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/block/overview.html.eex:13
+msgid "Genesis Block"
 msgstr ""

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -4,8 +4,32 @@ use Mix.Config
 
 import Bitwise
 
+block_transformers = %{
+  "clique" => Indexer.Block.Transform.Clique,
+  "base" => Indexer.Block.Transform.Base
+}
+
+# Compile time environment variable access requires recompilation.
+configured_transformer = System.get_env("BLOCK_TRANSFORMER") || "base"
+
+block_transformer =
+  case Map.get(block_transformers, configured_transformer) do
+    nil ->
+      raise """
+      No such block transformer: #{configured_transformer}.
+
+      Valid values are:
+      #{Enum.join(Map.keys(block_transformers), "\n")}
+
+      Please update environment variable BLOCK_TRANSFORMER accordingly.
+      """
+
+    transformer ->
+      transformer
+  end
+
 config :indexer,
-  block_transformer: Indexer.Block.Transform.Base,
+  block_transformer: block_transformer,
   ecto_repos: [Explorer.Repo],
   metadata_updater_days_interval: 7,
   # bytes

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -220,6 +220,10 @@ defmodule Indexer.Block.Realtime.Fetcher do
 
   defp determine_start_at(number, nil, nil), do: number
 
+  defp determine_start_at(number, nil, max_number_seen) do
+    determine_start_at(number, number - 1, max_number_seen)
+  end
+
   defp determine_start_at(number, previous_number, max_number_seen) do
     if reorg?(number, max_number_seen) do
       # set start_at to NOT fill in skipped numbers

--- a/apps/indexer/lib/indexer/block/reward/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/reward/fetcher.ex
@@ -88,6 +88,9 @@ defmodule Indexer.Block.Reward.Fetcher do
       {:ok, fetched_beneficiaries} ->
         run_fetched_beneficiaries(fetched_beneficiaries, hash_string_by_number)
 
+      :ignore ->
+        :ok
+
       {:error, reason} ->
         Logger.error(
           fn ->

--- a/apps/indexer/lib/indexer/block/transform.ex
+++ b/apps/indexer/lib/indexer/block/transform.ex
@@ -16,16 +16,6 @@ defmodule Indexer.Block.Transform do
   def transform_blocks(blocks) when is_list(blocks) do
     transformer = Application.get_env(:indexer, :block_transformer)
 
-    unless transformer do
-      raise ArgumentError,
-            """
-            No block transformer defined. Set a blocker transformer."
-
-               config :indexer,
-                 block_transformer: Indexer.Block.Transform.Base
-            """
-    end
-
     Enum.map(blocks, &transformer.transform/1)
   end
 end

--- a/apps/indexer/lib/indexer/block/transform/clique.ex
+++ b/apps/indexer/lib/indexer/block/transform/clique.ex
@@ -8,6 +8,8 @@ defmodule Indexer.Block.Transform.Clique do
   @behaviour Transform
 
   @impl Transform
+  def transform(%{number: 0} = block), do: block
+
   def transform(block) when is_map(block) do
     miner_address = Util.signer(block)
 

--- a/apps/indexer/test/indexer/block/transform_test.exs
+++ b/apps/indexer/test/indexer/block/transform_test.exs
@@ -46,11 +46,5 @@ defmodule Indexer.Block.TransformTest do
     test "transforms a list of blocks" do
       assert Transform.transform_blocks(@blocks)
     end
-
-    test "raises when no transformer is configured" do
-      Application.put_env(:indexer, :block_transformer, nil)
-
-      assert_raise ArgumentError, fn -> Transform.transform_blocks(@blocks) end
-    end
   end
 end


### PR DESCRIPTION
An alternative to: #1372

Resolves #1404
Resolves #1392

## Motivation

The genesis block on clique blockchains needs to be special cased.

## Changelog

### Enhancements

* Allow block_transformer to be configured via the environment variable `BLOCK_TRANSFORMER`. This must be done at compile time, so users may want to set it as an argument when building the container. Otherwise they will need to change that environment variable, and recompile. Alternatively, they can hardcode it as it was before.

### Bug Fixes
* Special case the genesis block in the clique block transformer.
* Resolve other small errors when using clique
* Add a small amount of UI sugar for the genesis block
