### PR TITLE
(Chore) Divide chains by Mainnet/Testnet in menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Chore
 
+ - [#1804](https://github.com/poanetwork/blockscout/pull/1804) - (Chore) Divide chains by Mainnet/Testnet in menu
  - [#1783](https://github.com/poanetwork/blockscout/pull/1783) - Update README with the chains that use Blockscout
  - [#1780](https://github.com/poanetwork/blockscout/pull/1780) - Update link to the Github repo in the footer
  - [#1757](https://github.com/poanetwork/blockscout/pull/1757) - Change twitter acc link to official Blockscout acc twitter

--- a/apps/block_scout_web/assets/css/components/_navbar.scss
+++ b/apps/block_scout_web/assets/css/components/_navbar.scss
@@ -161,6 +161,10 @@
 
   &.header {
     font-weight: bold;
+
+    &.division {
+      border-top: 1px solid rgb(183, 185, 184);
+    }
   }
 }
 

--- a/apps/block_scout_web/assets/css/components/_navbar.scss
+++ b/apps/block_scout_web/assets/css/components/_navbar.scss
@@ -158,6 +158,10 @@
     background-color: $tertiary;
     color: $white;
   }
+
+  &.header {
+    font-weight: bold;
+  }
 }
 
 .add-border {

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -120,7 +120,12 @@
               <%= subnetwork_title() %>
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <%= for %{url: url, title: title} <- other_networks() do %>
+              <a class="dropdown-item header">Mainnet</a>
+              <%= for %{url: url, title: title} <- main_nets() do %>
+                <a class="dropdown-item" href="<%= url%>"><%= title %></a>
+              <% end %>
+              <a class="dropdown-item header">Testnet</a>
+              <%= for %{url: url, title: title} <- test_nets() do %>
                 <a class="dropdown-item" href="<%= url%>"><%= title %></a>
               <% end %>
             </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -124,7 +124,7 @@
               <%= for %{url: url, title: title} <- main_nets() do %>
                 <a class="dropdown-item" href="<%= url%>"><%= title %></a>
               <% end %>
-              <a class="dropdown-item header">Testnet</a>
+              <a class="dropdown-item header division">Testnet</a>
               <%= for %{url: url, title: title} <- test_nets() do %>
                 <a class="dropdown-item" href="<%= url%>"><%= title %></a>
               <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
@@ -95,6 +95,7 @@ defmodule BlockScoutWeb.LayoutView do
     |> Enum.reject(fn %{title: title} ->
       title == subnetwork_title()
     end)
+    |> Enum.sort()
   end
 
   def main_nets do


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/1752

## Motivation

Chaos in chains menu

## Changelog

### Enhancements
![Screenshot 2019-04-22 at 17 58 40](https://user-images.githubusercontent.com/4341812/56506919-81a9d900-6528-11e9-803c-ce6f0f0762c9.png)



  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
