### PR TITLE
Retrieve `MIN_{CANDIDATE,DELEGATOR}_STAKE` from contract, not from env.

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/pools_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/pools_controller.ex
@@ -5,7 +5,7 @@ defmodule BlockScoutWeb.PoolsController do
   alias Explorer.Chain
   alias Explorer.Chain.BlockNumberCache
   alias Explorer.Counters.AverageBlockTime
-  alias Explorer.Staking.ChainReader
+  alias Explorer.Staking.ContractState
   alias Phoenix.View
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
@@ -66,8 +66,8 @@ defmodule BlockScoutWeb.PoolsController do
   end
 
   defp render_template(filter, conn, _) do
-    epoch_number = ChainReader.epoch_number() || 0
-    epoch_end_block = ChainReader.epoch_end_block() || 0
+    epoch_number = ContractState.epoch_number() || 0
+    epoch_end_block = ContractState.epoch_end_block() || 0
     block_number = BlockNumberCache.max_number()
     average_block_time = AverageBlockTime.average_block_time()
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/pools_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/pools_controller.ex
@@ -5,7 +5,7 @@ defmodule BlockScoutWeb.PoolsController do
   alias Explorer.Chain
   alias Explorer.Chain.BlockNumberCache
   alias Explorer.Counters.AverageBlockTime
-  alias Explorer.Staking.EpochCounter
+  alias Explorer.Staking.ChainReader
   alias Phoenix.View
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
@@ -66,8 +66,8 @@ defmodule BlockScoutWeb.PoolsController do
   end
 
   defp render_template(filter, conn, _) do
-    epoch_number = EpochCounter.epoch_number() || 0
-    epoch_end_block = EpochCounter.epoch_end_block() || 0
+    epoch_number = ChainReader.epoch_number() || 0
+    epoch_end_block = ChainReader.epoch_end_block() || 0
     block_number = BlockNumberCache.max_number()
     average_block_time = AverageBlockTime.average_block_time()
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transport.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transport.ex
@@ -103,19 +103,19 @@ defmodule EthereumJSONRPC.Transport do
   """
   @callback json_rpc(batch_request, options) :: {:ok, batch_response} | {:error, reason :: term()}
 
-  @doc """
-  Subscribes to event in `request`.
+  # @doc """
+  # Subscribes to event in `request`.
 
-  Events **MUST** be delivered in a tuple tagged with the `t:EthereumJSONRPC.Subscription.t/0` and containing the same
-  output as the single-request form of `json_rpc/2`.
+  # Events **MUST** be delivered in a tuple tagged with the `t:EthereumJSONRPC.Subscription.t/0` and containing the same
+  # output as the single-request form of `json_rpc/2`.
 
-  | Message                                                                           | Description                            |
-  |-----------------------------------------------------------------------------------|----------------------------------------|
-  | `{EthereumJSONRPC.Subscription.t(), {:ok, EthereumJSONRPC.Transport.result.t()}}` | New result in subscription             |
-  | `{EthereumJSONRPC.Subscription.t(), {:error, reason :: term()}}`                  | There was an error in the subscription |
+  # | Message                                                                           | Description                            |
+  # |-----------------------------------------------------------------------------------|----------------------------------------|
+  # | `{EthereumJSONRPC.Subscription.t(), {:ok, EthereumJSONRPC.Transport.result.t()}}` | New result in subscription             |
+  # | `{EthereumJSONRPC.Subscription.t(), {:error, reason :: term()}}`                  | There was an error in the subscription |
 
