### PR TITLE
Force block refetch if transaction is re-collated in a different block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [#1898](https://github.com/poanetwork/blockscout/pull/1898) - check if the constructor has arguments before verifying constructor arguments
 - [#1915](https://github.com/poanetwork/blockscout/pull/1915) - fallback to 2 latest evm versions
 - [#1937](https://github.com/poanetwork/blockscout/pull/1937) - Check the presence of overlap[i] object before retrieving properties from it
+- [#1917](https://github.com/poanetwork/blockscout/pull/1917) - Force block refetch if transaction is re-collated in a different block
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2565,7 +2565,7 @@ defmodule Explorer.Chain do
         join: duplicate in subquery(query),
         on: duplicate.nonce == pending.nonce,
         on: duplicate.from_address_hash == pending.from_address_hash,
-        where: pending.hash in ^hashes
+        where: pending.hash in ^hashes and is_nil(pending.block_hash)
       )
 
     Repo.update_all(transactions_to_update, [set: [error: "dropped/replaced", status: :error]], timeout: timeout)

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -10,7 +10,7 @@ defmodule Explorer.Chain.Block do
   alias Explorer.Chain.{Address, Gas, Hash, Transaction}
   alias Explorer.Chain.Block.{Reward, SecondDegreeRelation}
 
-  @optional_attrs ~w(internal_transactions_indexed_at size)a
+  @optional_attrs ~w(internal_transactions_indexed_at size refetch_needed)a
 
   @required_attrs ~w(consensus difficulty gas_limit gas_used hash miner_hash nonce number parent_hash timestamp total_difficulty)a
 
@@ -63,7 +63,8 @@ defmodule Explorer.Chain.Block do
           timestamp: DateTime.t(),
           total_difficulty: difficulty(),
           transactions: %Ecto.Association.NotLoaded{} | [Transaction.t()],
-          internal_transactions_indexed_at: DateTime.t()
+          internal_transactions_indexed_at: DateTime.t(),
+          refetch_needed: boolean()
         }
 
   @primary_key {:hash, Hash.Full, autogenerate: false}
@@ -78,6 +79,7 @@ defmodule Explorer.Chain.Block do
     field(:timestamp, :utc_datetime_usec)
     field(:total_difficulty, :decimal)
     field(:internal_transactions_indexed_at, :utc_datetime_usec)
+    field(:refetch_needed, :boolean)
 
     timestamps()
 

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -205,6 +205,11 @@ defmodule Explorer.Chain.Transaction do
     field(:v, :decimal)
     field(:value, Wei)
 
+    # A transient field for deriving old block hash during transaction upserts.
+    # Used to force refetch of a block in case a transaction is re-collated
+    # in a different block. See: https://github.com/poanetwork/blockscout/issues/1911
+    field(:old_block_hash, Hash.Full)
+
     timestamps()
 
     belongs_to(:block, Block, foreign_key: :block_hash, references: :hash, type: Hash.Full)

--- a/apps/explorer/priv/repo/migrations/20190508152922_add_old_block_hash_for_transactions.exs
+++ b/apps/explorer/priv/repo/migrations/20190508152922_add_old_block_hash_for_transactions.exs
@@ -1,0 +1,12 @@
+defmodule Explorer.Repo.Migrations.AddOldBlockHashForTransactions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:transactions) do
+      # A transient field for deriving old block hash during transaction upserts.
+      # Used to force refetch of a block in case a transaction is re-collated
+      # in a different block. See: https://github.com/poanetwork/blockscout/issues/1911
+      add(:old_block_hash, :bytea, null: true)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20190513134025_add_refetch_needed_to_block.exs
+++ b/apps/explorer/priv/repo/migrations/20190513134025_add_refetch_needed_to_block.exs
@@ -1,0 +1,11 @@
+defmodule Explorer.Repo.Migrations.AddRefetchNeededToBlock do
+  use Ecto.Migration
+
+  def change do
+    alter table(:blocks) do
+      add(:refetch_needed, :boolean, default: false)
+    end
+
+    execute("UPDATE blocks SET refetch_needed = TRUE;", "")
+  end
+end

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -92,6 +92,7 @@ After all deployed instances get all needed data, these fetchers should be depre
 
 - `uncataloged_token_transfers`: extracts token transfers from logs, which previously weren't parsed due to unknown format
 - `uncles_without_index`: adds previously unfetched `index` field for unfetched blocks in `block_second_degree_relations`
+- `blocks_transactions_mismatch`: refetches each block once and revokes consensus to those whose transaction number mismatches with the number currently stored. This is meant to force the correction of a race condition that caused successfully fetched transactions to be overwritten by a following non-consensus block: [#1911](https://github.com/poanetwork/blockscout/issues/1911).
 
 ## Memory Usage
 

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -24,6 +24,7 @@ defmodule Indexer.Supervisor do
   }
 
   alias Indexer.Temporary.{
+    BlocksTransactionsMismatch,
     UncatalogedTokenTransfers,
     UnclesWithoutIndex
   }
@@ -124,6 +125,8 @@ defmodule Indexer.Supervisor do
         # Temporary workers
         {UncatalogedTokenTransfers.Supervisor, [[]]},
         {UnclesWithoutIndex.Supervisor,
+         [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+        {BlocksTransactionsMismatch.Supervisor,
          [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]}
       ],
       strategy: :one_for_one

--- a/apps/indexer/lib/indexer/temporary/blocks_transactions_mismatch.ex
+++ b/apps/indexer/lib/indexer/temporary/blocks_transactions_mismatch.ex
@@ -1,0 +1,115 @@
+defmodule Indexer.Temporary.BlocksTransactionsMismatch do
+  @moduledoc """
+  Fetches `consensus` `t:Explorer.Chain.Block.t/0` and compares their transaction
+  number against a node, to revoke `consensus` on mismatch.
+
+  This is meant to fix incorrectly strored transactions that happened as a result
+  of a race condition due to the asynchronicity of indexer's components.
+  """
+
+  use Indexer.Fetcher
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias EthereumJSONRPC.Blocks
+  alias Explorer.Chain.Block
+  alias Explorer.Repo
+  alias Indexer.BufferedTask
+
+  @behaviour BufferedTask
+
+  @defaults [
+    flush_interval: :timer.seconds(3),
+    max_batch_size: 10,
+    max_concurrency: 4,
+    task_supervisor: Indexer.Temporary.BlocksTransactionsMismatch.TaskSupervisor,
+    metadata: [fetcher: :blocks_transactions_mismatch]
+  ]
+
+  @doc false
+  def child_spec([init_options, gen_server_options]) when is_list(init_options) do
+    {state, mergeable_init_options} = Keyword.pop(init_options, :json_rpc_named_arguments)
+
+    unless state do
+      raise ArgumentError,
+            ":json_rpc_named_arguments must be provided to `#{__MODULE__}.child_spec " <>
+              "to allow for json_rpc calls when running."
+    end
+
+    merged_init_options =
+      @defaults
+      |> Keyword.merge(mergeable_init_options)
+      |> Keyword.put(:state, state)
+
+    Supervisor.child_spec({BufferedTask, [{__MODULE__, merged_init_options}, gen_server_options]}, id: __MODULE__)
+  end
+
+  @impl BufferedTask
+  def init(initial, reducer, _) do
+    query =
+      from(block in Block,
+        join: transactions in assoc(block, :transactions),
+        where: block.consensus and block.refetch_needed,
+        group_by: block.hash,
+        select: {block, count(transactions.hash)}
+      )
+
+    {:ok, final} = Repo.stream_reduce(query, initial, &reducer.(&1, &2))
+
+    final
+  end
+
+  @impl BufferedTask
+  def run(blocks_data, json_rpc_named_arguments) do
+    hashes = Enum.map(blocks_data, fn {block, _trans_num} -> block.hash end)
+
+    Logger.debug("fetching")
+
+    case EthereumJSONRPC.fetch_blocks_by_hash(hashes, json_rpc_named_arguments) do
+      {:ok, blocks} ->
+        run_blocks(blocks, blocks_data)
+
+      {:error, reason} ->
+        Logger.error(fn -> ["failed to fetch: ", inspect(reason)] end)
+        {:retry, blocks_data}
+    end
+  end
+
+  defp run_blocks(%Blocks{blocks_params: []}, blocks_data), do: {:retry, blocks_data}
+
+  defp run_blocks(
+         %Blocks{transactions_params: transactions_params},
+         blocks_data
+       ) do
+    found_blocks_map =
+      transactions_params
+      |> Enum.group_by(&Map.fetch!(&1, :block_hash))
+      |> Map.new(fn {block_hash, trans_lst} -> {block_hash, Enum.count(trans_lst)} end)
+
+    {found_blocks_data, missing_blocks_data} =
+      Enum.split_with(blocks_data, fn {block, _trans_num} ->
+        Map.has_key?(found_blocks_map, to_string(block.hash))
+      end)
+
+    {:ok, _} =
+      found_blocks_data
+      |> Enum.reduce(Multi.new(), fn {block, trans_num}, multi ->
+        changes = %{
+          refetch_needed: false,
+          consensus: found_blocks_map[to_string(block.hash)] == trans_num
+        }
+
+        Multi.update(multi, block.hash, Block.changeset(block, changes))
+      end)
+      |> Repo.transaction()
+
+    if Enum.empty?(missing_blocks_data) do
+      :ok
+    else
+      {:retry, missing_blocks_data}
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Due to race conditions described in #1911 transactions from a consensus block might get overwritten by the same transactions from a non-consensus block.

## Changes

To prevent this we force a block refetch (by marking it as non-consensus), if a transaction belonging to it gets overwritten by the same transaction from a different block.

Also, a potential race condition is fixed in replaced transactions worker: it doesn't mark as `dropped/replaced` the transactions that eventually ended up in a block.

## Upgrading

A transient `old_block_hash` field is added to `transactions` table for atomic deriving of re-collated transactions.

## Checklist for your PR

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  you must be able to justify that.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
