### PR TITLE
add indexes required for blocks runner

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2170,7 +2170,7 @@ defmodule Explorer.Chain do
         on: tf.transaction_hash == l.transaction_hash and tf.log_index == l.index,
         where: l.first_topic == unquote(TokenTransfer.constant()),
         where: is_nil(tf.transaction_hash) and is_nil(tf.log_index),
-        where: not is_nil(t.block_number),
+        where: not is_nil(t.block_hash),
         select: t.block_number,
         distinct: t.block_number
       )

--- a/apps/explorer/priv/repo/migrations/20190215080049_add_index_on_fetched_coin_balance_to_addresses.exs
+++ b/apps/explorer/priv/repo/migrations/20190215080049_add_index_on_fetched_coin_balance_to_addresses.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.AddIndexOnFetchedCoinBalanceToAddresses do
+  use Ecto.Migration
+
+  def change do
+    create(index(:addresses, [:fetched_coin_balance]))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20190215093358_add_compound_index_address_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20190215093358_add_compound_index_address_token_balances.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.AddCompoundIndexAddressTokenBalances do
+  use Ecto.Migration
+
+  def change do
+    create(index(:address_current_token_balances, [:block_number], name: :address_cur_token_balances_index))
+  end
+end


### PR DESCRIPTION
Mainnet 's blocks import wasn't working correctly because there are very slow queries in blocks runner. This PR with https://github.com/poanetwork/blockscout/pull/1444 adds a couple of indexes that should fix the problem.

## Changelog

1. There wasn't index on `fetched_coin_balance` in `addresses` table. It is needed. It's used in `count_addresses_with_balance`. It may not directly related to the issue. But the query was very slow.
2. https://github.com/poanetwork/blockscout/pull/1412 - this  request adds `not is_nil(t.block_number),` to  `uncataloged_token_transfer_block_numbers`. Transactions don't have index on `block_number`
3. `address_current_token_balances` does not have index on `block_number` which is used for their deletion in blocks runner