### PR TITLE
Set internal_transactions_indexed_at for empty blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
  - [#1621](https://github.com/poanetwork/blockscout/pull/1621) - Modify query to fetch failed contract creations
  - [#1614](https://github.com/poanetwork/blockscout/pull/1614) - Do not fetch burn address token balance
+ - [#1643](https://github.com/poanetwork/blockscout/pull/1643) - Set internal_transactions_indexed_at for empty blocks
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -106,6 +106,14 @@ defmodule Explorer.Chain.Block do
     |> unique_constraint(:hash, name: :blocks_pkey)
   end
 
+  def number_only_changeset(%__MODULE__{} = block, attrs) do
+    block
+    |> cast(attrs, @required_attrs ++ @optional_attrs)
+    |> validate_required([:number])
+    |> foreign_key_constraint(:parent_hash)
+    |> unique_constraint(:hash, name: :blocks_pkey)
+  end
+
   def blocks_without_reward_query do
     from(
       b in __MODULE__,

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
   require Ecto.Query
 
   alias Ecto.{Changeset, Multi, Repo}
-  alias Explorer.Chain.{Block, Hash, Import, InternalTransaction, Transaction}
+  alias Explorer.Chain.{Hash, Import, InternalTransaction, Transaction}
   alias Explorer.Chain.Import.Runner
 
   import Ecto.Query, only: [from: 2]
@@ -53,9 +53,6 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     end)
     |> Multi.run(:internal_transactions_indexed_at_transactions, fn repo, _ ->
       update_transactions(repo, changes_list, update_transactions_options)
-    end)
-    |> Multi.run(:internal_transactions_indexed_at_blocks, fn repo, _ ->
-      update_blocks(repo, changes_list, update_transactions_options)
     end)
   end
 
@@ -193,39 +190,6 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     rescue
       postgrex_error in Postgrex.Error ->
         {:error, %{exception: postgrex_error, transaction_hashes: ordered_transaction_hashes}}
-    end
-  end
-
-  defp update_blocks(repo, internal_transactions, %{
-         timeout: timeout,
-         timestamps: timestamps
-       })
-       when is_list(internal_transactions) do
-    ordered_block_numbers =
-      internal_transactions
-      |> MapSet.new(& &1.block_number)
-      |> Enum.sort()
-
-    query =
-      from(
-        b in Block,
-        where: b.number in ^ordered_block_numbers and b.consensus,
-        update: [
-          set: [
-            internal_transactions_indexed_at: ^timestamps.updated_at
-          ]
-        ]
-      )
-
-    block_count = Enum.count(ordered_block_numbers)
-
-    try do
-      {^block_count, result} = repo.update_all(query, [], timeout: timeout)
-
-      {:ok, result}
-    rescue
-      postgrex_error in Postgrex.Error ->
-        {:error, %{exception: postgrex_error, block_numbers: ordered_block_numbers}}
     end
   end
 end

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions_indexed_at_blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions_indexed_at_blocks.ex
@@ -1,0 +1,84 @@
+defmodule Explorer.Chain.Import.Runner.InternalTransactionsIndexedAtBlocks do
+  @moduledoc """
+  Bulk updates `internal_transactions_indexed_at` for provided blocks
+  """
+
+  require Ecto.Query
+
+  alias Ecto.Multi
+  alias Explorer.Chain.Block
+  alias Explorer.Chain.Import.Runner
+
+  import Ecto.Query, only: [from: 2]
+
+  @behaviour Runner
+
+  # milliseconds
+  @timeout 60_000
+
+  @type imported :: [%{number: Block.block_number()}]
+
+  @impl Runner
+  def ecto_schema_module, do: Block
+
+  @impl Runner
+  def option_key, do: :internal_transactions_indexed_at_blocks
+
+  @impl Runner
+  def imported_table_row do
+    %{
+      value_type: "[%{number: Explorer.Chain.Block.block_number()}]",
+      value_description: "List of block numbers to set `internal_transactions_indexed_at` field for"
+    }
+  end
+
+  @impl Runner
+  def run(multi, changes_list, %{timestamps: timestamps} = options) when is_map(options) do
+    transactions_timeout = options[Runner.Transactions.option_key()][:timeout] || Runner.Transactions.timeout()
+
+    update_transactions_options = %{timeout: transactions_timeout, timestamps: timestamps}
+
+    multi
+    |> Multi.run(:internal_transactions_indexed_at_blocks, fn repo, _ ->
+      update_blocks(repo, changes_list, update_transactions_options)
+    end)
+  end
+
+  @impl Runner
+  def timeout, do: @timeout
+
+  defp update_blocks(_repo, [], %{}), do: {:ok, []}
+
+  defp update_blocks(repo, block_numbers, %{
+         timeout: timeout,
+         timestamps: timestamps
+       })
+       when is_list(block_numbers) do
+    ordered_block_numbers =
+      block_numbers
+      |> Enum.map(fn %{number: number} -> number end)
+      |> Enum.sort()
+
+    query =
+      from(
+        b in Block,
+        where: b.number in ^ordered_block_numbers and b.consensus,
+        update: [
+          set: [
+            internal_transactions_indexed_at: ^timestamps.updated_at
+          ]
+        ]
+      )
+
+    block_count = Enum.count(ordered_block_numbers)
+
+    try do
+      {^block_count, result} = repo.update_all(query, [], timeout: timeout)
+
+      {:ok, result}
+    rescue
+      postgrex_error in Postgrex.Error ->
+        {:error, %{exception: postgrex_error, block_numbers: ordered_block_numbers}}
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/chain/import/stage/address_referencing.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/address_referencing.ex
@@ -19,6 +19,7 @@ defmodule Explorer.Chain.Import.Stage.AddressReferencing do
       Runner.Transactions,
       Runner.Transaction.Forks,
       Runner.InternalTransactions,
+      Runner.InternalTransactionsIndexedAtBlocks,
       Runner.Logs,
       Runner.Tokens,
       Runner.TokenTransfers,

--- a/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
+++ b/apps/indexer/lib/indexer/internal_transaction/fetcher.ex
@@ -134,6 +134,10 @@ defmodule Indexer.InternalTransaction.Fetcher do
     block_number
   end
 
+  defp block_params(block_number) when is_integer(block_number) do
+    %{number: block_number}
+  end
+
   @impl BufferedTask
   @decorate trace(
               name: "fetch",
@@ -144,10 +148,12 @@ defmodule Indexer.InternalTransaction.Fetcher do
   def run(entries, json_rpc_named_arguments) do
     variant = Keyword.fetch!(json_rpc_named_arguments, :variant)
 
-    unique_entries =
+    unique_entries = unique_entries(entries, variant)
+
+    internal_transactions_indexed_at_blocks =
       case variant do
-        EthereumJSONRPC.Parity -> Enum.uniq(entries)
-        _ -> unique_entries(entries)
+        EthereumJSONRPC.Parity -> Enum.map(unique_entries, &block_params/1)
+        _ -> []
       end
 
     unique_entries_count = Enum.count(unique_entries)
@@ -184,6 +190,10 @@ defmodule Indexer.InternalTransaction.Fetcher do
                Chain.import(%{
                  addresses: %{params: addresses_params},
                  internal_transactions: %{params: internal_transactions_params_without_failed_creations},
+                 internal_transactions_indexed_at_blocks: %{
+                   params: internal_transactions_indexed_at_blocks,
+                   with: :number_only_changeset
+                 },
                  timeout: :infinity
                }) do
           async_import_coin_balances(imported, %{
@@ -219,8 +229,10 @@ defmodule Indexer.InternalTransaction.Fetcher do
     end
   end
 
+  defp unique_entries(entries, EthereumJSONRPC.Parity), do: Enum.uniq(entries)
+
   # Protection and improved reporting for https://github.com/poanetwork/blockscout/issues/289
-  defp unique_entries(entries) do
+  defp unique_entries(entries, _) do
     entries_by_hash_bytes = Enum.group_by(entries, &elem(&1, 1))
 
     if map_size(entries_by_hash_bytes) < length(entries) do


### PR DESCRIPTION
Fixes #1642

As there exist blocks without transactions we now pass the list of blocks to import routine instead of deriving this list from the list of fetched internal transactions.

This should prevent indexer from repeatedly fetching internal transactions for empty blocks, which is especially relevant for test-nets with lots of empty blocks.
