### PR TITLE
feat: decoding candidates for unverified contracts

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_decoded_input.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_decoded_input.html.eex
@@ -3,9 +3,9 @@
     <h1 class="card-title"><%= gettext "Input" %> </h1>
     <!-- Input -->
     <%= case @decoded_input_data do %>
-    <% {:error, :contract_not_verified} -> %>
+    <% {:error, :contract_not_verified, candidates} -> %>
     <div class="alert alert-info">
-      <%= gettext "To see decoded input data, the contract must be verified." %>
+      <%= gettext "To see accurate decoded input data, the contract must be verified." %>
       <%= case @transaction do %>
         <% %{to_address: %{hash: hash}} -> %>
           <%= gettext "Verify the contract " %><a href="<%= address_verify_contract_path(@conn, :new, hash)%>"><%= gettext "here" %></a>
@@ -13,57 +13,24 @@
           <%= nil %>
       <% end %>
     </div>
+    <%= unless Enum.empty?(candidates) do %>
+      <h3><%= gettext "Potential matches from our contract method database:" %></h3>
+      <%= gettext "IMPORTANT: This information is a best guess based on similar functions from other verified contracts." %>
+      <%= gettext "To have guaranteed accuracy, use the link above to verify the contract's source code." %>
+
+      <%= for {:ok, method_id, text, mapping} <- candidates do %>
+        <hr>
+        <h3><%= text %>: </h3>
+
+        <%= render(BlockScoutWeb.TransactionView, "_decoded_input_body.html", method_id: method_id, text: text, mapping: mapping) %>
+      <% end %>
+    <% end %>
     <% {:ok, method_id, text, mapping} -> %>
-    <table summary="<%= gettext "Transaction Info" %>" class="table thead-light table-bordered table-responsive transaction-info-table">
-      <tr>
-        <td><%= gettext "Method Id" %></td>
-        <td colspan="3"><code>0x<%= method_id %></code></td>
-      </tr>
-      <tr>
-        <td>Call</td>
-        <td colspan="3"><code><%= text %></code></td>
-      </tr>
-    </table>
-
-    <table summary="<%= gettext "Transaction Inputs" %>" class="table thead-light table-bordered table-responsive">
-      <tr>
-        <th scope="col"></th>
-        <th scope="col"><%= gettext "Name" %></th>
-        <th scope="col"><%= gettext "Type" %></th>
-        <th scope="col"><%= gettext "Data" %></th>
-      <tr>
-        <%= for {name, type, value} <- mapping do %>
-            <tr>
-              <th scope="row">
-                <%= case BlockScoutWeb.ABIEncodedValueView.copy_text(type, value) do %>
-                  <% :error -> %>
-                    <%= nil %>
-                  <% copy_text -> %>
-                    <button type="button" class="copy icon-link" data-toggle="tooltip" data-placement="top" data-clipboard-text="<%= copy_text %>" aria-label="<%= gettext "Copy Value" %>">
-                      <i class="fas fa-clone"></i>
-                    </button>
-                 <% end %>
-              </th>
-              <td><%= name %></td>
-              <td><%= type %></td>
-              <td>
-                <%= case BlockScoutWeb.ABIEncodedValueView.value_html(type, value) do %>
-                  <% :error -> %>
-                    <div class="alert alert-danger">
-                      <%= gettext "Error rendering value" %>
-                    </div>
-                  <% value -> %>
-                    <pre class="transaction-input-text tile"><code><%= value %></code></pre>
-                <% end %>
-
-              </td>
-            </tr>
-            <% end %>
-    </table>
+      <%= render(BlockScoutWeb.TransactionView, "_decoded_input_body.html", method_id: method_id, text: text, mapping: mapping) %>
     <% _ -> %>
         <div class="alert alert-danger">
           <%= gettext "Failed to decode input data." %>
         </div>
-        <% end %>
+    <% end %>
   </div>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex
