### PR TITLE
feat: add on demand fetching and stale attr to rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#1859](https://github.com/poanetwork/blockscout/pull/1859) - feat: show raw transaction traces
 - [#1920](https://github.com/poanetwork/blockscout/pull/1920) - fix: remove source code fields from list endpoint
 - [#1876](https://github.com/poanetwork/blockscout/pull/1876) - async calculate a count of blocks
+- [#1941](https://github.com/poanetwork/blockscout/pull/1941) - feat: add on demand fetching and stale attr to rpc
 
 ### Fixes
 

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -21,15 +21,18 @@ defmodule BlockScoutWeb.Etherscan do
     "result" => [
       %{
         "account" => "0xddbd2b932c763ba5b1b7ae3b362eac3e8d40121a",
-        "balance" => "40807168566070000000000"
+        "balance" => "40807168566070000000000",
+        "stale" => true
       },
       %{
         "account" => "0x63a9975ba31b0b9626b34300f7f627147df1f526",
-        "balance" => "332567136222827062478"
+        "balance" => "332567136222827062478",
+        "stale" => false
       },
       %{
         "account" => "0x198ef1ec325a96cc354c7266a038be8b5c558f67",
-        "balance" => "185178830000000000"
+        "balance" => "185178830000000000",
+        "stale" => false
       }
     ]
   }
@@ -496,6 +499,13 @@ defmodule BlockScoutWeb.Etherscan do
     example: ~s("0x95426f2bc716022fcf1def006dbc4bb81f5b5164")
   }
 
+  @stale_type %{
+    type: "boolean",
+    definition:
+      "Represents whether or not the balance has not been checked in the last 24 hours, and will be rechecked.",
+    example: true
+  }
+
   @transaction_hash_type %{
     type: "transaction hash",
     definition:
@@ -571,7 +581,8 @@ defmodule BlockScoutWeb.Etherscan do
     name: "AddressBalance",
     fields: %{
       address: @address_hash_type,
-      balance: @wei_type
+      balance: @wei_type,
+      stale: @stale_type
     }
   }
 
@@ -988,7 +999,16 @@ defmodule BlockScoutWeb.Etherscan do
 
   @account_balance_action %{
     name: "balance",
-    description: "Get balance for address. Also available through a GraphQL 'addresses' query.",
+    description: """
+        Get balance for address. Also available through a GraphQL 'addresses' query.
+
+        If the balance hasn't been updated in a long time, we will double check
+        with the node to fetch the absolute latest balance. This will not be
+        reflected in the current request, but once it is updated, subsequent requests
+        will show the updated balance. If you want to know whether or not we are checking
+        for another balance, use the `balancemulti` action. That contains a property
+        called `stale` that will let you know to recheck that balance in the near future.
+    """,
     required_params: [
       %{
         key: "address",
@@ -1022,7 +1042,15 @@ defmodule BlockScoutWeb.Etherscan do
 
   @account_balancemulti_action %{
     name: "balancemulti",
-    description: "Get balance for multiple addresses. Also available through a GraphQL 'addresses' query.",
+    description: """
+        Get balance for multiple addresses. Also available through a GraphQL 'addresses' query.
+
+        If the balance hasn't been updated in a long time, we will double check
+        with the node to fetch the absolute latest balance. This will not be
+        reflected in the current request, but once it is updated, subsequent requests
+        will show the updated balance. You can know that this is taking place via
+        the `stale` attribute, which is set to `true` if a new balance is being fetched.
+    """,
     required_params: [
       %{
         key: "address",

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -17,13 +17,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
   end
 
   def render("balancemulti.json", %{addresses: addresses}) do
-    data =
-      Enum.map(addresses, fn address ->
-        %{
-          "account" => "#{address.hash}",
-          "balance" => balance(address)
-        }
-      end)
+    data = Enum.map(addresses, &render_address/1)
 
     RPCView.render("show.json", data: data)
   end
@@ -61,10 +55,19 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
     RPCView.render("error.json", assigns)
   end
 
+  defp render_address(address) do
+    %{
+      "account" => "#{address.hash}",
+      "balance" => balance(address),
+      "stale" => address.stale? || false
+    }
+  end
+
   defp prepare_account(address) do
     %{
-      "balance" => to_string(address.fetched_coin_balance.value),
-      "address" => to_string(address.hash)
+      "balance" => to_string(address.fetched_coin_balance && address.fetched_coin_balance.value),
+      "address" => to_string(address.hash),
+      "stale" => address.stale? || false
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -1,13 +1,44 @@
 defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
-  use BlockScoutWeb.ConnCase
+  use BlockScoutWeb.ConnCase, async: false
 
-  alias Explorer.Chain
-  alias Explorer.Repo
-  alias Explorer.Chain.{Transaction, Wei}
+  import Mox
+
   alias BlockScoutWeb.API.RPC.AddressController
+  alias Explorer.Chain
+  alias Explorer.Chain.{BlockNumberCache, Events.Subscriber, Transaction, Wei}
+  alias Explorer.Counters.{AddressesWithBalanceCounter, AverageBlockTime}
+  alias Indexer.Fetcher.CoinBalanceOnDemand
+  alias Explorer.Repo
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  setup do
+    mocked_json_rpc_named_arguments = [
+      transport: EthereumJSONRPC.Mox,
+      transport_options: []
+    ]
+
+    start_supervised!({Task.Supervisor, name: Indexer.TaskSupervisor})
+    start_supervised!(AverageBlockTime)
+    start_supervised!({CoinBalanceOnDemand, [mocked_json_rpc_named_arguments, [name: CoinBalanceOnDemand]]})
+    start_supervised!(AddressesWithBalanceCounter)
+
+    Application.put_env(:explorer, AverageBlockTime, enabled: true)
+    BlockNumberCache.setup(cache_period: 0)
+
+    on_exit(fn ->
+      Application.put_env(:explorer, AverageBlockTime, enabled: false)
+    end)
+
+    :ok
+  end
 
   describe "listaccounts" do
     setup do
+      Subscriber.to(:addresses, :on_demand)
+      Subscriber.to(:address_coin_balances, :on_demand)
+
       %{params: %{"module" => "account", "action" => "listaccounts"}}
     end
 
@@ -46,6 +77,73 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
                  "balance" => "100"
                }
              ] = response["result"]
+    end
+
+    test "with a stale balance", %{conn: conn, params: params} do
+      now = Timex.now()
+
+      mining_address =
+        insert(:address,
+          fetched_coin_balance: 0,
+          fetched_coin_balance_block_number: 2,
+          inserted_at: Timex.shift(now, minutes: -10)
+        )
+
+      mining_address_hash = to_string(mining_address.hash)
+      # we space these very far apart so that we know it will consider the 0th block stale (it calculates how far
+      # back we'd need to go to get 24 hours in the past)
+      insert(:block, number: 0, timestamp: Timex.shift(now, hours: -50), miner: mining_address)
+      insert(:block, number: 1, timestamp: Timex.shift(now, hours: -25), miner: mining_address)
+      AverageBlockTime.refresh()
+
+      address =
+        insert(:address,
+          fetched_coin_balance: 100,
+          fetched_coin_balance_block_number: 0,
+          inserted_at: Timex.shift(now, minutes: -5)
+        )
+
+      address_hash = to_string(address.hash)
+
+      expect(EthereumJSONRPC.Mox, :json_rpc, 1, fn [
+                                                     %{
+                                                       id: id,
+                                                       method: "eth_getBalance",
+                                                       params: [^address_hash, "0x1"]
+                                                     }
+                                                   ],
+                                                   _options ->
+        {:ok, [%{id: id, jsonrpc: "2.0", result: "0x02"}]}
+      end)
+
+      response =
+        conn
+        |> get("/api", params)
+        |> json_response(200)
+
+      assert response["message"] == "OK"
+      assert response["status"] == "1"
+
+      assert [
+               %{
+                 "address" => ^mining_address_hash,
+                 "balance" => "0",
+                 "stale" => false
+               },
+               %{
+                 "address" => ^address_hash,
+                 "balance" => "100",
+                 "stale" => true
+               }
+             ] = response["result"]
+
+      {:ok, expected_wei} = Wei.cast(2)
+
+      assert_receive({:chain_event, :addresses, :on_demand, [received_address]})
+
+      assert received_address.hash == address.hash
+      assert received_address.fetched_coin_balance == expected_wei
+      assert received_address.fetched_coin_balance_block_number == 1
     end
   end
 
@@ -140,7 +238,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
 
       expected_result =
         Enum.map(addresses, fn address ->
-          %{"account" => "#{address.hash}", "balance" => "#{address.fetched_coin_balance.value}"}
+          %{"account" => "#{address.hash}", "balance" => "#{address.fetched_coin_balance.value}", "stale" => false}
         end)
 
       assert response =
@@ -209,8 +307,8 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       }
 
       expected_result = [
-        %{"account" => address1, "balance" => "0"},
-        %{"account" => address2, "balance" => "0"}
+        %{"account" => address1, "balance" => "0", "stale" => false},
+        %{"account" => address2, "balance" => "0", "stale" => false}
       ]
 
       assert response =
@@ -242,7 +340,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
 
       expected_result =
         Enum.map(addresses, fn address ->
-          %{"account" => "#{address.hash}", "balance" => "#{address.fetched_coin_balance.value}"}
+          %{"account" => "#{address.hash}", "balance" => "#{address.fetched_coin_balance.value}", "stale" => false}
         end)
 
       assert response =
@@ -266,8 +364,8 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       }
 
       expected_result = [
-        %{"account" => address2_hash, "balance" => "0"},
-        %{"account" => "#{address1.hash}", "balance" => "#{address1.fetched_coin_balance.value}"}
+        %{"account" => address2_hash, "balance" => "0", "stale" => false},
+        %{"account" => "#{address1.hash}", "balance" => "#{address1.fetched_coin_balance.value}", "stale" => false}
       ]
 
       assert response =
@@ -314,7 +412,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       }
 
       expected_result = [
-        %{"account" => "#{address.hash}", "balance" => "#{address.fetched_coin_balance.value}"}
+        %{"account" => "#{address.hash}", "balance" => "#{address.fetched_coin_balance.value}", "stale" => false}
       ]
 
       assert response =

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -76,6 +76,7 @@ defmodule Explorer.Chain.Address do
     field(:contract_code, Data)
     field(:nonce, :integer)
     field(:has_decompiled_code?, :boolean, virtual: true)
+    field(:stale?, :boolean, virtual: true)
 
     has_one(:smart_contract, SmartContract)
     has_one(:token, Token, foreign_key: :contract_address_hash)


### PR DESCRIPTION
Resolves #1891 

## Motivation
We want to trigger a balance fetch on any stale balances when they are retrieved via the API, not only when they are viewed in the UI. So that consumers would know, I added an attribute to the response called "stale" that is set to `true` when we have determined that the balance is old and is worth checking again. This doesn't mean that the balance is *wrong* (it will usually be right), it just means that we haven't seen an update for it in the last 24 hours, so we're going to check it again.

## Changelog

### Enhancements
* Fetch coin balance on demand for API requests.

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
