### PR TITLE
fix: support https for wobserver polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - [#1937](https://github.com/poanetwork/blockscout/pull/1937) - Check the presence of overlap[i] object before retrieving properties from it
 - [#1960](https://github.com/poanetwork/blockscout/pull/1960) - do not remove bold text in decompiled contacts
 - [#1917](https://github.com/poanetwork/blockscout/pull/1917) - Force block refetch if transaction is re-collated in a different block
+- [#1992](https://github.com/poanetwork/blockscout/pull/1992) - fix: support https for wobserver polling
 
 ### Chore
 

--- a/apps/block_scout_web/mix.exs
+++ b/apps/block_scout_web/mix.exs
@@ -128,7 +128,7 @@ defmodule BlockScoutWeb.Mixfile do
       {:timex, "~> 3.4"},
       {:wallaby, "~> 0.22", only: [:test], runtime: false},
       # `:cowboy` `~> 2.0` and Phoenix 1.4 compatibility
-      {:wobserver, "~> 0.2.0", github: "KronicDeth/wobserver", ref: "99683a936c75c0a94ebb884cef019f7ed0b97112"},
+      {:wobserver, "~> 0.2.0", github: "poanetwork/wobserver", branch: "support-https"},
       {:phoenix_form_awesomplete, "~> 0.1.4"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -109,5 +109,5 @@
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
   "wallaby": {:hex, :wallaby, "0.22.0", "e5d16bfa7ab23562c8a6e3b0a31445a2fd470ca622082a910114807ba823780d", [:mix], [{:httpoison, "~> 0.12 or ~> 1.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}], "hexpm"},
   "websocket_client": {:hex, :websocket_client, "1.3.0", "2275d7daaa1cdacebf2068891c9844b15f4fdc3de3ec2602420c2fb486db59b6", [:rebar3], [], "hexpm"},
-  "wobserver": {:git, "https://github.com/KronicDeth/wobserver.git", "99683a936c75c0a94ebb884cef019f7ed0b97112", [ref: "99683a936c75c0a94ebb884cef019f7ed0b97112"]},
+  "wobserver": {:git, "https://github.com/poanetwork/wobserver.git", "13bcda30a87f4f0be1878920a79433ad831eefbe", [branch: "support-https"]},
 }


### PR DESCRIPTION
## Motivation

* Wobserver has been getting out of date and is unsupported. I forked the fork we *were* using into one that was under poanetwork's umbrella so that we can fix it later if need be.
* This fixes an issue that caused wobserver to be unusable under https.
* I also had to clone the wobserver repo, and decided to clone it under the `poanetwork` umbrella, so that it could be changed more in the future if necessary.

## Changelog

### Bug Fixes
* Wobserver has a fallback to use polling instead of ws. The websockets are not working, but I was able to get the polling version to work with HTTPS, so this fixes the short term issue. We'd would prefer websockets to work, but I have yet to discover what is broken about them, and wobserver itself appears to be abandoned.

- [x] I added an entry to `CHANGELOG.md` with this PR
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so if necessary
