### PR TITLE
Fixed theme variables connection issue: removed natural_variables connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 - [#2115](https://github.com/poanetwork/blockscout/pull/2115) - fixed theme variables connection issue: removed natural_variables connection
+
 - [#2110](https://github.com/poanetwork/blockscout/pull/2110) - themes colors issues, ui issues
 - [#2103](https://github.com/poanetwork/blockscout/pull/2103) - ui issues for all themes
 - [#2090](https://github.com/poanetwork/blockscout/pull/2090) - updated some ETC theme colors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 - [#2075](https://github.com/poanetwork/blockscout/pull/2075) - add blocks cache
 
 ### Fixes
-- [#2115](https://github.com/poanetwork/blockscout/pull/2115) - fixed theme variables connection issue: removed natural_variables connection
-
 - [#2110](https://github.com/poanetwork/blockscout/pull/2110) - themes colors issues, ui issues
 - [#2103](https://github.com/poanetwork/blockscout/pull/2103) - ui issues for all themes
 - [#2090](https://github.com/poanetwork/blockscout/pull/2090) - updated some ETC theme colors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2075](https://github.com/poanetwork/blockscout/pull/2075) - add blocks cache
 
 ### Fixes
+- [#2115](https://github.com/poanetwork/blockscout/pull/2115) - fixed theme variables connection issue: removed natural_variables connection
 - [#2110](https://github.com/poanetwork/blockscout/pull/2110) - themes colors issues, ui issues
 - [#2103](https://github.com/poanetwork/blockscout/pull/2103) - ui issues for all themes
 - [#2090](https://github.com/poanetwork/blockscout/pull/2090) - updated some ETC theme colors

--- a/apps/block_scout_web/assets/css/theme/_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_variables.scss
@@ -1,5 +1,5 @@
 @import "theme/base_variables";
-@import "neutral_variables";
+// @import "neutral_variables";
 @import "ethereum_variables";
 // @import "dai_variables";
 // @import "ethereum_classic_variables";


### PR DESCRIPTION
- We need to keep only base_variables connected and current theme connected without natural_variables. Natural variables is for 'blockscout' theme only.

- This will fix issues with dropdown list in header and etc...

- Can you send me a list of branches what I should update and create similar pull request? (if we need to do this)