### PR TITLE
Remove duplicate params in `Indexer.Fetcher.TokenBalance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - [#2204](https://github.com/poanetwork/blockscout/pull/2204) - fix large contract verification
 - [#2247](https://github.com/poanetwork/blockscout/pull/2247) - hide logs search if there are no logs
 - [#2248](https://github.com/poanetwork/blockscout/pull/2248) - sort block after query execution for average block time
+- [#2270](https://github.com/poanetwork/blockscout/pull/2270) - Remove duplicate params in `Indexer.Fetcher.TokenBalance`
 
 ### Chore
 - [#2127](https://github.com/poanetwork/blockscout/pull/2127) - use previouse chromedriver version

--- a/apps/indexer/lib/indexer/fetcher/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance.ex
@@ -93,7 +93,10 @@ defmodule Indexer.Fetcher.TokenBalance do
   end
 
   def fetch_from_blockchain(params_list) do
-    retryable_params_list = Enum.filter(params_list, &(&1.retries_count <= @max_retries))
+    retryable_params_list =
+      params_list
+      |> Enum.filter(&(&1.retries_count <= @max_retries))
+      |> Enum.uniq_by(&Map.take(&1, [:token_contract_address_hash, :address_hash, :block_number]))
 
     Logger.metadata(count: Enum.count(retryable_params_list))
 


### PR DESCRIPTION

## Motivation

`Explorer.Chain.Import.Runner.Address.TokenBalances` fails with the `cardinality_violation` error because it tries to insert more than once token balances (for the same {token_contract_address_hash, address_hash, block_number} tuple) in a single database transaction.

## Changelog

### Bug Fixes
This PR filters out duplicate parameters in `Indexer.Fetcher.TokenBalance` so that no duplicates are sent to be imported.

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
