### PR TITLE
Use code fetcher for failed created addresses to properly employ batching

### DIFF
--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
@@ -86,15 +86,7 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
       transaction_with_internal_transactions = Repo.preload(transaction, [:internal_transactions])
 
       transaction_with_internal_transactions.internal_transactions
-      |> Enum.filter(fn internal_transaction ->
-        internal_transaction.created_contract_address_hash
-      end)
-      |> Enum.each(fn internal_transaction ->
-        :ok =
-          internal_transaction
-          |> code_entry()
-          |> Indexer.Code.Fetcher.run(json_rpc_named_arguments)
-      end)
+      |> Indexer.Code.Fetcher.async_fetch()
 
       Logger.debug(
         [
@@ -111,16 +103,5 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
           fetcher: :failed_created_addresses
         )
     end
-  end
-
-  def code_entry(%InternalTransaction{
-        block_number: block_number,
-        created_contract_address_hash: %{bytes: created_contract_bytes}
-      }) do
-    [{block_number, created_contract_bytes, <<>>}]
-  end
-
-  def transaction_entry(%Transaction{hash: %{bytes: bytes}, index: index, block_number: block_number}) do
-    [{block_number, bytes, index}]
   end
 end


### PR DESCRIPTION
The code fetcher task was running individually for each unfetched contract code.
This PR makes it use existing code fetcher facilities, such as buffering and batching requests.

```
2019-03-20T17:40:12.119 application=indexer fetcher=failed_created_addresses [debug] Started fixing transaction 0x3b241949ae0788a283f45c99b363f7229009ee8b3eb2bbcadcd89a468bd2bcaf
2019-03-20T17:40:12.124 application=indexer [debug] fetching created_contract_code for transactions
2019-03-20T17:40:12.142 application=indexer [debug] fetching created_contract_code for transactions
2019-03-20T17:40:12.159 application=indexer [debug] fetching created_contract_code for transactions
2019-03-20T17:40:12.182 application=indexer [debug] fetching created_contract_code for transactions
2019-03-20T17:40:12.200 application=indexer [debug] fetching created_contract_code for transactions
2019-03-20T17:40:12.201 application=indexer fetcher=failed_created_addresses [debug] Finished fixing transaction 0x3b241949ae0788a283f45c99b363f7229009ee8b3eb2bbcadcd89a468bd2bcaf
```