### PR TITLE
mix.exs: remove `--warnings-as-errors` compile flag

### DIFF
--- a/apps/block_scout_web/mix.exs
+++ b/apps/block_scout_web/mix.exs
@@ -141,7 +141,7 @@ defmodule BlockScoutWeb.Mixfile do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      compile: "compile --warnings-as-errors",
+      compile: "compile",
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: [

--- a/apps/ethereum_jsonrpc/mix.exs
+++ b/apps/ethereum_jsonrpc/mix.exs
@@ -54,7 +54,7 @@ defmodule EthereumJsonrpc.MixProject do
 
   defp env_aliases(:dev), do: []
 
-  defp env_aliases(_env), do: [compile: "compile --warnings-as-errors"]
+  defp env_aliases(_env), do: [compile: "compile"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -139,7 +139,7 @@ defmodule Explorer.Mixfile do
   defp env_aliases(:dev), do: []
 
   defp env_aliases(_env) do
-    [compile: "compile --warnings-as-errors"]
+    [compile: "compile"]
   end
 
   defp package do

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule BlockScout.Mixfile do
 
   defp env_aliases(_env) do
     [
-      compile: "compile --warnings-as-errors"
+      compile: "compile"
     ]
   end
 


### PR DESCRIPTION
Warnings are now treated as errors during the build.

* Docker build
* Operating System / base image: `bitwalker/alpine-elixir-phoenix:latest`

```
Jul 18 14:02:45 make[26845]: Step 14/16 : RUN mix compile
Jul 18 14:02:46 make[26845]: ---> Running in 068d8010237c
Jul 18 14:02:52 make[26845]: ==> ethereum_jsonrpc
Jul 18 14:02:52 make[26845]: Compiling 49 files (.ex)
Jul 18 14:02:58 make[26845]: warning: redefining @doc attribute previously set at line 94
Jul 18 14:02:58 make[26845]: lib/ethereum_jsonrpc/transport.ex:106: EthereumJSONRPC.Transport (module)
Jul 18 14:02:59 make[26845]: Compilation failed due to warnings while using the --warnings-as-errors option
Jul 18 14:03:00 make[26845]: The command '/bin/sh -c mix compile' returned a non-zero code: 1
Jul 18 14:03:00 make[26845]: make: *** [build] Error 1
```

Let's just remove the `--warning treated as error` build flag, unless there is a better solution.

closes #2380 