@@ -1,0 +1,47 @@
+<table summary="<%= gettext "Transaction Info" %>" class="table thead-light table-bordered table-responsive transaction-info-table">
+  <tr>
+  <td><%= gettext "Method Id" %></td>
+  <td colspan="3"><code>0x<%= @method_id %></code></td>
+  </tr>
+  <tr>
+  <td>Call</td>
+  <td colspan="3"><code><%= @text %></code></td>
+  </tr>
+</table>
+
+<%= unless Enum.empty?(@mapping) do %>
+  <table summary="<%= gettext "Transaction Inputs" %>" class="table thead-light table-bordered table-responsive">
+    <tr>
+    <th scope="col"></th>
+    <th scope="col"><%= gettext "Name" %></th>
+    <th scope="col"><%= gettext "Type" %></th>
+    <th scope="col"><%= gettext "Data" %></th>
+    <tr>
+    <%= for {name, type, value} <- @mapping do %>
+      <tr>
+        <th scope="row">
+          <%= case BlockScoutWeb.ABIEncodedValueView.copy_text(type, value) do %>
+            <% :error -> %>
+              <%= nil %>
+            <% copy_text -> %>
+              <button type="button" class="copy icon-link" data-toggle="tooltip" data-placement="top" data-clipboard-text="<%= copy_text %>" aria-label="<%= gettext "Copy Value" %>">
+                <i class="fas fa-clone"></i>
+              </button>
+          <% end %>
+        </th>
+        <td><%= name %></td>
+        <td><%= type %></td>
+        <td>
+          <%= case BlockScoutWeb.ABIEncodedValueView.value_html(type, value) do %>
+            <% :error -> %>
+              <div class="alert alert-danger">
+                <%= gettext "Error rendering value" %>
+              </div>
+            <% value -> %>
+              <pre class="transaction-input-text tile"><code><%= value %></code></pre>
+            <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -172,7 +172,7 @@
     </div>
   </div>
 
-  <%= unless should_decode?(@transaction) do %>
+  <%= unless skip_decoding?(@transaction) do %>
     <div class="row">
       <div class="col-md-12">
         <%= render BlockScoutWeb.TransactionView, "_decoded_input.html", Map.put(assigns, :decoded_input_data, decoded_input_data) %>

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -138,7 +138,7 @@ defmodule BlockScoutWeb.TransactionView do
     Cldr.Number.to_string!(gas)
   end
 
-  def should_decode?(transaction) do
+  def skip_decoding?(transaction) do
     contract_creation?(transaction) || value_transfer?(transaction)
   end
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -338,7 +338,7 @@ msgid "Curl"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:33
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:18
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:60
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:118
 msgid "Data"
@@ -574,7 +574,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:29
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:31
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:16
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:57
 msgid "Name"
 msgstr ""
@@ -1305,29 +1305,28 @@ msgid "Indexed?"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:32
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:58
 msgid "Type"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:19
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:3
 msgid "Method Id"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:8
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:31
 msgid "To see decoded input data, the contract must be verified."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:17
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:1
 msgid "Transaction Info"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:28
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:13
 msgid "Transaction Inputs"
 msgstr ""
 
@@ -1344,17 +1343,17 @@ msgid "here"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:65
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:32
 msgid "Failed to decode input data."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:53
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:38
 msgid "Error rendering value"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:42
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:27
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:69
 msgid "Copy Value"
 msgstr ""
@@ -1490,6 +1489,26 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/views/block_view.ex:64
 msgid "Uncle Reward"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:18
+msgid "IMPORTANT: This information is a best guess based on similar functions from other verified contracts."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:17
+msgid "Potential matches from our contract method database:"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:19
+msgid "To have guaranteed accuracy, use the link above to verify the contract's source code."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:8
+msgid "To see accurate decoded input data, the contract must be verified."
 msgstr ""
 
 #, elixir-format

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -338,7 +338,7 @@ msgid "Curl"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:33
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:18
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:60
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:118
 msgid "Data"
@@ -574,7 +574,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:29
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:31
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:16
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:57
 msgid "Name"
 msgstr ""
@@ -1305,29 +1305,28 @@ msgid "Indexed?"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:32
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:58
 msgid "Type"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:19
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:3
 msgid "Method Id"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:8
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:31
 msgid "To see decoded input data, the contract must be verified."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:17
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:1
 msgid "Transaction Info"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:28
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:13
 msgid "Transaction Inputs"
 msgstr ""
 
@@ -1344,17 +1343,17 @@ msgid "here"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:65
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:32
 msgid "Failed to decode input data."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:53
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:38
 msgid "Error rendering value"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:42
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:27
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:69
 msgid "Copy Value"
 msgstr ""
