### PR TITLE
add indexes for block_reward query

### DIFF
--- a/apps/explorer/priv/repo/migrations/20190219082636_add_indexes_for_block_reward_query.exs
+++ b/apps/explorer/priv/repo/migrations/20190219082636_add_indexes_for_block_reward_query.exs
@@ -1,0 +1,8 @@
+defmodule Explorer.Repo.Migrations.AddIndexesForBlockRewardQuery do
+  use Ecto.Migration
+
+  def change do
+    create(index(:blocks, [:number]))
+    create(index(:emission_rewards, [:block_range]))
+  end
+end


### PR DESCRIPTION
## Motivation

Inspecting `pgadmin`'s dashboards I found out that `block_reward` query is executed very slowly. It uses `number` field from `blocks` table `block_range` field from `block_rewards` table. Both of these fields don't have indexes

## Changelog
- add indexes for block_reward query