### PR TITLE
Add modal window with a pool's information

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/pools/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/pools/index.html.eex
@@ -14,6 +14,7 @@
 <section data-page="stakes" class="container" 
   data-user-address="<%= if @user, do: @user.address %>"
   data-epoch-end-sec="<%= epoch_end_sec(@epoch_end_in, @average_block_time) %>"
+  data-average-block-time=<%= Timex.Duration.to_seconds(@average_block_time) %>
 >
   <div class="card" data-async-load data-async-listing="<%= @current_path %>">
     <%= render BlockScoutWeb.StakesView, "_stakes_tabs.html", conn: @conn %>
@@ -61,3 +62,4 @@
 <%= render BlockScoutWeb.StakesView, "_stakes_modal_move_selected.html", min_delegator_stake: @min_delegator_stake %>
 <%= render BlockScoutWeb.StakesView, "_stakes_modal_withdraw.html" %>
 <%= render BlockScoutWeb.StakesView, "_stakes_modal_claim.html" %>
+<%= render BlockScoutWeb.StakesView, "_stakes_modal_pool_info.html" %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_address.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_address.html.eex
@@ -1,5 +1,5 @@
 <div class="stakes-address-container">
-    <span class="stakes-address js-validator-info-modal">
+    <span onclick="openPoolInfoModal('<%= to_string(@address) %>')" class="stakes-address">
         <%= binary_part(to_string(@address), 0, 13) %>
     </span>
     <%= if @tooltip do %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_pool_info.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_pool_info.html.eex
@@ -1,8 +1,16 @@
-<div class="modal fade" id="validatorInfoModal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade" id="poolInfoModal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-validator-info" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">0x18Bea833D503341C529a788c82909337e552a44e</h5>
+        <div>
+          <h5 class="modal-title" staking-address>0x18Bea833D503341C529a788c82909337e552a44e</h5>
+          <div>
+            <span class="modal-validator-info-item-title">Mining address:</span>
+            <span class="modal-validator-info-item-value" mining-address>
+              0x18Bea833D503341C529a788c82909337e552a44e
+            </span>
+          </div>
+        </div>
       </div>
       <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
       <div class="modal-validator-info-content">
@@ -10,54 +18,64 @@
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
           title: "Candidate’s Staked Amount",
-          value: "8800"
+          value: "8800",
+          name: "self-staked"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
-          title: "Delegors Staked Amount",
-          value: "3200"
+          title: "Delegator's Staked Amount",
+          value: "3200",
+          name: "delegators-staked"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
           title: "Stakes Ratio",
-          value: "3.2%"
+          value: "3.2%",
+          name: "stakes-ratio"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
-          title: "Reward Precent of the Pool",
-          value: "15%"
+          title: "Reward Percent of the Pool",
+          value: "15%",
+          name: "reward-percent"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
-          title: "How Many Times the Address was a Validator",
-          value: "108"
+          title: "How Many Times this Address has been a Validator",
+          value: "108",
+          name: "was-validator"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
-          title: "How Many Times the Address was Banned",
-          value: "0"
+          title: "How Many Times this Address has been Banned",
+          value: "0",
+          name: "was-banned"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
-          title: "The Block Number and Approximate Date When the  Address Will be Unbanned"
+          title: "The Block Number and Approximate Date When the  Address Will be Unbanned",
+          name: "unban-date",
+          value: "-"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
           title: "Likelihood of Becoming a Validator on the Next Epoch",
-          value: "30%"
+          value: "30%",
+          name: "likelihood"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
           title: "The Number of Delegators In the Pool",
-          value: "103"
+          value: "103",
+          name: "delegators-count"
         %>
       </div>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_validator_info_item.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_validator_info_item.html.eex
@@ -1,4 +1,6 @@
 <div class="modal-validator-info-item">
     <h2 class="modal-validator-info-item-title"><%= @title %></h2>
-    <p class="modal-validator-info-item-value"><%= if assigns[:value] do @value else "-" end %></p>
+    <p class="modal-validator-info-item-value" <%= if assigns[:name], do: @name %>>
+        <%= if assigns[:value] do @value else "-" end %>
+    </p>
 </div>


### PR DESCRIPTION
#1709
**Merge after [PR#2243](https://github.com/poanetwork/blockscout/pull/2243)**

Add modal window with a pool's information

## Changelog

* Add JS function to open a pool's information