### PR TITLE
(Chore) Add -f flag to clear_build.sh script delete static folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Chore
 
 - [#1814](https://github.com/poanetwork/blockscout/pull/1814) - Clear build artefacts script
+- [#1837](https://github.com/poanetwork/blockscout/pull/1837) - Add --f flag to clear_build.sh script delete static folder
 
 ## 1.3.10-beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Chore
 
 - [#1814](https://github.com/poanetwork/blockscout/pull/1814) - Clear build artefacts script
-- [#1837](https://github.com/poanetwork/blockscout/pull/1837) - Add --f flag to clear_build.sh script delete static folder
+- [#1837](https://github.com/poanetwork/blockscout/pull/1837) - Add -f flag to clear_build.sh script delete static folder
 
 ## 1.3.10-beta
 

--- a/rel/commands/clear_build.sh
+++ b/rel/commands/clear_build.sh
@@ -5,3 +5,8 @@ rm -rf ./deps
 rm -rf ./logs/dev
 rm -rf ./apps/explorer/node_modules
 rm -rf ./apps/block_scout_web/assets/node_modules
+
+case "$1" in
+		--f)
+		rm -rf ./apps/block_scout_web/priv/static;;
+esac

--- a/rel/commands/clear_build.sh
+++ b/rel/commands/clear_build.sh
@@ -7,6 +7,6 @@ rm -rf ./apps/explorer/node_modules
 rm -rf ./apps/block_scout_web/assets/node_modules
 
 case "$1" in
-		--f)
+		-f)
 		rm -rf ./apps/block_scout_web/priv/static;;
 esac


### PR DESCRIPTION
## Motivation

Add the ability to delete a folder with static assets before the launching of another Blockscocut instance.

## Changelog

### Enhancements
- `-f` flag has been added to `clear_build.sh` script to be able to also delete `./priv/static/` folder before the launching of another Blosckout instance

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
