### PR TITLE
Nav dropdown issue, logo size issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#2064](https://github.com/poanetwork/blockscout/pull/2064) - feat: add fields to tx apis, small cleanups
 
 ### Fixes
+- [#2098](https://github.com/poanetwork/blockscout/pull/2098) - nav dropdown issue, logo size issue
 - [#2082](https://github.com/poanetwork/blockscout/pull/2082) - dropdown styles, tooltip gap fix, 404 page added
 - [#2077](https://github.com/poanetwork/blockscout/pull/2077) - ui issues
 - [#2072](https://github.com/poanetwork/blockscout/pull/2072) - Fixed checkmarks not showing correctly in tabs.

--- a/apps/block_scout_web/assets/css/components/_dropdown.scss
+++ b/apps/block_scout_web/assets/css/components/_dropdown.scss
@@ -30,8 +30,10 @@
   font-size: 12px;
   padding: 10px 20px;
 
-  &:hover {
+  &:hover, &.active {
     color: #fff;
+    background-color: rgba($primary, .1) !important;
+    color: $primary;
   }
 
   &:first-child {

--- a/apps/block_scout_web/assets/css/components/_navbar.scss
+++ b/apps/block_scout_web/assets/css/components/_navbar.scss
@@ -10,7 +10,7 @@ $header-textfield-text-color: $header-links-color !default;
 $header-textfield-background-color: #f5f6fa !default;
 $header-textfield-magnifier-color: $header-links-color !default;
 $header-link-horizontal-padding: 0.71rem;
-$navbar-logo-height: 1.5em !default;
+$navbar-logo-height: 18px !default;
 $navbar-logo-width: auto !default;
 
 .navbar.navbar-primary {
@@ -208,7 +208,7 @@ $navbar-logo-width: auto !default;
 }
 
 .navbar-logo {
-  height: $navbar-logo-height;
+  max-height: $navbar-logo-height;
   width: $navbar-logo-width;
 }
 


### PR DESCRIPTION
Navbar element active class and hover
was:
![Screen Shot 2019-06-04 at 18 40 39](https://user-images.githubusercontent.com/50101080/58894483-bfd71280-86fa-11e9-9724-a3372c4f5121.png)
now:
![Screen Shot 2019-06-04 at 18 51 50](https://user-images.githubusercontent.com/50101080/58894494-c49bc680-86fa-11e9-9a3f-3acb4887f275.png)

Logo size
was:
![Screen Shot 2019-06-04 at 18 39 11](https://user-images.githubusercontent.com/50101080/58894515-d2e9e280-86fa-11e9-823e-13a189c0ce2a.png)
now:
![Screen Shot 2019-06-04 at 18 39 00](https://user-images.githubusercontent.com/50101080/58894525-d7160000-86fa-11e9-9975-5d9e3ff18f6d.png)
