### PR TITLE
fix: constructor_arguments must be type `text`

### DIFF
--- a/apps/explorer/priv/repo/migrations/20190228152333_change_constructor_arguments_to_text.exs
+++ b/apps/explorer/priv/repo/migrations/20190228152333_change_constructor_arguments_to_text.exs
@@ -1,0 +1,15 @@
+defmodule Explorer.Repo.Migrations.ChangeConstructorArgumentsToText do
+  use Ecto.Migration
+
+  def up do
+    alter table(:smart_contracts) do
+      modify(:constructor_arguments, :text)
+    end
+  end
+
+  def down do
+    alter table(:smart_contracts) do
+      modify(:constructor_arguments, :string)
+    end
+  end
+end


### PR DESCRIPTION
Resolves: #1497

## Changelog

### Bug Fixes
* Make constructor_arguments a `text` field so that it can be longer than 255 characters.