### PR TITLE
do not set contract code from transaction input

### DIFF
--- a/apps/indexer/lib/indexer/address_extraction.ex
+++ b/apps/indexer/lib/indexer/address_extraction.ex
@@ -86,8 +86,7 @@ defmodule Indexer.AddressExtraction do
     transactions: [
       [
         %{from: :block_number, to: :fetched_coin_balance_block_number},
-        %{from: :created_contract_address_hash, to: :hash},
-        %{from: :input, to: :contract_code}
+        %{from: :created_contract_address_hash, to: :hash}
       ],
       [
         %{from: :block_number, to: :fetched_coin_balance_block_number},


### PR DESCRIPTION
fixes https://github.com/poanetwork/blockscout/issues/1707

## Motivation

Some contracts created by main transactions. Other contracts are created by internal transactions. Setting the contract code from the main transaction's input will set invalid code if the contract was created in the internal transaction.

## Changelog

- do not set contract code from transaction input