### PR TITLE
Add ENV vars to manage updating period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [#2326](https://github.com/poanetwork/blockscout/pull/2326) - fix nested constructor arguments
 
 ### Chore
+- [#2401](https://github.com/poanetwork/blockscout/pull/2401) - add ENV vars to manage updating period of average block time and market history cache
 - [#2363](https://github.com/poanetwork/blockscout/pull/2363) - add parameters example for eth rpc
 - [#2342](https://github.com/poanetwork/blockscout/pull/2342) - Upgrade Postgres image version in Docker setup
 - [#2325](https://github.com/poanetwork/blockscout/pull/2325) - Reduce function input to address' hash only where possible

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -18,7 +18,7 @@ config :explorer,
   healthy_blocks_period: System.get_env("HEALTHY_BLOCKS_PERIOD") || :timer.minutes(5)
 
 average_block_period =
-  case Integer.parse(System.get_env("AVERAGE_BLOCK_PERIOD", "")) do
+  case Integer.parse(System.get_env("AVERAGE_BLOCK_CACHE_PERIOD", "")) do
     {secs, ""} -> :timer.seconds(secs)
     _ -> :timer.minutes(30)
   end
@@ -114,13 +114,13 @@ config :spandex_ecto, SpandexEcto.EctoLogger,
   tracer: Explorer.Tracer,
   otp_app: :explorer
 
-market_history_cache_ttl =
-  case Integer.parse(System.get_env("MARKET_HISTORY_CACHE_TTL", "")) do
+market_history_cache_period =
+  case Integer.parse(System.get_env("MARKET_HISTORY_CACHE_PERIOD", "")) do
     {secs, ""} -> :timer.seconds(secs)
     _ -> :timer.hours(6)
   end
 
-config :explorer, Explorer.Market.MarketHistoryCache, ttl: market_history_cache_ttl
+config :explorer, Explorer.Market.MarketHistoryCache, period: market_history_cache_period
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -18,16 +18,14 @@ config :explorer,
   healthy_blocks_period: System.get_env("HEALTHY_BLOCKS_PERIOD") || :timer.minutes(5)
 
 average_block_period =
-  try do
-    String.to_integer(System.get_env("AVERAGE_BLOCK_PERIOD"))
-  rescue
-    # 30 minutes
-    _ -> 30 * 60
+  case Integer.parse(System.get_env("AVERAGE_BLOCK_PERIOD", "")) do
+    {secs, ""} -> :timer.seconds(secs)
+    _ -> :timer.minutes(30)
   end
 
 config :explorer, Explorer.Counters.AverageBlockTime,
   enabled: true,
-  period: :timer.seconds(average_block_period)
+  period: average_block_period
 
 config :explorer, Explorer.Chain.Cache.BlockNumber, enabled: true
 
@@ -117,14 +115,12 @@ config :spandex_ecto, SpandexEcto.EctoLogger,
   otp_app: :explorer
 
 market_history_cache_ttl =
-  try do
-    String.to_integer(System.get_env("MARKET_HISTORY_CACHE_TTL"))
-  rescue
-    # 6 hours
-    _ -> 60 * 60 * 6
+  case Integer.parse(System.get_env("MARKET_HISTORY_CACHE_TTL", "")) do
+    {secs, ""} -> :timer.seconds(secs)
+    _ -> :timer.hours(6)
   end
 
-config :explorer, Explorer.Market.MarketHistoryCache, ttl: :timer.seconds(market_history_cache_ttl)
+config :explorer, Explorer.Market.MarketHistoryCache, ttl: market_history_cache_ttl
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -17,7 +17,17 @@ config :explorer,
     if(System.get_env("UNCLES_IN_AVERAGE_BLOCK_TIME") == "false", do: false, else: true),
   healthy_blocks_period: System.get_env("HEALTHY_BLOCKS_PERIOD") || :timer.minutes(5)
 
-config :explorer, Explorer.Counters.AverageBlockTime, enabled: true
+average_block_period =
+  try do
+    String.to_integer(System.get_env("AVERAGE_BLOCK_PERIOD"))
+  rescue
+    # 30 minutes
+    _ -> 30 * 60
+  end
+
+config :explorer, Explorer.Counters.AverageBlockTime,
+  enabled: true,
+  period: :timer.seconds(average_block_period)
 
 config :explorer, Explorer.Chain.Cache.BlockNumber, enabled: true
 

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -116,6 +116,16 @@ config :spandex_ecto, SpandexEcto.EctoLogger,
   tracer: Explorer.Tracer,
   otp_app: :explorer
 
+market_history_cache_ttl =
+  try do
+    String.to_integer(System.get_env("MARKET_HISTORY_CACHE_TTL"))
+  rescue
+    # 6 hours
+    _ -> 60 * 60 * 6
+  end
+
+config :explorer, Explorer.Market.MarketHistoryCache, ttl: :timer.seconds(market_history_cache_ttl)
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/apps/explorer/lib/explorer/counters/average_block_time.ex
+++ b/apps/explorer/lib/explorer/counters/average_block_time.ex
@@ -11,7 +11,7 @@ defmodule Explorer.Counters.AverageBlockTime do
   alias Explorer.Repo
   alias Timex.Duration
 
-  @refresh_period 30 * 60 * 1_000
+  @refresh_period Application.get_env(:explorer, __MODULE__)[:period]
 
   @doc """
   Starts a process to periodically update the counter of the token holders.

--- a/apps/explorer/lib/explorer/market/market_history_cache.ex
+++ b/apps/explorer/lib/explorer/market/market_history_cache.ex
@@ -12,7 +12,7 @@ defmodule Explorer.Market.MarketHistoryCache do
   @last_update_key :last_update
   @history_key :history
   # 6 hours
-  @cache_period 1_000 * 60 * 60 * 6
+  @cache_period Application.get_env(:explorer, __MODULE__)[:ttl]
   @recent_days 30
 
   def fetch do

--- a/apps/explorer/lib/explorer/market/market_history_cache.ex
+++ b/apps/explorer/lib/explorer/market/market_history_cache.ex
@@ -12,7 +12,7 @@ defmodule Explorer.Market.MarketHistoryCache do
   @last_update_key :last_update
   @history_key :history
   # 6 hours
-  @cache_period Application.get_env(:explorer, __MODULE__)[:ttl]
+  @cache_period Application.get_env(:explorer, __MODULE__)[:period]
   @recent_days 30
 
   def fetch do


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/2344 https://github.com/poanetwork/blockscout/issues/2343

## Motivation

Added two ENV vars to manage updating period of average block time and market history cache

* `AVERAGE_BLOCK_CACHE_PERIOD` in seconds
* `MARKET_HISTORY_CACHE_PERIOD` in seconds