### PR TITLE
add temporary module to fix failed internal transactions

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
@@ -87,7 +87,7 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
     from(address in Address,
       update: [
         set: [
-          contract_code: fragment("COALESCE(?, EXCLUDED.contract_code)", address.contract_code),
+          contract_code: fragment("COALESCE(EXCLUDED.contract_code, ?)", address.contract_code),
           # ARGMAX on two columns
           fetched_coin_balance:
             fragment(

--- a/apps/indexer/config/dev.exs
+++ b/apps/indexer/config/dev.exs
@@ -11,6 +11,11 @@ config :logger, :indexer_token_balances,
   path: Path.absname("logs/dev/indexer/token_balances/error.log"),
   metadata_filter: [fetcher: :token_balances]
 
+config :logger, :failed_contract_creations,
+  level: :debug,
+  path: Path.absname("logs/dev/indexer/failed_contract_creations.log"),
+  metadata_filter: [fetcher: :failed_created_addresses]
+
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
     "ganache"

--- a/apps/indexer/config/prod.exs
+++ b/apps/indexer/config/prod.exs
@@ -13,6 +13,11 @@ config :logger, :indexer_token_balances,
   metadata_filter: [fetcher: :token_balances],
   rotate: %{max_bytes: 52_428_800, keep: 19}
 
+config :logger, :failed_contract_creations,
+  level: :prod,
+  path: Path.absname("logs/prod/indexer/failed_contract_creations.log"),
+  metadata_filter: [fetcher: :failed_created_addresses]
+
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
     "parity"

--- a/apps/indexer/config/test.exs
+++ b/apps/indexer/config/test.exs
@@ -10,3 +10,8 @@ config :logger, :indexer_token_balances,
   level: :debug,
   path: Path.absname("logs/test/indexer/token_balances/error.log"),
   metadata_filter: [fetcher: :token_balances]
+
+config :logger, :failed_contract_creations,
+  level: :debug,
+  path: Path.absname("logs/test/indexer/failed_contract_creations.log"),
+  metadata_filter: [fetcher: :failed_created_addresses]

--- a/apps/indexer/lib/indexer/block/supervisor.ex
+++ b/apps/indexer/lib/indexer/block/supervisor.ex
@@ -5,6 +5,7 @@ defmodule Indexer.Block.Supervisor do
 
   alias Indexer.Block
   alias Indexer.Block.{Catchup, InvalidConsensus, Realtime, Reward, Uncle}
+  alias Indexer.Temporary.FailedCreatedAddresses
 
   use Supervisor
 
@@ -45,6 +46,11 @@ defmodule Indexer.Block.Supervisor do
          [
            [json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor],
            [name: Reward.Supervisor]
+         ]},
+        {FailedCreatedAddresses.Supervisor,
+         [
+           json_rpc_named_arguments,
+           [name: FailedCreatedAddresses.Supervisor]
          ]}
       ],
       strategy: :one_for_one

--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
@@ -63,6 +63,7 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
   end
 
   def fix_internal_transaction(internal_transaction, json_rpc_named_arguments) do
+    # credo:disable-for-next-line
     try do
       Logger.debug(
         [

--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
@@ -11,8 +11,9 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
   def run(json_rpc_named_arguments) do
     query =
       from(it in InternalTransaction,
-        left_join: t in assoc(it, :transaction),
-        where: t.error == 0 and not is_nil(it.created_contract_address_hash),
+        left_join: t in Transaction,
+        on: it.transaction_hash == t.hash,
+        where: t.status == ^0 and not is_nil(it.created_contract_address_hash),
         preload: :transaction
       )
 
@@ -33,7 +34,7 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
         block_number: block_number,
         created_contract_address_hash: %{bytes: created_contract_bytes}
       }) do
-    [{block_number, created_contract_bytes}]
+    [{block_number, created_contract_bytes, <<>>}]
   end
 
   def transaction_entry(%Transaction{hash: %{bytes: bytes}, index: index, block_number: block_number}) do

--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
@@ -12,7 +12,7 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
   alias Explorer.Repo
   alias Indexer.Temporary.FailedCreatedAddresses.TaskSupervisor
 
-  @task_options [max_concurrency: 3, timeout: 15_000]
+  @task_options [max_concurrency: 3, timeout: :infinity]
   @query_timeout :infinity
 
   def start_link([json_rpc_named_arguments, gen_server_options]) do

--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
@@ -24,7 +24,7 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
       |> code_entry()
       |> Indexer.Code.Fetcher.run(json_rpc_named_arguments)
 
-      internal_transaction.transaction_index
+      internal_transaction.transaction
       |> transaction_entry()
       |> Indexer.InternalTransaction.Fetcher.run(json_rpc_named_arguments)
     end)

--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
@@ -12,6 +12,7 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
   alias Indexer.Temporary.FailedCreatedAddresses.TaskSupervisor
 
   @task_options [max_concurrency: 3, timeout: 15_000]
+  @query_timeout :infinity
 
   def start_link([json_rpc_named_arguments, gen_server_options]) do
     GenServer.start_link(__MODULE__, json_rpc_named_arguments, gen_server_options)
@@ -33,7 +34,7 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
         preload: :transaction
       )
 
