### PR TITLE
add default evm version to smart contract verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#2360](https://github.com/poanetwork/blockscout/pull/2360) - add default evm version to smart contract verification
 - [#2294](https://github.com/poanetwork/blockscout/pull/2294) - add healthy block period checking endpoint
 
 ### Fixes

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
@@ -50,7 +50,7 @@
           <div class="smart-contract-form-group-inner-wrapper">
             <%= label :evm_version, :evm_version, gettext("EVM Version") %>
             <div class="center-column">
-              <%= select f, :evm_version, @evm_versions, class: "form-control border-rounded", selected: "petersburg", "aria-describedby": "evm-version-help-block" %>
+              <%= select f, :evm_version, @evm_versions, class: "form-control border-rounded", selected: "default", "aria-describedby": "evm-version-help-block" %>
             </div>
             <div class="smart-contract-form-group-tooltip">The EVM version the contract is written for. If the bytecode does not match the version, we try to verify using the latest EVM version. <a href="https://forum.poa.network/t/smart-contract-verification-evm-version-details/2318" target="_blank">EVM version details</a>.</div>
           </div>

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -12,7 +12,7 @@ config :explorer,
   token_functions_reader_max_retries: 3,
   allowed_evm_versions:
     System.get_env("ALLOWED_EVM_VERSIONS") ||
-      "homestead,tangerineWhistle,spuriousDragon,byzantium,constantinople,petersburg",
+      "homestead,tangerineWhistle,spuriousDragon,byzantium,constantinople,petersburg,default",
   include_uncles_in_average_block_time:
     if(System.get_env("UNCLES_IN_AVERAGE_BLOCK_TIME") == "false", do: false, else: true),
   healthy_blocks_period: System.get_env("HEALTHY_BLOCKS_PERIOD") || :timer.minutes(5)

--- a/apps/explorer/priv/compile_solc.js
+++ b/apps/explorer/priv/compile_solc.js
@@ -16,15 +16,7 @@ var solc = solc.setupMethods(compilerSnapshot);
 var fs = require('fs');
 var sourceCode = fs.readFileSync(sourceCodePath, 'utf8');
 
-const input = {
-  language: 'Solidity',
-  sources: {
-    [newContractName]: {
-      content: sourceCode
-    }
-  },
-  settings: {
-    evmVersion: evmVersion,
+var settings = {
     optimizer: {
       enabled: optimize == '1',
       runs: optimizationRuns
@@ -37,7 +29,20 @@ const input = {
         '*': ['*']
       }
     }
-  }
+}
+
+if (evmVersion !== 'default') {
+    settings = Object.assign(settings, {evmVersion: evmVersion})
+}
+
+const input = {
+  language: 'Solidity',
+  sources: {
+    [newContractName]: {
+      content: sourceCode
+    }
+  },
+  settings: settings
 }
 
 

--- a/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
@@ -53,6 +53,26 @@ defmodule Explorer.SmartContract.Solidity.CodeCompilerTest do
               }} = response
     end
 
+    test "compiles smart contract with default evm version", %{contract_code_info: contract_code_info} do
+      optimize = true
+
+      response =
+        CodeCompiler.run(
+          name: contract_code_info.name,
+          compiler_version: contract_code_info.version,
+          code: contract_code_info.source_code,
+          optimize: optimize,
+          evm_version: "default"
+        )
+
+      assert {:ok,
+              %{
+                "abi" => _,
+                "bytecode" => _,
+                "name" => _
+              }} = response
+    end
+
     test "compiles code with external libraries" do
       Enum.each(@compiler_tests, fn compiler_test ->
         compiler_version = compiler_test["compiler_version"]


### PR DESCRIPTION
Currently, a user manually has to select the evm version when verifying smart contract even if he didn't change compilation settings.

This PR adds `default` evm version which uses the evm version that defaults to the specified Solidity version.

## Changelog

- add default evm version to smart contract verification