### PR TITLE
feat: allow setting different configuration just for realtime fetcher

### DIFF
--- a/apps/indexer/config/dev/parity.exs
+++ b/apps/indexer/config/dev/parity.exs
@@ -16,6 +16,23 @@ config :indexer,
     ],
     variant: EthereumJSONRPC.Parity
   ],
+  # Example configuration to override json_rpc_named_arguments for just the realtime block fetcher
+  # realtime_overrides: [
+  #   json_rpc_named_arguments: [
+  #     transport: EthereumJSONRPC.HTTP,
+  #     transport_options: [
+  #       http: EthereumJSONRPC.HTTP.HTTPoison,
+  #       url: System.get_env("ETHEREUM_JSONRPC_REALTIME_HTTP_URL") || "http://localhost:8545",
+  #       method_to_url: [
+  #         eth_getBalance: System.get_env("ETHEREUM_JSONRPC_REALTIME_TRACE_URL") || "http://localhost:8545",
+  #         trace_block: System.get_env("ETHEREUM_JSONRPC_REALTIME_TRACE_URL") || "http://localhost:8545",
+  #         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_REALTIME_TRACE_URL") || "http://localhost:8545"
+  #       ],
+  #       http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+  #     ],
+  #     variant: EthereumJSONRPC.Parity
+  #   ]
+  # ],
   subscribe_named_arguments: [
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [

--- a/apps/indexer/lib/indexer/shrinkable/supervisor.ex
+++ b/apps/indexer/lib/indexer/shrinkable/supervisor.ex
@@ -48,10 +48,11 @@ defmodule Indexer.Shrinkable.Supervisor do
       |> Application.get_all_env()
       |> Keyword.take(
         ~w(blocks_batch_size blocks_concurrency block_interval json_rpc_named_arguments receipts_batch_size
-           receipts_concurrency subscribe_named_arguments)a
+           receipts_concurrency subscribe_named_arguments realtime_overrides)a
       )
       |> Enum.into(%{})
       |> Map.put(:memory_monitor, memory_monitor)
+      |> Map.put_new(:realtime_overrides, %{})
 
     Supervisor.init(
       [


### PR DESCRIPTION
Resolves #1566 

This allows a simple configuration to be set alongside other indexer configurations, which will just be merged with the entire configuration *only* for the realtime fetcher. This allows setting a dedicated node for the realtime fetcher.

There are a lot of downstream components called by the realtime fetcher, so we will definitely want to test this out in stg to make sure there are no unintended side effects.