### PR TITLE
do not fail if failure reason is atom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixes
 
  - [#1669](https://github.com/poanetwork/blockscout/pull/1669) - do not fail if multiple matching tokens are found
+ - [#1688](https://github.com/poanetwork/blockscout/pull/1688) - do not fail if failure reason is atom
 
 ### Chore
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
@@ -46,6 +46,7 @@ defmodule EthereumJSONRPC.Contract do
       |> case do
         {:ok, responses} -> responses
         {:error, {:bad_gateway, _request_url}} -> raise "Bad gateway"
+        {:error, reason} when is_atom(reason) -> raise Atom.to_string(reason)
         {:error, error} -> raise error
       end
       |> Enum.into(%{}, &{&1.id, &1})


### PR DESCRIPTION
fixes https://github.com/poanetwork/blockscout/issues/1682

sometimes requests return atoms as a reason for request failure. For example, `{:error, :closed}` or `{:error, :request_timeout}`. these atome were raised ```raise :closed``` which is caused the error.

## Changelog

- do not fail if failure reason is atom