### PR TITLE
feat: show an approximation of transaction time

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -74,6 +74,20 @@
               <%= formatted_fee(@transaction, denomination: :ether) %> (<span data-wei-value=<%= fee(@transaction) %> data-usd-exchange-rate=<%= @exchange_rate.usd_value %>></span>)
             </dd>
           </dl>
+          <!-- Processing Time -->
+          <%= case processing_time_duration(@transaction) do %>
+            <% :pending -> %>
+              <% nil %>
+            <% :unknown -> %>
+              <% nil %>
+            <% {:ok, interval_string} -> %>
+              <dl class="row">
+                <dt class="col-sm-3 text-muted"> <%= gettext "Transaction Speed" %> </dt>
+                <dd class="col-sm-9">
+                  <%= interval_string %>
+                </dd>
+              </dl>
+          <% end %>
 
           <%= unless value_transfer?(@transaction) do %>
           <dl class="row">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -49,7 +49,7 @@ msgid "%{subnetwork} Explorer - BlockScout"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:71
+#: lib/block_scout_web/views/transaction_view.ex:118
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
 
@@ -165,7 +165,7 @@ msgid "Block Number"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:18
+#: lib/block_scout_web/views/transaction_view.ex:19
 msgid "Block Pending"
 msgstr ""
 
@@ -278,12 +278,12 @@ msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:148
+#: lib/block_scout_web/views/transaction_view.ex:195
 msgid "Contract Call"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:147
+#: lib/block_scout_web/views/transaction_view.ex:194
 msgid "Contract Creation"
 msgstr ""
 
@@ -377,12 +377,12 @@ msgid "Error trying to fetch balances."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:75
+#: lib/block_scout_web/views/transaction_view.ex:122
 msgid "Error: %{reason}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:73
+#: lib/block_scout_web/views/transaction_view.ex:120
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
@@ -392,7 +392,7 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/app.html.eex:51
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:26
-#: lib/block_scout_web/templates/transaction/overview.html.eex:104
+#: lib/block_scout_web/templates/transaction/overview.html.eex:118
 #: lib/block_scout_web/views/wei_helpers.ex:72
 msgid "Ether"
 msgstr ""
@@ -431,7 +431,7 @@ msgid "GET"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:117
+#: lib/block_scout_web/templates/transaction/overview.html.eex:131
 msgid "Gas"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
 #: lib/block_scout_web/views/address_view.ex:270
-#: lib/block_scout_web/views/transaction_view.ex:201
+#: lib/block_scout_web/views/transaction_view.ex:248
 msgid "Internal Transactions"
 msgstr ""
 
@@ -513,7 +513,7 @@ msgid "Less than"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:129
+#: lib/block_scout_web/templates/transaction/overview.html.eex:143
 msgid "Limit"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:21
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:48
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:10
-#: lib/block_scout_web/views/transaction_view.ex:202
+#: lib/block_scout_web/views/transaction_view.ex:249
 msgid "Logs"
 msgstr ""
 
@@ -533,7 +533,7 @@ msgid "Market Cap"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:62
+#: lib/block_scout_web/views/transaction_view.ex:109
 msgid "Max of"
 msgstr ""
 
@@ -662,8 +662,8 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:44
 #: lib/block_scout_web/templates/transaction/overview.html.eex:55
-#: lib/block_scout_web/views/transaction_view.ex:70
-#: lib/block_scout_web/views/transaction_view.ex:104
+#: lib/block_scout_web/views/transaction_view.ex:117
+#: lib/block_scout_web/views/transaction_view.ex:151
 msgid "Pending"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex:8
-#: lib/block_scout_web/views/transaction_view.ex:72
+#: lib/block_scout_web/views/transaction_view.ex:119
 msgid "Success"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/_token_transfer.html.eex:4
-#: lib/block_scout_web/views/transaction_view.ex:146
+#: lib/block_scout_web/views/transaction_view.ex:193
 msgid "Token Transfer"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:36
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:10
 #: lib/block_scout_web/views/tokens/overview_view.ex:35
-#: lib/block_scout_web/views/transaction_view.ex:200
+#: lib/block_scout_web/views/transaction_view.ex:247
 msgid "Token Transfers"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgid "Total transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:149
+#: lib/block_scout_web/views/transaction_view.ex:196
 msgid "Transaction"
 msgstr ""
 
@@ -999,7 +999,7 @@ msgid "Unique Token"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:122
+#: lib/block_scout_web/templates/transaction/overview.html.eex:136
 msgid "Used"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgid "Validations"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:104
+#: lib/block_scout_web/templates/transaction/overview.html.eex:118
 msgid "Value"
 msgstr ""
 
@@ -1216,7 +1216,7 @@ msgid "This API is provided for developers transitioning their applications from
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:80
+#: lib/block_scout_web/templates/transaction/overview.html.eex:94
 msgid "Raw Input"
 msgstr ""
 
@@ -1636,4 +1636,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:41
 msgid "Transactions Sent"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/overview.html.eex:85
+msgid "Transaction Speed"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -49,7 +49,7 @@ msgid "%{subnetwork} Explorer - BlockScout"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:71
+#: lib/block_scout_web/views/transaction_view.ex:118
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
 
@@ -165,7 +165,7 @@ msgid "Block Number"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:18
+#: lib/block_scout_web/views/transaction_view.ex:19
 msgid "Block Pending"
 msgstr ""
 
