### PR TITLE
Add external 3 to fetched benficiaries

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
@@ -172,6 +172,7 @@ defmodule EthereumJSONRPC.Parity.FetchedBeneficiaries do
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 0, do: :validator
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 1, do: :emission_funds
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 2, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 3, do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "block", do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "uncle", do: :uncle
 end


### PR DESCRIPTION
Fixes #1430

## Motivation
On POA networks, rewardType will always be external and the type of the address being rewarded will depend on its position.

## Changelog

- Add index 3 to external validator type of fetched beneficiary