@@ -1490,6 +1489,26 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/views/block_view.ex:64
 msgid "Uncle Reward"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:18
+msgid "IMPORTANT: This information is a best guess based on similar functions from other verified contracts."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:17
+msgid "Potential matches from our contract method database:"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:19
+msgid "To have guaranteed accuracy, use the link above to verify the contract's source code."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:8
+msgid "To see accurate decoded input data, the contract must be verified."
 msgstr ""
 
 #, elixir-format

--- a/apps/explorer/lib/explorer/chain/contract_method.ex
+++ b/apps/explorer/lib/explorer/chain/contract_method.ex
@@ -1,0 +1,74 @@
+defmodule Explorer.Chain.ContractMethod do
+  @moduledoc """
+  The representation of an individual item from the ABI of a verified smart contract.
+  """
+
+  require Logger
+
+  use Explorer.Schema
+
+  alias Explorer.Chain.{Hash, MethodIdentifier}
+  alias Explorer.Repo
+
+  @type t :: %__MODULE__{
+          identifier: MethodIdentifier.t(),
+          abi: map(),
+          type: String.t()
+        }
+
+  schema "contract_methods" do
+    field(:identifier, MethodIdentifier)
+    field(:abi, :map)
+    field(:type, :string)
+
+    timestamps()
+  end
+
+  def upsert_from_abi(abi, address_hash) do
+    {successes, errors} =
+      abi
+      |> Enum.reject(fn selector ->
+        Map.get(selector, "type") in ["fallback", "constructor"]
+      end)
+      |> Enum.reduce({[], []}, fn selector, {successes, failures} ->
+        case abi_element_to_contract_method(selector) do
+          {:error, message} ->
+            {successes, [message | failures]}
+
+          selector ->
+            {[selector | successes], failures}
+        end
+      end)
+
+    unless Enum.empty?(errors) do
+      Logger.error(fn ->
+        ["Error parsing some abi elements at ", Hash.to_iodata(address_hash), ": ", Enum.intersperse(errors, "\n")]
+      end)
+    end
+
+    Repo.insert_all(__MODULE__, successes, on_conflict: :nothing, conflict_target: [:identifier, :abi])
+  end
+
+  defp abi_element_to_contract_method(element) do
+    case ABI.parse_specification([element], include_events?: true) do
+      [selector] ->
+        now = DateTime.utc_now()
+
+        %{
+          identifier: selector.method_id,
+          abi: element,
+          type: Atom.to_string(selector.type),
+          inserted_at: now,
+          updated_at: now
+        }
+
+      _ ->
+        {:error, "Failed to parse abi row."}
+    end
+  rescue
+    e ->
+      message = Exception.format(:error, e)
+
+      {:error, message}
+  end
+end

--- a/apps/explorer/lib/explorer/chain/method_identifier.ex
+++ b/apps/explorer/lib/explorer/chain/method_identifier.ex
@@ -1,0 +1,36 @@
+defmodule Explorer.Chain.MethodIdentifier do
+  @moduledoc """
+  The first four bytes of the [KECCAK-256](https://en.wikipedia.org/wiki/SHA-3) hash of a contract method or event.
+
+  Represented in the database as a 4 byte integer, decodes into a 4 byte bitstring
+  """
+
+  @behaviour Ecto.Type
+
+  @type t :: binary
+
+  @impl true
+  def type, do: :integer
+
+  @impl true
+  @spec load(integer) :: {:ok, t()}
+  def load(value) do
+    {:ok, <<value::integer-signed-32>>}
+  end
+
+  @impl true
+  @spec cast(binary) :: {:ok, t()} | :error
+  def cast(<<_::binary-size(4)>> = identifier) do
+    {:ok, identifier}
+  end
+
+  def cast(_), do: :error
+
+  @impl true
+  @spec dump(t()) :: {:ok, integer} | :error
+  def dump(<<num::integer-signed-32>>) do
+    {:ok, num}
+  end
+
+  def dump(_), do: :error
+end

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -8,9 +8,11 @@ defmodule Explorer.Chain.SmartContract do
   http://solidity.readthedocs.io/en/v0.4.24/introduction-to-smart-contracts.html
   """
 
-  alias Explorer.Chain.{Address, Hash}
+  require Logger
 
   use Explorer.Schema
+
+  alias Explorer.Chain.{Address, ContractMethod, Hash}
 
   @typedoc """
   The name of a parameter to a function or event.