@@ -278,12 +278,12 @@ msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:148
+#: lib/block_scout_web/views/transaction_view.ex:195
 msgid "Contract Call"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:147
+#: lib/block_scout_web/views/transaction_view.ex:194
 msgid "Contract Creation"
 msgstr ""
 
@@ -377,12 +377,12 @@ msgid "Error trying to fetch balances."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:75
+#: lib/block_scout_web/views/transaction_view.ex:122
 msgid "Error: %{reason}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:73
+#: lib/block_scout_web/views/transaction_view.ex:120
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
@@ -392,7 +392,7 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/app.html.eex:51
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:26
-#: lib/block_scout_web/templates/transaction/overview.html.eex:104
+#: lib/block_scout_web/templates/transaction/overview.html.eex:118
 #: lib/block_scout_web/views/wei_helpers.ex:72
 msgid "Ether"
 msgstr "POA"
@@ -431,7 +431,7 @@ msgid "GET"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:117
+#: lib/block_scout_web/templates/transaction/overview.html.eex:131
 msgid "Gas"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
 #: lib/block_scout_web/views/address_view.ex:270
-#: lib/block_scout_web/views/transaction_view.ex:201
+#: lib/block_scout_web/views/transaction_view.ex:248
 msgid "Internal Transactions"
 msgstr ""
 
@@ -513,7 +513,7 @@ msgid "Less than"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:129
+#: lib/block_scout_web/templates/transaction/overview.html.eex:143
 msgid "Limit"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:21
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:48
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:10
-#: lib/block_scout_web/views/transaction_view.ex:202
+#: lib/block_scout_web/views/transaction_view.ex:249
 msgid "Logs"
 msgstr ""
 
@@ -533,7 +533,7 @@ msgid "Market Cap"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:62
+#: lib/block_scout_web/views/transaction_view.ex:109
 msgid "Max of"
 msgstr ""
 
@@ -662,8 +662,8 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:44
 #: lib/block_scout_web/templates/transaction/overview.html.eex:55
-#: lib/block_scout_web/views/transaction_view.ex:70
-#: lib/block_scout_web/views/transaction_view.ex:104
+#: lib/block_scout_web/views/transaction_view.ex:117
+#: lib/block_scout_web/views/transaction_view.ex:151
 msgid "Pending"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex:8
-#: lib/block_scout_web/views/transaction_view.ex:72
+#: lib/block_scout_web/views/transaction_view.ex:119
 msgid "Success"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/_token_transfer.html.eex:4
-#: lib/block_scout_web/views/transaction_view.ex:146
+#: lib/block_scout_web/views/transaction_view.ex:193
 msgid "Token Transfer"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:36
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:10
 #: lib/block_scout_web/views/tokens/overview_view.ex:35
-#: lib/block_scout_web/views/transaction_view.ex:200
+#: lib/block_scout_web/views/transaction_view.ex:247
 msgid "Token Transfers"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgid "Total transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:149
+#: lib/block_scout_web/views/transaction_view.ex:196
 msgid "Transaction"
 msgstr ""
 
@@ -999,7 +999,7 @@ msgid "Unique Token"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:122
+#: lib/block_scout_web/templates/transaction/overview.html.eex:136
 msgid "Used"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgid "Validations"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:104
+#: lib/block_scout_web/templates/transaction/overview.html.eex:118
 msgid "Value"
 msgstr ""
 
@@ -1216,7 +1216,7 @@ msgid "This API is provided for developers transitioning their applications from
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:80
+#: lib/block_scout_web/templates/transaction/overview.html.eex:94
 msgid "Raw Input"
 msgstr ""
 
@@ -1633,7 +1633,12 @@ msgstr ""
 msgid "Last Balance Update: Block #"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:41
 msgid "Transactions Sent"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/block_scout_web/templates/transaction/overview.html.eex:85
+msgid "Transaction Speed"
 msgstr ""

--- a/apps/explorer/lib/explorer/counters/average_block_time_duration_format.ex
+++ b/apps/explorer/lib/explorer/counters/average_block_time_duration_format.ex
@@ -67,6 +67,7 @@ defmodule Explorer.Counters.AverageBlockTimeDurationFormat do
     duration
     |> Duration.to_milliseconds()
     |> round()
+    |> abs()
     |> do_format(locale)
   end
 

--- a/apps/explorer/priv/repo/migrations/20190213180502_add_earliest_processing_start_to_transactions.exs
+++ b/apps/explorer/priv/repo/migrations/20190213180502_add_earliest_processing_start_to_transactions.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddEarliestProcessingStartToTransactions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:transactions) do
+      add(:earliest_processing_start, :utc_datetime_usec)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1428

## Motivation

We want to show information on the time it took a transaction to complete.

We can't get this information completely accurately. All we can do is record the last time we checked for pending transactions, and the current time when we are fetching pending transactions. Using that information, we can determine a range in which the transaction must have started, and show that range in the explorer. If the process monitoring the pending transaction dies or if the application restarts, we will not be able to determine that information. We also won't be able to determine that information for any transaction that has already happened.

We should decide if we want to show anything at all on the pages where we have no information on how long the transaction took to complete. Should we show nothing? The current implementation shows `Unknown`. I'm also currently looking at ways to test this interaction in the pending transaction fetcher. All in all it came out to be a *much* simpler change than I was expecting.