### PR TITLE
fix: consolidate address w/ balance one at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#1956](https://github.com/poanetwork/blockscout/pull/1956) - add logs tab to address
 - [#1933](https://github.com/poanetwork/blockscout/pull/1933) - add eth_BlockNumber json rpc method
 - [#1952](https://github.com/poanetwork/blockscout/pull/1952) - feat: exclude empty contracts by default
+- [#1989](https://github.com/poanetwork/blockscout/pull/1989) - fix: consolidate address w/ balance one at a time
 
 ### Fixes
 


### PR DESCRIPTION
## Changelog

### Bug Fixes
* Start consolidating in a `handle_continue/2` hook instead of a task that is kicked off in the `init` callback.

- [x] I added an entry to `CHANGELOG.md` with this PR
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so if necessary


I checked the box here, but I can't reproduce whatever is causing the queries to stack up. However, spawning a task from the init like that is suspect, and isn't how that would normally be done.