### PR TITLE
fix: render a nicer error when creator cannot be determined

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -53,21 +53,27 @@
               <% end %>
             </span>
           </div>
+          <% from_address_hash = from_address_hash(@address) %>
+
           <%= if contract?(@address) do %>
             <span class="text-muted" data-test="address_contract_creator">
-              <%= gettext "Created by" %>
-              <%= link(
-                trimmed_hash(from_address_hash(@address)),
-                to: address_path(@conn, :show, from_address_hash(@address))
-              ) %>
+              <%= if from_address_hash do %>
+                <%= gettext "Created by" %>
+                <%= link(
+                  trimmed_hash(from_address_hash(@address)),
+                  to: address_path(@conn, :show, from_address_hash(@address))
+                ) %>
 
-              <%= gettext "at" %>
+                <%= gettext "at" %>
 
-              <%= link(
-                trimmed_hash(transaction_hash(@address)),
-                to: transaction_path(@conn, :show, transaction_hash(@address)),
-                "data-test": "transaction_hash_link"
-              ) %>
+                <%= link(
+                  trimmed_hash(transaction_hash(@address)),
+                  to: transaction_path(@conn, :show, transaction_hash(@address)),
+                  "data-test": "transaction_hash_link"
+                ) %>
+              <% else %>
+                <p class="alert alert-danger" role="alert"><%= gettext("Error: Could not determine contract creator.") %></p>
+              <% end %>
             </span>
           <% end %>
         </div>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -1,6 +1,8 @@
 defmodule BlockScoutWeb.AddressView do
   use BlockScoutWeb, :view
 
+  require Logger
+
   import BlockScoutWeb.AddressController, only: [validation_count: 1]
 
   alias BlockScoutWeb.LayoutView
@@ -232,6 +234,12 @@ defmodule BlockScoutWeb.AddressView do
 
   def from_address_hash(%Address{contracts_creation_transaction: %Transaction{}} = address) do
     address.contracts_creation_transaction.from_address_hash
+  end
+
+  def from_address_hash(address) do
+    Logger.error(fn -> ["Found a contract with no creator: ", to_string(address)] end)
+
+    nil
   end
 
   defp matching_address_check(%Address{hash: hash} = current_address, %Address{hash: hash}, contract?, truncate) do

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -99,7 +99,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:16
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:15
-#: lib/block_scout_web/views/address_view.ex:98
+#: lib/block_scout_web/views/address_view.ex:100
 msgid "Address"
 msgstr ""
 
@@ -192,7 +192,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:51
 #: lib/block_scout_web/templates/address_validation/index.html.eex:30
 #: lib/block_scout_web/templates/address_validation/index.html.eex:57
-#: lib/block_scout_web/views/address_view.ex:279
+#: lib/block_scout_web/views/address_view.ex:287
 msgid "Blocks Validated"
 msgstr ""
 
@@ -209,8 +209,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:37
-#: lib/block_scout_web/templates/address/overview.html.eex:89
-#: lib/block_scout_web/templates/address/overview.html.eex:97
+#: lib/block_scout_web/templates/address/overview.html.eex:95
+#: lib/block_scout_web/templates/address/overview.html.eex:103
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:91
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:99
 msgid "Close"
@@ -222,7 +222,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:39
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:119
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
-#: lib/block_scout_web/views/address_view.ex:276
+#: lib/block_scout_web/views/address_view.ex:284
 msgid "Code"
 msgstr ""
 
@@ -266,14 +266,14 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:13
-#: lib/block_scout_web/views/address_view.ex:96
+#: lib/block_scout_web/views/address_view.ex:98
 msgid "Contract Address"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:16
-#: lib/block_scout_web/views/address_view.ex:36
-#: lib/block_scout_web/views/address_view.ex:70
+#: lib/block_scout_web/views/address_view.ex:38
+#: lib/block_scout_web/views/address_view.ex:72
 msgid "Contract Address Pending"
 msgstr ""
 
@@ -328,7 +328,7 @@ msgid "Copy Txn Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:58
+#: lib/block_scout_web/templates/address/overview.html.eex:61
 msgid "Created by"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:275
+#: lib/block_scout_web/views/address_view.ex:283
 #: lib/block_scout_web/views/transaction_view.ex:258
 msgid "Internal Transactions"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:28
 #: lib/block_scout_web/templates/layout/app.html.eex:49
-#: lib/block_scout_web/views/address_view.ex:118
+#: lib/block_scout_web/views/address_view.ex:120
 msgid "Market Cap"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:13
-#: lib/block_scout_web/templates/address/overview.html.eex:88
+#: lib/block_scout_web/templates/address/overview.html.eex:94
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:13
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:13
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:90
@@ -702,7 +702,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:122
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
-#: lib/block_scout_web/views/address_view.ex:277
+#: lib/block_scout_web/views/address_view.ex:285
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -901,7 +901,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:12
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
 #: lib/block_scout_web/templates/address_validation/index.html.eex:19
-#: lib/block_scout_web/views/address_view.ex:273
+#: lib/block_scout_web/views/address_view.ex:281
 msgid "Tokens"
 msgstr ""
 
