### PR TITLE
Add PIRL to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Currently available block explorers (i.e. Etherscan and Etherchain) are closed s
 * [ARTIS](https://explorer.sigma1.artis.network)
 * [SafeChain](https://explorer.safechain.io)
 * [SpringChain](https://explorer.springrole.com/)
+* [PIRL](http://pirl.es/)
+
 
 ### Visual Interface
 


### PR DESCRIPTION
## Motivation

PIRL has now deployed BlockScout for their main explorer. I've added this to the BlockScout Readme.

http://pirl.es/