### PR TITLE
fix: show creating internal transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [#2017](https://github.com/poanetwork/blockscout/pull/2017) - fix: fix to/from filters on tx list pages
 - [#2008](https://github.com/poanetwork/blockscout/pull/2008) - add new function clause for xDai network beneficiaries
 - [#2009](https://github.com/poanetwork/blockscout/pull/2009) - addresses page improvements
+- [#2047](https://github.com/poanetwork/blockscout/pull/2047) - fix: show creating internal transactions
 
 ### Chore
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
@@ -153,6 +153,49 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
              end)
     end
 
+    test "returns internal an transaction that created the address", %{conn: conn} do
+      address = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(insert(:block, number: 1))
+
+      from_internal_transaction =
+        insert(:internal_transaction,
+          transaction: transaction,
+          from_address: address,
+          index: 1,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index
+        )
+
+      to_internal_transaction =
+        insert(:internal_transaction,
+          transaction: transaction,
+          to_address: nil,
+          created_contract_address: address,
+          index: 2,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index
+        )
+
+      path = address_internal_transaction_path(conn, :index, address, %{"filter" => "to", "type" => "JSON"})
+      conn = get(conn, path)
+
+      internal_transaction_tiles = json_response(conn, 200)["items"]
+
+      assert Enum.any?(internal_transaction_tiles, fn tile ->
+               String.contains?(tile, to_string(to_internal_transaction.transaction_hash)) &&
+                 String.contains?(tile, "data-internal-transaction-index=\"#{to_internal_transaction.index}\"")
+             end)
+
+      refute Enum.any?(internal_transaction_tiles, fn tile ->
+               String.contains?(tile, to_string(from_internal_transaction.transaction_hash)) &&
+                 String.contains?(tile, "data-internal-transaction-index=\"#{from_internal_transaction.index}\"")
+             end)
+    end
+
     test "returns next page of results based on last seen internal transaction", %{conn: conn} do
       address = insert(:address)
 

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -470,7 +470,12 @@ defmodule Explorer.Chain.InternalTransaction do
     from_address_hash, created_contract_address_hash from internal_transactions' table.
   """
   def where_address_fields_match(query, address_hash, :to) do
-    where(query, [t], t.to_address_hash == ^address_hash)
+    where(
+      query,
+      [t],
+      t.to_address_hash == ^address_hash or
+        (is_nil(t.to_address_hash) and t.created_contract_address_hash == ^address_hash)
+    )
   end
 
   def where_address_fields_match(query, address_hash, :from) do


### PR DESCRIPTION
Resolves: #1938

## Changelog

### Bug Fixes
* Show internal transactions that created the address when filtering for internal transactions *to* that address.

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
