### PR TITLE
add option to disable block rewards in indexer config

### DIFF
--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -36,6 +36,7 @@ config :indexer,
   memory_limit: 1 <<< 30
 
 # config :indexer, Indexer.ReplacedTransaction.Supervisor, disabled?: true
+# config :indexer, Indexer.Block.Reward.Supervisor, disabled?: true 
 
 config :indexer, Indexer.Tracer,
   service: :indexer,

--- a/apps/indexer/lib/indexer/block/reward/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/reward/fetcher.ex
@@ -18,6 +18,7 @@ defmodule Indexer.Block.Reward.Fetcher do
   alias Explorer.Chain.{Block, Wei}
   alias Indexer.Address.CoinBalances
   alias Indexer.{AddressExtraction, BufferedTask, CoinBalance, Tracer}
+  alias Indexer.Block.Reward.Supervisor, as: BlockRewardSupervisor
 
   @behaviour BufferedTask
 
@@ -34,7 +35,11 @@ defmodule Indexer.Block.Reward.Fetcher do
   """
   @spec async_fetch([Block.block_number()]) :: :ok
   def async_fetch(block_numbers) when is_list(block_numbers) do
-    BufferedTask.buffer(__MODULE__, block_numbers)
+    if BlockRewardSupervisor.disabled?() do
+      :ok
+    else
+      BufferedTask.buffer(__MODULE__, block_numbers)
+    end
   end
 
   @doc false

--- a/apps/indexer/lib/indexer/block/reward/supervisor.ex
+++ b/apps/indexer/lib/indexer/block/reward/supervisor.ex
@@ -22,7 +22,15 @@ defmodule Indexer.Block.Reward.Supervisor do
   end
 
   def start_link(arguments, gen_server_options \\ []) do
-    Supervisor.start_link(__MODULE__, arguments, Keyword.put_new(gen_server_options, :name, __MODULE__))
+    if disabled?() do
+      :ignore
+    else
+      Supervisor.start_link(__MODULE__, arguments, Keyword.put_new(gen_server_options, :name, __MODULE__))
+    end
+  end
+
+  def disabled?() do
+    Application.get_env(:indexer, __MODULE__, [])[:disabled?] == true
   end
 
   @impl Supervisor


### PR DESCRIPTION
Not all chains distribute block reward, e.g. [SpringChain](https://explorer.springrole.com/). If chain don't have block reward, console is spammed with error: `application=indexer fetcher=block_reward count=10 error_count=10 [error] failed to fetch: @㍪: (404) Not Found`

Fixes #1526 and #1563. 

Just uncomment the line `config :indexer, Indexer.Block.Reward.Supervisor, disabled?: true` in apps/indexer/config/config.exs