### PR TITLE
Make websocket optional for realtime fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  - [#1740](https://github.com/poanetwork/blockscout/pull/1740) - fix empty block time
  - [#1743](https://github.com/poanetwork/blockscout/pull/1743) - sort decompiled smart contracts in lexicographical order
  - [#1756](https://github.com/poanetwork/blockscout/pull/1756) - add today's token balance from the previous value
+ - [#1778](https://github.com/poanetwork/blockscout/pull/1778) - Make websocket optional for realtime fetcher
 
 ### Chore
 

--- a/apps/indexer/config/prod/parity.exs
+++ b/apps/indexer/config/prod/parity.exs
@@ -17,7 +17,7 @@ config :indexer,
     variant: EthereumJSONRPC.Parity
   ],
   subscribe_named_arguments: [
-    transport: EthereumJSONRPC.WebSocket,
+    transport: System.get_env("ETHEREUM_JSONRPC_WS_URL") && EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
       url: System.get_env("ETHEREUM_JSONRPC_WS_URL")

--- a/apps/indexer/config/prod/rsk.exs
+++ b/apps/indexer/config/prod/rsk.exs
@@ -19,7 +19,7 @@ config :indexer,
     variant: EthereumJSONRPC.RSK
   ],
   subscribe_named_arguments: [
-    transport: EthereumJSONRPC.WebSocket,
+    transport: System.get_env("ETHEREUM_JSONRPC_WS_URL") && EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
       url: System.get_env("ETHEREUM_JSONRPC_WS_URL")

--- a/apps/indexer/lib/indexer/block/realtime/supervisor.ex
+++ b/apps/indexer/lib/indexer/block/realtime/supervisor.ex
@@ -34,6 +34,16 @@ defmodule Indexer.Block.Realtime.Supervisor do
                [name: Indexer.Block.Realtime.Fetcher]
              ]}
           ]
+
+        _ ->
+          [
+            {Task.Supervisor, name: Indexer.Block.Realtime.TaskSupervisor},
+            {Indexer.Block.Realtime.Fetcher,
+             [
+               %{block_fetcher: block_fetcher, subscribe_named_arguments: nil},
+               [name: Indexer.Block.Realtime.Fetcher]
+             ]}
+          ]
       end
 
     Supervisor.init(children, strategy: :rest_for_one)


### PR DESCRIPTION
Realtime fetcher already uses both websocket and JSONRPC polling for more reliable new block fetching.
Though, if no websocket was available, the realtime fetcher wouldn't start, and no new blocks arrived at all.

As we already have a polling fallback, we now make websocket optional.
This will also help with supporting [nodes without websocket API](https://github.com/poanetwork/blockscout/issues/1607#issuecomment-484135189).

To disable websocket API, pass `nil` in `subscribe_named_arguments.transport`.

## Checklist for your PR

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  you must be able to justify that.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
