### PR TITLE
increase request idle timeout

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -40,14 +40,6 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
       idle_timeout: 90_000
     ]
   ],
-  https: [
-    protocol_options: [
-      idle_timeout: 90_000
-    ],
-    cipher_suite: :strong,
-    certfile: System.get_env("CERTFILE") || "priv/cert/selfsigned.pem",
-    keyfile: System.get_env("KEYFILE") || "priv/cert/selfsigned_key.pem"
-  ],
   url: [
     host: "localhost",
     path: System.get_env("NETWORK_PATH") || "/"

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -43,7 +43,10 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
   https: [
     protocol_options: [
       idle_timeout: 90_000
-    ]
+    ],
+    cipher_suite: :strong,
+    certfile: System.get_env("CERTFILE") || "priv/cert/selfsigned.pem",
+    keyfile: System.get_env("KEYFILE") || "priv/cert/selfsigned_key.pem"
   ],
   url: [
     host: "localhost",

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -35,6 +35,16 @@ config :block_scout_web, BlockScoutWeb.Counters.BlocksIndexedCounter, enabled: t
 # Configures the endpoint
 config :block_scout_web, BlockScoutWeb.Endpoint,
   instrumenters: [BlockScoutWeb.Prometheus.Instrumenter, SpandexPhoenix.Instrumenter],
+  http: [
+    protocol_options: [
+      idle_timeout: 90_000
+    ]
+  ],
+  https: [
+    protocol_options: [
+      idle_timeout: 90_000
+    ]
+  ],
   url: [
     host: "localhost",
     path: System.get_env("NETWORK_PATH") || "/"

--- a/apps/block_scout_web/config/dev.exs
+++ b/apps/block_scout_web/config/dev.exs
@@ -15,8 +15,16 @@ port =
   end
 
 config :block_scout_web, BlockScoutWeb.Endpoint,
-  http: [port: port || 4000],
+  http: [
+    protocol_options: [
+      idle_timeout: 90_000
+    ],
+    port: port || 4000
+  ],
   https: [
+    protocol_options: [
+      idle_timeout: 90_000
+    ],
     port: (port && port + 1) || 4001,
     cipher_suite: :strong,
     certfile: System.get_env("CERTFILE") || "priv/cert/selfsigned.pem",


### PR DESCRIPTION
Compiling smart contracts in the contract verification process takes too much time. That's why we're increasing the timeout.

This is a temporary solution. A better approach would be to make it contract verification async. 

## Changelog

- increase request idle timeout