### PR TITLE
Fix scheduling of latest block polling in Realtime Fetcher

### DIFF
--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -96,7 +96,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
 
     new_max_number = new_max_number(number, max_number_seen)
 
-    :timer.cancel(timer)
+    Process.cancel_timer(timer)
     new_timer = schedule_polling()
 
     {:noreply,


### PR DESCRIPTION
Timer is set using Elixir's `Process.send_after/3` method, which is incompatible with Erlang's `:timer` module.
Thus, `:timer.cancel` doesn't have any effect on it, and in fact returns `{:error, :badarg}`.
This causes more and more polling being scheduled after every websocket event, which might cause excessive flooding of a node with `eth_getBlockByNumber` requests after some running time.