-  `t:EthereumJSONRPC.Subscription.t/0` must be cancellable by passing it to `c:unsubscribe/1`
-  """
+  # `t:EthereumJSONRPC.Subscription.t/0` must be cancellable by passing it to `c:unsubscribe/1`
+  # """
   @callback subscribe(Subscription.event(), Subscription.params(), options) ::
               {:ok, Subscription.t()} | {:error, reason :: term()}
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transport.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transport.ex
@@ -103,19 +103,19 @@ defmodule EthereumJSONRPC.Transport do
   """
   @callback json_rpc(batch_request, options) :: {:ok, batch_response} | {:error, reason :: term()}
 
-  # @doc """
-  # Subscribes to event in `request`.
+  @doc """
+  Subscribes to event in `request`.
 
-  # Events **MUST** be delivered in a tuple tagged with the `t:EthereumJSONRPC.Subscription.t/0` and containing the same
-  # output as the single-request form of `json_rpc/2`.
+  Events **MUST** be delivered in a tuple tagged with the `t:EthereumJSONRPC.Subscription.t/0` and containing the same
+  output as the single-request form of `json_rpc/2`.
 
-  # | Message                                                                           | Description                            |
-  # |-----------------------------------------------------------------------------------|----------------------------------------|
-  # | `{EthereumJSONRPC.Subscription.t(), {:ok, EthereumJSONRPC.Transport.result.t()}}` | New result in subscription             |
-  # | `{EthereumJSONRPC.Subscription.t(), {:error, reason :: term()}}`                  | There was an error in the subscription |
+  | Message                                                                           | Description                            |
+  |-----------------------------------------------------------------------------------|----------------------------------------|
+  | `{EthereumJSONRPC.Subscription.t(), {:ok, EthereumJSONRPC.Transport.result.t()}}` | New result in subscription             |
+  | `{EthereumJSONRPC.Subscription.t(), {:error, reason :: term()}}`                  | There was an error in the subscription |
 
-  # `t:EthereumJSONRPC.Subscription.t/0` must be cancellable by passing it to `c:unsubscribe/1`
-  # """
+  `t:EthereumJSONRPC.Subscription.t/0` must be cancellable by passing it to `c:unsubscribe/1`
+  """
   @callback subscribe(Subscription.event(), Subscription.params(), options) ::
               {:ok, Subscription.t()} | {:error, reason :: term()}
 

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -64,11 +64,11 @@ config :explorer, Explorer.Staking.PoolsReader,
   staking_contract_address: System.get_env("POS_STAKING_CONTRACT")
 
 if System.get_env("POS_STAKING_CONTRACT") do
-  config :explorer, Explorer.Staking.EpochCounter,
+  config :explorer, Explorer.Staking.ChainReader,
     enabled: true,
     staking_contract_address: System.get_env("POS_STAKING_CONTRACT")
 else
-  config :explorer, Explorer.Staking.EpochCounter, enabled: false
+  config :explorer, Explorer.Staking.ChainReader, enabled: false
 end
 
 if System.get_env("SUPPLY_MODULE") == "TokenBridge" do

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -64,11 +64,11 @@ config :explorer, Explorer.Staking.PoolsReader,
   staking_contract_address: System.get_env("POS_STAKING_CONTRACT")
 
 if System.get_env("POS_STAKING_CONTRACT") do
-  config :explorer, Explorer.Staking.ChainReader,
+  config :explorer, Explorer.Staking.ContractState,
     enabled: true,
     staking_contract_address: System.get_env("POS_STAKING_CONTRACT")
 else
-  config :explorer, Explorer.Staking.ChainReader, enabled: false
+  config :explorer, Explorer.Staking.ContractState, enabled: false
 end
 
 if System.get_env("SUPPLY_MODULE") == "TokenBridge" do

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -56,7 +56,7 @@ defmodule Explorer.Application do
       configure(Explorer.Counters.AddressesWithBalanceCounter),
       configure(Explorer.Counters.AverageBlockTime),
       configure(Explorer.Validator.MetadataProcessor),
-      configure(Explorer.Staking.ChainReader)
+      configure(Explorer.Staking.ContractState)
     ]
     |> List.flatten()
   end

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -56,7 +56,7 @@ defmodule Explorer.Application do
       configure(Explorer.Counters.AddressesWithBalanceCounter),
       configure(Explorer.Counters.AverageBlockTime),
       configure(Explorer.Validator.MetadataProcessor),
-      configure(Explorer.Staking.EpochCounter)
+      configure(Explorer.Staking.ChainReader)
     ]
     |> List.flatten()
   end

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -16,15 +16,6 @@ defmodule Explorer.Staking.ContractState do
   @min_delegator_stake_key :min_delegator_stake
   @token_contract_address :token_contract_address
 
-  defp get(param, default) do
-    if :ets.info(@table_name) != :undefined do
-      case :ets.lookup(@table_name, param) do
-        [{_, value}] -> value
-        _ -> default
-      end
-    end
-  end
-
   @doc "Current staking epoch number"
   def epoch_number do
     get(@epoch_key, 0)
@@ -90,6 +81,15 @@ defmodule Explorer.Staking.ContractState do
     end
 
     {:noreply, state}
+  end
+
+  defp get(param, default) do
+    if :ets.info(@table_name) != :undefined do
+      case :ets.lookup(@table_name, param) do
+        [{_, value}] -> value
+        _ -> default
+      end
+    end
   end
 
   defp fetch_chain_info do

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -114,7 +114,7 @@ defmodule Explorer.Staking.ContractState do
     functions
     |> Enum.map(fn function ->
       %{
-        contract_address: staking_address(),
+        contract_address: staking_address(contract_abi),
         function_name: function,
         args: []
       }
@@ -126,8 +126,8 @@ defmodule Explorer.Staking.ContractState do
     end)
   end
 
-  defp staking_address do
-    Application.get_env(:explorer, __MODULE__, [])[:staking_contract_address]
+  defp staking_address(contract_abi) do
+    Reader.query_contract(%{function_name: "erc20TokenContract", args: []}, contract_abi, [])
   end
 
   # sobelow_skip ["Traversal"]

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -1,6 +1,12 @@
 defmodule Explorer.Staking.ContractState do
   @moduledoc """
