### PR TITLE
Rendering POSDAO's token symbol at templates

### DIFF
--- a/apps/block_scout_web/assets/js/lib/modals.js
+++ b/apps/block_scout_web/assets/js/lib/modals.js
@@ -67,8 +67,9 @@ window.openMoveStakeModal = async function (poolAddress) {
     })
 
     setProgressInfo(modal, pool)
-    $(`${modal} [user-staked]`).text(`${relation.stakeAmount} POA`)
-    $(`${modal} [max-allowed]`).text(`${relation.maxWithdrawAllowed} POA`)
+    const tokenSymbol = store.getState().tokenSymbol
+    $(`${modal} [user-staked]`).text(`${relation.stakeAmount} ${tokenSymbol}`)
+    $(`${modal} [max-allowed]`).text(`${relation.maxWithdrawAllowed} ${tokenSymbol}`)
 
     $.each($(`${modal} [pool-select] option:not(:first-child)`), (_, opt) => {
       opt.remove()
@@ -102,8 +103,9 @@ window.openMoveStakeSelectedModal = async function (fromAddress, toAddress, amou
   const relation = humps.camelizeKeys(response.relation)
 
   setProgressInfo(modal, fromPool, '.js-pool-from-progress')
-  $(`${modal} [user-staked]`).text(`${relation.stakeAmount} POA`)
-  $(`${modal} [max-allowed]`).text(`${relation.maxWithdrawAllowed} POA`)
+  const tokenSymbol = store.getState().tokenSymbol
+  $(`${modal} [user-staked]`).text(`${relation.stakeAmount} ${tokenSymbol}`)
+  $(`${modal} [max-allowed]`).text(`${relation.maxWithdrawAllowed} ${tokenSymbol}`)
   $(`${modal} [move-amount]`).val(amount)
 
   response = await $.getJSON('/staking_pool', { 'pool_hash': toAddress })
@@ -157,7 +159,8 @@ window.openClaimModal = function (poolAddress) {
       setProgressInfo(modal, pool)
       const relation = humps.camelizeKeys(response.relation)
 
-      $(`${modal} [ordered-amount]`).text(`${relation.orderedWithdraw} POA`)
+      const tokenSymbol = store.getState().tokenSymbol
+      $(`${modal} [ordered-amount]`).text(`${relation.orderedWithdraw} ${tokenSymbol}`)
 
       $(`${modal} form`).unbind('submit')
       $(`${modal} form`).on('submit', _ => claimWithdraw(modal, poolAddress))
@@ -178,7 +181,8 @@ window.openWithdrawModal = function (poolAddress) {
       setProgressInfo(modal, pool)
       const relation = humps.camelizeKeys(response.relation)
 
-      $(`${modal} [user-staked]`).text(`${relation.stakeAmount} POA`)
+      const tokenSymbol = store.getState().tokenSymbol
+      $(`${modal} [user-staked]`).text(`${relation.stakeAmount} ${tokenSymbol}`)
 
       const $withdraw = $(`${modal} .btn-full-primary.withdraw`)
       const $order = $(`${modal} .btn-full-primary.order_withdraw`)
@@ -329,7 +333,8 @@ async function becomeCandidate (el) {
     var min = $(el).data('min-stake')
     unlockAndHideModal(el)
     $submitButton.html(buttonText)
-    openErrorModal('Error', `You cannot stake less than ${min} POA20`)
+    const tokenSymbol = store.getState().tokenSymbol
+    openErrorModal('Error', `You cannot stake less than ${min} ${tokenSymbol}`)
     return false
   }
 
@@ -441,9 +446,10 @@ async function removeMyPool (el) {
 function makeStake (event, modal, poolAddress) {
   const amount = parseFloat(event.target[0].value)
   const minStake = parseFloat($(modal).data('min-stake'))
+  const tokenSymbol = store.getState().tokenSymbol
   if (amount < minStake) {
     $(modal).modal('hide')
-    openErrorModal('Error', `You cannot stake less than ${minStake} POA20`)
+    openErrorModal('Error', `You cannot stake less than ${minStake} ${tokenSymbol}`)
     return false
   }
 
@@ -479,10 +485,11 @@ function moveStake (e, modal, fromAddress, toAddress) {
   const amount = parseFloat(e.target[0].value)
   const allowed = parseFloat($(`${modal} [max-allowed]`).text())
   const minStake = parseInt($(modal).data('min-stake'))
+  const tokenSymbol = store.getState().tokenSymbol
 
   if (amount < minStake || amount > allowed) {
     $(modal).modal('hide')
-    openErrorModal('Error', `You cannot stake less than ${minStake} POA20 and more than ${allowed} POA20`)
+    openErrorModal('Error', `You cannot stake less than ${minStake} ${tokenSymbol} and more than ${allowed} ${tokenSymbol}`)
     return false
   }
 

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -8,7 +8,8 @@ import Web3 from 'web3'
 
 export const initialState = {
   web3: null,
-  blocksCount: null
+  blocksCount: null,
+  tokenSymbol: null
 }
 
 export function reducer (state = initialState, action) {
@@ -157,6 +158,11 @@ const elements = {
     render ($el, state, oldState) {
       if (state.epochEndIn === oldState.epochEndIn) return
       $el.text(`${state.epochEndIn}`)
+    }
+  },
+  '[data-page="stakes"]': {
+    load ($el) {
+      return { tokenSymbol: $el.data('token-symbol') }
     }
   }
 }

--- a/apps/block_scout_web/lib/block_scout_web/controllers/pools_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/pools_controller.ex
@@ -94,6 +94,7 @@ defmodule BlockScoutWeb.PoolsController do
     epoch_end_block = EpochCounter.epoch_end_block() || 0
     block_number = BlockNumberCache.max_number()
     stakes_setting = Application.get_env(:block_scout_web, :stakes)
+    token_symbol = get_token_symbol()
 
     user =
       conn
@@ -106,7 +107,8 @@ defmodule BlockScoutWeb.PoolsController do
       block_number: block_number,
       user: user,
       logged_in: user != nil,
-      min_candidate_stake: stakes_setting[:min_candidate_stake]
+      min_candidate_stake: stakes_setting[:min_candidate_stake],
+      token_symbol: token_symbol
     ]
 
     content =
@@ -188,6 +190,7 @@ defmodule BlockScoutWeb.PoolsController do
     block_number = BlockNumberCache.max_number()
     average_block_time = AverageBlockTime.average_block_time()
     stakes_setting = Application.get_env(:block_scout_web, :stakes)
+    token_symbol = get_token_symbol()
 
     user =
       conn
@@ -204,7 +207,8 @@ defmodule BlockScoutWeb.PoolsController do
       logged_in: user != nil,
       average_block_time: average_block_time,
       min_candidate_stake: stakes_setting[:min_candidate_stake],
-      min_delegator_stake: stakes_setting[:min_delegator_stake]
+      min_delegator_stake: stakes_setting[:min_delegator_stake],
+      token_symbol: token_symbol
     ]
 
     render(conn, "index.html", options)
@@ -290,4 +294,16 @@ defmodule BlockScoutWeb.PoolsController do
   defp check_access(_, :stake), do: true
 
   defp check_access(_, _), do: false
+
+  defp get_token_symbol do
+    stakes_token_name = System.get_env("STAKES_TOKEN_NAME") || "POSDAO"
+
+    case Chain.search_token(stakes_token_name) do
+      [token | _] ->
+        token.symbol
+
+      _ ->
+        "POA"
+    end
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/templates/pools/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/pools/index.html.eex
@@ -8,13 +8,15 @@
     block_number: @block_number,
     user: @user,
     logged_in: @logged_in,
-    min_candidate_stake: @min_candidate_stake
+    min_candidate_stake: @min_candidate_stake,
+    token_symbol: @token_symbol
   %>
 </div>
 <section data-page="stakes" class="container" 
   data-user-address="<%= if @user, do: @user.address %>"
   data-epoch-end-sec="<%= epoch_end_sec(@epoch_end_in, @average_block_time) %>"
   data-average-block-time=<%= Timex.Duration.to_seconds(@average_block_time) %>
+  data-token-symbol="<%= @token_symbol %>"
 >
   <div class="card" data-async-load data-async-listing="<%= @current_path %>">
     <%= render BlockScoutWeb.StakesView, "_stakes_tabs.html", conn: @conn %>
@@ -57,9 +59,15 @@
 
   </div>
 </section>
-<%= render BlockScoutWeb.StakesView, "_stakes_modal_stake.html", user: @user, min_delegator_stake: @min_delegator_stake %>
-<%= render BlockScoutWeb.StakesView, "_stakes_modal_move.html" %>
-<%= render BlockScoutWeb.StakesView, "_stakes_modal_move_selected.html", min_delegator_stake: @min_delegator_stake %>
-<%= render BlockScoutWeb.StakesView, "_stakes_modal_withdraw.html" %>
+<%= 
+  render BlockScoutWeb.StakesView, 
+  "_stakes_modal_stake.html", 
+  user: @user, 
+  min_delegator_stake: @min_delegator_stake,
+  token_symbol: @token_symbol
+%>
+<%= render BlockScoutWeb.StakesView, "_stakes_modal_move.html", token_symbol: @token_symbol %>
+<%= render BlockScoutWeb.StakesView, "_stakes_modal_move_selected.html", min_delegator_stake: @min_delegator_stake, token_symbol: @token_symbol %>
+<%= render BlockScoutWeb.StakesView, "_stakes_modal_withdraw.html", token_symbol: @token_symbol %>
 <%= render BlockScoutWeb.StakesView, "_stakes_modal_claim.html" %>
 <%= render BlockScoutWeb.StakesView, "_stakes_modal_pool_info.html" %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
@@ -10,13 +10,13 @@
           <div class="input-group form-group">
             <input candidate-stake type="text" class="form-control n-b-r" placeholder='<%= gettext("Amount") %>'>
             <div class="input-group-prepend last">
-              <div class="input-group-text">POA20</div>
+              <div class="input-group-text"><%= @token_symbol %></div>
             </div>
           </div>
           <div class="form-group">
             <input mining-address type="text" class="form-control" placeholder='<%= gettext("Your Mining Address") %>'>
           </div>
-          <p class="form-p">Minimum possible stake: <span class="text-dark"><%= @min_candidate_stake %> POA20</span></p>
+          <p class="form-p">Minimum possible stake: <span class="text-dark"><%= @min_candidate_stake %> <%= @token_symbol %></span></p>
           <div class="form-buttons"><%= render BlockScoutWeb.CommonComponentsView, "_btn_add_full.html", text: gettext("Become a Candidate"), extra_class: "full-width" %></div>
         </form>
       </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
@@ -15,7 +15,7 @@
               <div class="input-group form-group">
                 <input type="text" class="form-control n-b-r" placeholder='<%= gettext("Amount") %>' move-amount>
                 <div class="input-group-prepend last">
-                  <div class="input-group-text">POA20</div>
+                  <div class="input-group-text"><%= @token_symbol %></div>
                 </div>
               </div>
               <p class="form-p m-b-0">You Staked: <span class="text-dark" user-staked></span></p>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move_selected.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move_selected.html.eex
@@ -15,7 +15,7 @@
               <div class="input-group form-group">
                 <input name="amount" type="text" class="form-control n-b-r" placeholder='<%= gettext("Amount") %>' move-amount>
                 <div class="input-group-prepend last">
-                  <div class="input-group-text">POA20</div>
+                  <div class="input-group-text"><%= @token_symbol %></div>
                 </div>
               </div>
               <p class="form-p m-b-0">You Staked: <span class="text-dark" user-staked></span></p>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex
@@ -12,17 +12,17 @@
               <div class="input-group form-group">
                 <input type="text" class="form-control n-b-r" placeholder='<%= gettext("Amount") %>'>
                 <div class="input-group-prepend last">
-                  <div class="input-group-text">POA20</div>
+                  <div class="input-group-text"><%= @token_symbol %></div>
                 </div>
               </div>
               <p class="form-p m-b-0">Minimum Stake: 
                 <span class="text-dark">
-                  <%= @min_delegator_stake %> POA
+                  <%= @min_delegator_stake %> <%= @token_symbol %>
                 </span>
               </p>
               <p class="form-p">Your Balance: 
                 <span class="text-dark">
-                  <%= if @user, do: format_wei_value(@user.balance, :ether) %>
+                  <%= if @user, do: format_wei_value(@user.balance, :ether, include_unit_label: false) %> <%= @token_symbol %>
                 </span>
               </p>
               <div class="form-buttons">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
@@ -12,7 +12,7 @@
               <div class="input-group form-group">
                 <input amount type="text" class="form-control n-b-r" placeholder='<%= gettext("Amount") %>'>
                 <div class="input-group-prepend last">
-                  <div class="input-group-text">POA20</div>
+                  <div class="input-group-text"><%= @token_symbol %></div>
                 </div>
               </div>
               <p class="form-p">Your Staked: <span class="text-dark" user-staked></span></p>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex
@@ -17,20 +17,20 @@
     <span class="stakes-top-stats-label-item"><%= gettext "Balance" %>:
       <%=
         if @user[:balance] do
-          format_wei_value(@user.balance, :ether)
+          format_wei_value(@user.balance, :ether, include_unit_label: false)
         else
           "-"
         end
-      %>
+      %> <%= @token_symbol %>
     </span>
     <span class="stakes-top-stats-label-item"><%= gettext "Staked" %>:
       <%=
         if @user[:staked] do
-          format_wei_value(@user.staked, :ether)
+          format_wei_value(@user.staked, :ether, include_unit_label: false)
         else
           "-"
         end
-      %>
+      %>  <%= @token_symbol %>
     </span>
   </span>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_top.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_top.html.eex
@@ -4,7 +4,7 @@
       <%= render BlockScoutWeb.StakesView, "_stakes_stats_item.html", title: gettext("Epoch number"), value: @epoch_number, name: "epoch-number"  %>
       <%= render BlockScoutWeb.StakesView, "_stakes_stats_item.html", title: gettext("Block number"), value: @block_number, name: "block-number" %>
       <%= render BlockScoutWeb.StakesView, "_stakes_stats_item.html", title: gettext("Next epoch in"), value: @epoch_end_in, name: "epoch-end-in", unit: gettext("Blocks") %>
-      <%= render BlockScoutWeb.StakesView, "_stakes_stats_item_account.html", logged_in: @logged_in, user: @user %>
+      <%= render BlockScoutWeb.StakesView, "_stakes_stats_item_account.html", logged_in: @logged_in, user: @user, token_symbol: @token_symbol %>
       <!-- Buttons -->
       <div class="stakes-top-buttons">
         <%= if @logged_in and @user.has_pool do %>
@@ -17,5 +17,5 @@
   </div>
 </div>
 <%= if @logged_in do %>
-  <%= render BlockScoutWeb.StakesView, "_stakes_modal_become_candidate.html", min_candidate_stake: @min_candidate_stake %>
+  <%= render BlockScoutWeb.StakesView, "_stakes_modal_become_candidate.html", min_candidate_stake: @min_candidate_stake, token_symbol: @token_symbol %>
 <% end %>


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/2188

## Motivation

> The POA20 token name in the Staking DApp UI must NOT be hard-coded - it must be read from the token contract (see its symbol() public getter). The address of the token contract can be read with the erc20TokenContract() public getter of the StakingAuRa contract.

## Changelog

* Rendering POSDAO's token symbol at templates