### PR TITLE
use postgres stats as fallback for transaction count

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1871,7 +1871,7 @@ defmodule Explorer.Chain do
   def transaction_estimated_count do
     cached_value = TransactionCountCache.value()
 
-    if cached_value == 0 do
+    if is_nil(cached_value) do
       %Postgrex.Result{rows: [[rows]]} =
         SQL.query!(Repo, "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='transactions'")
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -20,6 +20,7 @@ defmodule Explorer.Chain do
 
   import EthereumJSONRPC, only: [integer_to_quantity: 1]
 
+  alias Ecto.Adapters.SQL
   alias Ecto.{Changeset, Multi}
 
   alias Explorer.Chain.{
@@ -1868,7 +1869,16 @@ defmodule Explorer.Chain do
   """
   @spec transaction_estimated_count() :: non_neg_integer()
   def transaction_estimated_count do
-    TransactionCountCache.value()
+    cached_value = TransactionCountCache.value()
+
+    if cached_value == 0 do
+      %Postgrex.Result{rows: [[rows]]} =
+        SQL.query!(Repo, "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='transactions'")
+
+      rows
+    else
+      cached_value
+    end
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/transaction_count_cache.ex
+++ b/apps/explorer/lib/explorer/chain/transaction_count_cache.ex
@@ -12,7 +12,7 @@ defmodule Explorer.Chain.TransactionCountCache do
 
   # 2 hours
   @cache_period 1_000 * 60 * 60 * 2
-  @default_value 0
+  @default_value nil
   @key "count"
   @name __MODULE__
 

--- a/apps/explorer/test/explorer/chain/transaction_count_cache_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction_count_cache_test.exs
@@ -8,7 +8,7 @@ defmodule Explorer.Chain.TransactionCountCacheTest do
 
     result = TransactionCountCache.value(TestCache)
 
-    assert result == 0
+    assert is_nil(result)
   end
 
   test "updates cache if initial value is zero" do


### PR DESCRIPTION
Updating cache takes much time so we will use Postgres stats to calculate estimated transaction count

## Changelog

- use Postgres stats as fallback for transaction count