### PR TITLE
remove pending transaction count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#2123](https://github.com/poanetwork/blockscout/pull/2123) - fix coins percentage view
 - [#2119](https://github.com/poanetwork/blockscout/pull/2119) - fix map logging
 - [#2130](https://github.com/poanetwork/blockscout/pull/2130) - fix navigation
+- [#2149](https://github.com/poanetwork/blockscout/pull/2149) - remove pending transaction count
 
 ### Chore
 - [#2127](https://github.com/poanetwork/blockscout/pull/2127) - use previouse chromedriver version

--- a/apps/block_scout_web/lib/block_scout_web/controllers/pending_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/pending_transaction_controller.ex
@@ -51,9 +51,7 @@ defmodule BlockScoutWeb.PendingTransactionController do
   end
 
   def index(conn, _params) do
-    render(conn, "index.html",
-      current_path: current_path(conn)
-    )
+    render(conn, "index.html", current_path: current_path(conn))
   end
 
   defp get_pending_transactions_and_next_page(options) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/pending_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/pending_transaction_controller.ex
@@ -52,8 +52,7 @@ defmodule BlockScoutWeb.PendingTransactionController do
 
   def index(conn, _params) do
     render(conn, "index.html",
-      current_path: current_path(conn),
-      pending_transaction_count: Chain.pending_transaction_count()
+      current_path: current_path(conn)
     )
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/pending_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/pending_transaction_controller_test.exs
@@ -37,15 +37,6 @@ defmodule BlockScoutWeb.PendingTransactionControllerTest do
       refute hd(json_response(conn, 200)["items"]) =~ to_string(dropped_replaced.hash)
     end
 
-    test "returns a count of pending transactions", %{conn: conn} do
-      insert(:transaction)
-
-      conn = get(conn, pending_transaction_path(BlockScoutWeb.Endpoint, :index))
-
-      assert html_response(conn, 200)
-      assert 1 == conn.assigns.pending_transaction_count
-    end
-
     test "works when there are no transactions", %{conn: conn} do
       conn = get(conn, pending_transaction_path(conn, :index))
 


### PR DESCRIPTION
Part of https://github.com/poanetwork/blockscout/issues/1612

Most of the time pending transaction query won't even start to execute because the request is timeout out on `Chain.pending_transaction_count()` query. Moreover, it looks like `pending_transaction_count` variable is not used

## Changelog

- remove pending transaction count