### PR TITLE
Get estimated count of blocks when cache is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#1933](https://github.com/poanetwork/blockscout/pull/1933) - add eth_BlockNumber json rpc method
 - [#1952](https://github.com/poanetwork/blockscout/pull/1952) - feat: exclude empty contracts by default
 - [#1954](https://github.com/poanetwork/blockscout/pull/1954) - feat: use creation init on self destruct
+- [#2002](https://github.com/poanetwork/blockscout/pull/2002) - Get estimated count of blocks when cache is empty
 
 ### Fixes
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -364,21 +364,6 @@ defmodule Explorer.Chain do
   end
 
   @doc """
-  The number of consensus blocks.
-
-      iex> insert(:block, consensus: true)
-      iex> insert(:block, consensus: false)
-      iex> Explorer.Chain.block_consensus_count()
-      1
-
-  """
-  def block_consensus_count do
-    Block
-    |> where(consensus: true)
-    |> Repo.aggregate(:count, :hash)
-  end
-
-  @doc """
   Reward for mining a block.
 
   The block reward is the sum of the following:

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1997,7 +1997,9 @@ defmodule Explorer.Chain do
     cached_value = BlockCountCache.count()
 
     if is_nil(cached_value) do
-      block_consensus_count()
+      %Postgrex.Result{rows: [[count]]} = Repo.query!("SELECT reltuples FROM pg_class WHERE relname = 'blocks';")
+
+      trunc(count * 0.90)
     else
       cached_value
     end


### PR DESCRIPTION
## Motivation

Replace `block_consensus_count` function with an estimated count of blocks when the cache is empty.
Get 90% of the estimated count, because consensus blocks are ~90% of the total count.