-    found_internal_transactions = Repo.all(query)
+    found_internal_transactions = Repo.all(query, timeout: @query_timeout)
 
     TaskSupervisor
     |> Task.Supervisor.async_stream(

--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
@@ -1,0 +1,42 @@
+defmodule Indexer.Temporary.FailedCreatedAddresses do
+  @moduledoc """
+  Temporary module to fix internal transactions and their created transactions if a parent transaction has failed.
+  """
+
+  import Ecto.Query
+
+  alias Explorer.Chain.{InternalTransaction, Transaction}
+  alias Explorer.Repo
+
+  def run(json_rpc_named_arguments) do
+    query =
+      from(it in InternalTransaction,
+        left_join: t in assoc(it, :transaction),
+        where: t.error == 0 and not is_nil(it.created_contract_address_hash),
+        preload: :transaction
+      )
+
+    query
+    |> Repo.all()
+    |> Enum.each(fn internal_transaction ->
+      internal_transaction
+      |> code_entry()
+      |> Indexer.Code.Fetcher.run(json_rpc_named_arguments)
+
+      internal_transaction.transaction_index
+      |> transaction_entry()
+      |> Indexer.InternalTransaction.Fetcher.run(json_rpc_named_arguments)
+    end)
+  end
+
+  def code_entry(%InternalTransaction{
+        block_number: block_number,
+        created_contract_address_hash: %{bytes: created_contract_bytes}
+      }) do
+    [{block_number, created_contract_bytes}]
+  end
+
+  def transaction_entry(%Transaction{hash: %{bytes: bytes}, index: index, block_number: block_number}) do
+    [{block_number, bytes, index}]
+  end
+end

--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses/supervisor.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses/supervisor.ex
@@ -18,7 +18,7 @@ defmodule Indexer.Temporary.FailedCreatedAddresses.Supervisor do
       type: :supervisor
     }
 
-    Supervisor.child_spec(default, []) |> IO.inspect()
+    Supervisor.child_spec(default, [])
   end
 
   def start_link(json_rpc_named_arguments, gen_server_options \\ []) do

--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses/supervisor.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses/supervisor.ex
@@ -1,0 +1,38 @@
+defmodule Indexer.Temporary.FailedCreatedAddresses.Supervisor do
+  @moduledoc """
+  Supervises `Indexer.Temporary.FailedCreatedAddresses`.
+  """
+
+  use Supervisor
+
+  alias Indexer.Temporary.FailedCreatedAddresses
+
+  def child_spec([init_arguments]) do
+    child_spec([init_arguments, []])
+  end
+
+  def child_spec([_init_arguments, _gen_server_options] = start_link_arguments) do
+    default = %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, start_link_arguments},
+      type: :supervisor
+    }
+
+    Supervisor.child_spec(default, []) |> IO.inspect()
+  end
+
+  def start_link(json_rpc_named_arguments, gen_server_options \\ []) do
+    Supervisor.start_link(__MODULE__, json_rpc_named_arguments, gen_server_options)
+  end
+
+  @impl Supervisor
+  def init(json_rpc_named_arguments) do
+    Supervisor.init(
+      [
+        {Task.Supervisor, name: Indexer.Temporary.FailedCreatedAddresses.TaskSupervisor},
+        {FailedCreatedAddresses, [json_rpc_named_arguments, [name: FailedCreatedAddresses]]}
+      ],
+      strategy: :rest_for_one
+    )
+  end
+end

--- a/apps/indexer/test/indexer/temporary/failed_created_addresses_test.exs
+++ b/apps/indexer/test/indexer/temporary/failed_created_addresses_test.exs
@@ -8,7 +8,7 @@ defmodule Indexer.Temporary.FailedCreatedAddressesTest do
 
   alias Explorer.Repo
   alias Explorer.Chain.{Address, InternalTransaction, Transaction}
-  alias Indexer.Temporary.FailedCreatedAddresses
+  alias Indexer.Temporary.FailedCreatedAddresses.Supervisor
   alias Indexer.CoinBalance
 
   @moduletag capture_log: true
@@ -105,7 +105,13 @@ defmodule Indexer.Temporary.FailedCreatedAddressesTest do
         end)
       end
 
