### PR TITLE
set timeout for ws blocks

### DIFF
--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -35,7 +35,8 @@ config :indexer,
     String.to_integer(System.get_env("TOKEN_METADATA_UPDATE_INTERVAL") || "#{2 * 24 * 60 * 60}"),
   # bytes
   memory_limit: 1 <<< 30,
-  first_block: System.get_env("FIRST_BLOCK") || "0"
+  first_block: System.get_env("FIRST_BLOCK") || "0",
+  ws_block_period: String.to_integer(System.get_env("WS_BLOCK_PERIOD") || "60000")
 
 # config :indexer, Indexer.Fetcher.ReplacedTransaction.Supervisor, disabled?: true
 # config :indexer, Indexer.Fetcher.BlockReward.Supervisor, disabled?: true


### PR DESCRIPTION
resolves https://github.com/poanetwork/blockscout/issues/2308

## Motivation

if blockscout receives too many messages through a web socket with new blocks, postgres will fail with out of connections error. 

This type of error occurs when blockscout uses not fully synchronized geth client.

## Changelog
- set timeout for ws blocks