-  Fetches current staking epoch number and the epoch end block number.
+  Fetches:
+  1) current staking epoch number;
+  2) the epoch end block number;
+  3) minimal candidate stake;
+  4) minimal delegate stake;
+  6) token contract address.
+
   It subscribes to handle new blocks and conclude whether the epoch is over.
   """
 
@@ -36,7 +42,7 @@ defmodule Explorer.Staking.ContractState do
     get(@min_delegator_stake_key, 1)
   end
 
-  @doc "Current staking epoch number"
+  @doc "Token contract address"
   def token_contract_address do
     get(@token_contract_address, nil)
   end

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -1,4 +1,4 @@
-defmodule Explorer.Staking.ChainReader do
+defmodule Explorer.Staking.ContractState do
   @moduledoc """
   Fetches current staking epoch number and the epoch end block number.
   It subscribes to handle new blocks and conclude whether the epoch is over.

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -15,10 +15,6 @@ defmodule Explorer.Staking.ContractState do
   @min_candidate_stake_key "min_candidate_stake"
   @min_delegator_stake_key "min_delegator_stake"
 
-  @doc """
-    Searches for a parameter in the ETS table associated with the module.
-    Returns a `default` value if parameter is not there.
-  """
   defp get(param, default) do
     case :ets.lookup(@table_name, param) do
       [{_, value}] -> value

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -94,10 +94,12 @@ defmodule Explorer.Staking.ContractState do
          {:ok, [epoch_end_block]} <- data["stakingEpochEndBlock"],
          {:ok, [min_delegator_stake]} <- data["getDelegatorMinStake"],
          {:ok, [min_candidate_stake]} <- data["getCandidateMinStake"] do
-      :ets.insert(@table_name, {@epoch_key, epoch_num})
-      :ets.insert(@table_name, {@epoch_end_key, epoch_end_block})
-      :ets.insert(@table_name, {@min_delegator_stake_key, min_delegator_stake})
-      :ets.insert(@table_name, {@min_candidate_stake_key, min_candidate_stake})
+      :ets.insert(@table_name, [
+        {@epoch_key, epoch_num},
+        {@epoch_end_key, epoch_end_block},
+        {@min_delegator_stake_key, min_delegator_stake},
+        {@min_candidate_stake_key, min_candidate_stake}
+      ])
     end
   end
 

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -10,10 +10,10 @@ defmodule Explorer.Staking.ContractState do
   alias Explorer.SmartContract.Reader
 
   @table_name __MODULE__
-  @epoch_key "epoch_num"
-  @epoch_end_key "epoch_end_block"
-  @min_candidate_stake_key "min_candidate_stake"
-  @min_delegator_stake_key "min_delegator_stake"
+  @epoch_key :epoch_num
+  @epoch_end_key :epoch_end_block
+  @min_candidate_stake_key :min_candidate_stake
+  @min_delegator_stake_key :min_delegator_stake
 
   defp get(param, default) do
     if :ets.info(@table_name) != :undefined do

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -16,9 +16,11 @@ defmodule Explorer.Staking.ContractState do
   @min_delegator_stake_key "min_delegator_stake"
 
   defp get(param, default) do
