### PR TITLE
Fix compiler warning on Elixir 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#2303](https://github.com/poanetwork/blockscout/pull/2303) - fix transaction csv download link
 - [#2304](https://github.com/poanetwork/blockscout/pull/2304) - footer grid fix for md resolution
 - [#2291](https://github.com/poanetwork/blockscout/pull/2291) - dashboard fix for md resolution, transactions load fix, block info row fix, addresses page issue, check mark issue
+- [#2327](https://github.com/poanetwork/blockscout/pull/2327) - Fix compiler warning on Elixir 1.9
 
 ### Chore
 - [#2305](https://github.com/poanetwork/blockscout/pull/2305) - Improve Address controllers

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transport.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transport.ex
@@ -77,10 +77,12 @@ defmodule EthereumJSONRPC.Transport do
   @type options :: term()
 
   @doc """
-  Run a single Remote Procedure Call (RPC) `t:EthereumJSONRPC.EthereumJSONRPC.request/0` with
-  `t:EthereumJSONRPC.EthereumJSONRPC.options/0`.
+  Run a single Remote Procedure Call (RPC) `t:EthereumJSONRPC.EthereumJSONRPC.request/0`
+  or a batch of calls with `t:EthereumJSONRPC.EthereumJSONRPC.options/0`.
 
   ## Returns
+
+  For single RPC call:
 
    * `{:ok, result}` - `result` is the `/result` from JSONRPC response object of format
      `%{"id" => ..., "result" => result}`.
@@ -88,19 +90,13 @@ defmodule EthereumJSONRPC.Transport do
      `%{"id" => ..., "error" => reason}`.  The transport can also give any `term()` for `reason` if a more specific
      reason is possible.
 
-  """
-  @callback json_rpc(request, options) :: {:ok, result} | {:error, reason :: term()}
-
-  @doc """
-  Runs a batch of Remote Procedure Call (RPC) `request`s with `options`.
-
-  ## Returns
+  For batch of RPC calls:
 
    * `{:ok, [response]}` unlike `json_rpc(request, options)`, the individual `t:response.t/0` are not unwrapped and it
      is the callers responsibility to extract the `t:result/0` or error `reason`.
    * `{:error, reason}` an error that affects *all* `t:request/0`s, such as the batch as a whole being rejected.
-
   """
+  @callback json_rpc(request, options) :: {:ok, result} | {:error, reason :: term()}
   @callback json_rpc(batch_request, options) :: {:ok, batch_response} | {:error, reason :: term()}
 
   @doc """


### PR DESCRIPTION
## Motivation

Elixir 1.9 was released and is now included in the base [Docker image](https://github.com/bitwalker/alpine-elixir-phoenix/commits/master) we use.
One of [non-breaking bug fixes](https://github.com/elixir-lang/elixir/blob/v1.9/CHANGELOG.md#elixir-1) affects handling of docs for multiple-clause callbacks, and a compiler warning is issued now for `EthereumJSONRPC.Transport.json_rpc` callback.

### Changes

Merge docs for both `json_rpc` callback clauses.

## Checklist for your PR

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  you must be able to justify that.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
