### PR TITLE
modify query to fetch failed contract creations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- [#1621](https://github.com/poanetwork/blockscout/pull/1621) - Modify query to fetch failed contract creations
+
 ### Chore
 
 

--- a/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
+++ b/apps/indexer/lib/indexer/temporary/failed_created_addresses.ex
@@ -8,7 +8,7 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
 
   import Ecto.Query
 
-  alias Explorer.Chain.{InternalTransaction, Transaction}
+  alias Explorer.Chain.{Address, Data, InternalTransaction, Transaction}
   alias Explorer.Repo
   alias Indexer.Temporary.FailedCreatedAddresses.TaskSupervisor
 
@@ -45,11 +45,15 @@ defmodule Indexer.Temporary.FailedCreatedAddresses do
       fetcher: :failed_created_addresses
     )
 
+    data = %Data{bytes: ""}
+
     query =
       from(t in Transaction,
         left_join: it in InternalTransaction,
         on: it.transaction_hash == t.hash,
-        where: t.status == ^0 and not is_nil(it.created_contract_address_hash),
+        left_join: address in Address,
+        on: address.hash == it.created_contract_address_hash,
+        where: t.status == ^0 and not is_nil(it.created_contract_address_hash) and address.contract_code != ^data,
         distinct: t.hash
       )
 


### PR DESCRIPTION
## Motivation

In this [commit](https://github.com/poanetwork/blockscout/commit/7f43ad585040fe8ff0f12e56dcce67f6ed5cc89a)
we stopped re-fetching internal transactions when fixing failed contract creations so  `status` field of internal transactions is not updated

Now, we will start using `contract_code` field of `addresses` to use as an indicator that we already processed that record.

## Changelog

- modify query to fetch failed contract creations