### PR TITLE
fix: add fields for contract filter performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - [#1960](https://github.com/poanetwork/blockscout/pull/1960) - do not remove bold text in decompiled contacts
 - [#1917](https://github.com/poanetwork/blockscout/pull/1917) - Force block refetch if transaction is re-collated in a different block
 - [#1992](https://github.com/poanetwork/blockscout/pull/1992) - fix: support https for wobserver polling
+- [#1966](https://github.com/poanetwork/blockscout/pull/1966) - fix: add fields for contract filter performance
 
 ### Chore
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -98,10 +98,10 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
         Chain.list_decompiled_contracts(page_size, offset, not_decompiled_with_version)
 
       :unverified ->
-        Chain.list_unverified_contracts(page_size, offset)
+        Chain.list_unordered_unverified_contracts(page_size, offset)
 
       :not_decompiled ->
-        Chain.list_not_decompiled_contracts(page_size, offset)
+        Chain.list_unordered_not_decompiled_contracts(page_size, offset)
 
       :empty ->
         Chain.list_empty_contracts(page_size, offset)

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -862,11 +862,6 @@ defmodule BlockScoutWeb.Etherscan do
     name: "Contract",
     fields: %{
       "Address" => @address_hash_type,
-      "DecompilerVersion" => %{
-        type: "decompiler version",
-        definition: "When decompiled source code is present, the decompiler version with which it was generated.",
-        example: "decompiler.version"
-      },
       "ABI" => %{
         type: "ABI",
         definition: "JSON string for the contract's Application Binary Interface (ABI)",
@@ -938,9 +933,16 @@ defmodule BlockScoutWeb.Etherscan do
     """
   }
 
+  @contract_decompiler_version_type %{
+    type: "decompiler version",
+    definition: "When decompiled source code is present, the decompiler version with which it was generated.",
+    example: "decompiler.version"
+  }
+
   @contract_with_sourcecode_model @contract_model
                                   |> put_in([:fields, "SourceCode"], @contract_source_code_type)
                                   |> put_in([:fields, "DecompiledSourceCode"], @contract_decompiled_source_code_type)
+                                  |> put_in([:fields, "DecompilerVersion"], @contract_decompiler_version_type)
 
   @transaction_receipt_status_model %{
     name: "TransactionReceiptStatus",
@@ -1831,7 +1833,12 @@ defmodule BlockScoutWeb.Etherscan do
 
   @contract_listcontracts_action %{
     name: "listcontracts",
-    description: "Get a list of contracts, sorted ascending by the time they were first seen by the explorer.",
+    description: """
+    Get a list of contracts, sorted ascending by the time they were first seen by the explorer.
+
+    If you provide the filters `not_decompiled`(`4`) or `not_verified(4)` the results will not
+    be sorted for performance reasons.
+    """,
     required_params: [],
     optional_params: [
       %{

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
@@ -76,16 +76,12 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
 
   defp prepare_contract(%Address{
          hash: hash,
-         smart_contract: nil,
-         decompiled_smart_contracts: decompiled_smart_contracts
+         smart_contract: nil
        }) do
-    decompiled_smart_contract = latest_decompiled_smart_contract(decompiled_smart_contracts)
-
     %{
       "Address" => to_string(hash),
       "ABI" => "Contract source code not verified",
       "ContractName" => "",
-      "DecompilerVersion" => decompiler_version(decompiled_smart_contract),
       "CompilerVersion" => "",
       "OptimizationUsed" => ""
     }
@@ -93,16 +89,12 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
 
   defp prepare_contract(%Address{
          hash: hash,
-         smart_contract: %SmartContract{} = contract,
-         decompiled_smart_contracts: decompiled_smart_contracts
+         smart_contract: %SmartContract{} = contract
        }) do
-    decompiled_smart_contract = latest_decompiled_smart_contract(decompiled_smart_contracts)
-
     %{
       "Address" => to_string(hash),
       "ABI" => Jason.encode!(contract.abi),
       "ContractName" => contract.name,
-      "DecompilerVersion" => decompiler_version(decompiled_smart_contract),
       "CompilerVersion" => contract.compiler_version,
       "OptimizationUsed" => if(contract.optimization, do: "1", else: "0")
     }

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -47,7 +47,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
                  "Address" => to_string(contract.address_hash),
                  "CompilerVersion" => contract.compiler_version,
                  "ContractName" => contract.name,
-                 "DecompilerVersion" => "",
                  "OptimizationUsed" => if(contract.optimization, do: "1", else: "0")
                }
              ]
@@ -70,7 +69,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
                  "Address" => to_string(address.hash),
                  "CompilerVersion" => "",
                  "ContractName" => "",
-                 "DecompilerVersion" => "",
                  "OptimizationUsed" => ""
                }
              ]
@@ -94,7 +92,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
                  "Address" => to_string(address.hash),
                  "CompilerVersion" => "",
                  "ContractName" => "",
-                 "DecompilerVersion" => "",
                  "OptimizationUsed" => ""
                }
              ]
@@ -122,7 +119,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
                  "Address" => to_string(address.hash),
                  "CompilerVersion" => "",
                  "ContractName" => "",
-                 "DecompilerVersion" => "",
                  "OptimizationUsed" => ""
                }
              ]
@@ -145,7 +141,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
                  "ABI" => Jason.encode!(contract.abi),
                  "Address" => to_string(contract.address_hash),
                  "CompilerVersion" => contract.compiler_version,
-                 "DecompilerVersion" => "",
                  "ContractName" => contract.name,
                  "OptimizationUsed" => if(contract.optimization, do: "1", else: "0")
                }
@@ -170,7 +165,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
                  "Address" => to_string(decompiled_smart_contract.address_hash),
                  "CompilerVersion" => "",
                  "ContractName" => "",
-                 "DecompilerVersion" => "test_decompiler",
                  "OptimizationUsed" => ""
                }
              ]
@@ -194,7 +188,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
                  "Address" => to_string(smart_contract.address_hash),
                  "CompilerVersion" => "",
                  "ContractName" => "",
-                 "DecompilerVersion" => "bizbuz",
                  "OptimizationUsed" => ""
                }
              ]
@@ -214,16 +207,15 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
       assert response["message"] == "OK"
       assert response["status"] == "1"
 
-      assert response["result"] == [
-               %{
-                 "ABI" => "Contract source code not verified",
-                 "Address" => to_string(smart_contract.address_hash),
-                 "CompilerVersion" => "",
-                 "ContractName" => "",
-                 "DecompilerVersion" => "bizbuz",
-                 "OptimizationUsed" => ""
-               }
-             ]
+      assert %{
+               "ABI" => "Contract source code not verified",
+               "Address" => to_string(smart_contract.address_hash),
+               "CompilerVersion" => "",
+               "ContractName" => "",
+               "OptimizationUsed" => ""
+             } in response["result"]
+
+      refute to_string(non_match.address_hash) in Enum.map(response["result"], &Map.get(&1, "Address"))
     end
 
     test "filtering for only not_decompiled (and by extension not verified contracts)", %{params: params, conn: conn} do
@@ -245,7 +237,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
                  "Address" => to_string(contract_address.hash),
                  "CompilerVersion" => "",
                  "ContractName" => "",
-                 "DecompilerVersion" => "",
                  "OptimizationUsed" => ""
                }
              ]
@@ -274,7 +265,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
                  "Address" => to_string(contract_address.hash),
                  "CompilerVersion" => "",
                  "ContractName" => "",
-                 "DecompilerVersion" => "",
                  "OptimizationUsed" => ""
                }
              ]

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v1/decompiled_smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v1/decompiled_smart_contract_controller_test.exs
@@ -2,7 +2,7 @@ defmodule BlockScoutWeb.API.V1.DecompiledControllerTest do
   use BlockScoutWeb.ConnCase
 
   alias Explorer.Repo
-  alias Explorer.Chain.DecompiledSmartContract
+  alias Explorer.Chain.{Address, DecompiledSmartContract}
 
   import Ecto.Query,
     only: [from: 2]
@@ -86,6 +86,24 @@ defmodule BlockScoutWeb.API.V1.DecompiledControllerTest do
       assert to_string(decompiled_smart_contract.address_hash) == address_hash
       assert decompiled_smart_contract.decompiler_version == decompiler_version
       assert decompiled_smart_contract.decompiled_source_code == decompiled_source_code
+    end
+
+    test "updates the address to be decompiled", %{conn: conn} do
+      address_hash = to_string(insert(:address, hash: "0x0000000000000000000000000000000000000001").hash)
+      decompiler_version = "test_decompiler"
+      decompiled_source_code = "hello world"
+
+      params = %{
+        "address_hash" => address_hash,
+        "decompiler_version" => decompiler_version,
+        "decompiled_source_code" => decompiled_source_code
+      }
+
+      request = post(conn, api_v1_decompiled_smart_contract_path(conn, :create), params)
+
+      assert request.status == 201
+
+      assert Repo.get!(Address, address_hash).decompiled
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -22,7 +22,7 @@ defmodule Explorer.Chain.Address do
     Wei
   }
 
-  @optional_attrs ~w(contract_code fetched_coin_balance fetched_coin_balance_block_number nonce)a
+  @optional_attrs ~w(contract_code fetched_coin_balance fetched_coin_balance_block_number nonce decompiled verified)a
   @required_attrs ~w(hash)a
   @allowed_attrs @optional_attrs ++ @required_attrs
 
@@ -75,6 +75,8 @@ defmodule Explorer.Chain.Address do
     field(:fetched_coin_balance_block_number, :integer)
     field(:contract_code, Data)
     field(:nonce, :integer)
+    field(:decompiled, :boolean, default: false)
+    field(:verified, :boolean, default: false)
     field(:has_decompiled_code?, :boolean, virtual: true)
     field(:stale?, :boolean, virtual: true)
 

--- a/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
@@ -13,6 +13,11 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
 
   @behaviour Import.Runner
 
+  @row_defaults %{
+    decompiled: false,
+    verified: false
+  }
+
   # milliseconds
   @timeout 60_000
 
@@ -45,9 +50,16 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
 
     update_transactions_options = %{timeout: transactions_timeout, timestamps: timestamps}
 
+    changes_list_with_defaults =
+      Enum.map(changes_list, fn change ->
+        Enum.reduce(@row_defaults, change, fn {default_key, default_value}, acc ->
+          Map.put_new(acc, default_key, default_value)
+        end)
+      end)
+
     multi
     |> Multi.run(:addresses, fn repo, _ ->
-      insert(repo, changes_list, insert_options)
+      insert(repo, changes_list_with_defaults, insert_options)
     end)
     |> Multi.run(:created_address_code_indexed_at_transactions, fn repo, %{addresses: addresses}
                                                                    when is_list(addresses) ->

--- a/apps/explorer/lib/explorer/smart_contract/solc_downloader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solc_downloader.ex
@@ -86,7 +86,7 @@ defmodule Explorer.SmartContract.SolcDownloader do
     download_path = "https://ethereum.github.io/solc-bin/bin/soljson-#{version}.js"
 
     download_path
-    |> HTTPoison.get!([], timeout: 60_000)
+    |> HTTPoison.get!([], timeout: 60_000, recv_timeout: 60_000)
     |> Map.get(:body)
   end
 end

--- a/apps/explorer/priv/repo/migrations/20190516140202_add_address_hash_index_to_decompiled_smart_contracts.exs
+++ b/apps/explorer/priv/repo/migrations/20190516140202_add_address_hash_index_to_decompiled_smart_contracts.exs
@@ -1,0 +1,14 @@
+defmodule Explorer.Repo.Migrations.AddAddressHashIndexToDecompiledSmartContracts do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      """
+      CREATE INDEX IF NOT EXISTS decompiled_smart_contracts_address_hash_index ON decompiled_smart_contracts(address_hash);
+      """,
+      """
+      DROP INDEX IF EXISTS decompiled_smart_contracts_address_hash_index
+      """
+    )
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20190516160535_add_decompiled_and_verified_flag_to_addresses.exs
+++ b/apps/explorer/priv/repo/migrations/20190516160535_add_decompiled_and_verified_flag_to_addresses.exs
@@ -1,0 +1,18 @@
+defmodule Explorer.Repo.Migrations.AddDecompiledAndVerifiedFlagToAddresses do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      """
+      ALTER TABLE addresses
+      ADD COLUMN IF NOT EXISTS decompiled BOOLEAN,
+      ADD COLUMN IF NOT EXISTS verified BOOLEAN;
+      """,
+      """
+      ALTER TABLE addresses
+      DROP COLUMN IF EXISTS decompiled,
+      DROP COLUMN IF EXISTS verified;
+      """
+    )
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2859,6 +2859,12 @@ defmodule Explorer.ChainTest do
       assert {:ok, _} = Chain.create_smart_contract(attrs)
       assert Repo.get_by(Address.Name, name: "SimpleStorage")
     end
+
+    test "sets the address verified field to true", %{valid_attrs: valid_attrs} do
+      assert {:ok, %SmartContract{} = smart_contract} = Chain.create_smart_contract(valid_attrs)
+
+      assert Repo.get_by(Address, hash: smart_contract.address_hash).verified == true
+    end
   end
 
   describe "stream_unfetched_balances/2" do

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -482,6 +482,7 @@ defmodule Explorer.Factory do
 
     address = %Address{
       hash: address_hash(),
+      verified: true,
       contract_code: contract_code_info().bytecode,
       smart_contract: smart_contract
     }
@@ -519,7 +520,7 @@ defmodule Explorer.Factory do
     contract_code_info = contract_code_info()
 
     %SmartContract{
-      address_hash: insert(:address, contract_code: contract_code_info.bytecode).hash,
+      address_hash: insert(:address, contract_code: contract_code_info.bytecode, verified: true).hash,
       compiler_version: contract_code_info.version,
       name: contract_code_info.name,
       contract_source_code: contract_code_info.source_code,
@@ -532,7 +533,7 @@ defmodule Explorer.Factory do
     contract_code_info = contract_code_info()
 
     %DecompiledSmartContract{
-      address_hash: insert(:address, contract_code: contract_code_info.bytecode).hash,
+      address_hash: insert(:address, contract_code: contract_code_info.bytecode, decompiled: true).hash,
       decompiler_version: "test_decompiler",
       decompiled_source_code: contract_code_info.source_code
     }


### PR DESCRIPTION
Resolves #1951

## Changelog

### Bug Fixes
* Due to poor performance with the filters for not decompiled and not verified smart contracts in the JSON RPC, this adds supporting fields on addresses to signify decompiled/verified contract addresses.
* Adds a Temporary fetcher that will backfill the old data.

### Incompatible Changes
* For performance reasons, I had to remove the "DecompilerVersion" attribute from the API response for listing contracts. I can add it back in if necessary, but things will become much slower. Since this was a new API endpoint, I don't think it would be too bad to remove that field. Let me know.

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
