### PR TITLE
Search length issue, tile link wrapping issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#2193](https://github.com/poanetwork/blockscout/pull/2193) - feat: add BLOCKSCOUT_HOST, and use it in API docs
 
 ### Fixes
+- [#2254](https://github.com/poanetwork/blockscout/pull/2254) - search length issue, tile link wrapping issue
 - [#2238](https://github.com/poanetwork/blockscout/pull/2238) - header content alignment issue, hide navbar on outside click
 - [#2229](https://github.com/poanetwork/blockscout/pull/2229) - gap issue between qr and copy button in token transfers, top cards width and height issue
 - [#2201](https://github.com/poanetwork/blockscout/pull/2201) - footer columns fix

--- a/apps/block_scout_web/assets/css/components/_navbar.scss
+++ b/apps/block_scout_web/assets/css/components/_navbar.scss
@@ -151,19 +151,13 @@ $navbar-logo-width: auto !default;
     }
 
     @include media-breakpoint-up(xl) {
-      width: 280px;
+      width: 340px;
     }
     @media (min-width: 1366px) {
-      width: 330px;
+      width: 500px;
     }
     @media (min-width: 1440px) {
-      width: 380px;
-    }
-    @media (min-width: 1580px) {
-      width: 430px;
-    }
-    @media (min-width: 1800px) {
-      width: 520px;
+      width: 580px;
     }
   }
   .input-group-append {

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
@@ -5,8 +5,8 @@
     <%= if assigns[:truncate] do %>
       <%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %>
     <% else %>
-      <span class="d-none d-md-none d-lg-inline"><%= @address %></span>
-      <span class="d-md-inline-block d-lg-none"><%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %></span>
+      <span class="d-none d-md-none d-xl-inline"><%= @address %></span>
+      <span class="d-md-inline-block d-xl-none"><%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %></span>
     <% end %>
   <% end %>
 </span>


### PR DESCRIPTION
1) Increased search length. Issue - https://github.com/poanetwork/blockscout/issues/2253
2) Removed link wrapping to next row (md-lg resolution)
before:
![Screen Shot 2019-06-26 at 17 38 28](https://user-images.githubusercontent.com/50101080/60193476-6a48de00-9840-11e9-87c2-b8e7dac9327a.png)
after:
![Screen Shot 2019-06-26 at 18 26 36](https://user-images.githubusercontent.com/50101080/60193482-6d43ce80-9840-11e9-880e-fd08ebfe5e35.png)
