### PR TITLE
Banner stats issues on sm resolutions, transactions title issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#2266](https://github.com/poanetwork/blockscout/pull/2266) - allow excluding uncles from average block time calculation
 
 ### Fixes
+- [#2286](https://github.com/poanetwork/blockscout/pull/2286) - banner stats issues on sm resolutions, transactions title issue
 - [#2284](https://github.com/poanetwork/blockscout/pull/2284) - add 404 status for not existing pages
 - [#2244](https://github.com/poanetwork/blockscout/pull/2244) - fix internal transactions failing to be indexed because of constraint
 - [#2281](https://github.com/poanetwork/blockscout/pull/2281) - typo issues, dropdown issues

--- a/apps/block_scout_web/assets/css/components/_card.scss
+++ b/apps/block_scout_web/assets/css/components/_card.scss
@@ -42,6 +42,12 @@ $card-tab-icon-color-active: #20b760 !default;
   line-height: 1.2rem;
   margin-bottom: 2rem;
 
+  &.lg-card-title {
+    @media (max-width: 374px) {
+      font-size: 13px;
+    }
+  }
+
   &.margin-bottom-md {
     margin-bottom: 25px;
   }

--- a/apps/block_scout_web/assets/css/components/_dashboard-banner.scss
+++ b/apps/block_scout_web/assets/css/components/_dashboard-banner.scss
@@ -80,6 +80,12 @@ $dashboard-banner-chart-axis-font-color: $dashboard-stats-item-value-color !defa
       flex-direction: row;
     }
 
+    @media (max-width: 599px) {
+      padding-top: 0;
+      padding-bottom: 0;
+      flex-direction: column;
+    }
+
     &::before {
       border-radius: 2px;
       content: "";
@@ -106,6 +112,11 @@ $dashboard-banner-chart-axis-font-color: $dashboard-stats-item-value-color !defa
     font-weight: 600;
     line-height: 1.2;
     margin: 0 0 5px;
+
+    @media (max-width: 374px) {
+      position: relative;
+      top: -2px;
+    }
 
     @include media-breakpoint-down(md) {
       margin: 0 5px 0 0;
@@ -140,11 +151,14 @@ $dashboard-banner-chart-axis-font-color: $dashboard-stats-item-value-color !defa
     height: auto;
     justify-content: flex-start;
     margin-left: 0;
-    margin-top: 15px;
     max-width: 100%;
     padding: 20px 0 20px 20px;
     width: 250px;
     box-shadow: 0 0 35px 0 rgba(0, 0, 0, 0.2);
+  }
+
+  @include media-breakpoint-down(lg) {
+    margin-top: 15px;
   }
 
   @include media-breakpoint-down(sm) {
@@ -186,4 +200,17 @@ $dashboard-banner-chart-axis-font-color: $dashboard-stats-item-value-color !defa
   }
 
   @include stats-item($dashboard-stats-item-border-color, $dashboard-stats-item-label-color, $dashboard-stats-item-value-color);
+
+  .dashboard-banner-network-stats-item {
+    @media (max-width: 374px) {
+      padding-left: calc(0.6rem + 4px);
+      padding-right: 0.5rem;
+    }
+  }
+
+  .dashboard-banner-network-stats-value {
+    @media (max-width: 374px) {
+      font-size: 0.9rem;
+    }
+  }
 }

--- a/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
@@ -105,7 +105,7 @@
   <div class="card card-chain-transactions">
     <div class="card-body">
       <%= link(gettext("View All Transactions"), to: transaction_path(BlockScoutWeb.Endpoint, :index), class: "btn-line float-right") %>
-      <h2 class="card-title"><%= gettext "Transactions" %></h2>
+      <h2 class="card-title lg-card-title"><%= gettext "Transactions" %></h2>
       <div data-selector="channel-batching-message" style="display: none;">
         <div data-selector="reload-button" class="alert alert-info">
           <a href="#" class="alert-link"><span data-selector="channel-batching-count"></span> <%= gettext "More transactions have come in" %></a>


### PR DESCRIPTION
1) Banner stats size and gaps on 320-374px resolution (iphone 5, se)
Before:
![Screen Shot 2019-07-03 at 11 10 40](https://user-images.githubusercontent.com/50101080/60583956-a7f3bc80-9d94-11e9-8bb0-c57ada25f96f.png)
After:
![Screen Shot 2019-07-03 at 11 12 46](https://user-images.githubusercontent.com/50101080/60583967-ac1fda00-9d94-11e9-980d-06b469561533.png)

2) Added gap for stats container on md resolution
Before:
![Screen Shot 2019-07-03 at 11 27 08](https://user-images.githubusercontent.com/50101080/60584021-c8237b80-9d94-11e9-9a6c-a0258221e1c2.png)
After:
![Screen Shot 2019-07-03 at 11 27 00](https://user-images.githubusercontent.com/50101080/60584026-cbb70280-9d94-11e9-97a9-110bef9b4abc.png)

3) Transactions title font-size issue
After:
![Screen Shot 2019-07-03 at 11 28 36](https://user-images.githubusercontent.com/50101080/60584051-d8d3f180-9d94-11e9-9f22-01144c6a1faf.png)
Before:
![Screen Shot 2019-07-03 at 11 34 12](https://user-images.githubusercontent.com/50101080/60584057-dd98a580-9d94-11e9-8a7f-0f6d8b62a1ab.png)
 