### PR TITLE
Chunk JSON-RPC batches in case connection times out

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
@@ -68,6 +68,9 @@ defmodule EthereumJSONRPC.HTTP do
           chunked_json_rpc(tail, options, [decoded_body | decoded_response_bodies])
         end
 
+      {:error, :timeout} ->
+        rechunk_json_rpc(chunks, options, :timeout, decoded_response_bodies)
+
       {:error, _} = error ->
         error
     end


### PR DESCRIPTION
There exists code to ensure long-running batch requests are split into smaller
batches in case we receive 504 (Gateway Timeout) errorfrom loadbalancer.

This PR adds handling of batches in the same manner in case there either is no
balancer, or its timeouts are configured larger than indexer's, and thus the
HTTP client library itself times out.