### PR TITLE
Fix hiding of loader for txs on the main page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#2324](https://github.com/poanetwork/blockscout/pull/2324) - set timeout for loading message on the main page
 
 ### Fixes
+- [#2421](https://github.com/poanetwork/blockscout/pull/2421) - Fix hiding of loader for txs on the main page
 - [#2416](https://github.com/poanetwork/blockscout/pull/2416) - Fix "page not found" handling in the router
 - [#2410](https://github.com/poanetwork/blockscout/pull/2410) - preload smart contract for logs decoding
 - [#2405](https://github.com/poanetwork/blockscout/pull/2405) - added templates for table loader and tile loader

--- a/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
@@ -117,7 +117,9 @@
             <%= gettext "Something went wrong, click to retry." %>
           </span>
         </button>
-        <%= render BlockScoutWeb.CommonComponentsView, "_tile-loader.html" %>
+        <div hidden data-selector="loading-message">
+          <%= render BlockScoutWeb.CommonComponentsView, "_tile-loader.html" %>
+        </div>
       </span>
     </div>
   </div>


### PR DESCRIPTION
This timeout was implemented here https://github.com/poanetwork/blockscout/pull/2324 and was broken with a new type of loader https://github.com/poanetwork/blockscout/pull/2405 

## Motivation

Fixing of hiding of loader for txs block on the main page if loading less then 1 min

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
