### PR TITLE
Update created_contract_code_indexed_at on transaction import conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2294](https://github.com/poanetwork/blockscout/pull/2294) - add healthy block period checking endpoint
 
 ### Fixes
+- [#2375](https://github.com/poanetwork/blockscout/pull/2375) - Update created_contract_code_indexed_at on transaction import conflict
 - [#2346](https://github.com/poanetwork/blockscout/pull/2346) - Avoid fetching internal transactions of blocks that still need refetching
 - [#2350](https://github.com/poanetwork/blockscout/pull/2350) - fix invalid User agent headers
 - [#2345](https://github.com/poanetwork/blockscout/pull/2345) - do not override existing market records

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -105,6 +105,7 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
           old_block_hash: transaction.block_hash,
           block_number: fragment("EXCLUDED.block_number"),
           created_contract_address_hash: fragment("EXCLUDED.created_contract_address_hash"),
+          created_contract_code_indexed_at: fragment("EXCLUDED.created_contract_code_indexed_at"),
           cumulative_gas_used: fragment("EXCLUDED.cumulative_gas_used"),
           error: fragment("EXCLUDED.error"),
           from_address_hash: fragment("EXCLUDED.from_address_hash"),
@@ -128,10 +129,11 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
       ],
       where:
         fragment(
-          "(EXCLUDED.block_hash, EXCLUDED.block_number, EXCLUDED.created_contract_address_hash, EXCLUDED.cumulative_gas_used, EXCLUDED.cumulative_gas_used, EXCLUDED.from_address_hash, EXCLUDED.gas, EXCLUDED.gas_price, EXCLUDED.gas_used, EXCLUDED.index, EXCLUDED.internal_transactions_indexed_at, EXCLUDED.input, EXCLUDED.nonce, EXCLUDED.r, EXCLUDED.s, EXCLUDED.status, EXCLUDED.to_address_hash, EXCLUDED.v, EXCLUDED.value) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          "(EXCLUDED.block_hash, EXCLUDED.block_number, EXCLUDED.created_contract_address_hash, EXCLUDED.created_contract_code_indexed_at, EXCLUDED.cumulative_gas_used, EXCLUDED.cumulative_gas_used, EXCLUDED.from_address_hash, EXCLUDED.gas, EXCLUDED.gas_price, EXCLUDED.gas_used, EXCLUDED.index, EXCLUDED.internal_transactions_indexed_at, EXCLUDED.input, EXCLUDED.nonce, EXCLUDED.r, EXCLUDED.s, EXCLUDED.status, EXCLUDED.to_address_hash, EXCLUDED.v, EXCLUDED.value) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
           transaction.block_hash,
           transaction.block_number,
           transaction.created_contract_address_hash,
+          transaction.created_contract_code_indexed_at,
           transaction.cumulative_gas_used,
           transaction.cumulative_gas_used,
           transaction.from_address_hash,

--- a/apps/explorer/test/explorer/chain/import/runner/transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/transactions_test.exs
@@ -1,0 +1,50 @@
+defmodule Explorer.Chain.Import.Runner.TransactionsTest do
+  use Explorer.DataCase
+
+  alias Ecto.Multi
+  alias Explorer.Chain.{Address, Transaction}
+  alias Explorer.Chain.Import.Runner.Transactions
+
+  describe "run/1" do
+    test "transaction's created_contract_code_indexed_at is modified on update" do
+      %Address{hash: address_hash} = insert(:address)
+
+      transaction =
+        insert(:transaction,
+          created_contract_address_hash: address_hash,
+          created_contract_code_indexed_at: DateTime.utc_now()
+        )
+
+      assert not is_nil(transaction.created_contract_code_indexed_at)
+
+      non_indexed_transaction_params = %{
+        from_address_hash: transaction.from_address.hash,
+        gas: transaction.gas,
+        gas_price: transaction.gas_price,
+        hash: transaction.hash,
+        input: transaction.input,
+        nonce: transaction.nonce,
+        r: transaction.r,
+        s: transaction.s,
+        to_address_hash: transaction.to_address.hash,
+        v: transaction.v,
+        value: transaction.value,
+        created_contract_address_hash: address_hash,
+        created_contract_code_indexed_at: nil
+      }
+
+      assert {:ok, _} = run_transactions([non_indexed_transaction_params])
+
+      assert is_nil(Repo.get(Transaction, transaction.hash).created_contract_code_indexed_at)
+    end
+  end
+
+  defp run_transactions(changes_list) when is_list(changes_list) do
+    Multi.new()
+    |> Transactions.run(changes_list, %{
+      timeout: :infinity,
+      timestamps: %{inserted_at: DateTime.utc_now(), updated_at: DateTime.utc_now()}
+    })
+    |> Repo.transaction()
+  end
+end


### PR DESCRIPTION
Solves a problem describe in [a #2105 comment](https://github.com/poanetwork/blockscout/issues/2105#issuecomment-510614617).

## Motivation

The problem is that a transaction's `created_contract_code_indexed_at` gets ignored during a conflicting update, so it is not updated.
In particular it is not reset to NULL and this has been source of errors.

## Changelog

### Bug Fixes
Add `created_contract_code_indexed_at` as a field to check and update during an import with conflict.

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
