### PR TITLE
Fix constructor arguments migration

### DIFF
--- a/apps/explorer/priv/repo/migrations/20190213105501_add_constructor_arguments_to_smart_contracts.exs
+++ b/apps/explorer/priv/repo/migrations/20190213105501_add_constructor_arguments_to_smart_contracts.exs
@@ -1,6 +1,11 @@
 defmodule Explorer.Repo.Migrations.AddConstructorArgumentsToSmartContracts do
   use Ecto.Migration
 
+  def up do
+    # Check for the existence of constructor arguments and remove
+    execute("ALTER TABLE smart_contracts DROP COLUMN IF EXISTS constructor_arguments")
+  end
+
   def change do
     alter table(:smart_contracts) do
       add(:constructor_arguments, :string, null: true)

--- a/apps/explorer/priv/repo/migrations/20190215105501_add_constructor_arguments_to_smart_contracts.exs
+++ b/apps/explorer/priv/repo/migrations/20190215105501_add_constructor_arguments_to_smart_contracts.exs
@@ -1,12 +1,8 @@
 defmodule Explorer.Repo.Migrations.AddConstructorArgumentsToSmartContracts do
   use Ecto.Migration
 
-  def up do
-    # Check for the existence of constructor arguments and remove
+  def change do
     execute("ALTER TABLE smart_contracts DROP COLUMN IF EXISTS constructor_arguments")
-  end
-
-  def down do
     alter table(:smart_contracts) do
       add(:constructor_arguments, :string, null: true)
     end

--- a/apps/explorer/priv/repo/migrations/20190215105501_add_constructor_arguments_to_smart_contracts.exs
+++ b/apps/explorer/priv/repo/migrations/20190215105501_add_constructor_arguments_to_smart_contracts.exs
@@ -3,6 +3,7 @@ defmodule Explorer.Repo.Migrations.AddConstructorArgumentsToSmartContracts do
 
   def change do
     execute("ALTER TABLE smart_contracts DROP COLUMN IF EXISTS constructor_arguments")
+
     alter table(:smart_contracts) do
       add(:constructor_arguments, :string, null: true)
     end

--- a/apps/explorer/priv/repo/migrations/20190215105501_add_constructor_arguments_to_smart_contracts.exs
+++ b/apps/explorer/priv/repo/migrations/20190215105501_add_constructor_arguments_to_smart_contracts.exs
@@ -6,7 +6,7 @@ defmodule Explorer.Repo.Migrations.AddConstructorArgumentsToSmartContracts do
     execute("ALTER TABLE smart_contracts DROP COLUMN IF EXISTS constructor_arguments")
   end
 
-  def change do
+  def down do
     alter table(:smart_contracts) do
       add(:constructor_arguments, :string, null: true)
     end


### PR DESCRIPTION
Fixes #1442 

## Motivation

This PR fixes an issue where a PR was merged that included a migration that was dated prior to migrations that have already occurred. 

## Changelog

- Drops `constructor_arguments` column from the `smart_contracts` table if it exists.
- Adds the `constructor_arguments` column to `smart_contracts` table

