### PR TITLE
fix transaction csv download link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#2303](https://github.com/poanetwork/blockscout/pull/2303) - fix transaction csv download link
 - [#2291](https://github.com/poanetwork/blockscout/pull/2291) - dashboard fix for md resolution, transactions load fix, block info row fix, addresses page issue, check mark issue
 
 ### Chore

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/index.html.eex
@@ -66,10 +66,10 @@
         </div>
 
         <div data-items></div>
-        
+
         <div class="transaction-bottom-panel">
           <div class="download-all-transactions">
-            Download <a class="download-all-transactions-link" href=<%= address_transaction_path(@conn, :token_transfers_csv, %{"address_id" => to_string(@address.hash)}) %>><%= gettext("CSV") %></span>
+            Download <a class="download-all-transactions-link" href=<%= address_transaction_path(@conn, :transactions_csv, %{"address_id" => to_string(@address.hash)}) %>><%= gettext("CSV") %></span>
               <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16">
                   <path fill="#333333" fill-rule="evenodd" d="M13 16H1c-.999 0-1-1-1-1V1s-.004-1 1-1h6l7 7v8s-.032 1-1 1zm-1-8c0-.99-1-1-1-1H8s-1 .001-1-1V3c0-.999-1-1-1-1H2v12h10V8z"/>
               </svg>


### PR DESCRIPTION
this commit https://github.com/poanetwork/blockscout/commit/9e1b6b3752ff0bcaf6cf86be6356caba8ead2356 added a wrong path for transaction csv download

## Changelog

- fix transaction csv download link