### PR TITLE
Fetch rewards in parallel with transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#2352](https://github.com/poanetwork/blockscout/pull/2352) - Fetch rewards in parallel with transactions
 - [#2294](https://github.com/poanetwork/blockscout/pull/2294) - add healthy block period checking endpoint
 
 ### Fixes

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -23,7 +23,8 @@ defmodule BlockScoutWeb.AddressTransactionController do
       [token_transfers: :token] => :optional,
       [token_transfers: :to_address] => :optional,
       [token_transfers: :from_address] => :optional,
-      [token_transfers: :token_contract_address] => :optional
+      [token_transfers: :token_contract_address] => :optional,
+      :block => :required
     }
   ]
 
@@ -34,7 +35,6 @@ defmodule BlockScoutWeb.AddressTransactionController do
          {:ok, address} <- Chain.hash_to_address(address_hash, address_options, false) do
       options =
         @transaction_necessity_by_association
-        |> put_in([:necessity_by_association, :block], :required)
         |> Keyword.merge(paging_options(params))
         |> Keyword.merge(current_filter(params))
 


### PR DESCRIPTION
Part of #2306 

## Changelog

### Enhancements

Part of the reason is that it has to execute 3 queries, but since 2 of these queries are unrelated to each other (transactions and rewards) they will be executed in parallel.

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
