### PR TITLE
allow bytes32 for name and symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [#1999](https://github.com/poanetwork/blockscout/pull/1999) - load data async on addresses page
 - [#2002](https://github.com/poanetwork/blockscout/pull/2002) - Get estimated count of blocks when cache is empty
 - [#1807](https://github.com/poanetwork/blockscout/pull/1807) - New theming capabilites.
-- [#2040](https://github.com/poanetwork/blockscout/pull/2040) - Verification links to other explorers for ETH 
+- [#2040](https://github.com/poanetwork/blockscout/pull/2040) - Verification links to other explorers for ETH
 
 ### Fixes
 - [#2043](https://github.com/poanetwork/blockscout/pull/2043) - Fixed modal dialog width for 'verify other explorers'
@@ -44,6 +44,7 @@
 - [#2017](https://github.com/poanetwork/blockscout/pull/2017) - fix: fix to/from filters on tx list pages
 - [#2008](https://github.com/poanetwork/blockscout/pull/2008) - add new function clause for xDai network beneficiaries
 - [#2009](https://github.com/poanetwork/blockscout/pull/2009) - addresses page improvements
+- [#2052](https://github.com/poanetwork/blockscout/pull/2052) - allow bytes32 for name and symbol
 
 ### Chore
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
@@ -53,13 +53,14 @@ defmodule EthereumJSONRPC.Contract do
       |> Enum.into(%{}, &{&1.id, &1})
 
     Enum.map(requests_with_index, fn {%{function_name: function_name}, index} ->
+      selectors = Enum.filter(parsed_abi, fn p_abi -> p_abi.function == function_name end)
+
       indexed_responses[index]
       |> case do
         nil ->
           {:error, "No result"}
 
         response ->
-          selectors = Enum.filter(parsed_abi, fn p_abi -> p_abi.function == function_name end)
           {^index, result} = Encoder.decode_result(response, selectors)
           result
       end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
@@ -28,10 +28,11 @@ defmodule EthereumJSONRPC.Contract do
 
   @spec execute_contract_functions([call()], [map()], EthereumJSONRPC.json_rpc_named_arguments()) :: [call_result()]
   def execute_contract_functions(requests, abi, json_rpc_named_arguments) do
-    functions =
+    parsed_abi =
       abi
       |> ABI.parse_specification()
-      |> Enum.into(%{}, &{&1.function, &1})
+
+    functions = Enum.into(parsed_abi, %{}, &{&1.function, &1})
 
     requests_with_index = Enum.with_index(requests)
 
@@ -58,7 +59,8 @@ defmodule EthereumJSONRPC.Contract do
           {:error, "No result"}
 
         response ->
-          {^index, result} = Encoder.decode_result(response, functions[function_name])
+          selectors = Enum.filter(parsed_abi, fn p_abi -> p_abi.function == function_name end)
+          {^index, result} = Encoder.decode_result(response, selectors)
           result
       end
     end)

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
@@ -42,7 +42,8 @@ defmodule EthereumJSONRPC.Encoder do
   end
 
   def decode_result(result, selectors) when is_list(selectors) do
-    Enum.map(selectors, fn selector ->
+    selectors
+    |> Enum.map(fn selector ->
       try do
         decode_result(result, selector)
       rescue

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -25,6 +25,16 @@ defmodule Explorer.Token.MetadataRetriever do
     %{
       "constant" => true,
       "inputs" => [],
+      "name" => "name",
+      "outputs" => [
+        %{"name" => "", "type" => "bytes32"}
+      ],
+      "payable" => false,
+      "type" => "function"
+    },
+    %{
+      "constant" => true,
+      "inputs" => [],
       "name" => "decimals",
       "outputs" => [
         %{
@@ -56,6 +66,19 @@ defmodule Explorer.Token.MetadataRetriever do
         %{
           "name" => "",
           "type" => "string"
+        }
+      ],
+      "payable" => false,
+      "type" => "function"
+    },
+    %{
+      "constant" => true,
+      "inputs" => [],
+      "name" => "symbol",
+      "outputs" => [
+        %{
+          "name" => "",
+          "type" => "bytes32"
         }
       ],
       "payable" => false,


### PR DESCRIPTION
We weren't setting name and symbol for some tokens because we were assuming they all have a string type

## Changelog

- allow bytes32 for name and symbol