### PR TITLE
add unique index on address_hash, block_hash and address_type for block_rewards

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
@@ -53,10 +53,7 @@ defmodule Explorer.Chain.Import.Runner.Block.Rewards do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # order so that row ShareLocks are grabbed in a consistent order
-    ordered_changes_list =
-      changes_list
-      |> Enum.uniq_by(&{&1.address_hash, &1.address_type, &1.block_hash})
-      |> Enum.sort_by(&{&1.address_hash, &1.address_type, &1.block_hash})
+    ordered_changes_list = Enum.sort_by(changes_list, &{&1.address_hash, &1.address_type, &1.block_hash})
 
     Import.insert_changes_list(
       repo,

--- a/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
@@ -58,7 +58,6 @@ defmodule Explorer.Chain.Import.Runner.Block.Rewards do
       |> Enum.uniq_by(&{&1.address_hash, &1.address_type, &1.block_hash})
       |> Enum.sort_by(&{&1.address_hash, &1.address_type, &1.block_hash})
 
-
     Import.insert_changes_list(
       repo,
       ordered_changes_list,

--- a/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
@@ -53,7 +53,11 @@ defmodule Explorer.Chain.Import.Runner.Block.Rewards do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # order so that row ShareLocks are grabbed in a consistent order
-    ordered_changes_list = Enum.sort_by(changes_list, &{&1.address_hash, &1.address_type, &1.block_hash})
+    ordered_changes_list =
+      changes_list
+      |> Enum.uniq_by(&{&1.address_hash, &1.address_type, &1.block_hash})
+      |> Enum.sort_by(&{&1.address_hash, &1.address_type, &1.block_hash})
+
 
     Import.insert_changes_list(
       repo,

--- a/apps/explorer/priv/repo/migrations/20190208113202_add_unique_index_to_rewards.exs
+++ b/apps/explorer/priv/repo/migrations/20190208113202_add_unique_index_to_rewards.exs
@@ -1,0 +1,12 @@
+defmodule Explorer.Repo.Migrations.AddUniqueIndexToRewards do
+  use Ecto.Migration
+
+  def change do
+    create(
+      unique_index(
+        :block_rewards,
+        [:address_hash, :block_hash, :address_type]
+      )
+    )
+  end
+end

--- a/apps/indexer/lib/indexer/block/reward/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/reward/fetcher.ex
@@ -177,7 +177,8 @@ defmodule Indexer.Block.Reward.Fetcher do
       |> Enum.map(& &1.block_hash)
       |> Chain.gas_payment_by_block_hash()
 
-    Enum.map(beneficiaries_params, fn %{block_hash: block_hash} = beneficiary ->
+    beneficiaries_params
+    |> Enum.map(fn %{block_hash: block_hash} = beneficiary ->
       case gas_payment_by_block_hash do
         %{^block_hash => gas_payment} ->
           {:ok, minted} = Wei.cast(beneficiary.reward)
@@ -187,6 +188,7 @@ defmodule Indexer.Block.Reward.Fetcher do
           beneficiary
       end
     end)
+    |> Enum.uniq()
   end
 
   defp import_block_reward_params(block_rewards_params) when is_list(block_rewards_params) do


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/1416

## Motivation

https://pganalyze.com/docs/log-insights/app-errors/U126

```
The ON CONFLICT statement inserts the same row twice, as identified by the values in the constrained columns (i.e. those supposed to differentiate rows).

This usually happens if you don't de-duplicate your input before passing it to Postgres, as then ON CONFLICT would operate twice on the same set of values for the constraint clause, which is currently not supported.
```

## Changelog

- add unique index for `block_rewards` table
- deduplicate input data before upserting block rewards