### PR TITLE
remove request idle timeout configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Chore
 
+- [#2293](https://github.com/poanetwork/blockscout/pull/2293) - remove request idle timeout configuration
+
 
 ## 2.0.1-beta
 

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -35,11 +35,6 @@ config :block_scout_web, BlockScoutWeb.Counters.BlocksIndexedCounter, enabled: t
 # Configures the endpoint
 config :block_scout_web, BlockScoutWeb.Endpoint,
   instrumenters: [BlockScoutWeb.Prometheus.Instrumenter, SpandexPhoenix.Instrumenter],
-  http: [
-    protocol_options: [
-      idle_timeout: 90_000
-    ]
-  ],
   url: [
     host: System.get_env("BLOCKSCOUT_HOST") || "localhost",
     path: System.get_env("NETWORK_PATH") || "/"

--- a/apps/block_scout_web/config/dev.exs
+++ b/apps/block_scout_web/config/dev.exs
@@ -16,15 +16,9 @@ port =
 
 config :block_scout_web, BlockScoutWeb.Endpoint,
   http: [
-    protocol_options: [
-      idle_timeout: 90_000
-    ],
     port: port || 4000
   ],
   https: [
-    protocol_options: [
-      idle_timeout: 90_000
-    ],
     port: (port && port + 1) || 4001,
     cipher_suite: :strong,
     certfile: System.get_env("CERTFILE") || "priv/cert/selfsigned.pem",


### PR DESCRIPTION
## Motivation

Initially, increased request idle timeout was introduced in https://github.com/poanetwork/blockscout/pull/2194 to mitigate smart contract verification failures. But after https://github.com/poanetwork/blockscout/pull/2264 it's not necessary.

Note: it should be merged after https://github.com/poanetwork/blockscout/pull/2264

## Changelog
- remove request idle timeout configuration