### PR TITLE
try to compile with the latest evm version if bytecode doesn't match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
  - [1611](https://github.com/poanetwork/blockscout/pull/1611) - allow setting the first indexing block
  - [1596](https://github.com/poanetwork/blockscout/pull/1596) - add endpoint to create decompiled contracts
-
+ - [1661](https://github.com/poanetwork/blockscout/pull/1661) - try to compile smart contract with the latest evm version
 
 ### Fixes
 


### PR DESCRIPTION
fixes https://github.com/poanetwork/blockscout/issues/1653

## Motivation

If user-provided evm version is wrong,  we can try to verify contract using the latest evm version. If we couldn't verify the contract with the latest evm version we will try the version before the latest version.

## Changelog

- try to compile with the latest evm version if bytecode doesn't match