### PR TITLE
Fix internal transactions failing to be indexed because of constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#2266](https://github.com/poanetwork/blockscout/pull/2266) - allow excluding uncles from average block time calculation
 
 ### Fixes
+- [#2244](https://github.com/poanetwork/blockscout/pull/2244) - fix internal transactions failing to be indexed because of constraint
 - [#2281](https://github.com/poanetwork/blockscout/pull/2281) - typo issues, dropdown issues
 - [#2278](https://github.com/poanetwork/blockscout/pull/2278) - increase threshold for scientific notation
 - [#2275](https://github.com/poanetwork/blockscout/pull/2275) - Description for networks selector

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -171,8 +171,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
               ),
             status:
               fragment(
-                "COALESCE(?, CASE WHEN (SELECT it.error FROM internal_transactions AS it WHERE it.transaction_hash = ? ORDER BY it.index ASC LIMIT 1) IS NULL THEN ? ELSE ? END)",
-                t.status,
+                "CASE WHEN (SELECT it.error FROM internal_transactions AS it WHERE it.transaction_hash = ? ORDER BY it.index ASC LIMIT 1) IS NULL THEN ? ELSE ? END",
                 t.hash,
                 type(^:ok, t.status),
                 type(^:error, t.status)

--- a/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
@@ -1,0 +1,61 @@
+defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
+  use Explorer.DataCase
+
+  alias Ecto.Multi
+  alias Explorer.Chain.{Data, Wei, Transaction}
+  alias Explorer.Chain.Import.Runner.InternalTransactions
+
+  describe "run/1" do
+    test "transaction's status becomes :error when its internal_transaction has an error" do
+      transaction = insert(:transaction) |> with_block(status: :ok)
+
+      assert :ok == transaction.status
+
+      index = 0
+      error = "Reverted"
+
+      internal_transaction_changes = make_internal_transaction_changes(transaction.hash, index, error)
+
+      assert {:ok, _} = run_internal_transactions([internal_transaction_changes])
+
+      assert :error == Repo.get(Transaction, transaction.hash).status
+    end
+  end
+
+  defp run_internal_transactions(changes_list) when is_list(changes_list) do
+    Multi.new()
+    |> InternalTransactions.run(changes_list, %{
+      timeout: :infinity,
+      timestamps: %{inserted_at: DateTime.utc_now(), updated_at: DateTime.utc_now()}
+    })
+    |> Repo.transaction()
+  end
+
+  defp make_internal_transaction_changes(transaction_hash, index, error) do
+    %{
+      from_address_hash: insert(:address).hash,
+      to_address_hash: insert(:address).hash,
+      call_type: :call,
+      gas: 22234,
+      gas_used:
+        if is_nil(error) do
+          18920
+        else
+          nil
+        end,
+      input: %Data{bytes: <<1>>},
+      output:
+        if is_nil(error) do
+          %Data{bytes: <<2>>}
+        else
+          nil
+        end,
+      index: index,
+      trace_address: [],
+      transaction_hash: transaction_hash,
+      type: :call,
+      value: Wei.from(Decimal.new(1), :wei),
+      error: error
+    }
+  end
+end


### PR DESCRIPTION
##Motivation

This solves a recurring error from `Explorer.Chain.Import.Runner.InternalTransactions` that prevents internal transactions to be imported because the respective transaction fail to be updated.

## Changelog

### Bug Fixes

The bug causing the problem is that when transactions have already their `status` set, the insertion of `internal_transactions` will not change it to reflect the existence of an error.

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
