### PR TITLE
parse url for api docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2294](https://github.com/poanetwork/blockscout/pull/2294) - add healthy block period checking endpoint
 
 ### Fixes
+- [#2310](https://github.com/poanetwork/blockscout/pull/2310) - parse url for api docs
 - [#2299](https://github.com/poanetwork/blockscout/pull/2299) - fix interpolation in error message
 - [#2303](https://github.com/poanetwork/blockscout/pull/2303) - fix transaction csv download link
 - [#2304](https://github.com/poanetwork/blockscout/pull/2304) - footer grid fix for md resolution

--- a/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
@@ -36,7 +36,9 @@ defmodule BlockScoutWeb.APIDocsView do
 
   def blockscout_url do
     if System.get_env("BLOCKSCOUT_HOST") do
-      "http://" <> System.get_env("BLOCKSCOUT_HOST")
+      %URI{host: host, scheme: scheme} = URI.parse(Endpoint.url())
+
+      scheme <> "://" <> host
     else
       Endpoint.url()
     end

--- a/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
@@ -37,8 +37,9 @@ defmodule BlockScoutWeb.APIDocsView do
   def blockscout_url do
     if System.get_env("BLOCKSCOUT_HOST") do
       %URI{host: host, scheme: scheme} = URI.parse(Endpoint.url())
+      path = System.get_env("NETWORK_PATH") || "/"
 
-      scheme <> "://" <> host
+      scheme <> "://" <> host <> path
     else
       Endpoint.url()
     end

--- a/apps/block_scout_web/test/block_scout_web/views/api_docs_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api_docs_view_test.exs
@@ -6,8 +6,9 @@ defmodule BlockScoutWeb.ApiDocsViewTest do
   describe "blockscout_url/0" do
     test "returns url with scheme and host without port" do
       System.put_env("BLOCKSCOUT_HOST", "localhost")
+      System.put_env("NETWORK_PATH", "")
 
-      assert APIDocsView.blockscout_url() == "http://localhost/"
+      assert APIDocsView.blockscout_url() == "http://localhost"
       assert Endpoint.url() == "http://localhost:4002"
     end
 

--- a/apps/block_scout_web/test/block_scout_web/views/api_docs_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api_docs_view_test.exs
@@ -7,8 +7,18 @@ defmodule BlockScoutWeb.ApiDocsViewTest do
     test "returns url with scheme and host without port" do
       System.put_env("BLOCKSCOUT_HOST", "localhost")
 
-      assert APIDocsView.blockscout_url() == "http://localhost"
+      assert APIDocsView.blockscout_url() == "http://localhost/"
       assert Endpoint.url() == "http://localhost:4002"
+    end
+
+    test "returns url with scheme and host with path" do
+      System.put_env("BLOCKSCOUT_HOST", "localhost/chain/dog")
+      System.put_env("NETWORK_PATH", "/chain/dog")
+
+      assert APIDocsView.blockscout_url() == "http://localhost/chain/dog"
+      assert Endpoint.url() == "http://localhost:4002"
+
+      System.put_env("NETWORK_PATH", "")
     end
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/views/api_docs_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api_docs_view_test.exs
@@ -1,0 +1,14 @@
+defmodule BlockScoutWeb.ApiDocsViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.{APIDocsView, Endpoint}
+
+  describe "blockscout_url/0" do
+    test "returns url with scheme and host without port" do
+      System.put_env("BLOCKSCOUT_HOST", "localhost")
+
+      assert APIDocsView.blockscout_url() == "http://localhost"
+      assert Endpoint.url() == "http://localhost:4002"
+    end
+  end
+end


### PR DESCRIPTION
the scheme was hardcoded to `HTTP` in api docs. Because of that api requests didn't work if the scheme is `HTTPS`

## Changelog

- parse url for api docs