### PR TITLE
(Feature) Exact date and time for Transaction details page

### DIFF
--- a/apps/block_scout_web/assets/js/lib/from_now.js
+++ b/apps/block_scout_web/assets/js/lib/from_now.js
@@ -19,7 +19,14 @@ function tryUpdateAge (el) {
   if (timestamp.isValid()) updateAge(el, timestamp)
 }
 function updateAge (el, timestamp) {
-  const fromNow = timestamp.fromNow()
+  let fromNow = timestamp.fromNow()
+  //show the exact time only for transaction details page. Otherwise, short entry
+  if (window.location.pathname.startsWith('/tx/')) {
+  	const offset = moment().utcOffset() / 60
+  	const sign = offset && Math.sign(offset) ? '+' : '-';
+  	const formatDate = `MMMM-DD-YYYY hh:mm:ss A ${sign}${offset} UTC`
+  	fromNow = `${fromNow} (${timestamp.format(formatDate)})`
+  }
   if (fromNow !== el.innerHTML) el.innerHTML = fromNow
 }
 updateAllAges()

--- a/apps/block_scout_web/assets/js/lib/from_now.js
+++ b/apps/block_scout_web/assets/js/lib/from_now.js
@@ -20,10 +20,10 @@ function tryUpdateAge (el) {
 }
 function updateAge (el, timestamp) {
   let fromNow = timestamp.fromNow()
-  //show the exact time only for transaction details page. Otherwise, short entry
+  // show the exact time only for transaction details page. Otherwise, short entry
   if (window.location.pathname.startsWith('/tx/')) {
     const offset = moment().utcOffset() / 60
-    const sign = offset && Math.sign(offset) ? '+' : '-';
+    const sign = offset && Math.sign(offset) ? '+' : '-'
     const formatDate = `MMMM-DD-YYYY hh:mm:ss A ${sign}${offset} UTC`
     fromNow = `${fromNow} (${timestamp.format(formatDate)})`
   }

--- a/apps/block_scout_web/assets/js/lib/from_now.js
+++ b/apps/block_scout_web/assets/js/lib/from_now.js
@@ -22,10 +22,10 @@ function updateAge (el, timestamp) {
   let fromNow = timestamp.fromNow()
   //show the exact time only for transaction details page. Otherwise, short entry
   if (window.location.pathname.startsWith('/tx/')) {
-  	const offset = moment().utcOffset() / 60
-  	const sign = offset && Math.sign(offset) ? '+' : '-';
-  	const formatDate = `MMMM-DD-YYYY hh:mm:ss A ${sign}${offset} UTC`
-  	fromNow = `${fromNow} (${timestamp.format(formatDate)})`
+    const offset = moment().utcOffset() / 60
+    const sign = offset && Math.sign(offset) ? '+' : '-';
+    const formatDate = `MMMM-DD-YYYY hh:mm:ss A ${sign}${offset} UTC`
+    fromNow = `${fromNow} (${timestamp.format(formatDate)})`
   }
   if (fromNow !== el.innerHTML) el.innerHTML = fromNow
 }


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/1506

## Motivation

There is no exact date and time in the Transaction details page. It is useful for some applications ☝️ 

## Changelog

### Enhancements
![Screenshot 2019-03-12 at 13 17 05](https://user-images.githubusercontent.com/4341812/54192899-089b7880-44ca-11e9-8446-c85c08ce7e81.png)

Exact date and time have been added only for Transaction details page. For other pages, a short record of date has been left.
