### PR TITLE
Optimize token holder count updates when importing address current balances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
  - [#1621](https://github.com/poanetwork/blockscout/pull/1621) - Modify query to fetch failed contract creations
  - [#1614](https://github.com/poanetwork/blockscout/pull/1614) - Do not fetch burn address token balance
+ - [#1639](https://github.com/poanetwork/blockscout/pull/1614) - Optimize token holder count updates when importing address current balances
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -40,6 +40,9 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
     field(:block_number, :integer)
     field(:value_fetched_at, :utc_datetime_usec)
 
+    # A transient field for deriving token holder count deltas during address_current_token_balances upserts
+    field(:old_value, :decimal)
+
     belongs_to(:address, Address, foreign_key: :address_hash, references: :hash, type: Hash.Address)
 
     belongs_to(

--- a/apps/explorer/priv/repo/migrations/20190321185644_add_old_value_for_current_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20190321185644_add_old_value_for_current_token_balances.exs
@@ -1,0 +1,10 @@
+defmodule Explorer.Repo.Migrations.AddOldValueForCurrentTokenBalances do
+  use Ecto.Migration
+
+  def change do
+    alter table(:address_current_token_balances) do
+      # A transient field for deriving token holder count deltas during address_current_token_balances upserts
+      add(:old_value, :decimal, null: true)
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/import/runner/address/current_token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/address/current_token_balances_test.exs
@@ -247,16 +247,6 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
 
       assert {:ok,
               %{
-                deleted_address_current_token_balances: [
-                  %{
-                    address_hash: ^non_holder_becomes_holder_address_hash,
-                    token_contract_address_hash: ^token_contract_address_hash
-                  },
-                  %{
-                    address_hash: ^holder_becomes_non_holder_address_hash,
-                    token_contract_address_hash: ^token_contract_address_hash
-                  }
-                ],
                 address_current_token_balances: [
                   %{
                     address_hash: ^non_holder_becomes_holder_address_hash,


### PR DESCRIPTION
**Problem**: realtime fetcher db transactions take too long and often fail with a timeout. The reason of timeout is the `:deleted_address_current_token_balances` step of import, which selects previous balances for the rows we are going to update. The `SELECT` query it makes is extremely slow.

**Solution**: we incorporate fetching old balance value into the upsert itself. This is done by help of a transient `old_value` field, which is updated in `ON CONFLICT` clause of `INSERT` with the previous `value` and returned.

As we don't impose any more performance penalties for `INSERT` while removing a heavy `SELECT` completely, realtime fetcher should run much faster after this change.

**Upgrading**: migration `20190321185644_add_old_value_for_current_token_balances.exs`
