### PR TITLE
Remove parentheses in market cap percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#2326](https://github.com/poanetwork/blockscout/pull/2326) - fix nested constructor arguments
 
 ### Chore
+- [#2418](https://github.com/poanetwork/blockscout/pull/2418) - Remove parentheses in market cap percentage
 - [#2401](https://github.com/poanetwork/blockscout/pull/2401) - add ENV vars to manage updating period of average block time and market history cache
 - [#2363](https://github.com/poanetwork/blockscout/pull/2363) - add parameters example for eth rpc
 - [#2342](https://github.com/poanetwork/blockscout/pull/2342) - Upgrade Postgres image version in Docker setup

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tile.html.eex
@@ -21,7 +21,7 @@
   <td class="stakes-td color-lighten">
     <!-- percentage of coins from total supply -->
     <%= if @total_supply do %>
-      (<%= balance_percentage(@address, @total_supply) %>)
+      <%= balance_percentage(@address, @total_supply) %>
     <% end %>
   </td>
   <td class="stakes-td">


### PR DESCRIPTION
## Motivation

Parentheses in % of market cap look redundant in `./accounts` page

**Before**
![Screenshot 2019-07-23 at 18 05 06](https://user-images.githubusercontent.com/4341812/61723255-77d88180-ad74-11e9-96e8-f4cecf89cc57.png)

**After**
![Screenshot 2019-07-23 at 18 03 03](https://user-images.githubusercontent.com/4341812/61723243-7444fa80-ad74-11e9-87a0-ce4cebc5ca3f.png)

## Changelog


## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
