### PR TITLE
pass external libraries to the Solidity compiler

### DIFF
--- a/apps/explorer/priv/compile_solc.js
+++ b/apps/explorer/priv/compile_solc.js
@@ -6,6 +6,7 @@ var sourceCode = process.argv[2];
 var version = process.argv[3];
 var optimize = process.argv[4];
 var newContractName = process.argv[5];
+var externalLibraries = JSON.parse(process.argv[6])
 
 var compiled_code = solc.loadRemoteVersion(version, function (err, solcSnapshot) {
   if (err) {
@@ -23,6 +24,9 @@ var compiled_code = solc.loadRemoteVersion(version, function (err, solcSnapshot)
         optimizer: {
           enabled: optimize == '1',
           runs: 200
+        },
+        libraries: {
+          [newContractName]: externalLibraries
         },
         outputSelection: {
           '*': {


### PR DESCRIPTION
## Motivation

Instead of manually replacing external library placeholders when compiling solidity code with external libraries we can pass them directly to the Solidity compiler.

https://solidity.readthedocs.io/en/v0.5.3/using-the-compiler.html#compiler-input-and-output-json-description

## Changelog

### Enhancements
- pass external libraries to the Solidity compiler