### PR TITLE
Fix "page not found" handling in the router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#2324](https://github.com/poanetwork/blockscout/pull/2324) - set timeout for loading message on the main page
 
 ### Fixes
+- [#2416](https://github.com/poanetwork/blockscout/pull/2416) - Fix "page not found" handling in the router
 - [#2410](https://github.com/poanetwork/blockscout/pull/2410) - preload smart contract for logs decoding
 - [#2398](https://github.com/poanetwork/blockscout/pull/2398) - show only one decoded candidate
 - [#2395](https://github.com/poanetwork/blockscout/pull/2395) - new block loading animation

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_logs_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_logs_controller.ex
@@ -115,4 +115,6 @@ defmodule BlockScoutWeb.AddressLogsController do
         not_found(conn)
     end
   end
+
+  def search_logs(conn, _), do: not_found(conn)
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -130,6 +130,8 @@ defmodule BlockScoutWeb.AddressTransactionController do
     end
   end
 
+  def token_transfers_csv(conn, _), do: not_found(conn)
+
   def transactions_csv(conn, %{"address_id" => address_hash_string}) do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, address} <- Chain.hash_to_address(address_hash) do
@@ -149,4 +151,6 @@ defmodule BlockScoutWeb.AddressTransactionController do
         not_found(conn)
     end
   end
+
+  def transactions_csv(conn, _), do: not_found(conn)
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
@@ -52,6 +52,8 @@ defmodule BlockScoutWeb.ChainController do
     end
   end
 
+  def search(conn, _), do: not_found(conn)
+
   def token_autocomplete(conn, %{"q" => term}) when is_binary(term) do
     if term == "" do
       json(conn, "{}")

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -30,6 +30,8 @@ defmodule BlockScoutWeb.SmartContractController do
     end
   end
 
+  def index(conn, _), do: not_found(conn)
+
   def show(conn, params) do
     with true <- ajax?(conn),
          {:ok, address_hash} <- Chain.string_to_address_hash(params["id"]),

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -261,6 +261,6 @@ defmodule BlockScoutWeb.Router do
     get("/api_docs", APIDocsController, :index)
     get("/eth_rpc_api_docs", APIDocsController, :eth_rpc)
 
-    get("/:page", PageNotFoundController, :index)
+    get("/*path", PageNotFoundController, :index)
   end
 end


### PR DESCRIPTION
## Motivation

BS renders `Page not found` view if the path consists only from one part in URL (for instance `/1`). If the wrong path consists of multiple parts (for instance `/1/2/3/4/5/6/`), Blockscout doesn't handle them.

## Changelog

### Bug Fixes

- search mask for `Page not found` page changed to:
https://github.com/poanetwork/blockscout/blob/7187e5766047df8fb0cf4840abb63f0b3616fa90/apps/block_scout_web/lib/block_scout_web/router.ex#L264

- Added missing function clauses for various controllers, that causes `Internal server error` when trying to open corresponding pages.

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
