### PR TITLE
do not do work in process initialization

### DIFF
--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
@@ -27,7 +27,7 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
   end
 
   def schedule_work do
-    Process.send_after(self, :run, 1_000)
+    Process.send_after(self(), :run, 1_000)
   end
 
   @impl GenServer

--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
@@ -21,9 +21,20 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
 
   @impl GenServer
   def init(json_rpc_named_arguments) do
-    run(json_rpc_named_arguments)
+    schedule_work()
 
     {:ok, json_rpc_named_arguments}
+  end
+
+  def schedule_work do
+    Process.send_after(self, :run, 1_000)
+  end
+
+  @impl GenServer
+  def handle_info(:run, json_rpc_named_arguments) do
+    run(json_rpc_named_arguments)
+
+    {:noreply, json_rpc_named_arguments}
   end
 
   def run(json_rpc_named_arguments) do


### PR DESCRIPTION
## Changelog

- do not do work in process initialization

### Bug Fixes

- `FailedCreatedAddress` process was doing heavy work in its initialization. It's wrong because it was blocking other processes. 