### PR TITLE
Force consensus loss for parent block if its hash mismatches parent_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
  - [#1643](https://github.com/poanetwork/blockscout/pull/1643) - Set internal_transactions_indexed_at for empty blocks
  - [#1647](https://github.com/poanetwork/blockscout/pull/1647) - Fix typo in view
  - [#1650](https://github.com/poanetwork/blockscout/pull/1650) - Add petersburg evm version to smart contract verifier
+ - [#1657](https://github.com/poanetwork/blockscout/pull/1657) - Force consensus loss for parent block if its hash mismatches parent_hash
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -573,12 +573,10 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     initial = from(t in Transaction, where: false)
 
     Enum.reduce(blocks_changes, initial, fn %{consensus: consensus, hash: hash, number: number}, acc ->
-      case consensus do
-        false ->
-          from(transaction in acc, or_where: transaction.block_hash == ^hash and transaction.block_number == ^number)
-
-        true ->
-          from(transaction in acc, or_where: transaction.block_hash != ^hash and transaction.block_number == ^number)
+      if consensus do
+        from(transaction in acc, or_where: transaction.block_hash != ^hash and transaction.block_number == ^number)
+      else
+        from(transaction in acc, or_where: transaction.block_hash == ^hash and transaction.block_number == ^number)
       end
     end)
   end
@@ -587,12 +585,10 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     initial = from(b in Block, where: false)
 
     Enum.reduce(blocks_changes, initial, fn %{consensus: consensus, parent_hash: parent_hash, number: number}, acc ->
-      case consensus do
-        false ->
-          acc
-
-        true ->
-          from(block in acc, or_where: block.number == ^(number - 1) and block.hash != ^parent_hash)
+      if consensus do
+        from(block in acc, or_where: block.number == ^(number - 1) and block.hash != ^parent_hash)
+      else
+        acc
       end
     end)
   end

--- a/apps/explorer/priv/repo/migrations/scripts/20190326202921_lose_consensus_for_invalid_blocks.sql
+++ b/apps/explorer/priv/repo/migrations/scripts/20190326202921_lose_consensus_for_invalid_blocks.sql
@@ -1,5 +1,5 @@
-UPDATE blocks SET consensus = FALSE
-WHERE number IN (
+UPDATE blocks SET consensus = FALSE, updated_at = NOW()
+WHERE consensus AND number IN (
   SELECT b0.number - 1 FROM "blocks" AS b0
   LEFT JOIN "blocks" AS b1 ON (b0."parent_hash" = b1."hash") AND b1."consensus"
   WHERE b0."number" > 0 AND b0."consensus" AND b1."hash" IS NULL

--- a/apps/explorer/priv/repo/migrations/scripts/20190326202921_lose_consensus_for_invalid_blocks.sql
+++ b/apps/explorer/priv/repo/migrations/scripts/20190326202921_lose_consensus_for_invalid_blocks.sql
@@ -1,0 +1,6 @@
+UPDATE blocks SET consensus = FALSE
+WHERE number IN (
+  SELECT b0.number - 1 FROM "blocks" AS b0
+  LEFT JOIN "blocks" AS b1 ON (b0."parent_hash" = b1."hash") AND b1."consensus"
+  WHERE b0."number" > 0 AND b0."consensus" AND b1."hash" IS NULL
+);


### PR DESCRIPTION
Fixes #1644

When reorg occurs and the older of new blocks fails to be imported, the old consensus block remains in the database. Catchup fetcher ignores it, and we get a discontinuity in the main chain.

This commit adds an additional consensus loss step during block import: the parent block with hash not matching parent_hash of current block is marked non-consensus, thus creating a hole in main chain, forcing catchup fetcher to retry fetching it.

## Upgrading

A query from `scripts/20190326202921_lose_consensus_for_invalid_blocks.sql` should be run to mark existing invalid blocks as non-consensus.