### PR TITLE
README.md: add blocks.ether1.wattpool.net for Ether-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Currently available block explorers (i.e. Etherscan and Etherchain) are closed s
 * [SpringChain](https://explorer.springrole.com/)
 * [PIRL](http://pirl.es/)
 * [Petrichor](https://explorer.petrichor-dev.com/)
+* [Ether-1](https://blocks.ether1.wattpool.net/)
 
 
 ### Visual Interface


### PR DESCRIPTION
Add Ether-1's Blockscout instance to README.md:
- blocks.ether1.wattpool.net