### PR TITLE
RSK v1.3.9: Change coin

### DIFF
--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -395,7 +395,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/overview.html.eex:145
 #: lib/block_scout_web/views/wei_helpers.ex:72
 msgid "Ether"
-msgstr "POA"
+msgstr "RBTC"
 
 #, elixir-format
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:163

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -8,7 +8,7 @@ use Mix.Config
 # General application configuration
 config :explorer,
   ecto_repos: [Explorer.Repo],
-  coin: System.get_env("COIN") || "POA",
+  coin: System.get_env("COIN") || "RBTC",
   token_functions_reader_max_retries: 3
 
 config :explorer, Explorer.Counters.AverageBlockTime, enabled: true


### PR DESCRIPTION
Motivation:
Adjust coin from POA to RBTC at RSK instance of BlockScout