### PR TITLE
remove smoothing from coin balance chart

### DIFF
--- a/apps/block_scout_web/assets/js/lib/coin_balance_history_chart.js
+++ b/apps/block_scout_web/assets/js/lib/coin_balance_history_chart.js
@@ -23,7 +23,8 @@ export function createCoinBalanceHistoryChart (el) {
         data: {
           datasets: [{
             label: 'coin balance',
-            data: coinBalanceHistoryData
+            data: coinBalanceHistoryData,
+            lineTension: 0
           }]
         },
         options: {

--- a/apps/block_scout_web/assets/js/lib/market_history_chart.js
+++ b/apps/block_scout_web/assets/js/lib/market_history_chart.js
@@ -12,6 +12,7 @@ const config = {
     datasets: []
   },
   options: {
+    bezierCurve : false,
     legend: {
       display: false
     },

--- a/apps/block_scout_web/assets/js/lib/market_history_chart.js
+++ b/apps/block_scout_web/assets/js/lib/market_history_chart.js
@@ -12,7 +12,6 @@ const config = {
     datasets: []
   },
   options: {
-    bezierCurve : false,
     legend: {
       display: false
     },


### PR DESCRIPTION
fixes https://github.com/poanetwork/blockscout/issues/1419

## Changelog
- remove smoothing from coin balance chart