### PR TITLE
Fix clearance of logs and node_modules folders in clearing script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 ### Chore
+- [#2450](https://github.com/poanetwork/blockscout/pull/2450) - Fix clearance of logs and node_modules folders in clearing script
 
 
 ## 2.0.2-beta

--- a/rel/commands/clear_build.sh
+++ b/rel/commands/clear_build.sh
@@ -2,9 +2,11 @@
 
 rm -rf ./_build
 rm -rf ./deps
-rm -rf ./logs/dev
-rm -rf ./apps/explorer/node_modules
-rm -rf ./apps/block_scout_web/assets/node_modules
+logs=$(find . -not -path '*/\.*' -name "logs" -type d)
+dev=$(find ${logs} -name "dev")
+rm -rf {ls -la ${dev}}
+
+find . -name "node_modules" -type d -exec rm -rf '{}' +
 
 case "$1" in
 		-f)


### PR DESCRIPTION
###  Motivation

Clearing script doesn't clear all `./node_modules` and `/logs/dev` folders

## Changelog

Add removal of all `/logs/dev` folders and all `/node_modules` excluding hidden folders and files

## Checklist for your PR


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
