### PR TITLE
fix constructor arguments verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
  - [#1769](https://github.com/poanetwork/blockscout/pull/1769) - add timestamp to block overview
  - [#1768](https://github.com/poanetwork/blockscout/pull/1768) - fix first block parameter
  - [#1778](https://github.com/poanetwork/blockscout/pull/1778) - Make websocket optional for realtime fetcher
+ - [#1790](https://github.com/poanetwork/blockscout/pull/1790) - fix constructor arguments verification
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/smart_contract/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier.ex
@@ -74,7 +74,7 @@ defmodule Explorer.SmartContract.Verifier do
       generated_bytecode != blockchain_bytecode_without_whisper ->
         {:error, :generated_bytecode}
 
-      !ConstructorArguments.verify(address_hash, blockchain_bytecode, arguments_data) ->
+      !ConstructorArguments.verify(address_hash, arguments_data) ->
         {:error, :constructor_arguments}
 
       true ->

--- a/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
@@ -5,13 +5,13 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
 
   alias Explorer.Chain
 
-  def verify(address_hash, bytecode, arguments_data) do
+  def verify(address_hash, arguments_data) do
     arguments_data = String.replace(arguments_data, "0x", "")
     creation_input_data = Chain.contract_creation_input_data(address_hash)
 
     expected_arguments_data =
       creation_input_data
-      |> String.split(bytecode)
+      |> String.split("0029")
       |> List.last()
       |> String.replace("0x", "")
 

--- a/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
@@ -9,9 +9,15 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
     arguments_data = String.replace(arguments_data, "0x", "")
     creation_input_data = Chain.contract_creation_input_data(address_hash)
 
-    expected_arguments_data =
+    data_with_swarm =
       creation_input_data
       |> String.split("0029")
+      |> List.first()
+      |> Kernel.<>("0029")
+
+    expected_arguments_data =
+      creation_input_data
+      |> String.split(data_with_swarm)
       |> List.last()
       |> String.replace("0x", "")
 

--- a/apps/explorer/test/explorer/smart_contract/verifier/constructor_arguments_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/verifier/constructor_arguments_test.exs
@@ -6,26 +6,7 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArgumentsTest do
   alias Explorer.Chain.Data
   alias Explorer.SmartContract.Verifier.ConstructorArguments
 
-  describe "verify/3" do
-    test "verifies constructor arguments" do
-      bytecode = "0x0102030"
-      constructor_arguments = "0x405"
-      address = insert(:address)
-
-      input = %Data{
-        bytes: <<1, 2, 3, 4, 5>>
-      }
-
-      :transaction
-      |> insert(created_contract_address_hash: address.hash, input: input)
-      |> with_block()
-
-      assert ConstructorArguments.verify(address.hash, bytecode, constructor_arguments)
-    end
-  end
-
   test "veriies constructor constructor arguments with whisper data" do
-    bytecode = "0x0102035d943c575be8a2aee2bb7737a765fdd2c6e49b74cd2c92ab0fa8e4282d1a75ae0029"
     constructor_arguments = "0x0405"
     address = insert(:address)
 
@@ -39,6 +20,6 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArgumentsTest do
     |> insert(created_contract_address_hash: address.hash, input: input)
     |> with_block()
 
-    assert ConstructorArguments.verify(address.hash, bytecode, constructor_arguments)
+    assert ConstructorArguments.verify(address.hash, constructor_arguments)
   end
 end


### PR DESCRIPTION
fixes https://github.com/poanetwork/blockscout/issues/1786

## Motivation

Currently, we're assuming that constructor arguments are concatenated with contract code in transaction input data. But some transactions have additional data between source code and constructor arguments in transaction input

## Changelog

- fix constructor arguments verification