### PR TITLE
add index to value_fetched_at

### DIFF
--- a/apps/explorer/priv/repo/migrations/20190305095926_add_index_to_value_fetched_at.exs
+++ b/apps/explorer/priv/repo/migrations/20190305095926_add_index_to_value_fetched_at.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.AddIndexToValueFetchedAt do
+  use Ecto.Migration
+
+  def change do
+    create(index(:address_coin_balances, [:value_fetched_at]))
+  end
+end


### PR DESCRIPTION
## Motivation

the query is using `value_fetched_at` field to filter records

```
  def stream_unfetched_balances(initial, reducer) when is_function(reducer, 2) do
    query =
      from(
        balance in CoinBalance,
        where: is_nil(balance.value_fetched_at),
        select: %{address_hash: balance.address_hash, block_number: balance.block_number}
      )

    Repo.stream_reduce(query, initial, reducer)
  end
```

https://github.com/poanetwork/blockscout/blob/master/apps/explorer/lib/explorer/chain.ex#L1121

before adding index:

```
Gather  (cost=1000.00..12287343.90 rows=20456553 width=29)
  Workers Planned: 2
  ->  Parallel Seq Scan on address_coin_balances a0  (cost=0.00..10240688.60 rows=8523564 width=29)
        Filter: (value_fetched_at IS NULL)
```

after adding index:
```
Bitmap Heap Scan on address_coin_balances a0  (cost=383588.04..8443884.54 rows=20493350 width=29)
  Recheck Cond: (value_fetched_at IS NULL)
  ->  Bitmap Index Scan on address_coin_balances_value_fetched_at_index  (cost=0.00..378464.70 rows=20493350 width=0)
        Index Cond: (value_fetched_at IS NULL)
```

## Changelog

- add index to value_fetched_at