### PR TITLE
remove not existing assigns in html code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - [#2204](https://github.com/poanetwork/blockscout/pull/2204) - fix large contract verification
 - [#2247](https://github.com/poanetwork/blockscout/pull/2247) - hide logs search if there are no logs
 - [#2248](https://github.com/poanetwork/blockscout/pull/2248) - sort block after query execution for average block time
+- [#2268](https://github.com/poanetwork/blockscout/pull/2268) - remove not existing assigns in html code
 
 ### Chore
 - [#2127](https://github.com/poanetwork/blockscout/pull/2127) - use previouse chromedriver version

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
@@ -67,17 +67,8 @@
         </div>
 
         <div data-items></div>
-        
-        <!--<div class="transaction-bottom-panel">
-          <div class="download-all-transactions">
-            Download <a class="download-all-transactions-link" href=<%= address_transaction_path(@conn, :token_transfers_csv, %{"address_id" => to_string(@address.hash)}) %>><%= gettext("CSV") %></span>
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16">
-                  <path fill="#333333" fill-rule="evenodd" d="M13 16H1c-.999 0-1-1-1-1V1s-.004-1 1-1h6l7 7v8s-.032 1-1 1zm-1-8c0-.99-1-1-1-1H8s-1 .001-1-1V3c0-.999-1-1-1-1H2v12h10V8z"/>
-              </svg>
-            </a>
-          </div>-->
-          <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "bottom", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
-        <!--</div>-->
+
+        <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "bottom", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
 
       </div>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/index.html.eex
@@ -27,17 +27,8 @@
         </div>
 
         <div data-items></div>
-        
-        <!--<div class="transaction-bottom-panel">
-          <div class="download-all-transactions">
-            Download <a class="download-all-transactions-link" href=<%= address_transaction_path(@conn, :token_transfers_csv, %{"address_id" => to_string(@address.hash)}) %>><%= gettext("CSV") %></span>
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16">
-                  <path fill="#333333" fill-rule="evenodd" d="M13 16H1c-.999 0-1-1-1-1V1s-.004-1 1-1h6l7 7v8s-.032 1-1 1zm-1-8c0-.99-1-1-1-1H8s-1 .001-1-1V3c0-.999-1-1-1-1H2v12h10V8z"/>
-              </svg>
-            </a>
-          </div>-->
-          <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "bottom", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
-        <!--</div>-->
+
+        <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "bottom", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
 
       </div>
     </div>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1771,10 +1771,8 @@ msgid "Testnet"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:73
 #: lib/block_scout_web/templates/address_token/index.html.eex:26
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:72
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:33
 msgid "CSV"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -112,7 +112,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:27
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:23
-#: lib/block_scout_web/templates/layout/_network_selector.html.eex:20
+#: lib/block_scout_web/templates/layout/_network_selector.html.eex:21
 #: lib/block_scout_web/views/address_internal_transaction_view.ex:8
 #: lib/block_scout_web/views/address_transaction_view.ex:8
 msgid "All"
@@ -734,7 +734,7 @@ msgid "There are no token transfers for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_token/index.html.eex:19
+#: lib/block_scout_web/templates/address_token/index.html.eex:18
 msgid "There are no tokens for this address."
 msgstr ""
 
@@ -812,7 +812,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:8
-#: lib/block_scout_web/templates/address_token/index.html.eex:9
+#: lib/block_scout_web/templates/address_token/index.html.eex:8
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:9
 #: lib/block_scout_web/views/address_view.ex:304
 msgid "Tokens"
@@ -1209,7 +1209,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_coin_balance/index.html.eex:34
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:61
 #: lib/block_scout_web/templates/address_logs/index.html.eex:21
-#: lib/block_scout_web/templates/address_token/index.html.eex:14
+#: lib/block_scout_web/templates/address_token/index.html.eex:13
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:20
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:59
 #: lib/block_scout_web/templates/address_validation/index.html.eex:22
@@ -1715,7 +1715,7 @@ msgstr ""
 msgid "However, in general, the"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/block_scout_web/templates/address_decompiled_contract/index.html.eex:27
 msgid "There is no decompilded contracts for this address."
 msgstr ""
@@ -1741,37 +1741,38 @@ msgid "here."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_network_selector.html.eex:10
+#: lib/block_scout_web/templates/layout/_network_selector.html.eex:11
 msgid "Change Network"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_network_selector.html.eex:23
+#: lib/block_scout_web/templates/layout/_network_selector.html.eex:24
 msgid "Favorites"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_network_selector.html.eex:11
+#: lib/block_scout_web/templates/layout/_network_selector.html.eex:12
 msgid "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_network_selector.html.eex:21
+#: lib/block_scout_web/templates/layout/_network_selector.html.eex:22
 msgid "Mainnet"
 msgstr ""
 
-#, elixir-format, fuzzy
-#: lib/block_scout_web/templates/layout/_network_selector.html.eex:17
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_network_selector.html.eex:18
 msgid "Search network"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_network_selector.html.eex:22
+#: lib/block_scout_web/templates/layout/_network_selector.html.eex:23
 msgid "Testnet"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_transaction/index.html.eex:74
+#: lib/block_scout_web/templates/address_token/index.html.eex:26
+#: lib/block_scout_web/templates/address_transaction/index.html.eex:72
 msgid "CSV"
 msgstr ""
 


### PR DESCRIPTION
fixes 
```
2019-06-28T11:08:39.926 [error] #PID<0.24465.30> running BlockScoutWeb.Endpoint (connection #PID<0.24400.30>, stream id 4) terminated
Server: 52.2.163.93:80 (http)
Request: GET /tokens/0xb22c9f8e45b3e351a955d89d777d2ccf14915268/token_transfers
** (exit) an exception was raised:
    ** (ArgumentError) assign @address not available in eex template.

Please make sure all proper assigns have been set. If this
is a child template, ensure assigns are given explicitly by
the parent template as they are not automatically forwarded.

Available assigns: [:conn, :current_path, :token, :total_token_holders, :total_token_transfers, :view_module, :view_template]

        (phoenix_html) lib/phoenix_html/engine.ex:132: Phoenix.HTML.Engine.fetch_assign!/2
        (block_scout_web) lib/block_scout_web/templates/tokens/transfer/index.html.eex:33: BlockScoutWeb.Tokens.TransferView."index.html"/1
        (block_scout_web) lib/block_scout_web/templates/layout/app.html.eex:43: BlockScoutWeb.LayoutView."app.html"/1
        (phoenix) lib/phoenix/view.ex:399: Phoenix.View.render_to_iodata/3
        (phoenix) lib/phoenix/controller.ex:729: Phoenix.Controller.__put_render__/5
        (block_scout_web) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.instrument/4
        (phoenix) lib/phoenix/controller.ex:746: Phoenix.Controller.instrument_render_and_send/4
        (block_scout_web) lib/block_scout_web/controllers/tokens/transfer_controller.ex:1: BlockScoutWeb.Tokens.TransferController.action/2
```

## Changelog

- remove not existing assigns in html code