### PR TITLE
fix coin balance params reducer for pending transaction

### DIFF
--- a/apps/indexer/lib/indexer/address/coin_balances.ex
+++ b/apps/indexer/lib/indexer/address/coin_balances.ex
@@ -28,7 +28,7 @@ defmodule Indexer.Address.CoinBalances do
   end
 
   defp reducer({:logs_params, logs_params}, acc) when is_list(logs_params) do
-    # a log MUST have and address_hash
+    # a log MUST have address_hash and block_number
     logs_params
     |> Enum.into(acc, fn
       %{address_hash: address_hash, block_number: block_number}

--- a/apps/indexer/lib/indexer/address/coin_balances.ex
+++ b/apps/indexer/lib/indexer/address/coin_balances.ex
@@ -29,10 +29,16 @@ defmodule Indexer.Address.CoinBalances do
 
   defp reducer({:logs_params, logs_params}, acc) when is_list(logs_params) do
     # a log MUST have and address_hash
-    Enum.into(logs_params, acc, fn %{address_hash: address_hash, block_number: block_number}
-                                   when is_binary(address_hash) and is_integer(block_number) ->
+    logs_params
+    |> Enum.into(acc, fn
       %{address_hash: address_hash, block_number: block_number}
+      when is_binary(address_hash) and is_integer(block_number) ->
+        %{address_hash: address_hash, block_number: block_number}
+
+      %{type: "pending"} ->
+        nil
     end)
+    |> Enum.reject(fn val -> is_nil(val) end)
   end
 
   defp reducer({:transactions_params, transactions_params}, initial) when is_list(transactions_params) do

--- a/apps/indexer/lib/indexer/address/coin_balances.ex
+++ b/apps/indexer/lib/indexer/address/coin_balances.ex
@@ -39,6 +39,7 @@ defmodule Indexer.Address.CoinBalances do
         nil
     end)
     |> Enum.reject(fn val -> is_nil(val) end)
+    |> MapSet.new()
   end
 
   defp reducer({:transactions_params, transactions_params}, initial) when is_list(transactions_params) do

--- a/apps/indexer/test/indexer/address/coin_balances_test.exs
+++ b/apps/indexer/test/indexer/address/coin_balances_test.exs
@@ -113,8 +113,8 @@ defmodule Indexer.Address.CoinBalancesTest do
 
       params_set = CoinBalances.params_set(%{logs_params: [log_params]})
 
-      assert Enum.count(params_set) == 1
-      assert %{address_hash: address_hash, block_number: block_number} == List.first(params_set)
+      assert MapSet.size(params_set) == 1
+      assert MapSet.new([%{address_hash: address_hash, block_number: block_number}]) == params_set
     end
 
     test "with log skips pending transactions" do
@@ -139,8 +139,8 @@ defmodule Indexer.Address.CoinBalancesTest do
 
       params_set = CoinBalances.params_set(%{logs_params: [log_params1, log_params2]})
 
-      assert Enum.count(params_set) == 1
-      assert %{address_hash: address_hash, block_number: block_number} == List.first(params_set)
+      assert MapSet.size(params_set) == 1
+      assert MapSet.new([%{address_hash: address_hash, block_number: block_number}]) == params_set
     end
 
     test "with transaction without to_address_hash extracts from_address_hash" do

--- a/apps/indexer/test/indexer/address/coin_balances_test.exs
+++ b/apps/indexer/test/indexer/address/coin_balances_test.exs
@@ -113,8 +113,34 @@ defmodule Indexer.Address.CoinBalancesTest do
 
       params_set = CoinBalances.params_set(%{logs_params: [log_params]})
 
-      assert MapSet.size(params_set) == 1
-      assert %{address_hash: address_hash, block_number: block_number}
+      assert Enum.count(params_set) == 1
+      assert %{address_hash: address_hash, block_number: block_number} == List.first(params_set)
+    end
+
+    test "with log skips pending transactions" do
+      block_number = 1
+
+      address_hash =
+        Factory.address_hash()
+        |> to_string()
+
+      log_params1 =
+        :log
+        |> Factory.params_for()
+        |> Map.put(:block_number, nil)
+        |> Map.put(:address_hash, address_hash)
+        |> Map.put(:type, "pending")
+
+      log_params2 =
+        :log
+        |> Factory.params_for()
+        |> Map.put(:block_number, block_number)
+        |> Map.put(:address_hash, address_hash)
+
+      params_set = CoinBalances.params_set(%{logs_params: [log_params1, log_params2]})
+
+      assert Enum.count(params_set) == 1
+      assert %{address_hash: address_hash, block_number: block_number} == List.first(params_set)
     end
 
     test "with transaction without to_address_hash extracts from_address_hash" do


### PR DESCRIPTION
## Motivation
We can't extract params from logs params of pending transactions

```
2019-03-03T18:15:54.317 [error] Task #PID<0.8286.0> started from Indexer.Block.Realtime.Fetcher terminating
** (FunctionClauseError) no function clause matching in anonymous fn/1 in Indexer.Address.CoinBalances.reducer/2
    (indexer) lib/indexer/address/coin_balances.ex:32: anonymous fn(%{address_hash: "0xdac17f958d2ee523a2206206994597c13d831ec7", block_number: nil, data: "0x00000000000000000000000000000000000000000000000000000000007839b0", first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", fourth_topic: nil, index: nil, second_topic: "0x00000000000000000000000048686372756193c2663d1081c35d3d48e022c5fa", third_topic: "0x000000000000000000000000a5b1a8d0d45fc9729cc3f57c4f5b8c35da14d6f5", transaction_hash: nil, type: "pending"}) in Indexer.Address.CoinBalances.reducer/2
```

## Changelog

- fix coin balance params reducer for pending transaction