-      FailedCreatedAddresses.run(json_rpc_named_arguments)
+      params = [json_rpc_named_arguments, [name: TestFailedCreatedAddresses]]
+
+      params
+      |> Supervisor.child_spec()
+      |> ExUnit.Callbacks.start_supervised!()
+
+      Process.sleep(3_000)
 
       query =
         from(t in Transaction,

--- a/apps/indexer/test/indexer/temporary/failed_created_addresses_test.exs
+++ b/apps/indexer/test/indexer/temporary/failed_created_addresses_test.exs
@@ -1,0 +1,91 @@
+defmodule Indexer.Temporary.FailedCreatedAddressesTest do
+  use Explorer.DataCase, async: false
+  use EthereumJSONRPC.Case, async: false
+
+  import Mox
+
+  alias Explorer.Repo
+  alias Explorer.Chain.InternalTransaction
+  alias Indexer.Temporary.FailedCreatedAddresses
+
+  @moduletag capture_log: true
+
+  setup :set_mox_global
+
+  setup :verify_on_exit!
+
+  describe "run/1" do
+    test "updates failed replaced transactions", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      transaction = :transaction |> insert(status: 0, error: "Reverted") |> with_block()
+      address = insert(:address)
+
+      internal_transaction =
+        insert(:internal_transaction,
+          block_number: transaction.block_number,
+          transaction: transaction,
+          index: 0,
+          created_contract_address_hash: address.hash
+        )
+
+      if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
+        EthereumJSONRPC.Mox
+        |> expect(:json_rpc, fn _json, _options ->
+          {:ok, [%{id: 0, jsonrpc: "2.0", result: "0x"}]}
+        end)
+        |> expect(:json_rpc, fn [%{id: id, method: "eth_getBalance", params: [_address, _block_quantity]}], _options ->
+          {:ok, [%{id: id, result: "0x0"}]}
+        end)
+        |> expect(:json_rpc, fn _json, _options ->
+          {:ok,
+           [
+             %{
+               id: 0,
+               jsonrpc: "2.0",
+               result: %{
+                 "output" => "0x",
+                 "stateDiff" => nil,
+                 "trace" => [
+                   %{
+                     "action" => %{
+                       "callType" => "call",
+                       "from" => "0xc73add416e2119d20ce80e0904fc1877e33ef246",
+                       "gas" => "0x13388",
+                       "input" => "0xc793bf97",
+                       "to" => "0x2d07e106b5d280e4ccc2d10deee62441c91d4340",
+                       "value" => "0x0"
+                     },
+                     "error" => "Reverted",
+                     "subtraces" => 1,
+                     "traceAddress" => [],
+                     "type" => "call"
+                   },
+                   %{
+                     "action" => %{
+                       "from" => "0x2d07e106b5d280e4ccc2d10deee62441c91d4340",
+                       "gas" => "0xb2ab",
+                       "init" =>
+                         "0x608060405234801561001057600080fd5b5060d38061001f6000396000f3fe6080604052600436106038577c010000000000000000000000000000000000000000000000000000000060003504633ccfd60b8114604f575b3360009081526020819052604090208025434019055005b348015605a57600080fd5b5060616063565b005b33600081815260208190526040808220805490839055905190929183156108fc02918491818181858888f1935050505015801560a3573d6000803e3d6000fd5b505056fea165627a7a72305820e9a226f249def650de957dd8b4127b85a3049d6bfa818cadc4e2d3c44b6a53530029",
+                       "value" => "0x0"
+                     },
+                     "result" => %{
+                       "address" => "0xf4a5afe28b91cf928c2568805cfbb36d477f0b75",
+                       "code" =>
+                         "0x6080604052600436106038577c010000000000000000000000000000000000000000000000000000000060003504633ccfd60b8114604f575b336000908152602081905260409020805434019055005b348015605a57600080fd5b5060616063565b005b33600081815260208190526040808220805490839055905190929183156108fc02918491818181858888f1935050505015801560a3573d6000803e3d6000fd5b505056fea165627a7a72305820e9a226f249def650de957dd8b4127b85a3049d6bfa818cadc4e2d3c44b6a53530029",
+                       "gasUsed" => "0xa535"
+                     },
+                     "subtraces" => 0,
+                     "traceAddress" => [0],
+                     "type" => "create"
+                   }
+                 ],
+                 "vmTrace" => nil
+               }
+             }
+           ]}
+        end)
+      end
+
+      FailedCreatedAddresses.run(json_rpc_named_arguments)
+    end
+  end
+end

--- a/apps/indexer/test/indexer/temporary/failed_created_addresses_test.exs
+++ b/apps/indexer/test/indexer/temporary/failed_created_addresses_test.exs
@@ -7,7 +7,7 @@ defmodule Indexer.Temporary.FailedCreatedAddressesTest do
   import Ecto.Query
 
   alias Explorer.Repo
-  alias Explorer.Chain.{Address, InternalTransaction, Transaction}
+  alias Explorer.Chain.{Address, Transaction}
   alias Indexer.Temporary.FailedCreatedAddresses.Supervisor
   alias Indexer.CoinBalance
 
@@ -40,13 +40,12 @@ defmodule Indexer.Temporary.FailedCreatedAddressesTest do
 
       address = insert(:address, contract_code: "0x0102030405")
 
-      internal_transaction =
-        insert(:internal_transaction,
-          block_number: transaction.block_number,
-          transaction: transaction,
-          index: 0,
-          created_contract_address_hash: address.hash
-        )
+      insert(:internal_transaction,
+        block_number: transaction.block_number,
+        transaction: transaction,
+        index: 0,
+        created_contract_address_hash: address.hash
+      )
 
       if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
         EthereumJSONRPC.Mox

--- a/apps/indexer/test/indexer/temporary/failed_created_addresses_test.exs
+++ b/apps/indexer/test/indexer/temporary/failed_created_addresses_test.exs
@@ -4,9 +4,12 @@ defmodule Indexer.Temporary.FailedCreatedAddressesTest do
 
   import Mox
 
+  import Ecto.Query
+
   alias Explorer.Repo
-  alias Explorer.Chain.InternalTransaction
+  alias Explorer.Chain.{Address, InternalTransaction, Transaction}
   alias Indexer.Temporary.FailedCreatedAddresses
+  alias Indexer.CoinBalance
 
   @moduletag capture_log: true
 
@@ -15,9 +18,27 @@ defmodule Indexer.Temporary.FailedCreatedAddressesTest do
   setup :verify_on_exit!
 
   describe "run/1" do
+    @tag :no_parity
+    @tag :no_geth
     test "updates failed replaced transactions", %{json_rpc_named_arguments: json_rpc_named_arguments} do
-      transaction = :transaction |> insert(status: 0, error: "Reverted") |> with_block()
-      address = insert(:address)
+      CoinBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert(
+          status: 0,
+          error: "Reverted",
+          internal_transactions_indexed_at: DateTime.utc_now(),
+          block: block,
+          block_number: block.number,
+          cumulative_gas_used: 200,
+          gas_used: 100,
+          index: 0
+        )
+
+      address = insert(:address, contract_code: "0x0102030405")
 
       internal_transaction =
         insert(:internal_transaction,
@@ -63,8 +84,7 @@ defmodule Indexer.Temporary.FailedCreatedAddressesTest do
                      "action" => %{
                        "from" => "0x2d07e106b5d280e4ccc2d10deee62441c91d4340",
                        "gas" => "0xb2ab",
-                       "init" =>
-                         "0x608060405234801561001057600080fd5b5060d38061001f6000396000f3fe6080604052600436106038577c010000000000000000000000000000000000000000000000000000000060003504633ccfd60b8114604f575b3360009081526020819052604090208025434019055005b348015605a57600080fd5b5060616063565b005b33600081815260208190526040808220805490839055905190929183156108fc02918491818181858888f1935050505015801560a3573d6000803e3d6000fd5b505056fea165627a7a72305820e9a226f249def650de957dd8b4127b85a3049d6bfa818cadc4e2d3c44b6a53530029",
+                       "init" => "0x4bb278f3",
                        "value" => "0x0"
                      },
                      "result" => %{
@@ -86,6 +106,29 @@ defmodule Indexer.Temporary.FailedCreatedAddressesTest do
       end
 
       FailedCreatedAddresses.run(json_rpc_named_arguments)
+
+      query =
+        from(t in Transaction,
+          where: t.hash == ^transaction.hash,
+          preload: [internal_transactions: :created_contract_address]
+        )
+
+      fetched_transaction = Repo.one(query)
+
+      assert Enum.count(fetched_transaction.internal_transactions) == 2
+
+      assert Enum.all?(fetched_transaction.internal_transactions, fn it ->
+               it.error && is_nil(it.created_contract_address_hash)
+             end)
+
+      fetched_address =
+        Repo.one(
+          from(a in Address,
+            where: a.hash == ^address.hash
+          )
+        )
+
+      assert fetched_address.contract_code == %Explorer.Chain.Data{bytes: ""}
     end
   end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,6 +26,7 @@ config :logger,
     # only :indexer, but all levels
     {LoggerFileBackend, :indexer},
     {LoggerFileBackend, :indexer_token_balances},
+    {LoggerFileBackend, :failed_contract_creations},
     {LoggerFileBackend, :reading_token_functions}
   ]
 


### PR DESCRIPTION
part of https://github.com/poanetwork/blockscout/issues/1438.

## Motivation
In the issue 1438 it was found that we didn't set the correct status to internal transactions if a parent call has failed. This PR adds code meant to fix old internal transaction already in the DB.

## Changelog
- add temporary module to fix failed internal transactions