### PR TITLE
(Fix) Exact timestamp display

### DIFF
--- a/apps/block_scout_web/assets/js/lib/from_now.js
+++ b/apps/block_scout_web/assets/js/lib/from_now.js
@@ -21,7 +21,8 @@ function tryUpdateAge (el) {
 function updateAge (el, timestamp) {
   let fromNow = timestamp.fromNow()
   // show the exact time only for transaction details page. Otherwise, short entry
-  if (window.location.pathname.startsWith('/tx/')) {
+  const elInTile = el.hasAttribute('in-tile')
+  if (window.location.pathname.includes('/tx/') && !elInTile) {
     const offset = moment().utcOffset() / 60
     const sign = offset && Math.sign(offset) ? '+' : '-'
     const formatDate = `MMMM-DD-YYYY hh:mm:ss A ${sign}${offset} UTC`

--- a/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
@@ -23,7 +23,7 @@
           to: block_path(BlockScoutWeb.Endpoint, :show, @internal_transaction.block_number)
         ) %>
       </span>
-      <span class="mr-2 mr-md-0 order-2" data-from-now="<%= @internal_transaction.transaction.block.timestamp %>"></span>
+      <span class="mr-2 mr-md-0 order-2" in-tile data-from-now="<%= @internal_transaction.transaction.block.timestamp %>"></span>
       <%= if assigns[:current_address] do %>
         <span class="mr-2 mr-md-0 order-0 order-md-3">
           <%= if assigns[:current_address].hash == @internal_transaction.from_address_hash do %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tile.html.eex
@@ -35,7 +35,7 @@
       <span class="mr-2 mr-md-0 order-1">
         <%= @transaction |> block_number() |> BlockScoutWeb.RenderHelpers.render_partial() %>
       </span>
-      <span class="mr-2 mr-md-0 order-2" data-from-now="<%= block_timestamp(@transaction) %>"></span>
+      <span class="mr-2 mr-md-0 order-2" in-tile data-from-now="<%= block_timestamp(@transaction) %>"></span>
       <%= if from_or_to_address?(@transaction, assigns[:current_address]) do %>
         <span class="mr-2 mr-md-0 order-0 order-md-3">
           <%= if @transaction.from_address_hash == assigns[:current_address].hash do %>


### PR DESCRIPTION
Relates https://github.com/poanetwork/blockscout/pull/1551

## Motivation

1. We shouldn't display an exact time in a tile (the original issue https://github.com/poanetwork/blockscout/issues/1506 was only about the display of exact time in transaction details block):
![Screenshot 2019-03-18 at 12 06 55](https://user-images.githubusercontent.com/4341812/54522928-6b37bd00-497f-11e9-8dc3-bd7a79c254e0.png)
2. Exact time doesn't display in transaction details block if the path doesn't start with `/tx`. For example, for Blockscocut instances tx details path begins with `/${preifx}/${chain}/tx`

## Changelog

- `in-tile` attribute has been added for elements inside tiles to exclude exact time display from them
- tx details page path search mask has been fixed.

### Bug Fixes

 - Exclude exact timestamp from tiles
 - fix tx details page path search mask for displaying of exact time
