### PR TITLE
Show modal window with validator/pool info

### DIFF
--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -4,6 +4,7 @@ import { subscribeChannel } from '../socket'
 import { connectElements } from '../lib/redux_helpers.js'
 import { createAsyncLoadStore, refreshPage } from '../lib/async_listing_load'
 import Web3 from 'web3'
+import { openValidatorInfoModal } from './stakes/validator_info'
 
 export const initialState = {
   channel: null,
@@ -74,6 +75,9 @@ if ($stakesPage.length) {
       tokenSymbol: msg.token_symbol
     })
   })
+
+  $(document.body)
+    .on('click', '.js-validator-info', event => openValidatorInfoModal(event, store))
 
   initializeWeb3(store)
 }

--- a/apps/block_scout_web/assets/js/pages/stakes/validator_info.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/validator_info.js
@@ -1,0 +1,10 @@
+import $ from 'jquery'
+import { openModal } from '../../lib/modals'
+
+export function openValidatorInfoModal (event, store) {
+  const address = $(event.target).closest('[data-address]').data('address')
+
+  store.getState().channel
+    .push('render_validator_info', { address })
+    .receive('ok', msg => openModal($(msg.html)))
+}

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_address.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_address.html.eex
@@ -1,8 +1,8 @@
-<div class="stakes-address-container">
-    <span class="stakes-address js-validator-info-modal">
-        <%= binary_part(to_string(@address), 0, 13) %>
-    </span>
-    <%= if @tooltip do %>
-        <%= render BlockScoutWeb.CommonComponentsView, "_check_tooltip.html", text: @tooltip %>
-    <% end %>
+<div class="stakes-address-container js-validator-info" data-address="<%= to_string(@address) %>">
+  <span class="stakes-address">
+    <%= BlockScoutWeb.AddressView.trimmed_hash(@address) %>
+  </span>
+  <%= if @tooltip do %>
+    <%= render BlockScoutWeb.CommonComponentsView, "_check_tooltip.html", text: @tooltip %>
+  <% end %>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_validator_info.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_validator_info.html.eex
@@ -1,8 +1,14 @@
-<div class="modal fade" id="validatorInfoModal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-validator-info" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">0x18Bea833D503341C529a788c82909337e552a44e</h5>
+        <div>
+          <h5 class="modal-title"><%= to_string(@validator.staking_address_hash) %></h5>
+          <div>
+            <span class="modal-validator-info-item-title">Mining address:</span>
+            <span class="modal-validator-info-item-value"><%= to_string(@validator.mining_address_hash) %></span>
+          </div>
+        </div>
       </div>
       <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
       <div class="modal-validator-info-content">
@@ -10,54 +16,55 @@
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
           title: "Candidate’s Staked Amount",
-          value: "8800"
+          value: "#{format_according_to_decimals(@validator.self_staked_amount, @token.decimals)} #{@token.symbol}"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
-          title: "Delegors Staked Amount",
-          value: "3200"
+          title: "Delegators’ Staked Amount",
+          value: "#{format_according_to_decimals(Decimal.sub(@validator.staked_amount, @validator.self_staked_amount), @token.decimals)} #{@token.symbol}"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
           title: "Stakes Ratio",
-          value: "3.2%"
+          value: "#{@validator.staked_ratio}%"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
-          title: "Reward Precent of the Pool",
-          value: "15%"
+          title: "Reward Percent",
+          value: "#{@validator.block_reward_ratio}%"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
-          title: "How Many Times the Address was a Validator",
-          value: "108"
+          title: "How Many Times this Address has been a Validator",
+          value: @validator.was_validator_count
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
-          title: "How Many Times the Address was Banned",
-          value: "0"
+          title: "How Many Times this Address has been Banned",
+          value: @validator.was_banned_count
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
-          title: "The Block Number and Approximate Date When the  Address Will be Unbanned"
+          title: "The Block Number and Approximate Date When the Address Will be Unbanned",
+          value: if(@validator.is_banned, do: "##{@validator.banned_until} (#{estimated_unban_day(@validator.banned_until, @average_block_time)})")
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
           title: "Likelihood of Becoming a Validator on the Next Epoch",
-          value: "30%"
+          value: "#{@validator.likelihood}%"
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
           title: "The Number of Delegators In the Pool",
-          value: "103"
+          value: @validator.delegators_count
         %>
       </div>
     </div>


### PR DESCRIPTION
The modal window is rendered entirely on server and requested via websocket.
Bubbling of events is used to avoid setting event handlers on multiple rows.