### PR TITLE
add index on block number to address token balances

### DIFF
--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -91,7 +91,7 @@ defmodule Explorer.Mixfile do
       {:math, "~> 0.3.0"},
       {:mock, "~> 0.3.0", only: [:test], runtime: false},
       {:mox, "~> 0.4", only: [:test]},
-      {:poison, "~> 3.1", only: [:test]},
+      {:poison, "~> 3.1"},
       {:postgrex, ">= 0.0.0"},
       # For compatibility with `prometheus_process_collector`, which hasn't been updated yet
       {:prometheus, "~> 4.0", override: true},

--- a/apps/explorer/priv/repo/migrations/20190214135850_add_index_on_block_number_to_address_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20190214135850_add_index_on_block_number_to_address_token_balances.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.AddIndexOnBlockNumberToAddressTokenBalances do
+  use Ecto.Migration
+
+  def change do
+    create(index(:address_token_balances, [:block_number]))
+  end
+end


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

I think the problem with importing new blocks is not in connection pool but  is that import query can not be finished because some sub queries take too long to execute. I see in pgadmin some requests that are still executing from my tests. 

https://github.com/poanetwork/blockscout/pull/1323

## Changelog

- add index on block number to address token balances