### PR TITLE
Disable lazy logging check in Credo

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -67,6 +67,9 @@
         {Credo.Check.Readability.TrailingBlankLine, false},
         {Credo.Check.Readability.TrailingWhiteSpace, false},
 
+        # outdated by lazy Logger in Elixir 1.7.  See https://elixir-lang.org/blog/2018/07/25/elixir-v1-7-0-released/
+        {Credo.Check.Warning.LazyLogging, false},
+
         # not handled by formatter
         {Credo.Check.Consistency.ExceptionNames},
         {Credo.Check.Consistency.ParameterPatternMatching},
@@ -118,7 +121,6 @@
         {Credo.Check.Warning.ExpensiveEmptyEnumCheck},
         {Credo.Check.Warning.IExPry},
         {Credo.Check.Warning.IoInspect},
-        {Credo.Check.Warning.LazyLogging},
         {Credo.Check.Warning.OperationOnSameValues},
         {Credo.Check.Warning.OperationWithConstantResult},
         {Credo.Check.Warning.UnusedEnumOperation},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
  - [#1753](https://github.com/poanetwork/blockscout/pull/1753) - Add a check mark to decompiled contract tab
  - [#1744](https://github.com/poanetwork/blockscout/pull/1744) - remove `0x0..0` from tests
  - [#1763](https://github.com/poanetwork/blockscout/pull/1763) - Describe indexer structure and list existing fetchers
+ - [#1800](https://github.com/poanetwork/blockscout/pull/1800) - Disable lazy logging check in Credo
 
 
 ## 1.3.9-beta


### PR DESCRIPTION
Logger macros don't evaluate their parameters since [Elixir 1.7.0](https://elixir-lang.org/blog/2018/07/25/elixir-v1-7-0-released/).
Creating a lambda for every log output is no longer needed.

## Checklist for your PR

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  you must be able to justify that.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
