### PR TITLE
Upgrade Postgres image version in Docker setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#2291](https://github.com/poanetwork/blockscout/pull/2291) - dashboard fix for md resolution, transactions load fix, block info row fix, addresses page issue, check mark issue
 
 ### Chore
+- [#2342](https://github.com/poanetwork/blockscout/pull/2342) - Upgrade Postgres image version in Docker setup
 - [#2325](https://github.com/poanetwork/blockscout/pull/2325) - Reduce function input to address' hash only where possible
 - [#2323](https://github.com/poanetwork/blockscout/pull/2323) - Group Explorer caches
 - [#2305](https://github.com/poanetwork/blockscout/pull/2305) - Improve Address controllers

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,7 +3,7 @@ HOST = host.docker.internal
 DOCKER_IMAGE = blockscout_prod
 BS_CONTAINER_NAME = blockscout
 PG_CONTAINER_NAME = postgres
-PG_CONTAINER_IMAGE = postgres:10.4
+PG_CONTAINER_IMAGE = postgres:10.6
 THIS_FILE = $(lastword $(MAKEFILE_LIST))
 
 ifeq ($(SYSTEM), Linux)


### PR DESCRIPTION
# Motivation

Upgrade Postgres image version in Docker setup up to `10.6` since we use this version of DB on all hosted by POA team BS instances

## Changelog

Upgrade Postgres container image up to `10.6` version

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
