### PR TITLE
fix: cleanup uncataloged fetcher query, and push_front

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2141,6 +2141,7 @@ defmodule Explorer.Chain do
         on: tf.transaction_hash == l.transaction_hash and tf.log_index == l.index,
         where: l.first_topic == unquote(TokenTransfer.constant()),
         where: is_nil(tf.transaction_hash) and is_nil(tf.log_index),
+        where: not is_nil(t.block_number),
         select: t.block_number,
         distinct: t.block_number
       )

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -3477,9 +3477,29 @@ defmodule Explorer.ChainTest do
 
   describe "uncataloged_token_transfer_block_numbers/0" do
     test "returns a list of block numbers" do
-      log = insert(:token_transfer_log)
+      block = insert(:block)
+      address = insert(:address)
+
+      log =
+        insert(:token_transfer_log,
+          transaction:
+            insert(:transaction,
+              block_number: block.number,
+              block_hash: block.hash,
+              cumulative_gas_used: 0,
+              gas_used: 0,
+              index: 0
+            ),
+          address_hash: address.hash
+        )
+
       block_number = log.transaction.block_number
       assert {:ok, [^block_number]} = Chain.uncataloged_token_transfer_block_numbers()
+    end
+
+    test "does not include transactions without a block_number" do
+      insert(:token_transfer_log)
+      assert {:ok, []} = Chain.uncataloged_token_transfer_block_numbers()
     end
   end
 

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -349,9 +349,13 @@ defmodule Indexer.Block.Catchup.Fetcher do
   def push_front(block_numbers) do
     if Process.whereis(@sequence_name) do
       Enum.reduce_while(block_numbers, :ok, fn block_number, :ok ->
-        case Sequence.push_front(@sequence_name, block_number..block_number) do
-          :ok -> {:cont, :ok}
-          {:error, _} = error -> {:halt, error}
+        if is_integer(block_number) do
+          case Sequence.push_front(@sequence_name, block_number..block_number) do
+            :ok -> {:cont, :ok}
+            {:error, _} = error -> {:halt, error}
+          end
+        else
+          Logger.warn(fn -> ["Received a non-integer block number: ", inspect(block_number)] end)
         end
       end)
     else

--- a/apps/indexer/test/indexer/token_transfer/uncataloged/worker_test.exs
+++ b/apps/indexer/test/indexer/token_transfer/uncataloged/worker_test.exs
@@ -28,7 +28,22 @@ defmodule Indexer.TokenTransfer.Uncataloged.WorkerTest do
     end
 
     test "sends message to self when uncataloged token transfers are found" do
-      log = insert(:token_transfer_log)
+      block = insert(:block)
+      address = insert(:address)
+
+      log =
+        insert(:token_transfer_log,
+          transaction:
+            insert(:transaction,
+              block_number: block.number,
+              block_hash: block.hash,
+              cumulative_gas_used: 0,
+              gas_used: 0,
+              index: 0
+            ),
+          address_hash: address.hash
+        )
+
       block_number = log.transaction.block_number
 
       expected_state = %{task_ref: nil, block_numbers: [block_number], retry_interval: 1}


### PR DESCRIPTION
In case something like #1411 happens again, we want to handle it a bit more gracefully.

## Changelog

### Bug Fixes
* Don't return `nil` block numbers from `uncataloged_token_transfer_block_numbers`.
* Don't attempt to add non-integer block numbers to the sequence, and warn if we get one.
