### PR TITLE
Add functionality to withdraw, order a withdraw and claim an order

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/pools/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/pools/index.html.eex
@@ -59,3 +59,5 @@
 <%= render BlockScoutWeb.StakesView, "_stakes_modal_stake.html", user: @user, min_delegator_stake: @min_delegator_stake %>
 <%= render BlockScoutWeb.StakesView, "_stakes_modal_move.html" %>
 <%= render BlockScoutWeb.StakesView, "_stakes_modal_move_selected.html", min_delegator_stake: @min_delegator_stake %>
+<%= render BlockScoutWeb.StakesView, "_stakes_modal_withdraw.html" %>
+<%= render BlockScoutWeb.StakesView, "_stakes_modal_claim.html" %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_control_withdraw.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_control_withdraw.html.eex
@@ -1,4 +1,10 @@
-<span class="stakes-control <%= if assigns[:extra_class] do @extra_class end %>">
+<span class="stakes-control <%= if assigns[:extra_class] do @extra_class end %>"
+    onclick=<%= if not @claim do %>
+        "openWithdrawModal('<%= to_string(@address) %>')"
+    <% else %>
+        "openClaimQuestionModal('<%= to_string(@address) %>')"
+    <% end %>
+>
     <svg class="stakes-control-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
         <path fill-rule="evenodd" d="M15 16H1a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1zm-1-3H2v1h12v-1zm-3.754-8.279L9 3.479V8a1 1 0 0 1-2 0V3.488L5.765 4.719a1.042 1.042 0 0 1-1.469 0 1.032 1.032 0 0 1 0-1.464L7.235.326a1.04 1.04 0 0 1 1.137-.22c.007.003.012.01.019.013.144.049.28.122.394.236l2.921 2.911a1.027 1.027 0 0 1 0 1.455 1.036 1.036 0 0 1-1.46 0z"/>
     </svg>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_claim.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_claim.html.eex
@@ -1,0 +1,27 @@
+<div class="modal fade" id="claimModal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-stake" role="document">
+    <div class="modal-content">
+      <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
+      <div class="modal-stake-two-cols">
+        <div>
+          <div class="modal-header">
+            <h5 class="modal-title"><%= gettext("Claim Ordered Withdraw") %></h5>
+          </div>
+          <div class="modal-body">
+            <form>
+              <p class="form-p">Your ordered amount</p>
+              <p class="form-p"><span class="text-dark" ordered-amount></span></p>
+              <div class="form-buttons">
+                <%= render BlockScoutWeb.StakesView, "_stakes_btn_withdraw.html", text: gettext("Claim the Amount"), extra_class: "full-width btn-add-full" %>
+              </div>
+            </form>
+          </div>
+          <%= render BlockScoutWeb.CommonComponentsView, "_modal_bottom_disclaimer.html", text: "Lorem ipsum dolor sit amet, consect adipiscing elit, sed do eiusmod temp incididunt ut labore et dolore magna. Sed do eiusmod temp incididunt ut.", extra_class: "b-b-r-0" %>
+        </div>
+        <div class="modal-stake-right">
+          <%= render BlockScoutWeb.StakesView, "_stakes_progress.html" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
@@ -3,38 +3,41 @@
     <div class="modal-content">
       <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
       <div class="modal-stake-two-cols">
-        <div class="modal-stake-left">
+        <div>
           <div class="modal-header">
             <h5 class="modal-title"><%= gettext("Withdraw") %></h5>
           </div>
           <div class="modal-body">
             <form>
               <div class="input-group form-group">
-                <input type="text" class="form-control n-b-r" placeholder='<%= gettext("Amount") %>'>
+                <input amount type="text" class="form-control n-b-r" placeholder='<%= gettext("Amount") %>'>
                 <div class="input-group-prepend last">
                   <div class="input-group-text">POA20</div>
                 </div>
               </div>
-              <p class="form-p m-b-0">Your Balance: <span class="text-dark">2000 POA20</span></p>
-              <p class="form-p">Your Staked: <span class="text-dark">600 POA20</span></p>
+              <p class="form-p">Your Staked: <span class="text-dark" user-staked></span></p>
               <div class="form-buttons">
-                <%= render BlockScoutWeb.StakesView, "_stakes_btn_withdraw.html", text: gettext("Withdraw Now"), extra_class: "full-width" %>
-                <%= render BlockScoutWeb.StakesView, "_stakes_btn_withdraw.html", text: gettext("Order Withdrawal"), extra_class: "full-width", disabled: true %>
+                <%=
+                  render BlockScoutWeb.StakesView,
+                  "_stakes_btn_withdraw.html",
+                  text: gettext("Withdraw Now"),
+                  extra_class: "full-width btn-add-full withdraw",
+                  disabled: true
+                %>
+                <%=
+                  render BlockScoutWeb.StakesView,
+                  "_stakes_btn_withdraw.html",
+                  text: gettext("Order Withdrawal"),
+                  extra_class: "full-width btn-add-full order_withdraw",
+                  disabled: true
+                %>
               </div>
             </form>
           </div>
           <%= render BlockScoutWeb.CommonComponentsView, "_modal_bottom_disclaimer.html", text: "Lorem ipsum dolor sit amet, consect adipiscing elit, sed do eiusmod temp incididunt ut labore et dolore magna. Sed do eiusmod temp incididunt ut.", extra_class: "b-b-r-0" %>
         </div>
         <div class="modal-stake-right">
-          <%=
-            render BlockScoutWeb.StakesView,
-            "_stakes_progress.html",
-            progress: "1250",
-            total: "3000",
-            pool: "0x7130-95a480",
-            stakes_ratio: "1.095%",
-            delegators: "3200"
-          %>
+          <%= render BlockScoutWeb.StakesView, "_stakes_progress.html" %>
         </div>
       </div>
     </div>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1591,7 +1591,7 @@ msgid "Next epoch in"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:22
+#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:30
 msgid "Order Withdrawal"
 msgstr ""
 
@@ -1642,7 +1642,7 @@ msgid "Withdraw"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:21
+#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:23
 msgid "Withdraw Now"
 msgstr ""
 
@@ -1876,4 +1876,14 @@ msgstr ""
 #: lib/block_scout_web/templates/stakes/_stakes_modal_move_selected.html.eex:11
 #: lib/block_scout_web/templates/stakes/_stakes_modal_move_selected.html.eex:29
 msgid "Move Stake"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_stakes_modal_claim.html.eex:8
+msgid "Claim Ordered Withdraw"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_stakes_modal_claim.html.eex:15
+msgid "Claim the Amount"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1591,7 +1591,7 @@ msgid "Next epoch in"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:22
+#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:30
 msgid "Order Withdrawal"
 msgstr ""
 
@@ -1642,7 +1642,7 @@ msgid "Withdraw"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:21
+#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:23
 msgid "Withdraw Now"
 msgstr ""
 
@@ -1876,4 +1876,14 @@ msgstr ""
 #: lib/block_scout_web/templates/stakes/_stakes_modal_move_selected.html.eex:11
 #: lib/block_scout_web/templates/stakes/_stakes_modal_move_selected.html.eex:29
 msgid "Move Stake"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_stakes_modal_claim.html.eex:8
+msgid "Claim Ordered Withdraw"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_stakes_modal_claim.html.eex:15
+msgid "Claim the Amount"
 msgstr ""


### PR DESCRIPTION
#1709
**Merge after [PR#2240](https://github.com/poanetwork/blockscout/pull/2240)**

Add functionality to withdraw, order a withdraw and claim an order

## Changelog

* Update modal windows' templates
* Add JS function to open withdraw and claim window
* Add JS function to call a contract's methods