### PR TITLE
Increase timeout for geth indexers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - [#1988](https://github.com/poanetwork/blockscout/pull/1988) - Fix wrong parity tasks names in Circle CI
 - [#2000](https://github.com/poanetwork/blockscout/pull/2000) - docker/Makefile: always set a container name
 - [#2018](https://github.com/poanetwork/blockscout/pull/2018) - Use PORT env variable in dev config
+- [#2055](https://github.com/poanetwork/blockscout/pull/2055) - Increase timeout for geth indexers
 
 ## 1.3.14-beta
 

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -7,7 +7,7 @@ config :indexer,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth
   ],


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/pull/1869#issuecomment-496886148

## Motivation

We should increase the timeout for geth indexers after implementing of https://github.com/poanetwork/blockscout/pull/1869

## Changelog

- increasing of the timeout for geth indexers from 1 minute to 10 minutes

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