@@ -962,7 +962,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:35
 #: lib/block_scout_web/templates/chain/show.html.eex:93
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:35
-#: lib/block_scout_web/views/address_view.ex:274
+#: lib/block_scout_web/views/address_view.ex:282
 msgid "Transactions"
 msgstr ""
 
@@ -1094,7 +1094,7 @@ msgid "Yes"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:64
+#: lib/block_scout_web/templates/address/overview.html.eex:67
 msgid "at"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:30
 #: lib/block_scout_web/templates/address/_tabs.html.eex:96
-#: lib/block_scout_web/views/address_view.ex:278
+#: lib/block_scout_web/views/address_view.ex:286
 msgid "Coin Balance History"
 msgstr ""
 
@@ -1685,4 +1685,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:31
 msgid "EVM Vesion"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/overview.html.eex:75
+msgid "Error: Could not determine contract creator."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -99,7 +99,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:16
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:15
-#: lib/block_scout_web/views/address_view.ex:98
+#: lib/block_scout_web/views/address_view.ex:100
 msgid "Address"
 msgstr ""
 
@@ -192,7 +192,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:51
 #: lib/block_scout_web/templates/address_validation/index.html.eex:30
 #: lib/block_scout_web/templates/address_validation/index.html.eex:57
-#: lib/block_scout_web/views/address_view.ex:279
+#: lib/block_scout_web/views/address_view.ex:287
 msgid "Blocks Validated"
 msgstr ""
 
@@ -209,8 +209,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:37
-#: lib/block_scout_web/templates/address/overview.html.eex:89
-#: lib/block_scout_web/templates/address/overview.html.eex:97
+#: lib/block_scout_web/templates/address/overview.html.eex:95
+#: lib/block_scout_web/templates/address/overview.html.eex:103
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:91
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:99
 msgid "Close"
@@ -222,7 +222,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:39
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:119
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
-#: lib/block_scout_web/views/address_view.ex:276
+#: lib/block_scout_web/views/address_view.ex:284
 msgid "Code"
 msgstr ""
 
@@ -266,14 +266,14 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:13
-#: lib/block_scout_web/views/address_view.ex:96
+#: lib/block_scout_web/views/address_view.ex:98
 msgid "Contract Address"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:16
-#: lib/block_scout_web/views/address_view.ex:36
-#: lib/block_scout_web/views/address_view.ex:70
+#: lib/block_scout_web/views/address_view.ex:38
+#: lib/block_scout_web/views/address_view.ex:72
 msgid "Contract Address Pending"
 msgstr ""
 
@@ -328,7 +328,7 @@ msgid "Copy Txn Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:58
+#: lib/block_scout_web/templates/address/overview.html.eex:61
 msgid "Created by"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:275
+#: lib/block_scout_web/views/address_view.ex:283
 #: lib/block_scout_web/views/transaction_view.ex:258
 msgid "Internal Transactions"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:28
 #: lib/block_scout_web/templates/layout/app.html.eex:49
-#: lib/block_scout_web/views/address_view.ex:118
+#: lib/block_scout_web/views/address_view.ex:120
 msgid "Market Cap"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:13
-#: lib/block_scout_web/templates/address/overview.html.eex:88
+#: lib/block_scout_web/templates/address/overview.html.eex:94
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:13
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:13
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:90
@@ -702,7 +702,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:122
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
-#: lib/block_scout_web/views/address_view.ex:277
+#: lib/block_scout_web/views/address_view.ex:285
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -901,7 +901,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:12
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
 #: lib/block_scout_web/templates/address_validation/index.html.eex:19
-#: lib/block_scout_web/views/address_view.ex:273
+#: lib/block_scout_web/views/address_view.ex:281
 msgid "Tokens"
 msgstr ""
 
@@ -962,7 +962,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:35
 #: lib/block_scout_web/templates/chain/show.html.eex:93
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:35
-#: lib/block_scout_web/views/address_view.ex:274
+#: lib/block_scout_web/views/address_view.ex:282
 msgid "Transactions"
 msgstr ""
 
@@ -1094,7 +1094,7 @@ msgid "Yes"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:64
+#: lib/block_scout_web/templates/address/overview.html.eex:67
 msgid "at"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:30
 #: lib/block_scout_web/templates/address/_tabs.html.eex:96
-#: lib/block_scout_web/views/address_view.ex:278
+#: lib/block_scout_web/views/address_view.ex:286
 msgid "Coin Balance History"
 msgstr ""
 
@@ -1685,4 +1685,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:31
 msgid "EVM Vesion"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/overview.html.eex:75
+msgid "Error: Could not determine contract creator."
 msgstr ""


### PR DESCRIPTION
Part of #1503 	

## Motivation

* To start off with, we should have a nicer error case when this happens. It makes it easier to debug, and also makes the problem less annoying for users, if determining the root cause takes a while.

## Changelog

### Bug Fixes
* Don't show internal server error page when a contract creator cannot be determined.

![Screen Shot 2019-03-12 at 09 42 27](https://user-images.githubusercontent.com/5722339/54204732-391fea00-44ab-11e9-95f6-642770ce3905.png)
