### PR TITLE
Check the presence of overlap[i] object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [#1904](https://github.com/poanetwork/blockscout/pull/1904) - fix `BLOCK_COUNT_CACHE_TTL` env var type
 - [#1898](https://github.com/poanetwork/blockscout/pull/1898) - check if the constructor has arguments before verifying constructor arguments
 - [#1915](https://github.com/poanetwork/blockscout/pull/1915) - fallback to 2 latest evm versions
+- [#1937](https://github.com/poanetwork/blockscout/pull/1937) - Check the presence of overlap[i] object before retrieving properties from it
 
 ### Chore
 

--- a/apps/block_scout_web/assets/js/lib/list_morph.js
+++ b/apps/block_scout_web/assets/js/lib/list_morph.js
@@ -42,8 +42,8 @@ export default function (container, newElements, { key, horizontal } = {}) {
 
   // update kept items
   currentList = currentList.map(({ el }, i) => ({
-    id: overlap[i].id,
-    el: el.outerHTML === overlap[i].el.outerHTML ? el : morph(el, overlap[i].el)
+    id: overlap[i] && overlap[i].id,
+    el: el.outerHTML === overlap[i] && overlap[i].el && overlap[i].el.outerHTML ? el : morph(el, overlap[i].el)
   }))
 
   // add new items


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/1298

## Checklist for your PR

Check the presence of overlap[i] object before retrieving properties from it

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
