### PR TITLE
docker/Dockerfile: pin bitwalker/alpine-elixir-phoenix:1.9.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-elixir-phoenix
+FROM bitwalker/alpine-elixir-phoenix:1.9.0
 
 RUN apk --no-cache --update add alpine-sdk gmp-dev automake libtool inotify-tools autoconf python
 


### PR DESCRIPTION
Warnings are now treated as errors during the build.

* Docker build
* Operating System / base image: `bitwalker/alpine-elixir-phoenix:latest`

```
Jul 18 14:02:45 make[26845]: Step 14/16 : RUN mix compile
Jul 18 14:02:46 make[26845]: ---> Running in 068d8010237c
Jul 18 14:02:52 make[26845]: ==> ethereum_jsonrpc
Jul 18 14:02:52 make[26845]: Compiling 49 files (.ex)
Jul 18 14:02:58 make[26845]: warning: redefining @doc attribute previously set at line 94
Jul 18 14:02:58 make[26845]: lib/ethereum_jsonrpc/transport.ex:106: EthereumJSONRPC.Transport (module)
Jul 18 14:02:59 make[26845]: Compilation failed due to warnings while using the --warnings-as-errors option
Jul 18 14:03:00 make[26845]: The command '/bin/sh -c mix compile' returned a non-zero code: 1
Jul 18 14:03:00 make[26845]: make: *** [build] Error 1
```

Fix the build by pinning the docker container build to `bitwalker/alpine-elixir-phoenix:1.9.0`

supercedes #2381 
closes #2381 
closes #2380