### PR TITLE
Dockerfile: remove 1.7.1 version pin FROM bitwalker/alpine-elixir-phoenix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-elixir-phoenix:1.7.1
+FROM bitwalker/alpine-elixir-phoenix
 
 RUN apk --no-cache --update add automake libtool inotify-tools autoconf python
 


### PR DESCRIPTION
Remove 1.7.1 version pin FROM bitwalker/alpine-elixir-phoenix

BlockScout now requires a later version of `alpine-elixir-phoenix`, so remove the pin to version 1.7.1

closes #1552