### PR TITLE
fix: configure BLOCKSCOUT_VERSION in a standard way

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -8,7 +8,8 @@ use Mix.Config
 # General application configuration
 config :block_scout_web,
   namespace: BlockScoutWeb,
-  ecto_repos: [Explorer.Repo]
+  ecto_repos: [Explorer.Repo],
+  version: System.get_env("BLOCKSCOUT_VERSION")
 
 config :block_scout_web, BlockScoutWeb.Chain,
   network: System.get_env("NETWORK"),

--- a/apps/block_scout_web/lib/block_scout_web.ex
+++ b/apps/block_scout_web/lib/block_scout_web.ex
@@ -16,14 +16,7 @@ defmodule BlockScoutWeb do
   below. Instead, define any helper function in modules
   and import those modules here.
   """
-
-  # This is intentionally compiled in. Version is set
-  # at compile time, and we don't want to make a system
-  # env call to retreive it every time anyone loads any
-  # page.
-  @version System.get_env("BLOCKSCOUT_VERSION") || "unknown"
-
-  def version(), do: @version
+  def version(), do: Application.get_env(:block_scout_web, :version)
 
   def controller do
     quote do


### PR DESCRIPTION
Resolves #1468

## Motivation

* BLOCKSCOUT_VERSION was configured in a non-standard way that is harder/more annoying to use. This treats it like all of the rest of the application env variables that are mapped to environment variables.

## Changelog

### Bug Fixes
* Switch BLOCKSCOUT_VERSION from compiled module attribute to application config.
