### PR TITLE
Stringify solc error message instead of Error instance

### DIFF
--- a/apps/explorer/priv/compile_solc.js
+++ b/apps/explorer/priv/compile_solc.js
@@ -12,7 +12,7 @@ var evmVersion = process.argv[8];
 
 var compiled_code = solc.loadRemoteVersion(version, function (err, solcSnapshot) {
   if (err) {
-    console.log(JSON.stringify(err));
+    console.log(JSON.stringify(err.message));
   } else {
     const input = {
       language: 'Solidity',


### PR DESCRIPTION
`err` in this context seems to be an instance of `Error` and stringifies into `{}` even if it has a message inside

