### PR TITLE
do not load associations for internal txs on transaction page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
@@ -10,18 +10,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionController do
 
   def index(conn, %{"transaction_id" => hash_string, "type" => "JSON"} = params) do
     with {:ok, hash} <- Chain.string_to_transaction_hash(hash_string),
-         {:ok, transaction} <-
-           Chain.hash_to_transaction(
-             hash,
-             necessity_by_association: %{
-               :block => :optional,
-               [created_contract_address: :names] => :optional,
-               [from_address: :names] => :optional,
-               [to_address: :names] => :optional,
-               [to_address: :smart_contract] => :optional,
-               :token_transfers => :optional
-             }
-           ) do
+         {:ok, transaction} <- Chain.hash_to_transaction(hash) do
       full_options =
         Keyword.merge(
           [


### PR DESCRIPTION
associations are loaded on the first page https://github.com/poanetwork/blockscout/blob/030c17c58bdd330fe54060585e9a8ccfb42fda9e/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex#L78

## Changelog

- do not load associations for internal txs on transaction page