### PR TITLE
Page performance: exclude moment.js localization files except EN, remove unused css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#2294](https://github.com/poanetwork/blockscout/pull/2294) - add healthy block period checking endpoint
 
 ### Fixes
+- [#2378](https://github.com/poanetwork/blockscout/pull/2378) - Page performance: exclude moment.js localization files except EN, remove unused css
 - [#2375](https://github.com/poanetwork/blockscout/pull/2375) - Update created_contract_code_indexed_at on transaction import conflict
 - [#2346](https://github.com/poanetwork/blockscout/pull/2346) - Avoid fetching internal transactions of blocks that still need refetching
 - [#2350](https://github.com/poanetwork/blockscout/pull/2350) - fix invalid User agent headers

--- a/apps/block_scout_web/assets/css/components/_footer.scss
+++ b/apps/block_scout_web/assets/css/components/_footer.scss
@@ -61,10 +61,6 @@ $footer-logo-width: auto !default;
   }
 }
 
-.footer-info {
-  padding-top: 1em;
-}
-
 .footer-link {
   color: $footer-link-color;
 

--- a/apps/block_scout_web/assets/css/components/_network-selector.scss
+++ b/apps/block_scout_web/assets/css/components/_network-selector.scss
@@ -287,16 +287,6 @@ $network-selector-item-icon-dimensions: 30px !default;
   }
 }
 
-.network-selector-load-more-container {
-  flex-shrink: 1;
-  padding: 0 $network-selector-horizontal-padding;
-
-  .btn-network-selector-load-more {
-    @include btn-line($btn-network-selector-load-more-background, $btn-network-selector-load-more-color);
-    width: 100%;
-  }
-}
-
 .network-selector-item-favorite {
   align-items: center;
   cursor: pointer;

--- a/apps/block_scout_web/assets/webpack.config.js
+++ b/apps/block_scout_web/assets/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const { ContextReplacementPlugin } = require('webpack')
 const glob = require("glob");
 
 function transpileViewScript(file) {
@@ -74,7 +75,8 @@ const appJs =
     },
     plugins: [
       new ExtractTextPlugin('../css/app.css'),
-      new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
+      new CopyWebpackPlugin([{ from: 'static/', to: '../' }]),
+      new ContextReplacementPlugin(/moment[\/\\]locale$/, /en/)
     ]
   }
 


### PR DESCRIPTION
## Motivation



Before:
<img width="1275" alt="Screenshot 2019-07-18 at 00 45 22" src="https://user-images.githubusercontent.com/4341812/61414112-df667b00-a8f5-11e9-86a7-e7da18a80616.png">


After:
<img width="1279" alt="Screenshot 2019-07-18 at 00 47 37" src="https://user-images.githubusercontent.com/4341812/61414122-e3929880-a8f5-11e9-9769-3c9e03adf17a.png">


## Changelog

- Configuration of webpack to exclude moment.js localization files except EN
- Removal of unused css


## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
