### PR TITLE
Themes color improvements, dropdown color issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#2112](https://github.com/poanetwork/blockscout/pull/2112) - themes color improvements, dropdown color issue
 - [#2110](https://github.com/poanetwork/blockscout/pull/2110) - themes colors issues, ui issues
 - [#2103](https://github.com/poanetwork/blockscout/pull/2103) - ui issues for all themes
 - [#2090](https://github.com/poanetwork/blockscout/pull/2090) - updated some ETC theme colors

--- a/apps/block_scout_web/assets/css/components/_btn_dropdown_line.scss
+++ b/apps/block_scout_web/assets/css/components/_btn_dropdown_line.scss
@@ -11,7 +11,7 @@ $btn-dropdown-line-font: #333;
 
   &:hover {
     background-color: $btn-dropdown-line-color-hover;
-    border-color: $btn-dropdown-line-color-hover;
+    border-color: $btn-dropdown-line-color;
     color: $btn-dropdown-line-font;
   }
 }

--- a/apps/block_scout_web/assets/css/theme/_goerli_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_goerli_variables.scss
@@ -3,6 +3,7 @@ $primary: #2b2b2b;
 $secondary: #eac247;
 $tertiary: #929292;
 $additional-font: #ffffff;
+$sub-accent-color: #a46f30;
 
 // footer
 $footer-background-color: $primary;
@@ -32,30 +33,34 @@ $dashboard-banner-network-plain-container-background-color: #424242; // stats bg
 
 // navigation
 .navbar { box-shadow: 0px 0px 30px 0px rgba(21, 53, 80, 0.12); } // header shadow
+$dropdown-menu-item-hover-color: $sub-accent-color !default;
+$dropdown-menu-item-hover-background: rgba($sub-accent-color, .1) !default;
+$header-icon-color-hover: $sub-accent-color;
+$header-icon-border-color-hover: $sub-accent-color;
 
 // buttons
 $btn-line-bg: #fff; // button bg
-$btn-line-color: #a46f30; // button border and font color && hover bg color
-$btn-copy-color: #a46f30; // btn copy
-$btn-qr-color: #a46f30; // btn qr-code
+$btn-line-color: $sub-accent-color; // button border and font color && hover bg color
+$btn-copy-color: $sub-accent-color; // btn copy
+$btn-qr-color: $sub-accent-color; // btn qr-code
 
 //links & tile
-$tile-body-a-color: #a46f30;
-$tile-type-block-color: #a46f30;
-$tile-type-progress-bar-color: #a46f30;
-a.tile-title { color: #a46f30 !important; }
+$tile-body-a-color: $sub-accent-color;
+$tile-type-block-color: $sub-accent-color;
+$tile-type-progress-bar-color: $sub-accent-color;
+a.tile-title { color: $sub-accent-color !important; }
 
 // card
-$card-background-1: #a46f30;
-$card-tab-active: #a46f30;
+$card-background-1: $sub-accent-color;
+$card-tab-active: $sub-accent-color;
 
 // dropdown
 .dropdown-item {
     &:hover,
     &:active,
     &.active {
-      background-color: rgba(#a46f30, .1) !important;
-      color: #a46f30 !important;
+      background-color: rgba($sub-accent-color, .1) !important;
+      color: $sub-accent-color !important;
     }
 }
 

--- a/apps/block_scout_web/assets/css/theme/_rinkeby_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_rinkeby_variables.scss
@@ -1,21 +1,22 @@
 // general
-$primary: #193653;
-$secondary: #49a2ee;
-$tertiary: #41c3a9;
-$additional-font: #a3ceff;
+$primary: #153550;
+$secondary: #38a9f5;
+$tertiary: #76f1ff;
+$additional-font: #89cae6;
 
 // footer
 $footer-background-color: $primary;
 $footer-title-color: #fff;
-$footer-text-color: $additional-font;
-$footer-item-disc-color: $additional-font;
+$footer-text-color: #89cae6;
+$footer-item-disc-color: $secondary;
 .footer-logo { filter: brightness(0) invert(1); }
+.footer-social-icons .footer-social-icon { color: $secondary; }
 
 // dashboard
 $dashboard-line-color-price: $tertiary; // price left border
 
-$dashboard-banner-chart-legend-label-color: $additional-font;
-$dashboard-stats-item-label-color: $additional-font;
+$dashboard-banner-chart-legend-label-color: #89cae6;
+$dashboard-stats-item-label-color: #89cae6;
 $dashboard-banner-chart-legend-value-color: #fff; // chart labels
 $dashboard-stats-item-value-color: #fff; // stat values
 
@@ -25,7 +26,7 @@ $dashboard-banner-gradient-start: $primary; // gradient begin
 
 $dashboard-banner-gradient-end: lighten($primary, 5); // gradient end
 
-$dashboard-banner-network-plain-container-background-color: #244468; // stats bg
+$dashboard-banner-network-plain-container-background-color: #1c476c; // stats bg
 
 
 // navigation
@@ -33,15 +34,15 @@ $dashboard-banner-network-plain-container-background-color: #244468; // stats bg
 
 // buttons
 $btn-line-bg: #fff; // button bg
-$btn-line-color: $tertiary; // button border and font color && hover bg color
-$btn-copy-color: $tertiary; // btn copy
-$btn-qr-color: $tertiary; // btn qr-code
+$btn-line-color: $secondary; // button border and font color && hover bg color
+$btn-copy-color: $secondary; // btn copy
+$btn-qr-color: $secondary; // btn qr-code
 
 //links & tile
-$tile-body-a-color: $tertiary;
-$tile-type-block-color: $tertiary;
-$tile-type-progress-bar-color: $tertiary;
-a.tile-title { color: $tertiary !important; }
+$tile-body-a-color: $secondary;
+$tile-type-block-color: $secondary;
+$tile-type-progress-bar-color: $secondary;
+a.tile-title { color: $secondary !important; }
 
 // card
 $card-background-1: $secondary;

--- a/apps/block_scout_web/assets/css/theme/_sokol_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_sokol_variables.scss
@@ -3,6 +3,7 @@ $primary: #093731;
 $secondary: #40bfb2;
 $tertiary: #25c9ff;
 $additional-font: #93e8dd;
+$sub-accent-color: #1c9f90;
 
 // footer
 $footer-background-color: $primary;
@@ -34,22 +35,26 @@ $dashboard-banner-network-plain-container-background-color: #0e534a; // stats bg
 
 // navigation
 .navbar { box-shadow: 0px 0px 30px 0px rgba(21, 53, 80, 0.12); } // header shadow
+$dropdown-menu-item-hover-color: $sub-accent-color !default;
+$dropdown-menu-item-hover-background: rgba($sub-accent-color, .1) !default;
+$header-icon-color-hover: $sub-accent-color;
+$header-icon-border-color-hover: $sub-accent-color;
 
 // buttons
 $btn-line-bg: #fff; // button bg
-$btn-line-color: #1c9f90; // button border and font color && hover bg color
-$btn-copy-color: #1c9f90; // btn copy
-$btn-qr-color: #1c9f90; // btn qr-code
+$btn-line-color: $sub-accent-color; // button border and font color && hover bg color
+$btn-copy-color: $sub-accent-color; // btn copy
+$btn-qr-color: $sub-accent-color; // btn qr-code
 
 //links & tile
-$tile-body-a-color: #1c9f90;
-$tile-type-block-color: #1c9f90;
-$tile-type-progress-bar-color: #1c9f90;
-a.tile-title { color: #1c9f90 !important; }
+$tile-body-a-color: $sub-accent-color;
+$tile-type-block-color: $sub-accent-color;
+$tile-type-progress-bar-color: $sub-accent-color;
+a.tile-title { color: $sub-accent-color !important; }
 
 // card
-$card-background-1: $secondary;
-$card-tab-active: $secondary;
+$card-background-1: $sub-accent-color;
+$card-tab-active: $sub-accent-color;
 
 .layout-container {
 	.dashboard-banner-container {


### PR DESCRIPTION
1) Changed border-color to darken on dropdown hover
![Screen Shot 2019-06-07 at 10 31 53](https://user-images.githubusercontent.com/50101080/59089432-c049f600-8912-11e9-96db-c71fc78369a3.png)

2) Sokol and Goerli: added more darken colors to dropdown item hover and navbar hovers
Now:
![Screen Shot 2019-06-07 at 10 56 58](https://user-images.githubusercontent.com/50101080/59089555-233b8d00-8913-11e9-966b-e495ca3e9e2e.png)
![Screen Shot 2019-06-07 at 10 57 04](https://user-images.githubusercontent.com/50101080/59089560-25055080-8913-11e9-84b8-c9670eb62cef.png)
![Screen Shot 2019-06-07 at 10 57 41](https://user-images.githubusercontent.com/50101080/59089562-26367d80-8913-11e9-9348-687f4598c876.png)
![Screen Shot 2019-06-07 at 10 57 44](https://user-images.githubusercontent.com/50101080/59089564-26cf1400-8913-11e9-9995-6de0975517fd.png)

3) Ropsten colors improvements (links, buttons, tabs, etc). Now it looks like ropsten theme
![screencapture-localhost-4000-2019-06-07-10_55_54](https://user-images.githubusercontent.com/50101080/59089468-d8ba1080-8912-11e9-840e-8e57e265f1b6.png)
