### PR TITLE
log search form styles added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#2037](https://github.com/poanetwork/blockscout/pull/2037) - add address logs search functionality
 
 ### Fixes
+- [#2056](https://github.com/poanetwork/blockscout/pull/2056) - log search form styles added
 - [#2043](https://github.com/poanetwork/blockscout/pull/2043) - Fixed modal dialog width for 'verify other explorers'
 - [#2025](https://github.com/poanetwork/blockscout/pull/2025) - Added a new color to display transactions' errors.
 - [#2033](https://github.com/poanetwork/blockscout/pull/2033) - Header nav. dropdown active element color issue

--- a/apps/block_scout_web/assets/css/app.scss
+++ b/apps/block_scout_web/assets/css/app.scss
@@ -122,7 +122,7 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "components/alerts";
 @import "components/verify_other_explorers";
 @import "components/errors";
-
+@import "components/log-search";
 :export {
   dashboardBannerChartAxisFontColor: $dashboard-banner-chart-axis-font-color;
   dashboardLineColorMarket: $dashboard-line-color-market;

--- a/apps/block_scout_web/assets/css/components/_log-search.scss
+++ b/apps/block_scout_web/assets/css/components/_log-search.scss
@@ -1,0 +1,60 @@
+.logs-topbar {
+	padding-bottom: 30px;
+	@media (min-width: 600px) {
+		display: flex;
+		justify-content: space-between;
+	}
+	.pagination-container.position-top {
+		padding-top: 0 !important;
+	}
+}
+
+.logs-search {
+	display: flex;
+	@media (max-width: 599px) {
+		margin-bottom: 30px;
+	}
+}
+
+.logs-search-input, .logs-search-btn, .logs-search-btn-cancel {
+	height: 24px;
+	background-color: #f5f6fa;
+	border: 1px solid #f5f6fa;
+	color: #333;
+	border-radius: 2px;
+	outline: none;
+	font-family: Nunito, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.logs-search-input {
+    padding-left: 6px;
+    display: inline-flex;
+    flex-grow: 2;
+    min-width: 160px;
+    &::placeholder {
+    	color: #a3a9b5;
+    }
+}
+
+.logs-search-btn {
+	margin-left: 6px;
+	color: #a3a9b5;
+	transition: .1s ease-in;
+	cursor: pointer;
+	&:hover {
+		background-color: $primary;
+		color: #fff;
+		border-color: $primary;
+	}
+}
+
+.logs-search-btn-cancel {
+	color: #a3a9b5;
+	cursor: pointer;
+	transition: .1s ease-in;
+	&:hover {
+		color: #333;
+	}
+}

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_logs/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_logs/index.html.eex
@@ -7,6 +7,7 @@
     <div class="card-body" data-async-load data-async-listing="<%= @current_path %>">
       <h2 class="card-title"><%= gettext "Logs" %></h2>
       <div class="logs-topbar">
+        
         <div class="logs-search">
           <input data-search-field class="logs-search-input" type='text' placeholder=<%= gettext("Topic") %> id='search-text-input' />
           <button data-cancel-search-button class="logs-search-btn-cancel" type="button">x</button>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_logs/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_logs/index.html.eex
@@ -6,12 +6,15 @@
 
     <div class="card-body" data-async-load data-async-listing="<%= @current_path %>">
       <h2 class="card-title"><%= gettext "Logs" %></h2>
+      <div class="logs-topbar">
+        <div class="logs-search">
+          <input data-search-field class="logs-search-input" type='text' placeholder=<%= gettext("Topic") %> id='search-text-input' />
+          <button data-cancel-search-button class="logs-search-btn-cancel" type="button">x</button>
+          <button data-search-button class="logs-search-btn" type="button"><%= gettext("Search") %></button>
+        </div>
 
-      <input data-search-field type='text' placeholder=<%= gettext("Topic") %> id='search-text-input' />
-      <button data-search-button type="button"><%= gettext("Search") %></button>
-      <button data-cancel-search-button type="button"><%= gettext("Cancel Search") %></button>
-
-      <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
+        <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
+      </div>
 
         <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -674,7 +674,7 @@ msgid "Responses"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:11
+#: lib/block_scout_web/templates/address_logs/index.html.eex:13
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:111
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:128
 msgid "Search"
@@ -1218,7 +1218,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_coin_balance/index.html.eex:34
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:61
-#: lib/block_scout_web/templates/address_logs/index.html.eex:17
+#: lib/block_scout_web/templates/address_logs/index.html.eex:20
 #: lib/block_scout_web/templates/address_token/index.html.eex:13
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:20
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:57
@@ -1683,7 +1683,7 @@ msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:22
+#: lib/block_scout_web/templates/address_logs/index.html.eex:25
 msgid "There are no logs for this address."
 msgstr ""
 
@@ -1723,11 +1723,6 @@ msgid "There are no token transfers for this transaction"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:12
-msgid "Cancel Search"
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:10
+#: lib/block_scout_web/templates/address_logs/index.html.eex:11
 msgid "Topic"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -674,7 +674,7 @@ msgid "Responses"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:13
+#: lib/block_scout_web/templates/address_logs/index.html.eex:14
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:111
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:128
 msgid "Search"
@@ -1218,7 +1218,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_coin_balance/index.html.eex:34
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:61
-#: lib/block_scout_web/templates/address_logs/index.html.eex:20
+#: lib/block_scout_web/templates/address_logs/index.html.eex:21
 #: lib/block_scout_web/templates/address_token/index.html.eex:13
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:20
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:57
@@ -1683,7 +1683,7 @@ msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:25
+#: lib/block_scout_web/templates/address_logs/index.html.eex:26
 msgid "There are no logs for this address."
 msgstr ""
 
@@ -1723,6 +1723,6 @@ msgid "There are no token transfers for this transaction"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:11
+#: lib/block_scout_web/templates/address_logs/index.html.eex:12
 msgid "Topic"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -674,7 +674,7 @@ msgid "Responses"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:13
+#: lib/block_scout_web/templates/address_logs/index.html.eex:14
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:111
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:128
 msgid "Search"
@@ -1218,7 +1218,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_coin_balance/index.html.eex:34
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:61
-#: lib/block_scout_web/templates/address_logs/index.html.eex:20
+#: lib/block_scout_web/templates/address_logs/index.html.eex:21
 #: lib/block_scout_web/templates/address_token/index.html.eex:13
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:20
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:57
@@ -1683,7 +1683,7 @@ msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:25
+#: lib/block_scout_web/templates/address_logs/index.html.eex:26
 msgid "There are no logs for this address."
 msgstr ""
 
@@ -1723,6 +1723,6 @@ msgid "There are no token transfers for this transaction"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:11
+#: lib/block_scout_web/templates/address_logs/index.html.eex:12
 msgid "Topic"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -674,7 +674,7 @@ msgid "Responses"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:11
+#: lib/block_scout_web/templates/address_logs/index.html.eex:13
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:111
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:128
 msgid "Search"
@@ -1218,7 +1218,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_coin_balance/index.html.eex:34
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:61
-#: lib/block_scout_web/templates/address_logs/index.html.eex:17
+#: lib/block_scout_web/templates/address_logs/index.html.eex:20
 #: lib/block_scout_web/templates/address_token/index.html.eex:13
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:20
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:57
@@ -1683,7 +1683,7 @@ msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/index.html.eex:22
+#: lib/block_scout_web/templates/address_logs/index.html.eex:25
 msgid "There are no logs for this address."
 msgstr ""
 
@@ -1722,12 +1722,7 @@ msgstr ""
 msgid "There are no token transfers for this transaction"
 msgstr ""
 
-#, elixir-format, fuzzy
-#: lib/block_scout_web/templates/address_logs/index.html.eex:12
-msgid "Cancel Search"
-msgstr ""
-
-#, elixir-format, fuzzy
-#: lib/block_scout_web/templates/address_logs/index.html.eex:10
+#, elixir-format
+#: lib/block_scout_web/templates/address_logs/index.html.eex:11
 msgid "Topic"
 msgstr ""


### PR DESCRIPTION
Issue: https://github.com/poanetwork/blockscout/pull/2037

We need to add _log-search.scss and connect it at the bottom of app.scss
Update index.html.eex at templates/address_logs

![screencapture-localhost-4000-address-0xd6d36cbf7397496dfdc123824dc5fd1f2d424cb2-logs-2019-05-29-12_11_25](https://user-images.githubusercontent.com/50101080/58555687-c4935680-8222-11e9-874a-9c5abe167298.png)
