### PR TITLE
Handle case when total supply is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#1829](https://github.com/poanetwork/blockscout/pull/1829) - Handle nil quantities in block decoding routine
 - [#1830](https://github.com/poanetwork/blockscout/pull/1830) - Make block size field nullable
+- [#1840](https://github.com/poanetwork/blockscout/pull/1840) - Handle case when total supply is nil
 
 ### Chore
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tile.html.eex
@@ -38,7 +38,11 @@
               <% end %>
             </span>
             <!-- percentage of coins from total supply -->
-            <span class="ml-0 ml-md-2">(<%= balance_percentage(@address, @total_supply) %>)</span>
+            <span class="ml-0 ml-md-2">
+              <% if @total_supply do %>
+                (<%= balance_percentage(@address, @total_supply) %>)
+              <% end %>
+            </span>
           </div>
         </div>
       </div>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -111,6 +111,8 @@ defmodule BlockScoutWeb.AddressView do
     format_wei_value(balance, :ether)
   end
 
+  def balance_percentage(_, nil), do: ""
+
   def balance_percentage(%Address{fetched_coin_balance: balance}, total_supply) do
     balance
     |> Wei.to(:ether)

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -192,7 +192,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:59
 #: lib/block_scout_web/templates/address_validation/index.html.eex:30
 #: lib/block_scout_web/templates/address_validation/index.html.eex:57
-#: lib/block_scout_web/views/address_view.ex:300
+#: lib/block_scout_web/views/address_view.ex:302
 msgid "Blocks Validated"
 msgstr ""
 
@@ -222,7 +222,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:39
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:119
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
-#: lib/block_scout_web/views/address_view.ex:296
+#: lib/block_scout_web/views/address_view.ex:298
 msgid "Code"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:295
+#: lib/block_scout_web/views/address_view.ex:297
 #: lib/block_scout_web/views/transaction_view.ex:339
 msgid "Internal Transactions"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:28
 #: lib/block_scout_web/templates/layout/app.html.eex:53
-#: lib/block_scout_web/views/address_view.ex:121
+#: lib/block_scout_web/views/address_view.ex:123
 msgid "Market Cap"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:142
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
-#: lib/block_scout_web/views/address_view.ex:298
+#: lib/block_scout_web/views/address_view.ex:300
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -898,7 +898,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:12
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
 #: lib/block_scout_web/templates/address_validation/index.html.eex:19
-#: lib/block_scout_web/views/address_view.ex:293
+#: lib/block_scout_web/views/address_view.ex:295
 msgid "Tokens"
 msgstr ""
 
@@ -959,7 +959,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:35
 #: lib/block_scout_web/templates/chain/show.html.eex:101
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:35
-#: lib/block_scout_web/views/address_view.ex:294
+#: lib/block_scout_web/views/address_view.ex:296
 msgid "Transactions"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:30
 #: lib/block_scout_web/templates/address/_tabs.html.eex:107
-#: lib/block_scout_web/views/address_view.ex:299
+#: lib/block_scout_web/views/address_view.ex:301
 msgid "Coin Balance History"
 msgstr ""
 
@@ -1710,7 +1710,7 @@ msgid "Copy Decompiled Contract Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_view.ex:297
+#: lib/block_scout_web/views/address_view.ex:299
 msgid "Decompiled Code"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -192,7 +192,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:59
 #: lib/block_scout_web/templates/address_validation/index.html.eex:30
 #: lib/block_scout_web/templates/address_validation/index.html.eex:57
-#: lib/block_scout_web/views/address_view.ex:300
+#: lib/block_scout_web/views/address_view.ex:302
 msgid "Blocks Validated"
 msgstr ""
 
@@ -222,7 +222,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_validation/index.html.eex:39
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:119
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:141
-#: lib/block_scout_web/views/address_view.ex:296
+#: lib/block_scout_web/views/address_view.ex:298
 msgid "Code"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:43
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:295
+#: lib/block_scout_web/views/address_view.ex:297
 #: lib/block_scout_web/views/transaction_view.ex:339
 msgid "Internal Transactions"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:28
 #: lib/block_scout_web/templates/layout/app.html.eex:53
-#: lib/block_scout_web/views/address_view.ex:121
+#: lib/block_scout_web/views/address_view.ex:123
 msgid "Market Cap"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:142
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:33
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:75
-#: lib/block_scout_web/views/address_view.ex:298
+#: lib/block_scout_web/views/address_view.ex:300
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -898,7 +898,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:12
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
 #: lib/block_scout_web/templates/address_validation/index.html.eex:19
-#: lib/block_scout_web/views/address_view.ex:293
+#: lib/block_scout_web/views/address_view.ex:295
 msgid "Tokens"
 msgstr ""
 
@@ -959,7 +959,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:35
 #: lib/block_scout_web/templates/chain/show.html.eex:101
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:35
-#: lib/block_scout_web/views/address_view.ex:294
+#: lib/block_scout_web/views/address_view.ex:296
 msgid "Transactions"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:30
 #: lib/block_scout_web/templates/address/_tabs.html.eex:107
-#: lib/block_scout_web/views/address_view.ex:299
+#: lib/block_scout_web/views/address_view.ex:301
 msgid "Coin Balance History"
 msgstr ""
 
@@ -1710,7 +1710,7 @@ msgid "Copy Decompiled Contract Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_view.ex:297
+#: lib/block_scout_web/views/address_view.ex:299
 msgid "Decompiled Code"
 msgstr ""
 

--- a/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
@@ -140,6 +140,12 @@ defmodule BlockScoutWeb.AddressViewTest do
     assert "1.0000% Market Cap" = AddressView.balance_percentage(address)
   end
 
+  test "balance_percentage with nil total_supply" do
+    address = insert(:address, fetched_coin_balance: 2_524_608_000_000_000_000_000_000)
+
+    assert "" = AddressView.balance_percentage(address, nil)
+  end
+
   describe "contract?/1" do
     test "with a smart contract" do
       {:ok, code} = Data.cast("0x000000000000000000000000862d67cb0773ee3f8ce7ea89b328ffea861ab3ef")

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2359,7 +2359,7 @@ defmodule Explorer.Chain do
   @doc """
   The current total number of coins minted minus verifiably burned coins.
   """
-  @spec total_supply :: non_neg_integer()
+  @spec total_supply :: non_neg_integer() | nil
   def total_supply do
     supply_module().total()
   end
@@ -2367,7 +2367,7 @@ defmodule Explorer.Chain do
   @doc """
   The current number coins in the market for trading.
   """
-  @spec circulating_supply :: non_neg_integer()
+  @spec circulating_supply :: non_neg_integer() | nil
   def circulating_supply do
     supply_module().circulating()
   end


### PR DESCRIPTION
*[Internal server error for Accounts page](https://github.com/poanetwork/blockscout/issues/1839)*

## Motivation

Total supply may be nil, so if it is, we don't compute the balance percentage.

## Changelog

- added function that matches nil total supply
- updated specs
- added new test

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