-    case :ets.lookup(@table_name, param) do
-      [{_, value}] -> value
-      _ -> default
+    if :ets.info(@table_name) != :undefined do
+      case :ets.lookup(@table_name, param) do
+        [{_, value}] -> value
+        _ -> default
+      end
     end
   end
 

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -15,33 +15,35 @@ defmodule Explorer.Staking.ContractState do
   @min_candidate_stake_key "min_candidate_stake"
   @min_delegator_stake_key "min_delegator_stake"
 
-  def get_parameter_or_default(param, default) do
-    if :ets.info(@table_name) != :undefined do
-      case :ets.lookup(@table_name, param) do
-        [{_, value}] -> value
-        _ -> default
-      end
+  @doc """
+    Searches for a parameter in the ETS table associated with the module.
+    Returns a `default` value if parameter is not there.
+  """
+  defp get(param, default) do
+    case :ets.lookup(@table_name, param) do
+      [{_, value}] -> value
+      _ -> default
     end
   end
 
   @doc "Current staking epoch number"
   def epoch_number do
-    get_parameter_or_default(@epoch_key, 0)
+    get(@epoch_key, 0)
   end
 
   @doc "Current staking epoch number"
   def epoch_end_block do
-    get_parameter_or_default(@epoch_end_key, 0)
+    get(@epoch_end_key, 0)
   end
 
   @doc "Minimal candidate stake"
   def min_candidate_stake do
-    get_parameter_or_default(@min_candidate_stake_key, 1)
+    get(@min_candidate_stake_key, 1)
   end
 
   @doc "Minimal delegator stake"
   def min_delegator_stake do
-    get_parameter_or_default(@min_delegator_stake_key, 1)
+    get(@min_delegator_stake_key, 1)
   end
 
   def start_link([]) do

--- a/apps/explorer/test/explorer/staking/contract_state_test.exs
+++ b/apps/explorer/test/explorer/staking/contract_state_test.exs
@@ -12,9 +12,12 @@ defmodule Explorer.Staking.ContractStateTest do
   @contract_a <<16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1>>
   @contract_b <<24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1>>
 
-  test "when disabled, it returns nil" do
-    assert ContractState.epoch_number() == nil
-    assert ContractState.epoch_end_block() == nil
+  test "when disabled, returns default values" do
+    assert ContractState.epoch_number() == 0
+    assert ContractState.epoch_end_block() == 0
+    assert ContractState.min_delegator_stake() == 1
+    assert ContractState.min_candidate_stake() == 1
+    assert ContractState.token_contract_address() == nil
   end
 
   test "fetch epoch data" do

--- a/apps/explorer/test/explorer/staking/epoch_counter_test.exs
+++ b/apps/explorer/test/explorer/staking/epoch_counter_test.exs
@@ -1,39 +1,39 @@
-defmodule Explorer.Staking.EpochCounterTest do
+defmodule Explorer.Staking.ChainReaderTest do
   use ExUnit.Case, async: false
 
   import Mox
 
-  alias Explorer.Staking.EpochCounter
+  alias Explorer.Staking.ChainReader
   alias Explorer.Chain.Events.Publisher
 
   setup :verify_on_exit!
   setup :set_mox_global
 
   test "when disabled, it returns nil" do
-    assert EpochCounter.epoch_number() == nil
-    assert EpochCounter.epoch_end_block() == nil
+    assert ChainReader.epoch_number() == nil
+    assert ChainReader.epoch_end_block() == nil
   end
 
   test "fetch epoch data" do
     set_mox(10, 880)
-    Application.put_env(:explorer, EpochCounter, enabled: true)
-    start_supervised!(EpochCounter)
+    Application.put_env(:explorer, ChainReader, enabled: true)
+    start_supervised!(ChainReader)
 
     Process.sleep(1_000)
 
-    assert EpochCounter.epoch_number() == 10
-    assert EpochCounter.epoch_end_block() == 880
+    assert ChainReader.epoch_number() == 10
+    assert ChainReader.epoch_end_block() == 880
   end
 
   test "fetch new epoch data" do
     set_mox(10, 880)
