### PR TITLE
infinity timeout for addresses without code query

### DIFF
--- a/apps/indexer/lib/indexer/temporary/addresses_without_code.ex
+++ b/apps/indexer/lib/indexer/temporary/addresses_without_code.ex
@@ -16,6 +16,7 @@ defmodule Indexer.Temporary.AddressesWithoutCode do
 
   @task_options [max_concurrency: 3, timeout: :infinity]
   @batch_size 500
+  @query_timeout :infinity
 
   def start_link([fetcher, gen_server_options]) do
     GenServer.start_link(__MODULE__, fetcher, gen_server_options)
@@ -104,7 +105,7 @@ defmodule Indexer.Temporary.AddressesWithoutCode do
   end
 
   defp process_query(query, fetcher) do
-    query_stream = Repo.stream(query, max_rows: @batch_size)
+    query_stream = Repo.stream(query, max_rows: @batch_size, timeout: @query_timeout)
 
     stream =
       TaskSupervisor

--- a/apps/indexer/lib/indexer/temporary/addresses_without_code.ex
+++ b/apps/indexer/lib/indexer/temporary/addresses_without_code.ex
@@ -115,7 +115,7 @@ defmodule Indexer.Temporary.AddressesWithoutCode do
         @task_options
       )
 
-    Repo.transaction(fn -> Stream.run(stream) end)
+    Repo.transaction(fn -> Stream.run(stream) end, timeout: @query_timeout)
   end
 
   def refetch_block(block, fetcher) do


### PR DESCRIPTION

## Motivation

`addresses without code` process is restarting on staging because the request to the database is timing out

```
10:31:49.877 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:32:50.879 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:33:51.881 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:34:52.883 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:35:53.885 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:36:54.887 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:37:55.889 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:38:56.891 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:39:57.893 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:40:58.895 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:41:59.897 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:43:00.899 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:44:01.901 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:45:02.903 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:46:03.905 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:47:04.907 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:48:05.910 [debug] Started fix_transaction_without_to_address_and_created_contract_address
10:49:06.912 [debug] Started fix_transaction_without_to_address_and_created_contract_address
```

## Changelog

- add infinity timeout for addresses without code query