### PR TITLE
Remove parentheses in market cap percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#2324](https://github.com/poanetwork/blockscout/pull/2324) - set timeout for loading message on the main page
 
 ### Fixes
+- [#2417](https://github.com/poanetwork/blockscout/pull/2417) - Remove parentheses in market cap percentage
 - [#2410](https://github.com/poanetwork/blockscout/pull/2410) - preload smart contract for logs decoding
 - [#2398](https://github.com/poanetwork/blockscout/pull/2398) - show only one decoded candidate
 - [#2395](https://github.com/poanetwork/blockscout/pull/2395) - new block loading animation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#2391](https://github.com/poanetwork/blockscout/pull/2391) - Controllers Improvements
 - [#2379](https://github.com/poanetwork/blockscout/pull/2379) - Disable network selector when is empty
 - [#2374](https://github.com/poanetwork/blockscout/pull/2374) - decode constructor arguments for verified smart contracts
 - [#2366](https://github.com/poanetwork/blockscout/pull/2366) - paginate eth logs

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
@@ -16,7 +16,7 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
 
   def index(conn, %{"address_id" => address_hash_string, "type" => "JSON"} = params) do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
-         {:ok, address} <- Chain.hash_to_address(address_hash, [], false) do
+         :ok <- Chain.check_address_exists(address_hash) do
       full_options = paging_options(params)
 
       coin_balances_plus_one = Chain.address_to_coin_balances(address_hash, full_options)
@@ -32,7 +32,7 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
             address_coin_balance_path(
               conn,
               :index,
-              address,
+              address_hash,
               Map.delete(next_page_params, "type")
             )
         end
@@ -52,7 +52,7 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
       :error ->
         unprocessable_entity(conn)
 
-      {:error, :not_found} ->
+      :not_found ->
         not_found(conn)
     end
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_controller.ex
@@ -8,8 +8,18 @@ defmodule BlockScoutWeb.AddressContractController do
   alias Indexer.Fetcher.CoinBalanceOnDemand
 
   def index(conn, %{"address_id" => address_hash_string}) do
+    address_options = [
+      necessity_by_association: %{
+        :contracts_creation_internal_transaction => :optional,
+        :names => :optional,
+        :smart_contract => :optional,
+        :token => :optional,
+        :contracts_creation_transaction => :optional
+      }
+    ]
+
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
-         {:ok, address} <- Chain.find_contract_address(address_hash) do
+         {:ok, address} <- Chain.find_contract_address(address_hash, address_options, true) do
       render(
         conn,
         "index.html",

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_logs_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_logs_controller.ex
@@ -16,7 +16,7 @@ defmodule BlockScoutWeb.AddressLogsController do
 
   def index(conn, %{"address_id" => address_hash_string, "type" => "JSON"} = params) do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
-         {:ok, address} <- Chain.hash_to_address(address_hash, [], false) do
+         :ok <- Chain.check_address_exists(address_hash) do
       logs_plus_one = Chain.address_to_logs(address_hash, paging_options(params))
       {results, next_page} = split_list_by_page(logs_plus_one)
 
@@ -26,7 +26,7 @@ defmodule BlockScoutWeb.AddressLogsController do
             nil
 
           next_page_params ->
-            address_logs_path(conn, :index, address, Map.delete(next_page_params, "type"))
+            address_logs_path(conn, :index, address_hash, Map.delete(next_page_params, "type"))
         end
 
       items =
@@ -74,7 +74,7 @@ defmodule BlockScoutWeb.AddressLogsController do
 
   def search_logs(conn, %{"topic" => topic, "address_id" => address_hash_string} = params) do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
-         {:ok, address} <- Chain.hash_to_address(address_hash, [], false) do
+         :ok <- Chain.check_address_exists(address_hash) do
       topic = String.trim(topic)
 
       formatted_topic = if String.starts_with?(topic, "0x"), do: topic, else: "0x" <> topic
@@ -89,7 +89,7 @@ defmodule BlockScoutWeb.AddressLogsController do
             nil
 
           next_page_params ->
-            address_logs_path(conn, :index, address, Map.delete(next_page_params, "type"))
+            address_logs_path(conn, :index, address_hash, Map.delete(next_page_params, "type"))
         end
 
       items =

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_read_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_read_contract_controller.ex
@@ -15,8 +15,18 @@ defmodule BlockScoutWeb.AddressReadContractController do
   import BlockScoutWeb.AddressController, only: [transaction_count: 1, validation_count: 1]
 
   def index(conn, %{"address_id" => address_hash_string}) do
+    address_options = [
+      necessity_by_association: %{
+        :contracts_creation_internal_transaction => :optional,
+        :names => :optional,
+        :smart_contract => :optional,
+        :token => :optional,
+        :contracts_creation_transaction => :optional
+      }
+    ]
+
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
-         {:ok, address} <- Chain.find_contract_address(address_hash) do
+         {:ok, address} <- Chain.find_contract_address(address_hash, address_options, true) do
       render(
         conn,
         "index.html",

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/block_controller.ex
@@ -8,8 +8,7 @@ defmodule BlockScoutWeb.API.RPC.BlockController do
   def getblockreward(conn, params) do
     with {:block_param, {:ok, unsafe_block_number}} <- {:block_param, Map.fetch(params, "blockno")},
          {:ok, block_number} <- ChainWeb.param_to_block_number(unsafe_block_number),
-         block_options = [necessity_by_association: %{transactions: :optional}],
-         {:ok, block} <- Chain.number_to_block(block_number, block_options) do
+         {:ok, block} <- Chain.number_to_block(block_number) do
       reward = Chain.block_reward(block)
 
       render(conn, :block_reward, block: block, reward: reward)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/block_controller.ex
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.API.RPC.BlockController do
     with {:block_param, {:ok, unsafe_block_number}} <- {:block_param, Map.fetch(params, "blockno")},
          {:ok, block_number} <- ChainWeb.param_to_block_number(unsafe_block_number),
          {:ok, block} <- Chain.number_to_block(block_number) do
-      reward = Chain.block_reward(block)
+      reward = Chain.block_reward(block_number)
 
       render(conn, :block_reward, block: block, reward: reward)
     else

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
@@ -10,7 +10,7 @@ defmodule BlockScoutWeb.API.RPC.TransactionController do
          {:format, {:ok, transaction_hash}} <- to_transaction_hash(txhash_param),
          {:transaction, {:ok, transaction}} <- transaction_from_hash(transaction_hash),
          paging_options <- paging_options(params) do
-      logs = Chain.transaction_to_logs(transaction, paging_options)
+      logs = Chain.transaction_to_logs(transaction_hash, paging_options)
       {logs, next_page} = split_list_by_page(logs)
 
       render(conn, :gettxinfo, %{

--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
@@ -26,7 +26,7 @@ defmodule BlockScoutWeb.BlockTransactionController do
           paging_options(params)
         )
 
-      transactions_plus_one = Chain.block_to_transactions(block, full_options)
+      transactions_plus_one = Chain.block_to_transactions(block.hash, full_options)
 
       {transactions, next_page} = split_list_by_page(transactions_plus_one)
 
@@ -89,7 +89,7 @@ defmodule BlockScoutWeb.BlockTransactionController do
                :rewards => :optional
              }
            ) do
-      block_transaction_count = Chain.block_to_transaction_count(block)
+      block_transaction_count = Chain.block_to_transaction_count(block.hash)
 
       render(
         conn,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
@@ -2,7 +2,7 @@ defmodule BlockScoutWeb.ChainController do
   use BlockScoutWeb, :controller
 
   alias BlockScoutWeb.ChainView
-  alias Explorer.{Chain, PagingOptions, Repo}
+  alias Explorer.{Chain, PagingOptions}
   alias Explorer.Chain.{Address, Block, Transaction}
   alias Explorer.Chain.Supply.RSK
   alias Explorer.Counters.AverageBlockTime
@@ -72,9 +72,15 @@ defmodule BlockScoutWeb.ChainController do
   def chain_blocks(conn, _params) do
     if ajax?(conn) do
       blocks =
-        [paging_options: %PagingOptions{page_size: 4}]
+        [
+          paging_options: %PagingOptions{page_size: 4},
+          necessity_by_association: %{
+            [miner: :names] => :optional,
+            :transactions => :optional,
+            :rewards => :optional
+          }
+        ]
         |> Chain.list_blocks()
-        |> Repo.preload([[miner: :names], :transactions, :rewards])
         |> Enum.map(fn block ->
           %{
             chain_block_html:

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -33,7 +33,7 @@ defmodule BlockScoutWeb.SmartContractController do
   def show(conn, params) do
     with true <- ajax?(conn),
          {:ok, address_hash} <- Chain.string_to_address_hash(params["id"]),
-         {:ok, _address} <- Chain.find_contract_address(address_hash),
+         :ok <- Chain.check_contract_address_exists(address_hash),
          outputs =
            Reader.query_function(
              address_hash,
@@ -51,7 +51,7 @@ defmodule BlockScoutWeb.SmartContractController do
       :error ->
         unprocessable_entity(conn)
 
-      {:error, :not_found} ->
+      :not_found ->
         not_found(conn)
 
       _ ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
@@ -62,15 +62,15 @@ defmodule BlockScoutWeb.TransactionController do
 
   def show(conn, %{"id" => id}) do
     with {:ok, transaction_hash} <- Chain.string_to_transaction_hash(id),
-         {:ok, %Chain.Transaction{} = transaction} <- Chain.hash_to_transaction(transaction_hash) do
-      if Chain.transaction_has_token_transfers?(transaction.hash) do
+         :ok <- Chain.check_transaction_exists(transaction_hash) do
+      if Chain.transaction_has_token_transfers?(transaction_hash) do
         redirect(conn, to: transaction_token_transfer_path(conn, :index, id))
       else
         redirect(conn, to: transaction_internal_transaction_path(conn, :index, id))
       end
     else
       :error -> conn |> put_status(422) |> render("invalid.html", transaction_hash: id)
-      {:error, :not_found} -> conn |> put_status(404) |> render("not_found.html", transaction_hash: id)
+      :not_found -> conn |> put_status(404) |> render("not_found.html", transaction_hash: id)
     end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
@@ -10,7 +10,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionController do
 
   def index(conn, %{"transaction_id" => hash_string, "type" => "JSON"} = params) do
     with {:ok, hash} <- Chain.string_to_transaction_hash(hash_string),
-         {:ok, transaction} <- Chain.hash_to_transaction(hash) do
+         :ok <- Chain.check_transaction_exists(hash) do
       full_options =
         Keyword.merge(
           [
@@ -37,7 +37,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionController do
             transaction_internal_transaction_path(
               conn,
               :index,
-              transaction,
+              hash,
               Map.delete(next_page_params, "type")
             )
         end
@@ -66,7 +66,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionController do
         |> put_view(TransactionView)
         |> render("invalid.html", transaction_hash: hash_string)
 
-      {:error, :not_found} ->
+      :not_found ->
         conn
         |> put_status(404)
         |> put_view(TransactionView)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
@@ -24,7 +24,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionController do
           paging_options(params)
         )
 
-      internal_transactions_plus_one = Chain.transaction_to_internal_transactions(transaction, full_options)
+      internal_transactions_plus_one = Chain.transaction_to_internal_transactions(hash, full_options)
 
       {internal_transactions, next_page} = split_list_by_page(internal_transactions_plus_one)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_log_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_log_controller.ex
@@ -24,7 +24,7 @@ defmodule BlockScoutWeb.TransactionLogController do
           paging_options(params)
         )
 
-      logs_plus_one = Chain.transaction_to_logs(transaction, full_options)
+      logs_plus_one = Chain.transaction_to_logs(transaction_hash, full_options)
 
       {logs, next_page} = split_list_by_page(logs_plus_one)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_raw_trace_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_raw_trace_controller.ex
@@ -19,7 +19,7 @@ defmodule BlockScoutWeb.TransactionRawTraceController do
                :token_transfers => :optional
              }
            ) do
-      internal_transactions = Chain.transaction_to_internal_transactions(transaction)
+      internal_transactions = Chain.transaction_to_internal_transactions(hash)
 
       render(
         conn,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
@@ -10,8 +10,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
 
   def index(conn, %{"transaction_id" => hash_string, "type" => "JSON"} = params) do
     with {:ok, hash} <- Chain.string_to_transaction_hash(hash_string),
-         {:ok, transaction} <-
-           Chain.hash_to_transaction(hash) do
+         :ok <- Chain.check_transaction_exists(hash) do
       full_options =
         Keyword.merge(
           [
@@ -34,7 +33,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
             nil
 
           next_page_params ->
-            transaction_token_transfer_path(conn, :index, transaction, Map.delete(next_page_params, "type"))
+            transaction_token_transfer_path(conn, :index, hash, Map.delete(next_page_params, "type"))
         end
 
       items =
@@ -62,7 +61,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
         |> put_view(TransactionView)
         |> render("invalid.html", transaction_hash: hash_string)
 
-      {:error, :not_found} ->
+      :not_found ->
         conn
         |> put_status(404)
         |> put_view(TransactionView)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
@@ -24,7 +24,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
           paging_options(params)
         )
 
-      token_transfers_plus_one = Chain.transaction_to_token_transfers(transaction, full_options)
+      token_transfers_plus_one = Chain.transaction_to_token_transfers(hash, full_options)
 
       {token_transfers, next_page} = split_list_by_page(token_transfers_plus_one)
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tile.html.eex
@@ -21,7 +21,7 @@
   <td class="stakes-td color-lighten">
     <!-- percentage of coins from total supply -->
     <%= if @total_supply do %>
-      (<%= balance_percentage(@address, @total_supply) %>)
+      <%= balance_percentage(@address, @total_supply) %>
     <% end %>
   </td>
   <td class="stakes-td">

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -8,7 +8,7 @@ defmodule Explorer.SmartContract.Reader do
 
   alias EthereumJSONRPC.Contract
   alias Explorer.Chain
-  alias Explorer.Chain.Hash
+  alias Explorer.Chain.{Hash, SmartContract}
 
   @typedoc """
   Map of functions to call with the values for the function to be called with.
@@ -34,6 +34,8 @@ defmodule Explorer.SmartContract.Reader do
   @doc """
   Queries the contract functions on the blockchain and returns the call results.
 
+  Optionally accepts the abi if it has already been fetched.
+
   ## Examples
 
   Note that for this example to work the database must be up to date with the
@@ -57,14 +59,20 @@ defmodule Explorer.SmartContract.Reader do
       )
       # => %{"sum" => {:error, "Data overflow encoding int, data `abc` cannot fit in 256 bits"}}
   """
-  @spec query_verified_contract(Hash.Address.t(), functions()) :: functions_results()
-  def query_verified_contract(address_hash, functions) do
+  @spec query_verified_contract(Hash.Address.t(), functions(), SmartContract.abi() | nil) :: functions_results()
+  def query_verified_contract(address_hash, functions, mabi \\ nil) do
     contract_address = Hash.to_string(address_hash)
 
     abi =
-      address_hash
-      |> Chain.address_hash_to_smart_contract()
-      |> Map.get(:abi)
+      case mabi do
+        nil ->
+          address_hash
+          |> Chain.address_hash_to_smart_contract()
+          |> Map.get(:abi)
+
+        _ ->
+          mabi
+      end
 
     query_contract(contract_address, abi, functions)
   end
@@ -156,40 +164,40 @@ defmodule Explorer.SmartContract.Reader do
   """
   @spec read_only_functions(Hash.t()) :: [%{}]
   def read_only_functions(contract_address_hash) do
-    contract_address_hash
-    |> Chain.address_hash_to_smart_contract()
-    |> Map.get(:abi, [])
-    |> Enum.filter(& &1["constant"])
-    |> fetch_current_value_from_blockchain(contract_address_hash, [])
-    |> Enum.reverse()
+    abi =
+      contract_address_hash
+      |> Chain.address_hash_to_smart_contract()
+      |> Map.get(:abi)
+
+    case abi do
+      nil ->
+        []
+
+      _ ->
+        abi
+        |> Enum.filter(& &1["constant"])
+        |> Enum.map(&fetch_current_value_from_blockchain(&1, abi, contract_address_hash))
+    end
   end
 
-  def fetch_current_value_from_blockchain(
-        [%{"inputs" => []} = function | tail],
-        contract_address_hash,
-        acc
-      ) do
+  defp fetch_current_value_from_blockchain(function, abi, contract_address_hash) do
     values =
-      fetch_from_blockchain(contract_address_hash, %{
-        name: function["name"],
-        args: function["inputs"],
-        outputs: function["outputs"]
-      })
+      case function do
+        %{"inputs" => []} ->
+          name = function["name"]
+          args = function["inputs"]
+          outputs = function["outputs"]
 
-    formatted = Map.replace!(function, "outputs", values)
+          contract_address_hash
+          |> query_verified_contract(%{name => normalize_args(args)}, abi)
+          |> link_outputs_and_values(outputs, name)
 
-    fetch_current_value_from_blockchain(tail, contract_address_hash, [formatted | acc])
+        _ ->
+          link_outputs_and_values(%{}, Map.get(function, "outputs", []), function["name"])
+      end
+
+    Map.replace!(function, "outputs", values)
   end
-
-  def fetch_current_value_from_blockchain([function | tail], contract_address_hash, acc) do
-    values = link_outputs_and_values(%{}, Map.get(function, "outputs", []), function["name"])
-
-    formatted = Map.replace!(function, "outputs", values)
-
-    fetch_current_value_from_blockchain(tail, contract_address_hash, [formatted | acc])
-  end
-
-  def fetch_current_value_from_blockchain([], _contract_address_hash, acc), do: acc
 
   @doc """
   Fetches the blockchain value of a function that requires arguments.
@@ -201,23 +209,27 @@ defmodule Explorer.SmartContract.Reader do
 
   @spec query_function(Hash.t(), %{name: String.t(), args: [term()]}) :: [%{}]
   def query_function(contract_address_hash, %{name: name, args: args}) do
-    function =
+    abi =
       contract_address_hash
       |> Chain.address_hash_to_smart_contract()
-      |> Map.get(:abi, [])
-      |> Enum.filter(fn function -> function["name"] == name end)
-      |> List.first()
+      |> Map.get(:abi)
 
-    fetch_from_blockchain(contract_address_hash, %{
-      name: name,
-      args: args,
-      outputs: function["outputs"]
-    })
-  end
+    outputs =
+      case abi do
+        nil ->
+          nil
 
-  defp fetch_from_blockchain(contract_address_hash, %{name: name, args: args, outputs: outputs}) do
+        _ ->
+          function =
+            abi
+            |> Enum.filter(fn function -> function["name"] == name end)
+            |> List.first()
+
+          function["outputs"]
+      end
+
     contract_address_hash
-    |> query_verified_contract(%{name => normalize_args(args)})
+    |> query_verified_contract(%{name => normalize_args(args)}, abi)
     |> link_outputs_and_values(outputs, name)
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -630,7 +630,7 @@ defmodule Explorer.ChainTest do
 
       assert Repo.aggregate(Transaction, :count, :hash) == 0
 
-      assert [] = Chain.block_to_transactions(block)
+      assert [] = Chain.block_to_transactions(block.hash)
     end
 
     test "with transactions" do
@@ -639,7 +639,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block()
 
-      assert [%Transaction{hash: ^transaction_hash}] = Chain.block_to_transactions(block)
+      assert [%Transaction{hash: ^transaction_hash}] = Chain.block_to_transactions(block.hash)
     end
 
     test "with transactions can be paginated by {index}" do
@@ -657,7 +657,7 @@ defmodule Explorer.ChainTest do
         |> with_block(block)
 
       assert second_page_hashes ==
-               block
+               block.hash
                |> Chain.block_to_transactions(paging_options: %PagingOptions{key: {index}, page_size: 50})
                |> Enum.map(& &1.hash)
                |> Enum.reverse()
@@ -683,7 +683,7 @@ defmodule Explorer.ChainTest do
         token: token
       )
 
-      fetched_transaction = List.first(Explorer.Chain.block_to_transactions(block))
+      fetched_transaction = List.first(Explorer.Chain.block_to_transactions(block.hash))
       assert fetched_transaction.hash == transaction.hash
       assert length(fetched_transaction.token_transfers) == 2
     end
@@ -693,7 +693,7 @@ defmodule Explorer.ChainTest do
     test "without transactions" do
       block = insert(:block)
 
-      assert Chain.block_to_transaction_count(block) == 0
+      assert Chain.block_to_transaction_count(block.hash) == 0
     end
 
     test "with transactions" do
@@ -702,7 +702,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block()
 
-      assert Chain.block_to_transaction_count(block) == 1
+      assert Chain.block_to_transaction_count(block.hash) == 1
     end
   end
 
@@ -2090,7 +2090,7 @@ defmodule Explorer.ChainTest do
     test "with transaction without internal transactions" do
       transaction = insert(:transaction)
 
-      assert [] = Chain.transaction_to_internal_transactions(transaction)
+      assert [] = Chain.transaction_to_internal_transactions(transaction.hash)
     end
 
     test "with transaction with internal transactions returns all internal transactions for a given transaction hash" do
@@ -2117,7 +2117,7 @@ defmodule Explorer.ChainTest do
           transaction_index: transaction.index
         )
 
-      results = [internal_transaction | _] = Chain.transaction_to_internal_transactions(transaction)
+      results = [internal_transaction | _] = Chain.transaction_to_internal_transactions(transaction.hash)
 
       assert 2 == length(results)
 
@@ -2151,7 +2151,7 @@ defmodule Explorer.ChainTest do
                  to_address: %Ecto.Association.NotLoaded{},
                  transaction: %Transaction{block: %Ecto.Association.NotLoaded{}}
                }
-             ] = Chain.transaction_to_internal_transactions(transaction)
+             ] = Chain.transaction_to_internal_transactions(transaction.hash)
 
       assert [
                %InternalTransaction{
@@ -2161,7 +2161,7 @@ defmodule Explorer.ChainTest do
                }
              ] =
                Chain.transaction_to_internal_transactions(
-                 transaction,
+                 transaction.hash,
                  necessity_by_association: %{
                    :from_address => :optional,
                    :to_address => :optional,
@@ -2183,7 +2183,7 @@ defmodule Explorer.ChainTest do
         transaction_index: transaction.index
       )
 
-      result = Chain.transaction_to_internal_transactions(transaction)
+      result = Chain.transaction_to_internal_transactions(transaction.hash)
 
       assert Enum.empty?(result)
     end
@@ -2202,7 +2202,7 @@ defmodule Explorer.ChainTest do
           transaction_index: transaction.index
         )
 
-      actual = Enum.at(Chain.transaction_to_internal_transactions(transaction), 0)
+      actual = Enum.at(Chain.transaction_to_internal_transactions(transaction.hash), 0)
 
       assert {actual.transaction_hash, actual.index} == {expected.transaction_hash, expected.index}
     end
@@ -2222,7 +2222,7 @@ defmodule Explorer.ChainTest do
           transaction_index: transaction.index
         )
 
-      actual = Enum.at(Chain.transaction_to_internal_transactions(transaction), 0)
+      actual = Enum.at(Chain.transaction_to_internal_transactions(transaction.hash), 0)
 
       assert {actual.transaction_hash, actual.index} == {expected.transaction_hash, expected.index}
     end
@@ -2243,7 +2243,7 @@ defmodule Explorer.ChainTest do
           transaction_index: transaction.index
         )
 
-      actual = Enum.at(Chain.transaction_to_internal_transactions(transaction), 0)
+      actual = Enum.at(Chain.transaction_to_internal_transactions(transaction.hash), 0)
 
       assert {actual.transaction_hash, actual.index} == {expected.transaction_hash, expected.index}
     end
@@ -2271,7 +2271,7 @@ defmodule Explorer.ChainTest do
         )
 
       result =
-        transaction
+        transaction.hash
         |> Chain.transaction_to_internal_transactions()
         |> Enum.map(&{&1.transaction_hash, &1.index})
 
@@ -2301,17 +2301,17 @@ defmodule Explorer.ChainTest do
         )
 
       assert [{first_transaction_hash, first_index}, {second_transaction_hash, second_index}] ==
-               transaction
+               transaction.hash
                |> Chain.transaction_to_internal_transactions(paging_options: %PagingOptions{key: {-1}, page_size: 2})
                |> Enum.map(&{&1.transaction_hash, &1.index})
 
       assert [{first_transaction_hash, first_index}] ==
-               transaction
+               transaction.hash
                |> Chain.transaction_to_internal_transactions(paging_options: %PagingOptions{key: {-1}, page_size: 1})
                |> Enum.map(&{&1.transaction_hash, &1.index})
 
       assert [{second_transaction_hash, second_index}] ==
-               transaction
+               transaction.hash
                |> Chain.transaction_to_internal_transactions(paging_options: %PagingOptions{key: {0}, page_size: 2})
                |> Enum.map(&{&1.transaction_hash, &1.index})
     end
@@ -2321,7 +2321,7 @@ defmodule Explorer.ChainTest do
     test "without logs" do
       transaction = insert(:transaction)
 
-      assert [] = Chain.transaction_to_logs(transaction)
+      assert [] = Chain.transaction_to_logs(transaction.hash)
     end
 
     test "with logs" do
@@ -2332,7 +2332,7 @@ defmodule Explorer.ChainTest do
 
       %Log{transaction_hash: transaction_hash, index: index} = insert(:log, transaction: transaction)
 
-      assert [%Log{transaction_hash: ^transaction_hash, index: ^index}] = Chain.transaction_to_logs(transaction)
+      assert [%Log{transaction_hash: ^transaction_hash, index: ^index}] = Chain.transaction_to_logs(transaction.hash)
     end
 
     test "with logs can be paginated" do
@@ -2349,7 +2349,7 @@ defmodule Explorer.ChainTest do
         |> Enum.map(& &1.index)
 
       assert second_page_indexes ==
-               transaction
+               transaction.hash
                |> Chain.transaction_to_logs(paging_options: %PagingOptions{key: {log.index}, page_size: 50})
                |> Enum.map(& &1.index)
     end
@@ -2364,7 +2364,7 @@ defmodule Explorer.ChainTest do
 
       assert [%Log{address: %Address{}, transaction: %Transaction{}}] =
                Chain.transaction_to_logs(
-                 transaction,
+                 transaction.hash,
                  necessity_by_association: %{
                    address: :optional,
                    transaction: :optional
@@ -2376,7 +2376,7 @@ defmodule Explorer.ChainTest do
                  address: %Ecto.Association.NotLoaded{},
                  transaction: %Ecto.Association.NotLoaded{}
                }
-             ] = Chain.transaction_to_logs(transaction)
+             ] = Chain.transaction_to_logs(transaction.hash)
     end
   end
 
@@ -2384,7 +2384,7 @@ defmodule Explorer.ChainTest do
     test "without token transfers" do
       transaction = insert(:transaction)
 
-      assert [] = Chain.transaction_to_token_transfers(transaction)
+      assert [] = Chain.transaction_to_token_transfers(transaction.hash)
     end
 
     test "with token transfers" do
@@ -2397,7 +2397,7 @@ defmodule Explorer.ChainTest do
         insert(:token_transfer, transaction: transaction)
 
       assert [%TokenTransfer{transaction_hash: ^transaction_hash, log_index: ^log_index}] =
-               Chain.transaction_to_token_transfers(transaction)
+               Chain.transaction_to_token_transfers(transaction.hash)
     end
 
     test "token transfers necessity_by_association loads associations" do
@@ -2410,7 +2410,7 @@ defmodule Explorer.ChainTest do
 
       assert [%TokenTransfer{token: %Token{}, transaction: %Transaction{}}] =
                Chain.transaction_to_token_transfers(
-                 transaction,
+                 transaction.hash,
                  necessity_by_association: %{
                    token: :optional,
                    transaction: :optional
@@ -2422,7 +2422,7 @@ defmodule Explorer.ChainTest do
                  token: %Ecto.Association.NotLoaded{},
                  transaction: %Ecto.Association.NotLoaded{}
                }
-             ] = Chain.transaction_to_token_transfers(transaction)
+             ] = Chain.transaction_to_token_transfers(transaction.hash)
     end
   end
 
@@ -2533,7 +2533,7 @@ defmodule Explorer.ChainTest do
         |> Decimal.add(Decimal.new(3))
         |> Wei.from(:wei)
 
-      assert expected == Chain.block_reward(block)
+      assert expected == Chain.block_reward(block.number)
     end
 
     test "with block without transactions", %{block: block, emission_reward: emission_reward} do

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2480,7 +2480,17 @@ defmodule Explorer.ChainTest do
         insert(:address, contract_code: Factory.data("contract_code"), smart_contract: nil, names: [])
         |> Repo.preload([:contracts_creation_internal_transaction, :contracts_creation_transaction, :token])
 
-      response = Chain.find_contract_address(address.hash)
+      options = [
+        necessity_by_association: %{
+          :contracts_creation_internal_transaction => :optional,
+          :names => :optional,
+          :smart_contract => :optional,
+          :token => :optional,
+          :contracts_creation_transaction => :optional
+        }
+      ]
+
+      response = Chain.find_contract_address(address.hash, options, true)
 
       assert response == {:ok, address}
     end
@@ -2527,7 +2537,7 @@ defmodule Explorer.ChainTest do
     end
 
     test "with block without transactions", %{block: block, emission_reward: emission_reward} do
-      assert emission_reward.reward == Chain.block_reward(block)
+      assert emission_reward.reward == Chain.block_reward(block.number)
     end
   end
 

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -102,7 +102,7 @@ defmodule Explorer.SmartContract.ReaderTest do
     end
   end
 
-  describe "query_verified_contract/2" do
+  describe "query_verified_contract/3" do
     test "correctly returns the results of the smart contract functions" do
       hash =
         :smart_contract


### PR DESCRIPTION
## Motivation

Parentheses in % of market cap look redundant in `./accounts` page

**Before**
![Screenshot 2019-07-23 at 18 05 06](https://user-images.githubusercontent.com/4341812/61723255-77d88180-ad74-11e9-96e8-f4cecf89cc57.png)

**After**
![Screenshot 2019-07-23 at 18 03 03](https://user-images.githubusercontent.com/4341812/61723243-7444fa80-ad74-11e9-87a0-ce4cebc5ca3f.png)

## Changelog


## Checklist for your PR

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
