### PR TITLE
make coinmarketcap's number of pages configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  - [#1790](https://github.com/poanetwork/blockscout/pull/1790) - fix constructor arguments verification
  - [#1793](https://github.com/poanetwork/blockscout/pull/1793) - fix top nav autocomplete
  - [#1795](https://github.com/poanetwork/blockscout/pull/1795) - fix line numbers for decompiled contracts
+ - [#1802](https://github.com/poanetwork/blockscout/pull/1802) - make coinmarketcap's number of pages configurable
 
 ### Chore
 

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -13,6 +13,9 @@ config :explorer,
 
 config :explorer, Explorer.Counters.AverageBlockTime, enabled: true
 
+config :explorer, Explorer.ExchangeRates.Source.CoinMarketCap,
+  pages: String.to_integer(System.get_env("COINMARKETCAP_PAGES") || "10")
+
 balances_update_interval =
   if System.get_env("ADDRESS_WITH_BALANCES_UPDATE_INTERVAL") do
     case Integer.parse(System.get_env("ADDRESS_WITH_BALANCES_UPDATE_INTERVAL")) do

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
@@ -38,7 +38,7 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCap do
     "#{base_url()}/v1/ticker/?start=#{page - 1}00"
   end
 
-  def max_page_number, do: 10
+  def max_page_number, do: config(:pages) || 10
 
   defp base_url do
     config(:base_url) || "https://api.coinmarketcap.com"

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
@@ -38,7 +38,7 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCap do
     "#{base_url()}/v1/ticker/?start=#{page - 1}00"
   end
 
-  def max_page_number, do: config(:pages) || 10
+  def max_page_number, do: config(:pages)
 
   defp base_url do
     config(:base_url) || "https://api.coinmarketcap.com"


### PR DESCRIPTION
We couldn't fetch coin price for some coins

## Changelog

- make coinmarketcap's number of pages configurable