### PR TITLE
Hide dropdown menu then other networks list is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 - [#2109](https://github.com/poanetwork/blockscout/pull/2109) - use bigger updates instead of `Multi` transactions in BlocksTransactionsMismatch
 - [#2075](https://github.com/poanetwork/blockscout/pull/2075) - add blocks cache
+- [#2151](https://github.com/poanetwork/blockscout/pull/2151) - hide dropdown menu then other networks list is empty
 
 ### Fixes
 - [#2144](https://github.com/poanetwork/blockscout/pull/2144) - 'page not found' images path fixed for goerli

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -77,7 +77,7 @@
           </div>
         </li>
         <li class="nav-item dropdown nav-item-networks">
-          <a class="nav-link topnav-nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a class="nav-link topnav-nav-link <%= if dropdown_nets() == [], do: "disabled", else: "dropdown-toggle" %>" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="nav-link-icon">
               <%= render BlockScoutWeb.IconsView, "_active_icon.html" %>
             </span>


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/2132

## Motivation

Then `SUPPORTED_CHAINS` is `[]`, we should hide the dropdown menu on the header

_Before_

![Screenshot from 2019-06-12 17 32 09](https://user-images.githubusercontent.com/11743366/59360022-1dd9aa80-8d38-11e9-8697-a354f1b79fe7.png)

_After_

![Screenshot from 2019-06-12 17 25 59](https://user-images.githubusercontent.com/11743366/59359861-cafff300-8d37-11e9-903a-1ba162e749a7.png)