-    Application.put_env(:explorer, EpochCounter, enabled: true)
-    start_supervised!(EpochCounter)
+    Application.put_env(:explorer, ChainReader, enabled: true)
+    start_supervised!(ChainReader)
 
     Process.sleep(1_000)
 
-    assert EpochCounter.epoch_number() == 10
-    assert EpochCounter.epoch_end_block() == 880
+    assert ChainReader.epoch_number() == 10
+    assert ChainReader.epoch_end_block() == 880
 
     event_type = :blocks
     broadcast_type = :realtime
@@ -44,8 +44,8 @@ defmodule Explorer.Staking.EpochCounterTest do
 
     Process.sleep(1_000)
 
-    assert EpochCounter.epoch_number() == 11
-    assert EpochCounter.epoch_end_block() == 960
+    assert ChainReader.epoch_number() == 11
+    assert ChainReader.epoch_end_block() == 960
   end
 
   defp set_mox(epoch_num, end_block_num) do

--- a/apps/explorer/test/explorer/staking/epoch_counter_test.exs
+++ b/apps/explorer/test/explorer/staking/epoch_counter_test.exs
@@ -6,6 +6,8 @@ defmodule Explorer.Staking.ContractStateTest do
   alias Explorer.Staking.ContractState
   alias Explorer.Chain.Events.Publisher
 
+  require Logger
+
   setup :verify_on_exit!
   setup :set_mox_global
 
@@ -15,7 +17,7 @@ defmodule Explorer.Staking.ContractStateTest do
   end
 
   test "fetch epoch data" do
-    set_mox(10, 880)
+    set_mox(%{epoch_num: 10, end_block_num: 880, min_delegator_stake: 1, min_candidate_stake: 2})
     Application.put_env(:explorer, ContractState, enabled: true)
     start_supervised!(ContractState)
 
@@ -23,10 +25,12 @@ defmodule Explorer.Staking.ContractStateTest do
 
     assert ContractState.epoch_number() == 10
     assert ContractState.epoch_end_block() == 880
+    assert ContractState.min_delegator_stake() == 1
+    assert ContractState.min_candidate_stake() == 2
   end
 
   test "fetch new epoch data" do
-    set_mox(10, 880)
+    set_mox(%{epoch_num: 10, end_block_num: 880, min_delegator_stake: 1, min_candidate_stake: 2})
     Application.put_env(:explorer, ContractState, enabled: true)
     start_supervised!(ContractState)
 
@@ -34,52 +38,88 @@ defmodule Explorer.Staking.ContractStateTest do
 
     assert ContractState.epoch_number() == 10
     assert ContractState.epoch_end_block() == 880
+    assert ContractState.min_delegator_stake() == 1
+    assert ContractState.min_candidate_stake() == 2
 
     event_type = :blocks
     broadcast_type = :realtime
     event_data = [%Explorer.Chain.Block{number: 881}]
 
-    set_mox(11, 960)
+    set_mox(%{epoch_num: 11, end_block_num: 960, min_delegator_stake: 3, min_candidate_stake: 4})
     Publisher.broadcast([{event_type, event_data}], broadcast_type)
 
     Process.sleep(1_000)
 
     assert ContractState.epoch_number() == 11
     assert ContractState.epoch_end_block() == 960
+    assert ContractState.min_delegator_stake() == 3
+    assert ContractState.min_candidate_stake() == 4
   end
 
