### PR TITLE
feat: add BLOCKSCOUT_HOST, and use it in API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2075](https://github.com/poanetwork/blockscout/pull/2075) - add blocks cache
 - [#2151](https://github.com/poanetwork/blockscout/pull/2151) - hide dropdown menu then other networks list is empty
 - [#2146](https://github.com/poanetwork/blockscout/pull/2146) - feat: add eth_getLogs rpc endpoint
+- [#2193](https://github.com/poanetwork/blockscout/pull/2193) - feat: add BLOCKSCOUT_HOST, and use it in API docs
 
 ### Fixes
 - [#2201](https://github.com/poanetwork/blockscout/pull/2201) - footer columns fix

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -41,7 +41,7 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
     ]
   ],
   url: [
-    host: "localhost",
+    host: System.get_env("BLOCKSCOUT_HOST") || "localhost",
     path: System.get_env("NETWORK_PATH") || "/"
   ],
   render_errors: [view: BlockScoutWeb.ErrorView, accepts: ~w(html json)],

--- a/apps/block_scout_web/lib/block_scout_web/templates/api_docs/eth_rpc.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/api_docs/eth_rpc.html.eex
@@ -2,7 +2,7 @@
   <div class="card">
     <div class="card-body">
       <h1 class="card-title margin-bottom-sm"><%= gettext("ETH RPC API Documentation") %></h2>
-      <p class="api-text-monospace" data-endpoint-url="<%= BlockScoutWeb.Endpoint.url() %>/api/eth_rpc">[ <%= gettext "Base URL:" %> <%= @conn.host %>/api/eth_rpc ]</p>
+      <p class="api-text-monospace" data-endpoint-url="<%= BlockScoutWeb.Endpoint.url() %>/api/eth_rpc">[ <%= gettext "Base URL:" %> <%= BlockScoutWeb.Endpoint.url() %>/api/eth_rpc ]</p>
       <p class="card-subtitle margin-bottom-0">
         <%= gettext "This API is provided to support some rpc methods in the exact format specified for ethereum nodes, which can be found " %> 
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/api_docs/eth_rpc.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/api_docs/eth_rpc.html.eex
@@ -2,9 +2,9 @@
   <div class="card">
     <div class="card-body">
       <h1 class="card-title margin-bottom-sm"><%= gettext("ETH RPC API Documentation") %></h2>
-      <p class="api-text-monospace" data-endpoint-url="<%= BlockScoutWeb.Endpoint.url() %>/api/eth_rpc">[ <%= gettext "Base URL:" %> <%= BlockScoutWeb.Endpoint.url() %>/api/eth_rpc ]</p>
+      <p class="api-text-monospace" data-endpoint-url="<%= BlockScoutWeb.Endpoint.url() %>/api/eth_rpc">[ <%= gettext "Base URL:" %> <%= url() %>/api/eth_rpc ]</p>
       <p class="card-subtitle margin-bottom-0">
-        <%= gettext "This API is provided to support some rpc methods in the exact format specified for ethereum nodes, which can be found " %> 
+        <%= gettext "This API is provided to support some rpc methods in the exact format specified for ethereum nodes, which can be found " %>
 
         <a href="https://github.com/ethereum/wiki/wiki/JSON-RPC"><%= gettext "here." %></a>
         <%= gettext "This is useful to allow sending requests to blockscout without having to change anything about the request." %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/api_docs/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/api_docs/index.html.eex
@@ -2,7 +2,7 @@
   <div class="card">
     <div class="card-body">
       <h1 class="card-title margin-bottom-sm"><%= gettext("API Documentation") %></h2>
-      <p class="api-text-monospace" data-endpoint-url="<%= BlockScoutWeb.Endpoint.url() %>/api">[ <%= gettext "Base URL:" %> <%= BlockScoutWeb.Endpoint.url() %>/api ]</p>
+      <p class="api-text-monospace" data-endpoint-url="<%= BlockScoutWeb.Endpoint.url() %>/api">[ <%= gettext "Base URL:" %> <%= url() %>/api ]</p>
       <p class="card-subtitle margin-bottom-0"><%= gettext "This API is provided for developers transitioning their applications from Etherscan to BlockScout. It supports GET and POST requests." %></p>
     </div>
     <div class="api-anchors-list">

--- a/apps/block_scout_web/lib/block_scout_web/templates/api_docs/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/api_docs/index.html.eex
@@ -2,7 +2,7 @@
   <div class="card">
     <div class="card-body">
       <h1 class="card-title margin-bottom-sm"><%= gettext("API Documentation") %></h2>
-      <p class="api-text-monospace" data-endpoint-url="<%= BlockScoutWeb.Endpoint.url() %>/api">[ <%= gettext "Base URL:" %> <%= @conn.host %>/api ]</p>
+      <p class="api-text-monospace" data-endpoint-url="<%= BlockScoutWeb.Endpoint.url() %>/api">[ <%= gettext "Base URL:" %> <%= BlockScoutWeb.Endpoint.url() %>/api ]</p>
       <p class="card-subtitle margin-bottom-0"><%= gettext "This API is provided for developers transitioning their applications from Etherscan to BlockScout. It supports GET and POST requests." %></p>
     </div>
     <div class="api-anchors-list">

--- a/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.APIDocsView do
   use BlockScoutWeb, :view
 
-  alias BlockScoutWeb.LayoutView
+  alias BlockScoutWeb.{Endpoint, LayoutView}
 
   def action_tile_id(module, action) do
     "#{module}-#{action}"
@@ -32,5 +32,13 @@ defmodule BlockScoutWeb.APIDocsView do
     Enum.map(action.required_params, fn param ->
       "&#{param.key}=" <> "{<strong>#{param.placeholder}</strong>}"
     end)
+  end
+
+  defp url do
+    if System.get_env("BLOCKSCOUT_HOST") do
+      "http://" <> System.get_env("BLOCKSCOUT_HOST")
+    else
+      Endpoint.url()
+    end
   end
 end


### PR DESCRIPTION
## Motivation

* Right now the host is wrong in the API documentation page. 

### Enhancements
* This uses the correct value to render the host in api docs, and allows it to be configured via `BLOCKSCOUT_HOST` env variable.

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
