### PR TITLE
add log index to transaction view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - [#1900](https://github.com/poanetwork/blockscout/pull/1900) - SUPPORTED_CHAINS ENV var
 - [#1892](https://github.com/poanetwork/blockscout/pull/1892) - Remove temporary worker modules
 - [#1958](https://github.com/poanetwork/blockscout/pull/1958) - Default value for release link env var
+- [#1975](https://github.com/poanetwork/blockscout/pull/1975) - add log index to transaction view
 
 ## 1.3.10-beta
 

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -594,6 +594,11 @@ defmodule BlockScoutWeb.Etherscan do
         type: "block number",
         definition: "A nonnegative number used to identify blocks.",
         example: ~s("0x5c958")
+      },
+      index: %{
+        type: "log index",
+        definition: "A nonnegative number used to identify logs.",
+        example: ~s("1")
       }
     }
   }

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/transaction_view.ex
@@ -77,7 +77,8 @@ defmodule BlockScoutWeb.API.RPC.TransactionView do
     %{
       "address" => "#{log.address_hash}",
       "topics" => get_topics(log),
-      "data" => "#{log.data}"
+      "data" => "#{log.data}",
+      "index" => "#{log.index}"
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
@@ -460,7 +460,8 @@ defmodule BlockScoutWeb.API.RPC.TransactionControllerTest do
           %{
             "address" => "#{address.hash}",
             "data" => "#{log.data}",
-            "topics" => ["first topic", "second topic", nil, nil]
+            "topics" => ["first topic", "second topic", nil, nil],
+            "index" => "#{log.index}"
           }
         ],
         "next_page_params" => nil


### PR DESCRIPTION
if a transaction has a big number of logs it's not apparent which page of logs is requested. Also, log index is  used for logs pagination

## Changelog
- add log index to transaction view 