### PR TITLE
feat: add listcontracts endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
  - [#1589](https://github.com/poanetwork/blockscout/pull/1589) - RPC endpoint to list addresses
  - [#1567](https://github.com/poanetwork/blockscout/pull/1567) - Allow setting different configuration just for realtime fetcher
  - [#1562](https://github.com/poanetwork/blockscout/pull/1562) - Add incoming transactions count to contract view
+ - [#1608](https://github.com/poanetwork/blockscout/pull/1608) - Add listcontracts RPC Endpoint
 
 ### Fixes
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
@@ -1,6 +1,7 @@
 defmodule BlockScoutWeb.API.RPC.AddressController do
   use BlockScoutWeb, :controller
 
+  alias BlockScoutWeb.API.RPC.Helpers
   alias Explorer.{Chain, Etherscan}
   alias Explorer.Chain.{Address, Wei}
 
@@ -162,7 +163,7 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
   end
 
   def getminedblocks(conn, params) do
-    options = put_pagination_options(%{}, params)
+    options = Helpers.put_pagination_options(%{}, params)
 
     with {:address_param, {:ok, address_param}} <- fetch_address(params),
          {:format, {:ok, address_hash}} <- to_address_hash(address_param),
@@ -188,7 +189,7 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
   def optional_params(params) do
     %{}
     |> put_order_by_direction(params)
-    |> put_pagination_options(params)
+    |> Helpers.put_pagination_options(params)
     |> put_start_block(params)
     |> put_end_block(params)
     |> put_filter_by(params)
@@ -336,24 +337,6 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
       _ ->
         options
     end
-  end
-
-  defp put_pagination_options(options, params) do
-    with %{"page" => page, "offset" => offset} <- params,
-         {page_number, ""} when page_number > 0 <- Integer.parse(page),
-         {page_size, ""} when page_size > 0 <- Integer.parse(offset),
-         :ok <- validate_max_page_size(page_size) do
-      options
-      |> Map.put(:page_number, page_number)
-      |> Map.put(:page_size, page_size)
-    else
-      _ ->
-        options
-    end
-  end
-
-  defp validate_max_page_size(page_size) do
-    if page_size <= Etherscan.page_size_max(), do: :ok, else: :error
   end
 
   defp put_start_block(options, params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -1,7 +1,30 @@
 defmodule BlockScoutWeb.API.RPC.ContractController do
   use BlockScoutWeb, :controller
 
+  alias BlockScoutWeb.API.RPC.Helpers
   alias Explorer.Chain
+  alias Explorer.Chain.SmartContract
+
+  def listcontracts(conn, params) do
+    with pagination_options <- Helpers.put_pagination_options(%{}, params),
+         {:params, {:ok, options}} <- {:params, add_filter(pagination_options, params)} do
+      options_with_defaults =
+        options
+        |> Map.put_new(:page_number, 0)
+        |> Map.put_new(:page_size, 10)
+
+      contracts = list_contracts(options_with_defaults)
+
+      conn
+      |> put_status(200)
+      |> render(:listcontracts, %{contracts: contracts})
+    else
+      {:params, {:error, error}} ->
+        conn
+        |> put_status(400)
+        |> render(:error, error: error)
+    end
+  end
 
   def getabi(conn, params) do
     with {:address_param, {:ok, address_param}} <- fetch_address(params),
@@ -24,7 +47,10 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
     with {:address_param, {:ok, address_param}} <- fetch_address(params),
          {:format, {:ok, address_hash}} <- to_address_hash(address_param),
          {:contract, {:ok, contract}} <- to_smart_contract(address_hash) do
-      render(conn, :getsourcecode, %{contract: contract})
+      render(conn, :getsourcecode, %{
+        contract: contract,
+        address_hash: address_hash
+      })
     else
       {:address_param, :error} ->
         render(conn, :error, error: "Query parameter address is required")
@@ -33,8 +59,62 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
         render(conn, :error, error: "Invalid address hash")
 
       {:contract, :not_found} ->
-        render(conn, :getsourcecode, %{contract: nil})
+        render(conn, :getsourcecode, %{contract: nil, address_hash: nil})
     end
+  end
+
+  defp list_contracts(%{page_number: page_number, page_size: page_size} = opts) do
+    offset = (max(page_number, 1) - 1) * page_size
+
+    case Map.get(opts, :filter) do
+      :verified ->
+        Chain.list_verified_contracts(page_size, offset)
+
+      :decompiled ->
+        Chain.list_decompiled_contracts(page_size, offset)
+
+      :unverified ->
+        Chain.list_unverified_contracts(page_size, offset)
+
+      :not_decompiled ->
+        Chain.list_not_decompiled_contracts(page_size, offset)
+
+      _ ->
+        Chain.list_contracts(page_size, offset)
+    end
+  end
+
+  defp add_filter(options, params) do
+    with {:param, {:ok, value}} <- {:param, Map.fetch(params, "filter")},
+         {:validation, {:ok, filter}} <- {:validation, contracts_filter(value)} do
+      {:ok, Map.put(options, :filter, filter)}
+    else
+      {:param, :error} -> {:ok, options}
+      {:validation, {:error, error}} -> {:error, error}
+    end
+  end
+
+  defp contracts_filter(nil), do: {:ok, nil}
+  defp contracts_filter(1), do: {:ok, :verified}
+  defp contracts_filter(2), do: {:ok, :decompiled}
+  defp contracts_filter(3), do: {:ok, :unverified}
+  defp contracts_filter(4), do: {:ok, :not_decompiled}
+  defp contracts_filter("verified"), do: {:ok, :verified}
+  defp contracts_filter("decompiled"), do: {:ok, :decompiled}
+  defp contracts_filter("unverified"), do: {:ok, :unverified}
+  defp contracts_filter("not_decompiled"), do: {:ok, :not_decompiled}
+
+  defp contracts_filter(filter) when is_bitstring(filter) do
+    case Integer.parse(filter) do
+      {number, ""} -> contracts_filter(number)
+      _ -> {:error, contracts_filter_error_message(filter)}
+    end
+  end
+
+  defp contracts_filter(filter), do: {:error, contracts_filter_error_message(filter)}
+
+  defp contracts_filter_error_message(filter) do
+    "#{filter} is not a valid value for `filter`. Please use one of: verified, decompiled, unverified, not_decompiled, 1, 2, 3, 4."
   end
 
   defp fetch_address(params) do
@@ -48,8 +128,11 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
   defp to_smart_contract(address_hash) do
     result =
       case Chain.address_hash_to_smart_contract(address_hash) do
-        nil -> :not_found
-        contract -> {:ok, contract}
+        nil ->
+          :not_found
+
+        contract ->
+          {:ok, SmartContract.preload_decompiled_smart_contract(contract)}
       end
 
     {:contract, result}

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/helpers.ex
@@ -1,0 +1,42 @@
+defmodule BlockScoutWeb.API.RPC.Helpers do
+  @moduledoc """
+  Small helpers for RPC api controllers.
+  """
+  alias Explorer.Etherscan
+
+  def put_pagination_options(options, params) do
+    options
+    |> put_page_option(params)
+    |> put_offset_option(params)
+  end
+
+  def put_page_option(options, %{"page" => page}) do
+    case Integer.parse(page) do
+      {page_number, ""} when page_number > 0 ->
+        Map.put(options, :page_number, page_number)
+
+      _ ->
+        options
+    end
+  end
+
+  def put_page_option(options, _), do: options
+
+  def put_offset_option(options, %{"offset" => offset}) do
+    with {page_size, ""} when page_size > 0 <- Integer.parse(offset),
+         :ok <- validate_max_page_size(page_size) do
+      Map.put(options, :page_size, page_size)
+    else
+      _ ->
+        options
+    end
+  end
+
+  def put_offset_option(options, _) do
+    options
+  end
+
+  defp validate_max_page_size(page_size) do
+    if page_size <= Etherscan.page_size_max(), do: :ok, else: :error
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
@@ -2,40 +2,88 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
   use BlockScoutWeb, :view
 
   alias BlockScoutWeb.API.RPC.RPCView
+  alias Explorer.Chain.{Address, DecompiledSmartContract, SmartContract}
+
+  def render("listcontracts.json", %{contracts: contracts}) do
+    contracts = Enum.map(contracts, &prepare_contract/1)
+
+    RPCView.render("show.json", data: contracts)
+  end
 
   def render("getabi.json", %{abi: abi}) do
     RPCView.render("show.json", data: Jason.encode!(abi))
   end
 
-  def render("getsourcecode.json", %{contract: contract}) do
-    RPCView.render("show.json", data: prepare_contract(contract))
+  def render("getsourcecode.json", %{contract: contract, address_hash: address_hash}) do
+    RPCView.render("show.json", data: [prepare_source_code_contract(contract, address_hash)])
   end
 
   def render("error.json", assigns) do
     RPCView.render("error.json", assigns)
   end
 
-  defp prepare_contract(nil) do
-    [
-      %{
-        "SourceCode" => "",
-        "ABI" => "Contract source code not verified",
-        "ContractName" => "",
-        "CompilerVersion" => "",
-        "OptimizationUsed" => ""
-      }
-    ]
+  defp prepare_source_code_contract(nil, address_hash) do
+    %{
+      "Address" => to_string(address_hash),
+      "SourceCode" => "",
+      "ABI" => "Contract source code not verified",
+      "ContractName" => "",
+      "CompilerVersion" => "",
+      "DecompiledSourceCode" => "",
+      "DecompilerVersion" => "",
+      "OptimizationUsed" => ""
+    }
   end
 
-  defp prepare_contract(contract) do
-    [
-      %{
-        "SourceCode" => contract.contract_source_code,
-        "ABI" => Jason.encode!(contract.abi),
-        "ContractName" => contract.name,
-        "CompilerVersion" => contract.compiler_version,
-        "OptimizationUsed" => if(contract.optimization, do: "1", else: "0")
-      }
-    ]
+  defp prepare_source_code_contract(contract, _) do
+    %{
+      "Address" => to_string(contract.address_hash),
+      "SourceCode" => contract.contract_source_code,
+      "ABI" => Jason.encode!(contract.abi),
+      "ContractName" => contract.name,
+      "DecompiledSourceCode" => decompiled_source_code(contract.decompiled_smart_contract),
+      "DecompilerVersion" => decompiler_version(contract.decompiled_smart_contract),
+      "CompilerVersion" => contract.compiler_version,
+      "OptimizationUsed" => if(contract.optimization, do: "1", else: "0")
+    }
   end
+
+  defp prepare_contract(%Address{hash: hash, smart_contract: nil, decompiled_smart_contract: decompiled_smart_contract}) do
+    %{
+      "Address" => to_string(hash),
+      "SourceCode" => "",
+      "ABI" => "Contract source code not verified",
+      "ContractName" => "",
+      "DecompiledSourceCode" => decompiled_source_code(decompiled_smart_contract),
+      "DecompilerVersion" => decompiler_version(decompiled_smart_contract),
+      "CompilerVersion" => "",
+      "OptimizationUsed" => ""
+    }
+  end
+
+  defp prepare_contract(%Address{
+         hash: hash,
+         smart_contract: %SmartContract{} = contract,
+         decompiled_smart_contract: decompiled_smart_contract
+       }) do
+    %{
+      "Address" => to_string(hash),
+      "SourceCode" => contract.contract_source_code,
+      "ABI" => Jason.encode!(contract.abi),
+      "ContractName" => contract.name,
+      "DecompiledSourceCode" => decompiled_source_code(decompiled_smart_contract),
+      "DecompilerVersion" => decompiler_version(decompiled_smart_contract),
+      "CompilerVersion" => contract.compiler_version,
+      "OptimizationUsed" => if(contract.optimization, do: "1", else: "0")
+    }
+  end
+
+  defp decompiled_source_code(nil), do: "Contract source code not decompiled."
+
+  defp decompiled_source_code(%DecompiledSmartContract{decompiled_source_code: decompiled_source_code}) do
+    decompiled_source_code
+  end
+
+  defp decompiler_version(nil), do: ""
+  defp decompiler_version(%DecompiledSmartContract{decompiler_version: decompiler_version}), do: decompiler_version
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -767,34 +767,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       assert response["message"] == "OK"
     end
 
-    test "ignores pagination params if page is less than 1", %{conn: conn} do
-      address = insert(:address)
-
-      6
-      |> insert_list(:transaction, from_address: address)
-      |> with_block()
-
-      params = %{
-        "module" => "account",
-        "action" => "txlist",
-        "address" => "#{address.hash}",
-        # page number
-        "page" => "0",
-        # page size
-        "offset" => "2"
-      }
-
-      assert response =
-               conn
-               |> get("/api", params)
-               |> json_response(200)
-
-      assert length(response["result"]) == 6
-      assert response["status"] == "1"
-      assert response["message"] == "OK"
-    end
-
-    test "ignores pagination params if offset is less than 1", %{conn: conn} do
+    test "ignores offset param if offset is less than 1", %{conn: conn} do
       address = insert(:address)
 
       6
@@ -821,7 +794,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       assert response["message"] == "OK"
     end
 
-    test "ignores pagination params if offset is over 10,000", %{conn: conn} do
+    test "ignores offset param if offset is over 10,000", %{conn: conn} do
       address = insert(:address)
 
       6

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -1,6 +1,190 @@
 defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
   use BlockScoutWeb.ConnCase
 
+  describe "listcontracts" do
+    setup do
+      %{params: %{"module" => "contract", "action" => "listcontracts"}}
+    end
+
+    test "with an invalid filter value", %{conn: conn, params: params} do
+      response =
+        conn
+        |> get("/api", Map.put(params, "filter", "invalid"))
+        |> json_response(400)
+
+      assert response["message"] ==
+               "invalid is not a valid value for `filter`. Please use one of: verified, decompiled, unverified, not_decompiled, 1, 2, 3, 4."
+
+      assert response["status"] == "0"
+    end
+
+    test "with no contracts", %{conn: conn, params: params} do
+      response =
+        conn
+        |> get("/api", params)
+        |> json_response(200)
+
+      assert response["message"] == "OK"
+      assert response["status"] == "1"
+      assert response["result"] == []
+    end
+
+    test "with a verified smart contract, all contract information is shown", %{conn: conn, params: params} do
+      contract = insert(:smart_contract)
+
+      response =
+        conn
+        |> get("/api", params)
+        |> json_response(200)
+
+      assert response["message"] == "OK"
+      assert response["status"] == "1"
+
+      assert response["result"] == [
+               %{
+                 "ABI" => Jason.encode!(contract.abi),
+                 "Address" => to_string(contract.address_hash),
+                 "CompilerVersion" => contract.compiler_version,
+                 "ContractName" => contract.name,
+                 "DecompiledSourceCode" => "Contract source code not decompiled.",
+                 "DecompilerVersion" => "",
+                 "OptimizationUsed" => if(contract.optimization, do: "1", else: "0"),
+                 "SourceCode" => contract.contract_source_code
+               }
+             ]
+    end
+
+    test "with an unverified contract address, only basic information is shown", %{conn: conn, params: params} do
+      address = insert(:contract_address)
+
+      response =
+        conn
+        |> get("/api", params)
+        |> json_response(200)
+
+      assert response["message"] == "OK"
+      assert response["status"] == "1"
+
+      assert response["result"] == [
+               %{
+                 "ABI" => "Contract source code not verified",
+                 "Address" => to_string(address.hash),
+                 "CompilerVersion" => "",
+                 "ContractName" => "",
+                 "DecompiledSourceCode" => "Contract source code not decompiled.",
+                 "DecompilerVersion" => "",
+                 "OptimizationUsed" => "",
+                 "SourceCode" => ""
+               }
+             ]
+    end
+
+    test "filtering for only unverified contracts shows only unverified contracts", %{params: params, conn: conn} do
+      address = insert(:contract_address)
+      insert(:smart_contract)
+
+      response =
+        conn
+        |> get("/api", Map.put(params, "filter", "unverified"))
+        |> json_response(200)
+
+      assert response["message"] == "OK"
+      assert response["status"] == "1"
+
+      assert response["result"] == [
+               %{
+                 "ABI" => "Contract source code not verified",
+                 "Address" => to_string(address.hash),
+                 "CompilerVersion" => "",
+                 "ContractName" => "",
+                 "DecompiledSourceCode" => "Contract source code not decompiled.",
+                 "DecompilerVersion" => "",
+                 "OptimizationUsed" => "",
+                 "SourceCode" => ""
+               }
+             ]
+    end
+
+    test "filtering for only verified contracts shows only verified contracts", %{params: params, conn: conn} do
+      insert(:contract_address)
+      contract = insert(:smart_contract)
+
+      response =
+        conn
+        |> get("/api", Map.put(params, "filter", "verified"))
+        |> json_response(200)
+
+      assert response["message"] == "OK"
+      assert response["status"] == "1"
+
+      assert response["result"] == [
+               %{
+                 "ABI" => Jason.encode!(contract.abi),
+                 "Address" => to_string(contract.address_hash),
+                 "CompilerVersion" => contract.compiler_version,
+                 "DecompiledSourceCode" => "Contract source code not decompiled.",
+                 "DecompilerVersion" => "",
+                 "ContractName" => contract.name,
+                 "OptimizationUsed" => if(contract.optimization, do: "1", else: "0"),
+                 "SourceCode" => contract.contract_source_code
+               }
+             ]
+    end
+
+    test "filtering for only decompiled contracts shows only decompiled contracts", %{params: params, conn: conn} do
+      insert(:contract_address)
+      decompiled_smart_contract = insert(:decompiled_smart_contract)
+
+      response =
+        conn
+        |> get("/api", Map.put(params, "filter", "decompiled"))
+        |> json_response(200)
+
+      assert response["message"] == "OK"
+      assert response["status"] == "1"
+
+      assert response["result"] == [
+               %{
+                 "ABI" => "Contract source code not verified",
+                 "Address" => to_string(decompiled_smart_contract.address_hash),
+                 "CompilerVersion" => "",
+                 "ContractName" => "",
+                 "DecompiledSourceCode" => decompiled_smart_contract.decompiled_source_code,
+                 "DecompilerVersion" => "test_decompiler",
+                 "OptimizationUsed" => "",
+                 "SourceCode" => ""
+               }
+             ]
+    end
+
+    test "filtering for only not_decompiled (and by extension not verified contracts)", %{params: params, conn: conn} do
+      insert(:decompiled_smart_contract)
+      insert(:smart_contract)
+      contract_address = insert(:contract_address)
+
+      response =
+        conn
+        |> get("/api", Map.put(params, "filter", "not_decompiled"))
+        |> json_response(200)
+
+      assert response["message"] == "OK"
+      assert response["status"] == "1"
+
+      assert response["result"] == [
+               %{
+                 "ABI" => "Contract source code not verified",
+                 "Address" => to_string(contract_address.hash),
+                 "CompilerVersion" => "",
+                 "ContractName" => "",
+                 "DecompiledSourceCode" => "Contract source code not decompiled.",
+                 "DecompilerVersion" => "",
+                 "OptimizationUsed" => "",
+                 "SourceCode" => ""
+               }
+             ]
+    end
+  end
+
   describe "getabi" do
     test "with missing address hash", %{conn: conn} do
       params = %{
@@ -119,11 +303,14 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
 
       expected_result = [
         %{
+          "Address" => "",
           "SourceCode" => "",
           "ABI" => "Contract source code not verified",
           "ContractName" => "",
           "CompilerVersion" => "",
-          "OptimizationUsed" => ""
+          "OptimizationUsed" => "",
+          "DecompiledSourceCode" => "",
+          "DecompilerVersion" => ""
         }
       ]
 
@@ -148,13 +335,16 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
 
       expected_result = [
         %{
+          "Address" => to_string(contract.address_hash),
           "SourceCode" => contract.contract_source_code,
           "ABI" => Jason.encode!(contract.abi),
           "ContractName" => contract.name,
           "CompilerVersion" => contract.compiler_version,
+          "DecompiledSourceCode" => "Contract source code not decompiled.",
           # The contract's optimization value is true, so the expected value
           # for `OptimizationUsed` is "1". If it was false, the expected value
           # would be "0".
+          "DecompilerVersion" => "",
           "OptimizationUsed" => "1"
         }
       ]

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2629,6 +2629,88 @@ defmodule Explorer.Chain do
     Repo.all(query, timeout: :infinity)
   end
 
+  def list_decompiled_contracts(limit, offset) do
+    query =
+      from(
+        address in Address,
+        join: decompiled_smart_contract in DecompiledSmartContract,
+        on: decompiled_smart_contract.address_hash == address.hash,
+        preload: [{:decompiled_smart_contract, decompiled_smart_contract}, :smart_contract],
+        order_by: [asc: address.inserted_at],
+        limit: ^limit,
+        offset: ^offset
+      )
+
+    Repo.all(query)
+  end
+
+  def list_verified_contracts(limit, offset) do
+    query =
+      from(
+        address in Address,
+        where: not is_nil(address.contract_code),
+        join: smart_contract in SmartContract,
+        on: smart_contract.address_hash == address.hash,
+        preload: [{:smart_contract, smart_contract}, :decompiled_smart_contract],
+        order_by: [asc: address.inserted_at],
+        limit: ^limit,
+        offset: ^offset
+      )
+
+    Repo.all(query)
+  end
+
+  def list_contracts(limit, offset) do
+    query =
+      from(
+        address in Address,
+        where: not is_nil(address.contract_code),
+        preload: [:smart_contract, :decompiled_smart_contract],
+        order_by: [asc: address.inserted_at],
+        limit: ^limit,
+        offset: ^offset
+      )
+
+    Repo.all(query)
+  end
+
+  def list_unverified_contracts(limit, offset) do
+    query =
+      from(
+        address in Address,
+        left_join: smart_contract in SmartContract,
+        on: smart_contract.address_hash == address.hash,
+        where: not is_nil(address.contract_code),
+        where: is_nil(smart_contract.address_hash),
+        preload: [{:smart_contract, smart_contract}, :decompiled_smart_contract],
+        order_by: [asc: address.inserted_at],
+        limit: ^limit,
+        offset: ^offset
+      )
+
+    Repo.all(query)
+  end
+
+  def list_not_decompiled_contracts(limit, offset) do
+    query =
+      from(
+        address in Address,
+        left_join: smart_contract in SmartContract,
+        on: smart_contract.address_hash == address.hash,
+        left_join: decompiled_smart_contract in DecompiledSmartContract,
+        on: decompiled_smart_contract.address_hash == address.hash,
+        preload: [smart_contract: smart_contract, decompiled_smart_contract: decompiled_smart_contract],
+        where: not is_nil(address.contract_code),
+        where: is_nil(smart_contract.address_hash),
+        where: is_nil(decompiled_smart_contract.address_hash),
+        order_by: [asc: address.inserted_at],
+        limit: ^limit,
+        offset: ^offset
+      )
+
+    Repo.all(query)
+  end
+
   @doc """
   Combined block reward from all the fees.
   """

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -8,7 +8,19 @@ defmodule Explorer.Chain.Address do
   use Explorer.Schema
 
   alias Ecto.Changeset
-  alias Explorer.Chain.{Address, Block, Data, Hash, InternalTransaction, SmartContract, Token, Transaction, Wei}
+
+  alias Explorer.Chain.{
+    Address,
+    Block,
+    Data,
+    DecompiledSmartContract,
+    Hash,
+    InternalTransaction,
+    SmartContract,
+    Token,
+    Transaction,
+    Wei
+  }
 
   @optional_attrs ~w(contract_code fetched_coin_balance fetched_coin_balance_block_number nonce)a
   @required_attrs ~w(hash)a
@@ -64,6 +76,7 @@ defmodule Explorer.Chain.Address do
     field(:nonce, :integer)
 
     has_one(:smart_contract, SmartContract)
+    has_one(:decompiled_smart_contract, DecompiledSmartContract)
     has_one(:token, Token, foreign_key: :contract_address_hash)
 
     has_one(

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -12,7 +12,8 @@ defmodule Explorer.Chain.SmartContract do
 
   use Explorer.Schema
 
-  alias Explorer.Chain.{Address, ContractMethod, Hash}
+  alias Explorer.Chain.{Address, ContractMethod, DecompiledSmartContract, Hash}
+  alias Explorer.Repo
 
   @typedoc """
   The name of a parameter to a function or event.
@@ -208,6 +209,12 @@ defmodule Explorer.Chain.SmartContract do
     field(:constructor_arguments, :string)
     field(:abi, {:array, :map})
 
+    has_one(
+      :decompiled_smart_contract,
+      DecompiledSmartContract,
+      foreign_key: :address_hash
+    )
+
     belongs_to(
       :address,
       Address,
@@ -217,6 +224,10 @@ defmodule Explorer.Chain.SmartContract do
     )
 
     timestamps()
+  end
+
+  def preload_decompiled_smart_contract(contract) do
+    Repo.preload(contract, :decompiled_smart_contract)
   end
 
   def changeset(%__MODULE__{} = smart_contract, attrs) do


### PR DESCRIPTION
The first part of #1569 

This adds an rpc endpoint to list contracts according to the spec on that issue. We will probably want to leave this open until #1596 is merged, so that I can add those filters to this PR

## Changelog

### Enhancements
* Adds a listcontracts action to the contracts rpc endpoint. See the attached issue for more information
* Adds a field `Address` to the contract model, to support the list endpoint.
* Modularize some of the pagination code so that you can set *one* of the pagination parameters without having to set both.