### PR TITLE
do not fail if multiple matching tokens are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+ - [#1669](https://github.com/poanetwork/blockscout/pull/1669) - https://github.com/poanetwork/blockscout/pull/1669
+
 ### Chore
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
- - [#1669](https://github.com/poanetwork/blockscout/pull/1669) - https://github.com/poanetwork/blockscout/pull/1669
+ - [#1669](https://github.com/poanetwork/blockscout/pull/1669) - do not fail if multiple matching tokens are found
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -691,10 +691,10 @@ defmodule Explorer.Chain do
       )
 
     query
-    |> Repo.one()
+    |> Repo.all()
     |> case do
-      nil -> {:error, :not_found}
-      hash -> {:ok, hash}
+      [] -> {:error, :not_found}
+      hashes -> {:ok, List.first(hashes)}
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -869,6 +869,15 @@ defmodule Explorer.ChainTest do
 
       assert {:ok, _} = Chain.token_contract_address_from_token_name(name)
     end
+
+    test "return only one result if multiple records are found" do
+      name = "TOKEN"
+
+      insert(:token, symbol: name)
+      insert(:token, symbol: name)
+
+      assert {:ok, _} = Chain.token_contract_address_from_token_name(name)
+    end
   end
 
   describe "find_or_insert_address_from_hash/1" do


### PR DESCRIPTION
When a user searches token by its name multiple matching addresses can be found

## Changelog

- do not fail if multiple matching tokens are found