### PR TITLE
Make block size field nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - [#1829](https://github.com/poanetwork/blockscout/pull/1829) - Handle nil quantities in block decoding routine
+- [#1830](https://github.com/poanetwork/blockscout/pull/1830) - Make block size field nullable
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -10,10 +10,9 @@ defmodule Explorer.Chain.Block do
   alias Explorer.Chain.{Address, Gas, Hash, Transaction}
   alias Explorer.Chain.Block.{Reward, SecondDegreeRelation}
 
-  @optional_attrs ~w(internal_transactions_indexed_at)a
+  @optional_attrs ~w(internal_transactions_indexed_at size)a
 
-  @required_attrs ~w(consensus difficulty gas_limit gas_used hash miner_hash nonce number parent_hash size timestamp
-                     total_difficulty)a
+  @required_attrs ~w(consensus difficulty gas_limit gas_used hash miner_hash nonce number parent_hash timestamp total_difficulty)a
 
   @typedoc """
   How much work is required to find a hash with some number of leading 0s.  It is measured in hashes for PoW

--- a/apps/explorer/priv/repo/migrations/20190424170833_change_block_size_to_nullable.exs
+++ b/apps/explorer/priv/repo/migrations/20190424170833_change_block_size_to_nullable.exs
@@ -1,0 +1,15 @@
+defmodule Explorer.Repo.Migrations.ChangeBlockSizeToNullable do
+  use Ecto.Migration
+
+  def up do
+    alter table(:blocks) do
+      modify(:size, :integer, null: true)
+    end
+  end
+
+  def down do
+    alter table(:blocks) do
+      modify(:size, :integer, null: false)
+    end
+  end
+end


### PR DESCRIPTION
Uncle block API returns null values for block size, and we need to properly store them in the database.

## Checklist for your PR

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  you must be able to justify that.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
