### PR TITLE
Reduce Lodash lib size (86% of lib methods are not used)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2294](https://github.com/poanetwork/blockscout/pull/2294) - add healthy block period checking endpoint
 
 ### Fixes
+- [#2389](https://github.com/poanetwork/blockscout/pull/2389) - Reduce Lodash lib size (86% of lib methods are not used)
 - [#2378](https://github.com/poanetwork/blockscout/pull/2378) - Page performance: exclude moment.js localization files except EN, remove unused css
 - [#2368](https://github.com/poanetwork/blockscout/pull/2368) - add two columns of smart contract info
 - [#2375](https://github.com/poanetwork/blockscout/pull/2375) - Update created_contract_code_indexed_at on transaction import conflict

--- a/apps/block_scout_web/assets/__tests__/pages/pending_transactions.js
+++ b/apps/block_scout_web/assets/__tests__/pages/pending_transactions.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import { reducer, initialState } from '../../js/pages/pending_transactions'
 
 test('CHANNEL_DISCONNECTED', () => {

--- a/apps/block_scout_web/assets/js/lib/async_listing_load.js
+++ b/apps/block_scout_web/assets/js/lib/async_listing_load.js
@@ -1,5 +1,6 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import map from 'lodash/map'
+import merge from 'lodash/merge'
 import URI from 'urijs'
 import humps from 'humps'
 import listMorph from '../lib/list_morph'
@@ -164,7 +165,7 @@ export const elements = {
 
       if (state.itemKey) {
         const container = $el[0]
-        const newElements = _.map(state.items, (item) => $(item)[0])
+        const newElements = map(state.items, (item) => $(item)[0])
         listMorph(container, newElements, { key: state.itemKey })
         return
       }
@@ -244,7 +245,7 @@ export const elements = {
  * adding or removing with the correct animation. Check list_morph.js for more informantion.
  */
 export function createAsyncLoadStore (reducer, initialState, itemKey) {
-  const state = _.merge(asyncInitialState, initialState)
+  const state = merge(asyncInitialState, initialState)
   const store = createStore(reduceReducers(asyncReducer, reducer, state))
 
   if (typeof itemKey !== 'undefined') {

--- a/apps/block_scout_web/assets/js/lib/infinite_scroll_helpers.js
+++ b/apps/block_scout_web/assets/js/lib/infinite_scroll_helpers.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
 import humps from 'humps'
 import { connectElements } from './redux_helpers.js'
 
@@ -12,7 +12,7 @@ const initialState = {
 function infiniteScrollReducer (state = initialState, action) {
   switch (action.type) {
     case 'INFINITE_SCROLL_ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'LOADING_NEXT_PAGE': {
       return Object.assign({}, state, {

--- a/apps/block_scout_web/assets/js/lib/list_morph.js
+++ b/apps/block_scout_web/assets/js/lib/list_morph.js
@@ -1,5 +1,10 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import map from 'lodash/map'
+import get from 'lodash/get'
+import noop from 'lodash/noop'
+import find from 'lodash/find'
+import intersectionBy from 'lodash/intersectionBy'
+import differenceBy from 'lodash/differenceBy'
 import morph from 'nanomorph'
 import { updateAllAges } from './from_now'
 
@@ -25,12 +30,12 @@ import { updateAllAges } from './from_now'
 export default function (container, newElements, { key, horizontal } = {}) {
   if (!container) return
   const oldElements = $(container).children().get()
-  let currentList = _.map(oldElements, (el) => ({ id: _.get(el, key), el }))
-  const newList = _.map(newElements, (el) => ({ id: _.get(el, key), el }))
-  const overlap = _.intersectionBy(newList, currentList, 'id').map(({ id, el }) => ({ id, el: updateAllAges($(el))[0] }))
+  let currentList = map(oldElements, (el) => ({ id: get(el, key), el }))
+  const newList = map(newElements, (el) => ({ id: get(el, key), el }))
+  const overlap = intersectionBy(newList, currentList, 'id').map(({ id, el }) => ({ id, el: updateAllAges($(el))[0] }))
 
   // remove old items
-  const removals = _.differenceBy(currentList, newList, 'id')
+  const removals = differenceBy(currentList, newList, 'id')
   let canAnimate = !horizontal && removals.length <= 1
   removals.forEach(({ el }) => {
     if (!canAnimate) return el.remove()
@@ -38,7 +43,7 @@ export default function (container, newElements, { key, horizontal } = {}) {
     $el.addClass('shrink-out')
     setTimeout(() => { slideUpRemove($el) }, 400)
   })
-  currentList = _.differenceBy(currentList, removals, 'id')
+  currentList = differenceBy(currentList, removals, 'id')
 
   // update kept items
   currentList = currentList.map(({ el }, i) => ({
@@ -47,14 +52,14 @@ export default function (container, newElements, { key, horizontal } = {}) {
   }))
 
   // add new items
-  const finalList = newList.map(({ id, el }) => _.get(_.find(currentList, { id }), 'el', el)).reverse()
+  const finalList = newList.map(({ id, el }) => get(find(currentList, { id }), 'el', el)).reverse()
   canAnimate = !horizontal
   finalList.forEach((el, i) => {
     if (el.parentElement) return
-    if (!canAnimate) return container.insertBefore(el, _.get(finalList, `[${i - 1}]`))
+    if (!canAnimate) return container.insertBefore(el, get(finalList, `[${i - 1}]`))
     canAnimate = false
-    if (!_.get(finalList, `[${i - 1}]`)) return slideDownAppend($(container), el)
-    slideDownBefore($(_.get(finalList, `[${i - 1}]`)), el)
+    if (!get(finalList, `[${i - 1}]`)) return slideDownAppend($(container), el)
+    slideDownBefore($(get(finalList, `[${i - 1}]`)), el)
   })
 }
 
@@ -80,7 +85,7 @@ function slideUpRemove ($el) {
   })
 }
 
-function smarterSlideDown ($el, { insert = _.noop } = {}) {
+function smarterSlideDown ($el, { insert = noop } = {}) {
   if (!$el.length) return
   const originalScrollHeight = document.body.scrollHeight
   const scrollPosition = window.scrollY
@@ -100,7 +105,7 @@ function smarterSlideDown ($el, { insert = _.noop } = {}) {
   }
 }
 
-function smarterSlideUp ($el, { complete = _.noop } = {}) {
+function smarterSlideUp ($el, { complete = noop } = {}) {
   if (!$el.length) return
   const originalScrollHeight = document.body.scrollHeight
   const scrollPosition = window.scrollY

--- a/apps/block_scout_web/assets/js/lib/redux_helpers.js
+++ b/apps/block_scout_web/assets/js/lib/redux_helpers.js
@@ -1,5 +1,7 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import reduce from 'lodash/reduce'
+import isObject from 'lodash/isObject'
+import forIn from 'lodash/forIn'
 import { createStore as reduxCreateStore } from 'redux'
 
 /**
@@ -97,17 +99,17 @@ export function createStore (reducer) {
  */
 export function connectElements ({ elements, store, action = 'ELEMENTS_LOAD' }) {
   function loadElements () {
-    return _.reduce(elements, (pageLoadParams, { load }, selector) => {
+    return reduce(elements, (pageLoadParams, { load }, selector) => {
       if (!load) return pageLoadParams
       const $el = $(selector)
       if (!$el.length) return pageLoadParams
       const morePageLoadParams = load($el, store)
-      return _.isObject(morePageLoadParams) ? Object.assign(pageLoadParams, morePageLoadParams) : pageLoadParams
+      return isObject(morePageLoadParams) ? Object.assign(pageLoadParams, morePageLoadParams) : pageLoadParams
     }, {})
   }
 
   function renderElements (state, oldState) {
-    _.forIn(elements, ({ render }, selector) => {
+    forIn(elements, ({ render }, selector) => {
       if (!render) return
       const $el = $(selector)
       if (!$el.length) return

--- a/apps/block_scout_web/assets/js/lib/utils.js
+++ b/apps/block_scout_web/assets/js/lib/utils.js
@@ -1,8 +1,8 @@
-import _ from 'lodash'
+import debounce from 'lodash/debounce'
 
 export function batchChannel (func) {
   let msgs = []
-  const debouncedFunc = _.debounce(() => {
+  const debouncedFunc = debounce(() => {
     func.apply(this, [msgs])
     msgs = []
   }, 1000, { maxWait: 5000 })

--- a/apps/block_scout_web/assets/js/pages/address.js
+++ b/apps/block_scout_web/assets/js/pages/address.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
 import URI from 'urijs'
 import humps from 'humps'
 import numeral from 'numeral'
@@ -25,7 +25,7 @@ export function reducer (state = initialState, action) {
   switch (action.type) {
     case 'PAGE_LOAD':
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'CHANNEL_DISCONNECTED': {
       if (state.beyondPageOne) return state

--- a/apps/block_scout_web/assets/js/pages/address/coin_balances.js
+++ b/apps/block_scout_web/assets/js/pages/address/coin_balances.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
 import humps from 'humps'
 import socket from '../../socket'
 import { connectElements } from '../../lib/redux_helpers.js'
@@ -14,7 +14,7 @@ export function reducer (state, action) {
   switch (action.type) {
     case 'PAGE_LOAD':
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'CHANNEL_DISCONNECTED': {
       if (state.beyondPageOne) return state

--- a/apps/block_scout_web/assets/js/pages/address/internal_transactions.js
+++ b/apps/block_scout_web/assets/js/pages/address/internal_transactions.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
 import humps from 'humps'
 import numeral from 'numeral'
 import socket from '../../socket'
@@ -20,7 +20,7 @@ export function reducer (state, action) {
   switch (action.type) {
     case 'PAGE_LOAD':
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'CHANNEL_DISCONNECTED': {
       if (state.beyondPageOne) return state

--- a/apps/block_scout_web/assets/js/pages/address/logs.js
+++ b/apps/block_scout_web/assets/js/pages/address/logs.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
 import humps from 'humps'
 import { connectElements } from '../../lib/redux_helpers.js'
 import { createAsyncLoadStore } from '../../lib/async_listing_load'
@@ -13,7 +13,7 @@ export function reducer (state, action) {
   switch (action.type) {
     case 'PAGE_LOAD':
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'START_SEARCH': {
       return Object.assign({}, state, {pagesStack: [], isSearch: true})

--- a/apps/block_scout_web/assets/js/pages/address/transactions.js
+++ b/apps/block_scout_web/assets/js/pages/address/transactions.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
 import URI from 'urijs'
 import humps from 'humps'
 import { subscribeChannel } from '../../socket'
@@ -16,7 +16,7 @@ export function reducer (state, action) {
   switch (action.type) {
     case 'PAGE_LOAD':
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'CHANNEL_DISCONNECTED': {
       if (state.beyondPageOne) return state

--- a/apps/block_scout_web/assets/js/pages/address/validations.js
+++ b/apps/block_scout_web/assets/js/pages/address/validations.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
 import humps from 'humps'
 import socket from '../../socket'
 import { connectElements } from '../../lib/redux_helpers.js'
@@ -14,7 +14,7 @@ export function reducer (state = initialState, action) {
   switch (action.type) {
     case 'PAGE_LOAD':
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'CHANNEL_DISCONNECTED': {
       return Object.assign({}, state, { channelDisconnected: true })

--- a/apps/block_scout_web/assets/js/pages/blocks.js
+++ b/apps/block_scout_web/assets/js/pages/blocks.js
@@ -1,5 +1,10 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
+import last from 'lodash/last'
+import min from 'lodash/min'
+import max from 'lodash/max'
+import keys from 'lodash/keys'
+import rangeRight from 'lodash/rangeRight'
 import humps from 'humps'
 import socket from '../socket'
 import { connectElements } from '../lib/redux_helpers.js'
@@ -14,7 +19,7 @@ export const blockReducer = withMissingBlocks(baseReducer)
 function baseReducer (state = initialState, action) {
   switch (action.type) {
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'CHANNEL_DISCONNECTED': {
       return Object.assign({}, state, {
@@ -25,7 +30,7 @@ function baseReducer (state = initialState, action) {
       if (state.channelDisconnected || state.beyondPageOne || state.blockType !== 'block') return state
 
       const blockNumber = getBlockNumber(action.msg.blockHtml)
-      const minBlock = getBlockNumber(_.last(state.items))
+      const minBlock = getBlockNumber(last(state.items))
 
       if (state.items.length && blockNumber < minBlock) return state
 
@@ -62,12 +67,12 @@ function withMissingBlocks (reducer) {
       return acc
     }, {})
 
-    const blockNumbers = _(blockNumbersToItems).keys().map(x => parseInt(x, 10)).value()
-    const minBlock = _.min(blockNumbers)
-    const maxBlock = _.max(blockNumbers)
+    const blockNumbers = keys(blockNumbersToItems).map(x => parseInt(x, 10))
+    const minBlock = min(blockNumbers)
+    const maxBlock = max(blockNumbers)
 
     return Object.assign({}, result, {
-      items: _.rangeRight(minBlock, maxBlock + 1)
+      items: rangeRight(minBlock, maxBlock + 1)
         .map((blockNumber) => blockNumbersToItems[blockNumber] || placeHolderBlock(blockNumber))
     })
   }

--- a/apps/block_scout_web/assets/js/pages/chain.js
+++ b/apps/block_scout_web/assets/js/pages/chain.js
@@ -1,5 +1,9 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
+import first from 'lodash/first'
+import rangeRight from 'lodash/rangeRight'
+import find from 'lodash/find'
+import map from 'lodash/map'
 import humps from 'humps'
 import numeral from 'numeral'
 import socket from '../socket'
@@ -33,7 +37,7 @@ export const reducer = withMissingBlocks(baseReducer)
 function baseReducer (state = initialState, action) {
   switch (action.type) {
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'RECEIVED_NEW_ADDRESS_COUNT': {
       return Object.assign({}, state, {
@@ -122,12 +126,12 @@ function withMissingBlocks (reducer) {
 
     if (!result.blocks || result.blocks.length < 2) return result
 
-    const maxBlock = _.first(result.blocks).blockNumber
+    const maxBlock = first(result.blocks).blockNumber
     const minBlock = maxBlock - (result.blocks.length - 1)
 
     return Object.assign({}, result, {
-      blocks: _.rangeRight(minBlock, maxBlock + 1)
-        .map((blockNumber) => _.find(result.blocks, ['blockNumber', blockNumber]) || {
+      blocks: rangeRight(minBlock, maxBlock + 1)
+        .map((blockNumber) => find(result.blocks, ['blockNumber', blockNumber]) || {
           blockNumber,
           chainBlockHtml: placeHolderBlock(blockNumber)
         })
@@ -194,7 +198,7 @@ const elements = {
       const container = $el[0]
 
       if (state.blocksLoading === false) {
-        const blocks = _.map(state.blocks, ({ chainBlockHtml }) => $(chainBlockHtml)[0])
+        const blocks = map(state.blocks, ({ chainBlockHtml }) => $(chainBlockHtml)[0])
         listMorph(container, blocks, { key: 'dataset.blockNumber', horizontal: true })
       }
     }
@@ -234,7 +238,7 @@ const elements = {
     render ($el, state, oldState) {
       if (oldState.transactions === state.transactions) return
       const container = $el[0]
-      const newElements = _.map(state.transactions, ({ transactionHtml }) => $(transactionHtml)[0])
+      const newElements = map(state.transactions, ({ transactionHtml }) => $(transactionHtml)[0])
       listMorph(container, newElements, { key: 'dataset.identifierHash' })
     }
   },

--- a/apps/block_scout_web/assets/js/pages/pending_transactions.js
+++ b/apps/block_scout_web/assets/js/pages/pending_transactions.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
 import humps from 'humps'
 import numeral from 'numeral'
 import socket from '../socket'
@@ -20,7 +20,7 @@ export const initialState = {
 export function reducer (state = initialState, action) {
   switch (action.type) {
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'CHANNEL_DISCONNECTED': {
       return Object.assign({}, state, {

--- a/apps/block_scout_web/assets/js/pages/transaction.js
+++ b/apps/block_scout_web/assets/js/pages/transaction.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
 import humps from 'humps'
 import numeral from 'numeral'
 import socket from '../socket'
@@ -13,7 +13,7 @@ export const initialState = {
 export function reducer (state = initialState, action) {
   switch (action.type) {
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'RECEIVED_NEW_BLOCK': {
       if ((action.msg.blockNumber - state.blockNumber) > state.confirmations) {

--- a/apps/block_scout_web/assets/js/pages/transactions.js
+++ b/apps/block_scout_web/assets/js/pages/transactions.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
 import humps from 'humps'
 import numeral from 'numeral'
 import socket from '../socket'
@@ -18,7 +18,7 @@ export const initialState = {
 export function reducer (state = initialState, action) {
   switch (action.type) {
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'CHANNEL_DISCONNECTED': {
       return Object.assign({}, state, {

--- a/apps/block_scout_web/assets/js/pages/verification_form.js
+++ b/apps/block_scout_web/assets/js/pages/verification_form.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import _ from 'lodash'
+import omit from 'lodash/omit'
 import URI from 'urijs'
 import humps from 'humps'
 import { subscribeChannel } from '../socket'
@@ -15,7 +15,7 @@ export function reducer (state = initialState, action) {
   switch (action.type) {
     case 'PAGE_LOAD':
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, _.omit(action, 'type'))
+      return Object.assign({}, state, omit(action, 'type'))
     }
     case 'CHANNEL_DISCONNECTED': {
       if (state.beyondPageOne) return state

--- a/apps/block_scout_web/assets/webpack.config.js
+++ b/apps/block_scout_web/assets/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const { ContextReplacementPlugin } = require('webpack')
+const { ContextReplacementPlugin } = require('webpack');
 const glob = require("glob");
 
 function transpileViewScript(file) {


### PR DESCRIPTION
A part of https://github.com/poanetwork/blockscout/issues/2390

## Motivation

We don't use all of the methods of Lodash lib but we retrieve them all on the page load. This PR replaces imports of the whole Lodash lib with the methods used. It drastically decreases Lodash lib to load.

The lib size decreased from *527Kb* to *76Kb* (**86%** of savings)
The total size of app js code reduced from *2.24Mb* to *1.74Mb* (**23%** of savings)

**Before**:
<img width="584" alt="Screenshot 2019-07-19 at 11 42 24" src="https://user-images.githubusercontent.com/4341812/61529333-bf37d880-aa29-11e9-8898-8ce04a43f50d.png">
![Screenshot 2019-07-19 at 12 45 19_2](https://user-images.githubusercontent.com/4341812/61529403-e5f60f00-aa29-11e9-9ef0-240362fecb7e.png)

**After**:
<img width="253" alt="Screenshot 2019-07-19 at 12 51 26" src="https://user-images.githubusercontent.com/4341812/61529435-f9a17580-aa29-11e9-81c7-f11095c14d5e.png">
![Screenshot 2019-07-19 at 12 51 08_2](https://user-images.githubusercontent.com/4341812/61530372-8a795080-aa2c-11e9-9389-af5861196dc0.png)



## Changelog


## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
