### PR TITLE
fetch ERC721 token balances if sender is '0x0..0'

### DIFF
--- a/apps/indexer/lib/indexer/address/token_balances.ex
+++ b/apps/indexer/lib/indexer/address/token_balances.ex
@@ -37,10 +37,6 @@ defmodule Indexer.Address.TokenBalances do
     Enum.filter(token_transfers_params, &do_filter_burn_address/1)
   end
 
-  def do_filter_burn_address(%{from_address_hash: "0x0000000000000000000000000000000000000000", token_type: "ERC-721"}) do
-    false
-  end
-
   def do_filter_burn_address(%{to_address_hash: "0x0000000000000000000000000000000000000000", token_type: "ERC-721"}) do
     false
   end

--- a/apps/indexer/test/indexer/address/token_balances_test.exs
+++ b/apps/indexer/test/indexer/address/token_balances_test.exs
@@ -35,7 +35,7 @@ defmodule Indexer.Address.TokenBalancesTest do
       assert %{address_hash: token_contract_address_hash, block_number: block_number}
     end
 
-    test "does not set params when the from_address_hash is the burn address for the Token ERC-721" do
+    test "does set params when the from_address_hash is the burn address for the Token ERC-721" do
       block_number = 1
       from_address_hash = "0x0000000000000000000000000000000000000000"
       to_address_hash = "0x5b8410f67eb8040bb1cd1e8a4ff9d5f6ce678a15"
@@ -51,7 +51,19 @@ defmodule Indexer.Address.TokenBalancesTest do
 
       params_set = TokenBalances.params_set(%{token_transfers_params: [token_transfer_params]})
 
-      assert MapSet.size(params_set) == 0
+      assert params_set ==
+               MapSet.new([
+                 %{
+                   address_hash: "0x0000000000000000000000000000000000000000",
+                   block_number: 1,
+                   token_contract_address_hash: "0xe18035bf8712672935fdb4e5e431b1a0183d2dfc"
+                 },
+                 %{
+                   address_hash: "0x5b8410f67eb8040bb1cd1e8a4ff9d5f6ce678a15",
+                   block_number: 1,
+                   token_contract_address_hash: "0xe18035bf8712672935fdb4e5e431b1a0183d2dfc"
+                 }
+               ])
     end
 
     test "does not set params when the to_address_hash is the burn address for the Token ERC-721" do


### PR DESCRIPTION
fixes https://github.com/poanetwork/blockscout/issues/1464

## Changelog

- fetch ERC721 token balances if sender is '0x0..0'