### PR TITLE
docker/Makefile: always set a container name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Current
+- [#2000](https://github.com/poanetwork/blockscout/pull/2000) - docker/Makefile: always set a container name
 
 ### Features
 - [#1963](https://github.com/poanetwork/blockscout/pull/1963) - added rinkeby theme and rinkeby logo

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,7 @@
 SYSTEM = $(shell uname -s)
 HOST = host.docker.internal
 DOCKER_IMAGE = blockscout_prod
+BS_CONTAINER_NAME = blockscout
 PG_CONTAINER_NAME = postgres
 PG_CONTAINER_IMAGE = postgres:10.4
 THIS_FILE = $(lastword $(MAKEFILE_LIST))
@@ -87,7 +88,7 @@ endif
 
 start: build postgres 
 	@echo "==> Starting blockscout"
-	@docker run --rm \
+	@docker run --rm --name $(BS_CONTAINER_NAME) \
 					$(BLOCKSCOUT_CONTAINNER_PARAMS) \
 					-p 4000:4000 \
 					$(DOCKER_IMAGE) /bin/sh -c "mix phx.server"


### PR DESCRIPTION
* Generate a predictable name for the blockscout container just as we do for the postgres container, rather than random generated names, for the sake of scripting.