@@ -189,6 +191,7 @@ defmodule Explorer.Chain.SmartContract do
   * `abi` - The [JSON ABI specification](https://solidity.readthedocs.io/en/develop/abi-spec.html#json) for this
     contract.
   """
+
   @type t :: %Explorer.Chain.SmartContract{
           name: String.t(),
           compiler_version: String.t(),
@@ -229,6 +232,7 @@ defmodule Explorer.Chain.SmartContract do
     ])
     |> validate_required([:name, :compiler_version, :optimization, :contract_source_code, :abi, :address_hash])
     |> unique_constraint(:address_hash)
+    |> prepare_changes(&upsert_contract_methods/1)
   end
 
   def invalid_contract_changeset(%__MODULE__{} = smart_contract, attrs, error) do
@@ -237,6 +241,21 @@ defmodule Explorer.Chain.SmartContract do
     |> validate_required([:name, :compiler_version, :optimization, :address_hash])
     |> add_error(:contract_source_code, error_message(error))
   end
+
+  defp upsert_contract_methods(%Ecto.Changeset{changes: %{abi: abi}} = changeset) do
+    ContractMethod.upsert_from_abi(abi, get_field(changeset, :address_hash))
+
+    changeset
+  rescue
+    exception ->
+      message = Exception.format(:error, exception, __STACKTRACE__)
+
+      Logger.error(fn -> ["Error while upserting contract methods: ", message] end)
+
+      changeset
+  end
+
+  defp upsert_contract_methods(changeset), do: changeset
 
   defp error_message(:compilation), do: "There was an error compiling your contract."
   defp error_message(:generated_bytecode), do: "Bytecode does not match, please try again."

--- a/apps/explorer/priv/repo/migrations/20181221145054_add_contract_methods.exs
+++ b/apps/explorer/priv/repo/migrations/20181221145054_add_contract_methods.exs
@@ -1,0 +1,15 @@
+defmodule Explorer.Repo.Migrations.AddContractMethods do
+  use Ecto.Migration
+
+  def change do
+    create table(:contract_methods) do
+      add(:identifier, :integer, null: false)
+      add(:abi, :map, null: false)
+      add(:type, :string, null: false)
+
+      timestamps()
+    end
+
+    create(unique_index(:contract_methods, [:identifier, :abi]))
+  end
+end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -17,6 +17,7 @@ defmodule Explorer.Factory do
     Address.TokenBalance,
     Address.CoinBalance,
     Block,
+    ContractMethod,
     Data,
     Hash,
     InternalTransaction,
@@ -140,6 +141,22 @@ defmodule Explorer.Factory do
       gas_limit: Enum.random(1..100_000),
       gas_used: Enum.random(1..100_000),
       timestamp: DateTime.utc_now()
+    }
+  end
+
+  def contract_method_factory() do
+    %ContractMethod{
+      identifier: Base.decode16!("60fe47b1", case: :lower),
+      abi: %{
+        "constant" => false,
+        "inputs" => [%{"name" => "x", "type" => "uint256"}],
+        "name" => "set",
+        "outputs" => [],
+        "payable" => false,
+        "stateMutability" => "nonpayable",
+        "type" => "function"
+      },
+      type: "function"
     }
   end
 
@@ -496,7 +513,7 @@ defmodule Explorer.Factory do
     contract_code_info = contract_code_info()
 
     %SmartContract{
-      address_hash: insert(:address).hash,
+      address_hash: insert(:address, contract_code: contract_code_info.bytecode).hash,
       compiler_version: contract_code_info.version,
       name: contract_code_info.name,
       contract_source_code: contract_code_info.source_code,


### PR DESCRIPTION
## Motivation

* In order to show what function we suspect was called, we need to store and then list any potential contract ABI matches from other verified smart contracts. This will give users as much information as possible about unverified contract.

## Changelog

### Enhancements
* Store any new method identifiers we receive.
* List them as possibilities on transactions for unverified transactions.

<img width="1106" alt="screen shot 2019-02-27 at 11 36 02 am" src="https://user-images.githubusercontent.com/17620007/53506419-ecd4b300-3a83-11e9-89dc-a5d0b38eb735.png">
