### PR TITLE
(Fix) colour for release link in the footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+ - [#1630](https://github.com/poanetwork/blockscout/pull/1630) - (Fix) colour for release link in the footer
  - [#1621](https://github.com/poanetwork/blockscout/pull/1621) - Modify query to fetch failed contract creations
  - [#1614](https://github.com/poanetwork/blockscout/pull/1614) - Do not fetch burn address token balance
 

--- a/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
@@ -82,7 +82,7 @@ defmodule BlockScoutWeb.LayoutView do
     if release_link == "" || release_link == nil do
       version
     else
-      html_escape({:safe, "<a href=\"#{release_link}\" target=\"_blank\">#{version}</a>"})
+      html_escape({:safe, "<a href=\"#{release_link}\" class=\"footer-link\" target=\"_blank\">#{version}</a>"})
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/views/layout_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/layout_view_test.exs
@@ -83,7 +83,7 @@ defmodule BlockScoutWeb.LayoutViewTest do
 
       assert LayoutView.release_link("1.3.4") ==
                {:safe,
-                ~s(<a href="https://github.com/poanetwork/blockscout/releases/tag/v1.3.4-beta" target="_blank">1.3.4</a>)}
+                ~s(<a href="https://github.com/poanetwork/blockscout/releases/tag/v1.3.4-beta" class="footer-link" target="_blank">1.3.4</a>)}
     end
   end
 end


### PR DESCRIPTION
## Motivation

The colour of the release link is too pale. For example for Goerli:
![Screenshot 2019-03-21 at 21 26 51](https://user-images.githubusercontent.com/4341812/54777294-15833f00-4c23-11e9-9453-b2811a55c9e9.png)


## Changelog

### Enhancements
- class `footer-link` is added to to the release link in the footer.

![Screenshot 2019-03-21 at 21 26 28](https://user-images.githubusercontent.com/4341812/54777337-26cc4b80-4c23-11e9-9e5b-27207797831a.png)