-  defp set_mox(epoch_num, end_block_num) do
+  defp set_mox(%{
+         epoch_num: epoch_num,
+         end_block_num: end_block_num,
+         min_delegator_stake: min_delegator_stake,
+         min_candidate_stake: min_candidate_stake
+       }) do
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,
-      fn [
-           %{
-             id: 0,
-             jsonrpc: "2.0",
-             method: "eth_call",
-             params: _
-           },
-           %{
-             id: 1,
-             jsonrpc: "2.0",
-             method: "eth_call",
-             params: _
-           }
-         ],
-         _options ->
-        {:ok,
-         [
-           %{
-             id: 0,
-             jsonrpc: "2.0",
-             result: encode_num(epoch_num)
-           },
-           %{
-             id: 1,
-             jsonrpc: "2.0",
-             result: encode_num(end_block_num)
-           }
-         ]}
+      fn
+        [
+          %{
+            id: 0,
+            jsonrpc: "2.0",
+            method: "eth_call",
+            params: _
+          },
+          %{
+            id: 1,
+            jsonrpc: "2.0",
+            method: "eth_call",
+            params: _
+          },
+          %{
+            id: 2,
+            jsonrpc: "2.0",
+            method: "eth_call",
+            params: _
+          },
+          %{
+            id: 3,
+            jsonrpc: "2.0",
+            method: "eth_call",
+            params: _
+          }
+        ],
+        _options ->
+          {:ok,
+           [
+             %{
+               id: 0,
+               jsonrpc: "2.0",
+               result: encode_num(epoch_num)
+             },
+             %{
+               id: 1,
+               jsonrpc: "2.0",
+               result: encode_num(end_block_num)
+             },
+             %{
+               id: 2,
+               jsonrpc: "2.0",
+               result: encode_num(min_delegator_stake)
+             },
+             %{
+               id: 3,
+               jsonrpc: "2.0",
+               result: encode_num(min_candidate_stake)
+             }
+           ]}
+
+        other, _opts ->
+          Logger.error("EthereumJSONRPC.Mox.json_rpc(#{inspect(other)})")
+          1 = 2
       end
     )
   end

--- a/apps/explorer/test/explorer/staking/epoch_counter_test.exs
+++ b/apps/explorer/test/explorer/staking/epoch_counter_test.exs
@@ -1,39 +1,39 @@
-defmodule Explorer.Staking.ChainReaderTest do
+defmodule Explorer.Staking.ContractStateTest do
   use ExUnit.Case, async: false
 
   import Mox
 
-  alias Explorer.Staking.ChainReader
+  alias Explorer.Staking.ContractState
   alias Explorer.Chain.Events.Publisher
 
   setup :verify_on_exit!
   setup :set_mox_global
 
   test "when disabled, it returns nil" do
-    assert ChainReader.epoch_number() == nil
-    assert ChainReader.epoch_end_block() == nil
+    assert ContractState.epoch_number() == nil
+    assert ContractState.epoch_end_block() == nil
   end
 
   test "fetch epoch data" do
     set_mox(10, 880)
-    Application.put_env(:explorer, ChainReader, enabled: true)
-    start_supervised!(ChainReader)
+    Application.put_env(:explorer, ContractState, enabled: true)
+    start_supervised!(ContractState)
 
     Process.sleep(1_000)
 
-    assert ChainReader.epoch_number() == 10
-    assert ChainReader.epoch_end_block() == 880
+    assert ContractState.epoch_number() == 10
+    assert ContractState.epoch_end_block() == 880
   end
 
   test "fetch new epoch data" do
     set_mox(10, 880)
-    Application.put_env(:explorer, ChainReader, enabled: true)
-    start_supervised!(ChainReader)
+    Application.put_env(:explorer, ContractState, enabled: true)
+    start_supervised!(ContractState)
 
     Process.sleep(1_000)
 
-    assert ChainReader.epoch_number() == 10
-    assert ChainReader.epoch_end_block() == 880
+    assert ContractState.epoch_number() == 10
+    assert ContractState.epoch_end_block() == 880
 
     event_type = :blocks
     broadcast_type = :realtime
@@ -44,8 +44,8 @@ defmodule Explorer.Staking.ChainReaderTest do
 
     Process.sleep(1_000)
 
-    assert ChainReader.epoch_number() == 11
-    assert ChainReader.epoch_end_block() == 960
+    assert ContractState.epoch_number() == 11
+    assert ContractState.epoch_end_block() == 960
   end
 
   defp set_mox(epoch_num, end_block_num) do


### PR DESCRIPTION
## Motivation

We should retrieve `MIN_CANDIDATE_STAKE` and `MIN_DELEGATOR_STAKE` from contract, not from env.

## Changelog

- [x] `EpochCounter` is `ChainReader`;
- [x] Made `ChainReader` retrieve both stakes from chain;
- [ ] Replace usage of stakes from env with stakes from chain.

## Checklist for your PR

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  you must be able to justify that.
-->

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
