### PR TITLE
add petersburg evm version to smart contract verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  - [#1614](https://github.com/poanetwork/blockscout/pull/1614) - Do not fetch burn address token balance
  - [#1643](https://github.com/poanetwork/blockscout/pull/1643) - Set internal_transactions_indexed_at for empty blocks
  - [#1647](https://github.com/poanetwork/blockscout/pull/1647) - Fix typo in view
+ - [#1650](https://github.com/poanetwork/blockscout/pull/1650) - Add petersburg evm version to smart contract verifier
 
 ### Chore
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
@@ -2,9 +2,7 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
   use BlockScoutWeb, :controller
 
   alias Explorer.Chain.SmartContract
-  alias Explorer.SmartContract.{Publisher, Solidity.CompilerVersion}
-
-  @evm_versions ["homestead", "tangerineWhistle", "spuriousDragon", "byzantium", "constantinople"]
+  alias Explorer.SmartContract.{Publisher, Solidity.CodeCompiler, Solidity.CompilerVersion}
 
   def new(conn, %{"address_id" => address_hash_string}) do
     changeset =
@@ -15,7 +13,11 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
 
     {:ok, compiler_versions} = CompilerVersion.fetch_versions()
 
-    render(conn, "new.html", changeset: changeset, compiler_versions: compiler_versions, evm_versions: @evm_versions)
+    render(conn, "new.html",
+      changeset: changeset,
+      compiler_versions: compiler_versions,
+      evm_versions: CodeCompiler.allowed_evm_versions()
+    )
   end
 
   def create(
@@ -36,7 +38,11 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
       {:error, changeset} ->
         {:ok, compiler_versions} = CompilerVersion.fetch_versions()
 
-        render(conn, "new.html", changeset: changeset, compiler_versions: compiler_versions, evm_versions: @evm_versions)
+        render(conn, "new.html",
+          changeset: changeset,
+          compiler_versions: compiler_versions,
+          evm_versions: CodeCompiler.allowed_evm_versions()
+        )
     end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
@@ -29,7 +29,7 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
           "evm_version" => evm_version
         }
       ) do
-    smart_sontact_with_evm_version = Map.put(smart_contract, "evm_version", evm_version)
+    smart_sontact_with_evm_version = Map.put(smart_contract, "evm_version", evm_version["evm_version"])
 
     case Publisher.publish(address_hash_string, smart_sontact_with_evm_version, external_libraries) do
       {:ok, _smart_contract} ->

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
@@ -29,7 +29,7 @@
 
         <div class="form-group">
           <%= label :evm_version, :evm_version, gettext("EVM Version") %>
-          <%= select :evm_version, :evm_version, @evm_versions, class: "form-control", selected: "byzantium", "aria-describedby": "evm-version-help-block" %>
+          <%= select :evm_version, :evm_version, @evm_versions, class: "form-control", selected: "petersburg", "aria-describedby": "evm-version-help-block" %>
         </div>
 
         <div class="form-group mb-4">

--- a/apps/block_scout_web/test/block_scout_web/features/address_contract_verification_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/address_contract_verification_test.exs
@@ -36,7 +36,8 @@ defmodule BlockScoutWeb.AddressContractVerificationTest do
       contract_name: name,
       version: version,
       optimization: false,
-      source_code: source_code
+      source_code: source_code,
+      evm_version: "byzantium"
     })
     |> ContractVerifyPage.verify_and_publish()
 

--- a/apps/block_scout_web/test/block_scout_web/features/pages/contract_verify_page.ex
+++ b/apps/block_scout_web/test/block_scout_web/features/pages/contract_verify_page.ex
@@ -13,7 +13,8 @@ defmodule BlockScoutWeb.ContractVerifyPage do
         contract_name: contract_name,
         version: version,
         optimization: optimization,
-        source_code: source_code
+        source_code: source_code,
+        evm_version: evm_version
       }) do
     session
     |> fill_in(css("[data-test='contract_name']"), with: contract_name)
@@ -22,6 +23,11 @@ defmodule BlockScoutWeb.ContractVerifyPage do
     case version do
       nil -> nil
       _ -> click(session, option(version))
+    end
+
+    case evm_version do
+      nil -> nil
+      _ -> click(session, option(evm_version))
     end
 
     case optimization do

--- a/apps/explorer/lib/explorer/smart_contract/solidity/code_compiler.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/code_compiler.ex
@@ -98,6 +98,8 @@ defmodule Explorer.SmartContract.Solidity.CodeCompiler do
     end
   end
 
+  def allowed_evm_versions, do: @allowed_evm_versions
+
   def get_contract_info(contracts, _) when contracts == %{}, do: {:error, :compilation}
 
   def get_contract_info(contracts, name) do

--- a/apps/explorer/lib/explorer/smart_contract/solidity/code_compiler.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/code_compiler.ex
@@ -4,7 +4,7 @@ defmodule Explorer.SmartContract.Solidity.CodeCompiler do
   """
 
   @new_contract_name "New.sol"
-  @allowed_evm_versions ["homestead", "tangerineWhistle", "spuriousDragon", "byzantium", "constantinople"]
+  @allowed_evm_versions ["homestead", "tangerineWhistle", "spuriousDragon", "byzantium", "constantinople", "petersburg"]
 
   @doc """
   Compiles a code in the solidity command line.


### PR DESCRIPTION
## Changelog

- add petersburg evm version to smart contract verifier
- make petersburg default evm version