### PR TITLE
rescue failing repo in block number cache update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
  - [#1684](https://github.com/poanetwork/blockscout/pull/1684) - Discard child block with parent_hash not matching hash of imported block
  - [#1699](https://github.com/poanetwork/blockscout/pull/1699) - use seconds as transaction cache period measure
  - [#1697](https://github.com/poanetwork/blockscout/pull/1697) - fix failing in rpc if balance is empty
- 
+ - [#1711](https://github.com/poanetwork/blockscout/pull/1711) - rescue failing repo in block number cache update
+
 ### Chore
 
 

--- a/apps/explorer/lib/explorer/chain/block_number_cache.ex
+++ b/apps/explorer/lib/explorer/chain/block_number_cache.ex
@@ -61,7 +61,7 @@ defmodule Explorer.Chain.BlockNumberCache do
 
   defp update_cache do
     current_time = current_time()
-    {min, max} = Chain.fetch_min_and_max_block_numbers()
+    {min, max} = min_and_max_from_db()
     tuple = {min, max, current_time}
 
     :ets.insert(@tab, {@key, tuple})
@@ -83,6 +83,13 @@ defmodule Explorer.Chain.BlockNumberCache do
     [{_, cache_period}] = :ets.lookup(@tab, @opts_key)
 
     cache_period
+  end
+
+  defp min_and_max_from_db do
+    Chain.fetch_min_and_max_block_numbers()
+  rescue
+    _e ->
+      {0, 0}
   end
 
   defp current_time do


### PR DESCRIPTION
fixes the error when block number cache is initialized before repo

## Changelog

- rescue failing repo in block number cache update