### PR TITLE
Add with version filter

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/rpc_translator.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/rpc_translator.ex
@@ -66,6 +66,7 @@ defmodule BlockScoutWeb.API.RPC.RPCTranslator do
   def call_controller(conn, controller, action) do
     {:ok, controller.call(conn, action)}
   rescue
-    Conn.WrapperError -> :error
+    Conn.WrapperError ->
+      :error
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -1719,6 +1719,12 @@ defmodule BlockScoutWeb.Etherscan do
         type: "string",
         description:
           "verified|decompiled|unverified|not_decompiled, or 1|2|3|4 respectively. This requests only contracts with that status."
+      },
+      %{
+        key: "not_decompiled_with_version",
+        type: "string",
+        description:
+          "Ensures that none of the returned contracts were decompiled with the provided version. Ignored unless filtering for decompiled contracts."
       }
     ],
     responses: [

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
@@ -36,19 +36,27 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
   end
 
   defp prepare_source_code_contract(contract, _) do
+    decompiled_smart_contract = latest_decompiled_smart_contract(contract.decompiled_smart_contracts)
+
     %{
       "Address" => to_string(contract.address_hash),
       "SourceCode" => contract.contract_source_code,
       "ABI" => Jason.encode!(contract.abi),
       "ContractName" => contract.name,
-      "DecompiledSourceCode" => decompiled_source_code(contract.decompiled_smart_contract),
-      "DecompilerVersion" => decompiler_version(contract.decompiled_smart_contract),
+      "DecompiledSourceCode" => decompiled_source_code(decompiled_smart_contract),
+      "DecompilerVersion" => decompiler_version(decompiled_smart_contract),
       "CompilerVersion" => contract.compiler_version,
       "OptimizationUsed" => if(contract.optimization, do: "1", else: "0")
     }
   end
 
-  defp prepare_contract(%Address{hash: hash, smart_contract: nil, decompiled_smart_contract: decompiled_smart_contract}) do
+  defp prepare_contract(%Address{
+         hash: hash,
+         smart_contract: nil,
+         decompiled_smart_contracts: decompiled_smart_contracts
+       }) do
+    decompiled_smart_contract = latest_decompiled_smart_contract(decompiled_smart_contracts)
+
     %{
       "Address" => to_string(hash),
       "SourceCode" => "",
@@ -64,8 +72,10 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
   defp prepare_contract(%Address{
          hash: hash,
          smart_contract: %SmartContract{} = contract,
-         decompiled_smart_contract: decompiled_smart_contract
+         decompiled_smart_contracts: decompiled_smart_contracts
        }) do
+    decompiled_smart_contract = latest_decompiled_smart_contract(decompiled_smart_contracts)
+
     %{
       "Address" => to_string(hash),
       "SourceCode" => contract.contract_source_code,
@@ -76,6 +86,12 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
       "CompilerVersion" => contract.compiler_version,
       "OptimizationUsed" => if(contract.optimization, do: "1", else: "0")
     }
+  end
+
+  defp latest_decompiled_smart_contract([]), do: nil
+
+  defp latest_decompiled_smart_contract(contracts) do
+    Enum.max_by(contracts, fn contract -> DateTime.to_unix(contract.inserted_at) end)
   end
 
   defp decompiled_source_code(nil), do: "Contract source code not decompiled."

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -78,7 +78,6 @@ defmodule Explorer.Chain.Address do
     field(:has_decompiled_code?, :boolean, virtual: true)
 
     has_one(:smart_contract, SmartContract)
-    has_one(:decompiled_smart_contract, DecompiledSmartContract)
     has_one(:token, Token, foreign_key: :contract_address_hash)
 
     has_one(

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -209,8 +209,8 @@ defmodule Explorer.Chain.SmartContract do
     field(:constructor_arguments, :string)
     field(:abi, {:array, :map})
 
-    has_one(
-      :decompiled_smart_contract,
+    has_many(
+      :decompiled_smart_contracts,
       DecompiledSmartContract,
       foreign_key: :address_hash
     )
@@ -227,7 +227,7 @@ defmodule Explorer.Chain.SmartContract do
   end
 
   def preload_decompiled_smart_contract(contract) do
-    Repo.preload(contract, :decompiled_smart_contract)
+    Repo.preload(contract, :decompiled_smart_contracts)
   end
 
   def changeset(%__MODULE__{} = smart_contract, attrs) do


### PR DESCRIPTION
This adds a `not_decompiled_with_version` filter to get decompiled contracts that were not decompiled with a specific version of the decompiler.

This includes everything from #1608 as well, so we should merge that first, then this will be a very small PR.
