### PR TITLE
fix market history overriding  with zeroes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2294](https://github.com/poanetwork/blockscout/pull/2294) - add healthy block period checking endpoint
 
 ### Fixes
+- [#2311](https://github.com/poanetwork/blockscout/pull/2311) - fix market history overriding with zeroes
 - [#2299](https://github.com/poanetwork/blockscout/pull/2299) - fix interpolation in error message
 - [#2303](https://github.com/poanetwork/blockscout/pull/2303) - fix transaction csv download link
 - [#2304](https://github.com/poanetwork/blockscout/pull/2304) - footer grid fix for md resolution

--- a/apps/explorer/lib/explorer/market/history/source/crypto_compare.ex
+++ b/apps/explorer/lib/explorer/market/history/source/crypto_compare.ex
@@ -48,13 +48,18 @@ defmodule Explorer.Market.History.Source.CryptoCompare do
   defp format_data(data) do
     json = Jason.decode!(data)
 
-    for item <- json["Data"] do
-      %{
-        closing_price: Decimal.new(to_string(item["close"])),
-        date: date(item["time"]),
-        opening_price: Decimal.new(to_string(item["open"]))
-      }
-    end
+    items =
+      for item <- json["Data"] do
+        %{
+          closing_price: Decimal.new(to_string(item["close"])),
+          date: date(item["time"]),
+          opening_price: Decimal.new(to_string(item["open"]))
+        }
+      end
+
+    Enum.reject(items, fn item ->
+      Decimal.equal?(item.closing_price, 0) && Decimal.equal?(item.opening_price, 0)
+    end)
   end
 
   @spec history_url(non_neg_integer()) :: String.t()

--- a/apps/explorer/lib/explorer/market/history/source/crypto_compare.ex
+++ b/apps/explorer/lib/explorer/market/history/source/crypto_compare.ex
@@ -24,7 +24,12 @@ defmodule Explorer.Market.History.Source.CryptoCompare do
 
     case HTTPoison.get(url, headers) do
       {:ok, %Response{body: body, status_code: 200}} ->
-        {:ok, format_data(body)}
+        result =
+          body
+          |> format_data()
+          |> reject_zeros()
+
+        {:ok, result}
 
       _ ->
         :error
@@ -48,18 +53,13 @@ defmodule Explorer.Market.History.Source.CryptoCompare do
   defp format_data(data) do
     json = Jason.decode!(data)
 
-    items =
-      for item <- json["Data"] do
-        %{
-          closing_price: Decimal.new(to_string(item["close"])),
-          date: date(item["time"]),
-          opening_price: Decimal.new(to_string(item["open"]))
-        }
-      end
-
-    Enum.reject(items, fn item ->
-      Decimal.equal?(item.closing_price, 0) && Decimal.equal?(item.opening_price, 0)
-    end)
+    for item <- json["Data"] do
+      %{
+        closing_price: Decimal.new(to_string(item["close"])),
+        date: date(item["time"]),
+        opening_price: Decimal.new(to_string(item["open"]))
+      }
+    end
   end
 
   @spec history_url(non_neg_integer()) :: String.t()
@@ -71,5 +71,11 @@ defmodule Explorer.Market.History.Source.CryptoCompare do
     }
 
     "#{base_url()}/data/histoday?#{URI.encode_query(query_params)}"
+  end
+
+  defp reject_zeros(items) do
+    Enum.reject(items, fn item ->
+      Decimal.equal?(item.closing_price, 0) && Decimal.equal?(item.opening_price, 0)
+    end)
   end
 end

--- a/apps/explorer/lib/explorer/market/market.ex
+++ b/apps/explorer/lib/explorer/market/market.ex
@@ -40,7 +40,12 @@ defmodule Explorer.Market do
 
   @doc false
   def bulk_insert_history(records) do
-    Repo.insert_all(MarketHistory, records, on_conflict: :replace_all, conflict_target: [:date])
+    records_without_zeroes =
+      Enum.reject(records, fn item ->
+        Decimal.equal?(item.closing_price, 0) && Decimal.equal?(item.opening_price, 0)
+      end)
+
+    Repo.insert_all(MarketHistory, records_without_zeroes, on_conflict: :replace_all, conflict_target: [:date])
   end
 
   def add_price(%{symbol: symbol} = token) do

--- a/apps/explorer/test/explorer/market/history/source/crypto_compare_test.exs
+++ b/apps/explorer/test/explorer/market/history/source/crypto_compare_test.exs
@@ -86,5 +86,59 @@ defmodule Explorer.Market.History.Source.CryptoCompareTest do
 
       assert :error == CryptoCompare.fetch_history(3)
     end
+
+    test "rejects empty prices", %{bypass: bypass} do
+      json = """
+      {
+        "Response": "Success",
+        "Type": 100,
+        "Aggregated": false,
+        "Data": [
+          {
+            "time": 1524528000,
+            "close": 0,
+            "high": 9741.91,
+            "low": 8957.68,
+            "open": 0,
+            "volumefrom": 136352.05,
+            "volumeto": 1276464750.74
+          },
+          {
+            "time": 1524614400,
+            "close": 0,
+            "high": 9765.23,
+            "low": 8757.06,
+            "open": 0,
+            "volumefrom": 192797.41,
+            "volumeto": 1779806222.98
+          },
+          {
+            "time": 1524700800,
+            "close": 8804.32,
+            "high": 8965.84,
+            "low": 8669.38,
+            "open": 8873.57,
+            "volumefrom": 74704.5,
+            "volumeto": 661168891
+          }
+        ],
+        "TimeTo": 1524700800,
+        "TimeFrom": 1523836800,
+        "FirstValueInArray": true,
+        "ConversionType": {
+          "type": "direct",
+          "conversionSymbol": ""
+        }
+      }
+      """
+
+      Bypass.expect(bypass, fn conn -> Conn.resp(conn, 200, json) end)
+
+      expected = [
+        %{closing_price: Decimal.from_float(8804.32), date: ~D[2018-04-26], opening_price: Decimal.from_float(8873.57)}
+      ]
+
+      assert {:ok, expected} == CryptoCompare.fetch_history(3)
+    end
   end
 end

--- a/apps/explorer/test/explorer/market/market_test.exs
+++ b/apps/explorer/test/explorer/market/market_test.exs
@@ -72,6 +72,25 @@ defmodule Explorer.MarketTest do
       assert missing_records == %{}
     end
 
+    test "doesn't replace existing records with zeros" do
+      date = ~D[2018-04-01]
+
+      {:ok, old_record} =
+        Repo.insert(%MarketHistory{date: date, closing_price: Decimal.new(1), opening_price: Decimal.new(1)})
+
+      new_record = %{
+        date: date,
+        closing_price: Decimal.new(0),
+        opening_price: Decimal.new(0)
+      }
+
+      Market.bulk_insert_history([new_record])
+
+      fetched_record = Repo.get_by(MarketHistory, date: date)
+      assert fetched_record.closing_price == old_record.closing_price
+      assert fetched_record.opening_price == old_record.opening_price
+    end
+
     test "overrides existing records on date conflict" do
       date = ~D[2018-04-01]
       Repo.insert(%MarketHistory{date: date})


### PR DESCRIPTION
## Motivation 

Service API that we're using for market history fetching started returning zeroes for some coins.

## Changelog

- fix market history overriding with zeroes