### PR TITLE
fix interpolation in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#2299](https://github.com/poanetwork/blockscout/pull/2299) - fix interpolation in error message
 - [#2291](https://github.com/poanetwork/blockscout/pull/2291) - dashboard fix for md resolution, transactions load fix, block info row fix, addresses page issue, check mark issue
 
 ### Chore

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
@@ -141,7 +141,9 @@ defmodule EthereumJSONRPC.HTTP do
     case unstandardized do
       %{"result" => _, "error" => _} ->
         raise ArgumentError,
-              "result and error keys are mutually exclusive in JSONRPC 2.0 response objects, but got #{unstandardized}"
+              "result and error keys are mutually exclusive in JSONRPC 2.0 response objects, but got #{
+                inspect(unstandardized)
+              }"
 
       %{"result" => result} ->
         Map.put(standardized, :result, result)


### PR DESCRIPTION
fixes 
```
** (Protocol.UndefinedError) protocol String.Chars not implemented for %{"error" => %{"code" => -32601, "data" => nil, "message" => "Cannot find ommer for hash: 0x1251a9f1416c95e8f08a26422459202abbbfe71cdd9d90d3605d0711b6a4f78f"}, "id" => "0x0", "jsonrpc" => "2.0", "result" => nil}. This protocol is implemented for: Explorer.Chain.Address, Explorer.Chain.Data, Explorer.Chain.Hash, Postgrex.Copy, Postgrex.Query, Cldr.Unit, Decimal, Float, DateTime, Time, List, Version.Requirement, Atom, Integer, Version, Date, BitString, NaiveDateTime, URI
    (elixir) /private/tmp/elixir-20190202-21222-1ilp2g0/elixir-1.8.1/lib/elixir/lib/string/chars.ex:3: String.Chars.impl_for!/1
    (elixir) /private/tmp/elixir-20190202-21222-1ilp2g0/elixir-1.8.1/lib/elixir/lib/string/chars.ex:22: String.Chars.to_string/1
    (ethereum_jsonrpc) lib/ethereum_jsonrpc/http.ex:144: EthereumJSONRPC.HTTP.standardize_response/1
    (elixir) lib/enum.ex:1327: Enum."-map/2-lists^map/1-0-"/2
    (ethereum_jsonrpc) lib/ethereum_jsonrpc/http.ex:44: EthereumJSONRPC.HTTP.chunked_json_rpc/3
    (ethereum_jsonrpc) lib/ethereum_jsonrpc/request_coordinator.ex:86: anonymous fn/3 in EthereumJSONRPC.RequestCoordinator.perform/4
    (ethereum_jsonrpc) lib/ethereum_jsonrpc/request_coordinator.ex:106: EthereumJSONRPC.RequestCoordinator.trace_request/2
    (ethereum_jsonrpc) lib/ethereum_jsonrpc.ex:453: EthereumJSONRPC.fetch_blocks_by_params/3
    (indexer) lib/indexer/fetcher/uncle_block.ex:83: Indexer.Fetcher.UncleBlock.run/2
    (elixir) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (elixir) lib/task/supervised.ex:35: Task.Supervised.reply/5
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

## Changelog
- fix interpolation in error message