### PR TITLE
Refetch blocks that don't belong to the main chain

### DIFF
--- a/apps/indexer/lib/indexer/block/supervisor.ex
+++ b/apps/indexer/lib/indexer/block/supervisor.ex
@@ -71,6 +71,11 @@ defmodule Indexer.Block.Supervisor do
          [
            fixing_realtime_fetcher,
            [name: AddressesWithoutCode.Supervisor]
+         ]},
+        {NonConsensusBlocks.Supervisor,
+         [
+           fixing_realtime_fetcher,
+           [name: NonConsensusBlocks.Supervisor]
          ]}
       ],
       strategy: :one_for_one

--- a/apps/indexer/lib/indexer/block/supervisor.ex
+++ b/apps/indexer/lib/indexer/block/supervisor.ex
@@ -5,7 +5,7 @@ defmodule Indexer.Block.Supervisor do
 
   alias Indexer.Block
   alias Indexer.Block.{Catchup, InvalidConsensus, Realtime, Reward, Uncle}
-  alias Indexer.Temporary.{AddressesWithoutCode, FailedCreatedAddresses}
+  alias Indexer.Temporary.{AddressesWithoutCode, FailedCreatedAddresses, NonConsensusBlocks}
 
   use Supervisor
 

--- a/apps/indexer/lib/indexer/temporary/non_consensus_blocks.ex
+++ b/apps/indexer/lib/indexer/temporary/non_consensus_blocks.ex
@@ -1,0 +1,81 @@
+defmodule Indexer.Temporary.NonConsensusBlocks do
+  @moduledoc """
+  Temporary module to refetch blocks, which are in main chain despite being non-consensus.
+  """
+
+  use GenServer
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Explorer.Chain.Block
+  alias Explorer.Repo
+  alias Indexer.Block.Realtime.Fetcher
+  alias Indexer.Temporary.NonConsensusBlocks.TaskSupervisor
+
+  @task_options [max_concurrency: 3, timeout: :infinity]
+  @batch_size 10
+  @query_timeout :infinity
+
+  def start_link([fetcher, gen_server_options]) do
+    GenServer.start_link(__MODULE__, fetcher, gen_server_options)
+  end
+
+  @impl GenServer
+  def init(fetcher) do
+    schedule_work()
+
+    {:ok, fetcher}
+  end
+
+  def schedule_work do
+    Process.send_after(self(), :run, 1_000)
+  end
+
+  @impl GenServer
+  def handle_info(:run, fetcher) do
+    run(fetcher)
+
+    {:noreply, fetcher}
+  end
+
+  def run(fetcher) do
+    Indexer.Logger.metadata(
+      fn ->
+        Logger.debug("Started non-consensus block re-fetcher")
+
+        query =
+          from(block in Block,
+            left_join: parent_block in Block,
+            on: block.parent_hash == parent_block.hash and parent_block.consensus,
+            where: block.number > 0 and block.consensus and is_nil(parent_block.hash)
+          )
+
+        query_stream = Repo.stream(query, max_rows: @batch_size, timeout: @query_timeout)
+
+        stream =
+          TaskSupervisor
+          |> Task.Supervisor.async_stream_nolink(
+            query_stream,
+            fn block -> refetch_block_parent(block, fetcher) end,
+            @task_options
+          )
+
+        Repo.transaction(fn -> Stream.run(stream) end, timeout: @query_timeout)
+      end,
+      fetcher: :non_consensus_blocks
+    )
+  end
+
+  def refetch_block_parent(block, fetcher) do
+    Logger.debug(fn -> "Refetching block #{block.number - 1}" end)
+
+    Fetcher.fetch_and_import_block(block.number - 1, fetcher, false)
+
+    Logger.debug(fn -> "Finished refetching block #{block.number - 1}" end)
+  rescue
+    e ->
+      Logger.debug(fn -> "Failed to refetch block #{block.number - 1}: #{inspect(e)}" end)
+  end
+end

--- a/apps/indexer/lib/indexer/temporary/non_consensus_blocks/supervisor.ex
+++ b/apps/indexer/lib/indexer/temporary/non_consensus_blocks/supervisor.ex
@@ -1,0 +1,38 @@
+defmodule Indexer.Temporary.NonConsensusBlocks.Supervisor do
+  @moduledoc """
+  Supervises `Indexer.Temporary.NonConsensusBlocks`.
+  """
+
+  use Supervisor
+
+  alias Indexer.Temporary.NonConsensusBlocks
+
+  def child_spec([init_arguments]) do
+    child_spec([init_arguments, []])
+  end
+
+  def child_spec([_init_arguments, _gen_server_options] = start_link_arguments) do
+    default = %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, start_link_arguments},
+      type: :supervisor
+    }
+
+    Supervisor.child_spec(default, [])
+  end
+
+  def start_link(fetcher, gen_server_options \\ []) do
+    Supervisor.start_link(__MODULE__, fetcher, gen_server_options)
+  end
+
+  @impl Supervisor
+  def init(fetcher) do
+    Supervisor.init(
+      [
+        {Task.Supervisor, name: Indexer.Temporary.NonConsensusBlocks.TaskSupervisor},
+        {NonConsensusBlocks, [fetcher, [name: NonConsensusBlocks]]}
+      ],
+      strategy: :rest_for_one
+    )
+  end
+end


### PR DESCRIPTION
Due to a bug in the realtime fetcher some of the blocks weren't marked as non-consensus and now they create a discontinuity in the main chain (#1644).

This PR adds a temporary fetcher, which forces a refetch of blocks that don't belong to the main chain.
