### PR TITLE
(Chore) Clear build artefacts script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Chore
 
+- [#1814](https://github.com/poanetwork/blockscout/pull/1814) - Clear build artefacts script
 
 ## 1.3.10-beta
 

--- a/rel/commands/clear_build.sh
+++ b/rel/commands/clear_build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+rm -rf ./_build
+rm -rf ./deps
+rm -rf ./logs/dev
+rm -rf ./apps/explorer/node_modules
+rm -rf ./apps/block_scout_web/assets/node_modules


### PR DESCRIPTION
## Motivation

To prepare code for deployment to the instance after local testing we need to clear build artefacts. We do it manually now.

## Changelog

### Enhancements
- `./rel/commands/clear_build.sh` bash script has been added, which removes all of those artefacts
- I've updated deployment instruction here: https://forum.poa.network/t/deploying-blockscout-with-terraform/1952#preparing-blockscout.

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
