### PR TITLE
Add generic client-side utilities for staking modals

### DIFF
--- a/apps/block_scout_web/assets/css/components/_stakes_progress.scss
+++ b/apps/block_scout_web/assets/css/components/_stakes_progress.scss
@@ -38,6 +38,11 @@
   }
 }
 
+.stakes-progress-info-link {
+  color: $secondary;
+  cursor: pointer;
+}
+
 .stakes-progress-graph {
   margin: 0 0 20px;
   position: relative;

--- a/apps/block_scout_web/assets/js/lib/async_listing_load.js
+++ b/apps/block_scout_web/assets/js/lib/async_listing_load.js
@@ -40,6 +40,8 @@ import { createStore, connectElements } from '../lib/redux_helpers.js'
 export const asyncInitialState = {
   /* it will consider any query param in the current URI as paging */
   beyondPageOne: (URI(window.location).query() !== ''),
+  /* will be sent along with { type: 'JSON' } to controller, useful for dynamically changing parameters */
+  additionalParams: {},
   /* an array with every html element of the list being shown */
   items: [],
   /* the key for diffing the elements in the items array */
@@ -52,6 +54,8 @@ export const asyncInitialState = {
   emptyResponse: false,
   /* if it is loading the first page */
   loadingFirstPage: true,
+  /* link to the current page */
+  currentPagePath: null,
   /* link to the next page */
   nextPagePath: null,
   /* link to the previous page */
@@ -63,7 +67,10 @@ export const asyncInitialState = {
 export function asyncReducer (state = asyncInitialState, action) {
   switch (action.type) {
     case 'ELEMENTS_LOAD': {
-      return Object.assign({}, state, { nextPagePath: action.nextPagePath })
+      return Object.assign({}, state, {
+        nextPagePath: action.nextPagePath,
+        currentPagePath: action.nextPagePath
+      })
     }
     case 'ADD_ITEM_KEY': {
       return Object.assign({}, state, { itemKey: action.itemKey })
@@ -71,7 +78,8 @@ export function asyncReducer (state = asyncInitialState, action) {
     case 'START_REQUEST': {
       return Object.assign({}, state, {
         loading: true,
-        requestError: false
+        requestError: false,
+        currentPagePath: action.path
       })
     }
     case 'REQUEST_ERROR': {
@@ -251,24 +259,26 @@ export function createAsyncLoadStore (reducer, initialState, itemKey) {
   return store
 }
 
+export function refreshPage (store) {
+  loadPage(store, store.getState().currentPagePath)
+}
+
+function loadPage (store, path) {
+  store.dispatch({type: 'START_REQUEST', path})
+  $.getJSON(path, _.merge({type: 'JSON'}, store.getState().additionalParams))
+    .done(response => store.dispatch(Object.assign({type: 'ITEMS_FETCHED'}, humps.camelizeKeys(response))))
+    .fail(() => store.dispatch({type: 'REQUEST_ERROR'}))
+    .always(() => store.dispatch({type: 'FINISH_REQUEST'}))
+}
+
 function firstPageLoad (store) {
   const $element = $('[data-async-listing]')
   function loadItemsNext () {
-    const path = store.getState().nextPagePath
-    store.dispatch({type: 'START_REQUEST'})
-    $.getJSON(path, {type: 'JSON'})
-      .done(response => store.dispatch(Object.assign({type: 'ITEMS_FETCHED'}, humps.camelizeKeys(response))))
-      .fail(() => store.dispatch({type: 'REQUEST_ERROR'}))
-      .always(() => store.dispatch({type: 'FINISH_REQUEST'}))
+    loadPage(store, store.getState().nextPagePath)
   }
 
   function loadItemsPrev () {
-    const path = store.getState().prevPagePath
-    store.dispatch({type: 'START_REQUEST'})
-    $.getJSON(path, {type: 'JSON'})
-      .done(response => store.dispatch(Object.assign({type: 'ITEMS_FETCHED'}, humps.camelizeKeys(response))))
-      .fail(() => store.dispatch({type: 'REQUEST_ERROR'}))
-      .always(() => store.dispatch({type: 'FINISH_REQUEST'}))
+    loadPage(store, store.getState().prevPagePath)
   }
   loadItemsNext()
 

--- a/apps/block_scout_web/assets/js/lib/modals.js
+++ b/apps/block_scout_web/assets/js/lib/modals.js
@@ -1,76 +1,140 @@
 import $ from 'jquery'
-import Chart from 'chart.js'
 
-$(function () {
-  $('.js-become-candidate').on('click', function () {
-    $('#becomeCandidateModal').modal()
-  })
+let $currentModal = null
+let modalLocked = false
 
-  $('.js-validator-info-modal').on('click', function () {
-    $('#validatorInfoModal').modal()
-  })
+const spinner =
+  `
+    <span class="loading-spinner-small mr-2">
+      <span class="loading-spinner-block-1"></span>
+      <span class="loading-spinner-block-2"></span>
+    </span>
+  `
 
-  $('.js-move-stake').on('click', function () {
-    $('#errorStatusModal').modal()
-  })
-
-  $('.js-remove-pool').on('click', function () {
-    $('#warningStatusModal').modal()
-  })
-
-  $('.js-copy-address').on('click', function () {
-    $('#successStatusModal').modal()
-  })
-
-  $('.js-stake-stake').on('click', function () {
-    const modal = '#stakeModal'
-    const progress = parseInt($(`${modal} .js-stakes-progress-data-progress`).text())
-    const total = parseInt($(`${modal} .js-stakes-progress-data-total`).text())
-
-    $(modal).modal()
-
-    setupStakesProgress(progress, total, modal)
-  })
-
-  $('.js-withdraw-stake').on('click', function () {
-    const modal = '#withdrawModal'
-    const progress = parseInt($(`${modal} .js-stakes-progress-data-progress`).text())
-    const total = parseInt($(`${modal} .js-stakes-progress-data-total`).text())
-
-    $(modal).modal()
-
-    setupStakesProgress(progress, total, modal)
-  })
-
-  function setupStakesProgress (progress, total, modal) {
-    const stakeProgress = $(`${modal} .js-stakes-progress`)
-    const primaryColor = $('.btn-full-primary').css('background-color')
-    const backgroundColors = [
-      primaryColor,
-      'rgba(202, 199, 226, 0.5)'
-    ]
-    const progressBackground = total - progress
-
-    // eslint-disable-next-line no-unused-vars
-    let myChart = new Chart(stakeProgress, {
-      type: 'doughnut',
-      data: {
-        datasets: [{
-          data: [progress, progressBackground],
-          backgroundColor: backgroundColors,
-          hoverBackgroundColor: backgroundColors,
-          borderWidth: 0
-        }]
-      },
-      options: {
-        cutoutPercentage: 80,
-        legend: {
-          display: false
-        },
-        tooltips: {
-          enabled: false
-        }
-      }
-    })
+$(document.body).on('hide.bs.modal', e => {
+  if (modalLocked) {
+    e.preventDefault()
+    e.stopPropagation()
+    return false
   }
+
+  $currentModal = null
 })
+
+export function openModal ($modal) {
+  if ($currentModal) {
+    modalLocked = false
+
+    $currentModal
+      .one('hidden.bs.modal', () => {
+        $modal.modal('show')
+        $currentModal = $modal
+      })
+      .modal('hide')
+  } else {
+    $modal.modal('show')
+    $currentModal = $modal
+  }
+}
+
+export function lockModal ($modal, $submitButton = null) {
+  $modal.find('.close-modal').attr('disabled', true)
+
+  const $button = $submitButton || $modal.find('.btn-add-full')
+
+  $button
+    .attr('data-text', $button.text())
+    .attr('disabled', true)
+    .html(spinner)
+
+  modalLocked = true
+}
+
+export function unlockModal ($modal, $submitButton = null) {
+  $modal.find('.close-modal').attr('disabled', false)
+
+  const $button = $submitButton || $modal.find('.btn-add-full')
+
+  $button
+    .text($button.attr('data-text'))
+    .attr('disabled', false)
+
+  modalLocked = false
+}
+
+export function openErrorModal (title, text) {
+  const $modal = $('#errorStatusModal')
+  $modal.find('.modal-status-title').text(title)
+  $modal.find('.modal-status-text').text(text)
+  openModal($modal)
+}
+
+export function openWarningModal (title, text) {
+  const $modal = $('#warningStatusModal')
+  $modal.find('.modal-status-title').text(title)
+  $modal.find('.modal-status-text').text(text)
+  openModal($modal)
+}
+
+export function openSuccessModal (title, text) {
+  const $modal = $('#successStatusModal')
+  $modal.find('.modal-status-title').text(title)
+  $modal.find('.modal-status-text').text(text)
+  openModal($modal)
+}
+
+export function openQuestionModal (title, text, acceptCallback = null, exceptCallback = null, acceptText = 'Yes', exceptText = 'No') {
+  const $modal = $('#questionStatusModal')
+
+  $modal.find('.modal-status-title').text(title)
+  $modal.find('.modal-status-text').text(text)
+
+  const $accept = $modal.find('.btn-line.accept')
+  const $except = $modal.find('.btn-line.except')
+
+  $accept
+    .removeAttr('data-dismiss')
+    .unbind('click')
+    .find('.btn-line-text').text(acceptText)
+
+  $except.removeAttr('data-dismiss')
+    .removeAttr('data-dismiss')
+    .unbind('click')
+    .find('.btn-line-text').text(exceptText)
+
+  if (acceptCallback) {
+    $accept.on('click', event => {
+      $accept
+        .unbind('click')
+        .find('.btn-line-text').html(spinner)
+      $except
+        .unbind('click')
+        .removeAttr('data-dismiss')
+
+      modalLocked = true
+      acceptCallback($modal, event)
+    })
+  } else {
+    $accept.attr('data-dismiss', 'modal')
+  }
+
+  if (exceptCallback) {
+    $except.on('click', event => {
+      $modal.find('.close-modal').attr('disabled', true)
+
+      $except
+        .unbind('click')
+        .find('.btn-line-text').html(spinner)
+      $accept
+        .unbind('click')
+        .removeAttr('data-dismiss')
+
+      modalLocked = true
+      exceptCallback($modal, event)
+    })
+  } else {
+    $except.attr('data-dismiss', 'modal')
+  }
+
+  openModal($modal)
+}

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -8,7 +8,11 @@ import Web3 from 'web3'
 export const initialState = {
   channel: null,
   web3: null,
-  account: null
+  account: null,
+  stakingContract: null,
+  blockRewardContract: null,
+  tokenDecimals: 0,
+  tokenSymbol: ''
 }
 
 export function reducer (state = initialState, action) {
@@ -29,6 +33,13 @@ export function reducer (state = initialState, action) {
         additionalParams: { account: action.account }
       })
     }
+    case 'RECEIVED_CONTRACTS': {
+      return Object.assign({}, state, {
+        stakingContract: action.stakingContract,
+        blockRewardContract: action.blockRewardContract,
+        tokenDecimals: action.tokenDecimals,
+        tokenSymbol: action.tokenSymbol
+      })
     }
     default:
       return state
@@ -39,23 +50,32 @@ const elements = {
 }
 
 const $stakesPage = $('[data-page="stakes"]')
+const $stakesTop = $('[data-selector="stakes-top"]')
 if ($stakesPage.length) {
   const store = createAsyncLoadStore(reducer, initialState, 'dataset.identifierPool')
   connectElements({ store, elements })
 
   const channel = subscribeChannel('stakes:staking_update')
-  channel.on('staking_update', msg => onStakingUpdate(msg, store))
   store.dispatch({ type: 'CHANNEL_CONNECTED', channel })
 
+  channel.on('staking_update', msg => $stakesTop.html(msg.top_html))
+  channel.on('contracts', msg => {
+    const web3 = store.getState().web3
+    const stakingContract =
+      new web3.eth.Contract(msg.staking_contract.abi, msg.staking_contract.address)
+    const blockRewardContract =
+      new web3.eth.Contract(msg.block_reward_contract.abi, msg.block_reward_contract.address)
+
+    store.dispatch({
+      type: 'RECEIVED_CONTRACTS',
+      stakingContract,
+      blockRewardContract,
+      tokenDecimals: parseInt(msg.token_decimals),
+      tokenSymbol: msg.token_symbol
+    })
+  })
+
   initializeWeb3(store)
-}
-
-function onStakingUpdate (msg, store) {
-  $('[data-selector="stakes-top"]').html(msg.top_html)
-
-  if (store.getState().web3) {
-    $('[data-selector="login-button"]').on('click', loginByMetamask)
-  }
 }
 
 function initializeWeb3 (store) {
@@ -71,6 +91,8 @@ function initializeWeb3 (store) {
         setAccount(account, store)
       }
     }, 100)
+
+    $stakesTop.on('click', '[data-selector="login-button"]', loginByMetamask)
   }
 }
 

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -2,7 +2,7 @@ import $ from 'jquery'
 import _ from 'lodash'
 import { subscribeChannel } from '../socket'
 import { connectElements } from '../lib/redux_helpers.js'
-import { createAsyncLoadStore } from '../lib/async_listing_load'
+import { createAsyncLoadStore, refreshPage } from '../lib/async_listing_load'
 import Web3 from 'web3'
 
 export const initialState = {
@@ -24,7 +24,11 @@ export function reducer (state = initialState, action) {
       return Object.assign({}, state, { web3: action.web3 })
     }
     case 'ACCOUNT_UPDATED': {
-      return Object.assign({}, state, { account: action.account })
+      return Object.assign({}, state, {
+        account: action.account,
+        additionalParams: { account: action.account }
+      })
+    }
     }
     default:
       return state
@@ -73,6 +77,7 @@ function initializeWeb3 (store) {
 function setAccount (account, store) {
   store.dispatch({ type: 'ACCOUNT_UPDATED', account })
   store.getState().channel.push('set_account', account)
+  refreshPage(store)
 }
 
 async function loginByMetamask (event) {

--- a/apps/block_scout_web/assets/js/pages/stakes/utils.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/utils.js
@@ -1,0 +1,33 @@
+import { refreshPage } from '../../lib/async_listing_load'
+import { openErrorModal, openSuccessModal } from '../../lib/modals'
+
+export async function makeContractCall (call, store) {
+  let timeout
+
+  try {
+    const account = store.getState().account
+    const gas = await call.estimateGas({
+      from: account,
+      gasPrice: 1000000000
+    })
+
+    await call.send({
+      from: account,
+      gas: Math.ceil(gas * 1.2),
+      gasPrice: 1000000000
+    }).once('transactionHash', (hash) => {
+      timeout = setTimeout(() => {
+        openErrorModal('Error', 'Your transaction cannot be mined at the moment. Please, try again with the increased gas price or fixed nonce (use Reset Account feature of MetaMask).')
+      }, 15000)
+    })
+
+    clearTimeout(timeout)
+    refreshPage(store)
+    openSuccessModal('Success', 'Transaction is confirmed.')
+  } catch (err) {
+    console.log(err)
+    clearTimeout(timeout)
+    openErrorModal('Error', err.message)
+  }
+}
+

--- a/apps/block_scout_web/assets/js/pages/stakes/utils.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/utils.js
@@ -1,3 +1,5 @@
+import $ from 'jquery'
+import Chart from 'chart.js'
 import { refreshPage } from '../../lib/async_listing_load'
 import { openErrorModal, openSuccessModal } from '../../lib/modals'
 
@@ -31,3 +33,33 @@ export async function makeContractCall (call, store) {
   }
 }
 
+export function setupChart ($canvas, self, total) {
+  const primaryColor = $('.btn-full-primary').css('background-color')
+  const backgroundColors = [
+    primaryColor,
+    'rgba(202, 199, 226, 0.5)'
+  ]
+  const data = total > 0 ? [self, total - self] : [0, 1]
+
+  // eslint-disable-next-line no-new
+  new Chart($canvas, {
+    type: 'doughnut',
+    data: {
+      datasets: [{
+        data: data,
+        backgroundColor: backgroundColors,
+        hoverBackgroundColor: backgroundColors,
+        borderWidth: 0
+      }]
+    },
+    options: {
+      cutoutPercentage: 80,
+      legend: {
+        display: false
+      },
+      tooltips: {
+        enabled: false
+      }
+    }
+  })
+}

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -5,6 +5,7 @@ defmodule BlockScoutWeb.StakesChannel do
   use BlockScoutWeb, :channel
 
   alias BlockScoutWeb.StakesController
+  alias Explorer.Staking.ContractState
 
   intercept(["staking_update"])
 
@@ -13,7 +14,11 @@ defmodule BlockScoutWeb.StakesChannel do
   end
 
   def handle_in("set_account", account, socket) do
-    socket = assign(socket, :account, account)
+    socket =
+      socket
+      |> assign(:account, account)
+      |> push_staking_contract()
+
     handle_out("staking_update", nil, socket)
   end
 
@@ -23,5 +28,22 @@ defmodule BlockScoutWeb.StakesChannel do
     })
 
     {:noreply, socket}
+  end
+
+  defp push_staking_contract(socket) do
+    if socket.assigns[:contract_sent] do
+      socket
+    else
+      token = ContractState.get(:token)
+
+      push(socket, "contracts", %{
+        staking_contract: ContractState.get(:staking_contract),
+        block_reward_contract: ContractState.get(:block_reward_contract),
+        token_decimals: token.decimals,
+        token_symbol: token.symbol
+      })
+
+      assign(socket, :contract_sent, true)
+    end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
@@ -47,7 +47,7 @@ defmodule BlockScoutWeb.StakesController do
       |> Map.get("position", "0")
       |> String.to_integer()
 
-    pools_plus_one = Chain.staking_pools(filter, options)
+    pools_plus_one = Chain.staking_pools(filter, options, params["account"])
 
     {pools, next_page} = split_list_by_page(pools_plus_one)
 
@@ -67,11 +67,12 @@ defmodule BlockScoutWeb.StakesController do
 
     average_block_time = AverageBlockTime.average_block_time()
     token = ContractState.get(:token, %Token{})
+    epoch_number = ContractState.get(:epoch_number, 0)
 
     items =
       pools
       |> Enum.with_index(last_index + 1)
-      |> Enum.map(fn {pool, index} ->
+      |> Enum.map(fn {%{pool: pool, delegator: delegator}, index} ->
         View.render_to_string(
           StakesView,
           "_rows.html",
@@ -79,7 +80,12 @@ defmodule BlockScoutWeb.StakesController do
           pool: pool,
           index: index,
           average_block_time: average_block_time,
-          pools_type: filter
+          pools_type: filter,
+          buttons: %{
+            stake: true,
+            move: move_allowed?(delegator),
+            withdraw: withdraw_allowed?(delegator, epoch_number)
+          }
         )
       end)
 
@@ -111,5 +117,19 @@ defmodule BlockScoutWeb.StakesController do
 
   defp next_page_path(:inactive, conn, params) do
     inactive_pools_path(conn, :index, params)
+  end
+
+  defp move_allowed?(nil), do: false
+
+  defp move_allowed?(delegator) do
+    delegator.is_active and Decimal.positive?(delegator.max_withdraw_allowed)
+  end
+
+  defp withdraw_allowed?(nil, _epoch_number), do: false
+
+  defp withdraw_allowed?(delegator, epoch_number) do
+    (delegator.is_active and Decimal.positive?(delegator.max_withdraw_allowed)) or
+      (delegator.is_active and Decimal.positive?(delegator.max_ordered_withdraw_allowed)) or
+      (Decimal.positive?(delegator.ordered_withdraw) and delegator.ordered_withdraw_epoch < epoch_number)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_modal_status.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_modal_status.html.eex
@@ -3,44 +3,25 @@
     <div class="modal-content">
       <div class="modal-status-graph modal-status-graph-<%= if assigns[:status] do @status end %>">
         <%=
-          if @status == "error" do
-            render BlockScoutWeb.CommonComponentsView, "_icon_error_modal.html"
-          end
-        %>
-        <%=
-          if @status == "success" do
-            render BlockScoutWeb.CommonComponentsView, "_icon_success_modal.html"
-          end
-        %>
-        <%=
-          if @status == "warning" do
-            render BlockScoutWeb.CommonComponentsView, "_icon_warning_modal.html"
-          end
-        %>
-        <%=
-          if @status == "question" do
-            render BlockScoutWeb.CommonComponentsView, "_icon_question_modal.html"
+          if @status in ["error", "success", "warning", "question"] do
+            render BlockScoutWeb.CommonComponentsView, "_icon_#{@status}_modal.html"
           end
         %>
       </div>
       <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
       <div class="modal-body modal-status-body">
-        <%= if assigns[:title] do %>
-        <h2 class="modal-status-title"><%= @title %></h2>
-        <% end %>
-        <%= if assigns[:text] do %>
-        <p class="modal-status-text"><%= @text %></p>
-        <% end %>
+        <h2 class="modal-status-title"><%= if assigns[:title] do @title end %></h2>
+        <p class="modal-status-text"><%= if assigns[:text] do @text end %></p>
         <div class="modal-status-button-wrapper">
           <%= if @status !== "question" do %>
             <button class="btn-line" type="button" data-dismiss="modal">
               <span class="btn-line-text">Ok</span>
             </button>
           <% else %>
-            <button class="btn-line except" type="button" data-dismiss="modal">
+            <button class="btn-line except" type="button">
               <span class="btn-line-text">No</span>
             </button>
-            <button class="btn-line accept" type="button" data-dismiss="modal">
+            <button class="btn-line accept" type="button">
               <span class="btn-line-text">Yes</span>
             </button>
           <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -44,6 +44,11 @@
       </main>
       <%= render BlockScoutWeb.LayoutView, "_footer.html", assigns %>
     </div>
+    <%=
+      for status <- ["error", "warning", "success", "question"] do
+        render BlockScoutWeb.CommonComponentsView, "_modal_status.html", status: status
+      end
+    %>
     <script>
       window.localized = {
         'Blocks Indexed': '<%= gettext("Blocks Indexed") %>',

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
@@ -34,9 +34,15 @@
       </span>
     <% else %>
       <div class="stakes-controls">
-        <%= render BlockScoutWeb.StakesView, "_stakes_control_move.html", address: @pool.staking_address_hash %>
-        <%= render BlockScoutWeb.StakesView, "_stakes_control_withdraw.html", address: @pool.staking_address_hash %>
-        <%= render BlockScoutWeb.StakesView, "_stakes_control_stake.html", address: @pool.staking_address_hash %>
+        <%= if @buttons.move do %>
+          <%= render BlockScoutWeb.StakesView, "_stakes_control_move.html", address: @pool.staking_address_hash %>
+        <% end %>
+        <%= if @buttons.withdraw do %>
+          <%= render BlockScoutWeb.StakesView, "_stakes_control_withdraw.html", address: @pool.staking_address_hash %>
+        <% end %>
+        <%= if @buttons.stake do %>
+          <%= render BlockScoutWeb.StakesView, "_stakes_control_stake.html", address: @pool.staking_address_hash %>
+        <% end %>
       </div>
     <% end %>
   </td>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_progress.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_progress.html.eex
@@ -1,31 +1,35 @@
 <div class="stakes-progress">
   <div class="stakes-progress-graph">
     <canvas
-      class="stakes-progress-graph-canvas js-stakes-progress"
+      class="stakes-progress-graph-canvas js-stakes-progress <%= if assigns[:extra_class], do: @extra_class %>"
       height="125"
       width="125"
     ></canvas>
     <div class="stakes-progress-data">
-      <div class="stakes-progress-data-progress js-stakes-progress-data-progress"><%= if assigns[:progress] do @progress end %></div>
-      <div class="stakes-progress-data-total js-stakes-progress-data-total"><%= if assigns[:total] do @total end %></div>
+      <div class="stakes-progress-data-progress js-stakes-progress-data-progress">
+        <%= format_according_to_decimals(@pool.self_staked_amount, @token.decimals) %>
+      </div>
+      <div class="stakes-progress-data-total js-stakes-progress-data-total">
+        <%= format_according_to_decimals(@pool.staked_amount, @token.decimals) %>
+      </div>
     </div>
   </div>
   <div class="stakes-progress-info">
-      <h2 class="stakes-progress-info-title"><%= gettext("Pool") %></h2>
-      <p class="stakes-progress-info-value link-color">
-        <%= if assigns[:pool] do @pool end %>
-      </p>
+    <h2 class="stakes-progress-info-title"><%= gettext("Pool") %></h2>
+    <p class="stakes-progress-info-value stakes-progress-info-link js-validator-info" data-address="<%= to_string(@pool.staking_address_hash) %>">
+      <%= BlockScoutWeb.AddressView.trimmed_hash(@pool.staking_address_hash) %>
+    </p>
   </div>
   <div class="stakes-progress-info">
-      <h2 class="stakes-progress-info-title"><%= gettext("Stakes Ratio") %></h2>
-      <p class="stakes-progress-info-value">
-        <%= if assigns[:stakes_ratio] do @stakes_ratio end %>
-      </p>
+    <h2 class="stakes-progress-info-title"><%= gettext("Stakes Ratio") %></h2>
+    <p class="stakes-progress-info-value">
+      <%= @pool.staked_ratio %>%
+    </p>
   </div>
   <div class="stakes-progress-info">
-      <h2 class="stakes-progress-info-title"><%= gettext("Delegators") %></h2>
-      <p class="stakes-progress-info-value link-color">
-        <%= if assigns[:delegators] do @delegators end %>
-      </p>
+    <h2 class="stakes-progress-info-title"><%= gettext("Delegators") %></h2>
+    <p class="stakes-progress-info-value stakes-progress-info-link js-delegators-list" data-address="<%= to_string(@pool.staking_address_hash) %>">
+      <%= @pool.delegators_count %>
+    </p>
   </div>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_table.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_table.html.eex
@@ -36,31 +36,3 @@
     <tbody data-items></tbody>
   </table>
 </div>
-<%=
-  render BlockScoutWeb.CommonComponentsView,
-  "_modal_status.html",
-  status: "error",
-  title: "Lorem Ipsum",
-  text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor."
-%>
-<%=
-  render BlockScoutWeb.CommonComponentsView,
-  "_modal_status.html",
-  status: "warning",
-  title: "Lorem Ipsum",
-  text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor."
-%>
-<%=
-  render BlockScoutWeb.CommonComponentsView,
-  "_modal_status.html",
-  status: "success",
-  title: "Lorem Ipsum",
-  text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor."
-%>
-<%=
-  render BlockScoutWeb.CommonComponentsView,
-  "_modal_status.html",
-  status: "question",
-  title: "Remove my Pool",
-  text: "Do you really want to remove your pool?"
-%>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -157,7 +157,7 @@ msgid "Block Height: %{height}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:50
+#: lib/block_scout_web/templates/layout/app.html.eex:55
 msgid "Block Mined, awaiting import..."
 msgstr ""
 
@@ -184,7 +184,7 @@ msgid "Blocks"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:49
+#: lib/block_scout_web/templates/layout/app.html.eex:54
 msgid "Blocks Indexed"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_balance_card.html.eex:15
 #: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:21
-#: lib/block_scout_web/templates/layout/app.html.eex:55
+#: lib/block_scout_web/templates/layout/app.html.eex:60
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:20
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:30
 #: lib/block_scout_web/templates/transaction/overview.html.eex:192
@@ -454,7 +454,7 @@ msgid "IN"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:51
+#: lib/block_scout_web/templates/layout/app.html.eex:56
 msgid "Indexing Tokens"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid "Inventory"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:52
+#: lib/block_scout_web/templates/layout/app.html.eex:57
 msgid "Less than"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:31
-#: lib/block_scout_web/templates/layout/app.html.eex:53
+#: lib/block_scout_web/templates/layout/app.html.eex:58
 #: lib/block_scout_web/views/address_view.ex:121
 msgid "Market Cap"
 msgstr ""
@@ -620,7 +620,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:24
-#: lib/block_scout_web/templates/layout/app.html.eex:54
+#: lib/block_scout_web/templates/layout/app.html.eex:59
 msgid "Price"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1574,7 +1574,7 @@ msgid "Block number"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:26
+#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:30
 msgid "Delegators"
 msgstr ""
 
@@ -1600,7 +1600,7 @@ msgid "Order Withdrawal"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:14
+#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:18
 msgid "Pool"
 msgstr ""
 
@@ -1630,7 +1630,7 @@ msgid "Stakes"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:20
+#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:24
 msgid "Stakes Ratio"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -157,7 +157,7 @@ msgid "Block Height: %{height}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:50
+#: lib/block_scout_web/templates/layout/app.html.eex:55
 msgid "Block Mined, awaiting import..."
 msgstr ""
 
@@ -184,7 +184,7 @@ msgid "Blocks"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:49
+#: lib/block_scout_web/templates/layout/app.html.eex:54
 msgid "Blocks Indexed"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_balance_card.html.eex:15
 #: lib/block_scout_web/templates/internal_transaction/_tile.html.eex:21
-#: lib/block_scout_web/templates/layout/app.html.eex:55
+#: lib/block_scout_web/templates/layout/app.html.eex:60
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:20
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:30
 #: lib/block_scout_web/templates/transaction/overview.html.eex:192
@@ -454,7 +454,7 @@ msgid "IN"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:51
+#: lib/block_scout_web/templates/layout/app.html.eex:56
 msgid "Indexing Tokens"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid "Inventory"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:52
+#: lib/block_scout_web/templates/layout/app.html.eex:57
 msgid "Less than"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:31
-#: lib/block_scout_web/templates/layout/app.html.eex:53
+#: lib/block_scout_web/templates/layout/app.html.eex:58
 #: lib/block_scout_web/views/address_view.ex:121
 msgid "Market Cap"
 msgstr ""
@@ -620,7 +620,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:24
-#: lib/block_scout_web/templates/layout/app.html.eex:54
+#: lib/block_scout_web/templates/layout/app.html.eex:59
 msgid "Price"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1574,7 +1574,7 @@ msgid "Block number"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:26
+#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:30
 msgid "Delegators"
 msgstr ""
 
@@ -1600,7 +1600,7 @@ msgid "Order Withdrawal"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:14
+#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:18
 msgid "Pool"
 msgstr ""
 
@@ -1630,7 +1630,7 @@ msgid "Stakes"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:20
+#: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:24
 msgid "Stakes Ratio"
 msgstr ""
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -7,11 +7,13 @@ defmodule Explorer.Chain do
     only: [
       from: 2,
       join: 4,
+      join: 5,
       limit: 2,
       order_by: 2,
       order_by: 3,
       preload: 2,
       select: 2,
+      select: 3,
       subquery: 1,
       union_all: 2,
       where: 2,
@@ -3123,34 +3125,50 @@ defmodule Explorer.Chain do
   end
 
   @doc "Get staking pools from the DB"
-  @spec staking_pools(filter :: :validator | :active | :inactive, options :: PagingOptions.t()) :: [map()]
-  def staking_pools(filter, paging_options \\ @default_paging_options) do
-    filter
-    |> staking_pools_query(paging_options)
-    |> Repo.all()
-  end
-
-  defp staking_pools_query(filter, paging_options) do
-    page_size = paging_options.page_size
-
+  @spec staking_pools(
+          filter :: :validator | :active | :inactive,
+          options :: PagingOptions.t(),
+          delegator_address_hash :: Hash.t() | nil
+        ) :: [map()]
+  def staking_pools(filter, paging_options \\ @default_paging_options, delegator_address_hash \\ nil) do
     base_query =
       StakingPool
       |> where(is_deleted: false)
       |> staking_pool_filter(filter)
-      |> limit(^page_size)
+      |> staking_pools_paging_query(paging_options)
+
+    query =
+      if delegator_address_hash do
+        base_query
+        |> join(:left, [p], pd in StakingPoolsDelegator,
+          on: p.staking_address_hash == pd.pool_address_hash and pd.delegator_address_hash == ^delegator_address_hash
+        )
+        |> select([p, pd], %{pool: p, delegator: pd})
+      else
+        base_query
+        |> select([p], %{pool: p, delegator: nil})
+      end
+
+    Repo.all(query)
+  end
+
+  defp staking_pools_paging_query(base_query, paging_options) do
+    paging_query =
+      base_query
+      |> limit(^paging_options.page_size)
       |> order_by(desc: :staked_ratio, asc: :staking_address_hash)
 
     case paging_options.key do
       {value, address_hash} ->
         where(
-          base_query,
+          paging_query,
           [p],
           p.staked_ratio < ^value or
             (p.staked_ratio == ^value and p.staking_address_hash > ^address_hash)
         )
 
       _ ->
-        base_query
+        paging_query
     end
   end
 

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -19,7 +19,10 @@ defmodule Explorer.Staking.ContractState do
     :min_candidate_stake,
     :min_delegator_stake,
     :epoch_number,
-    :epoch_end_block
+    :epoch_end_block,
+    :staking_contract,
+    :validator_set_contract,
+    :block_reward_contract
   ]
 
   defstruct [
@@ -74,6 +77,12 @@ defmodule Explorer.Staking.ContractState do
       },
       abi: staking_abi ++ validator_set_abi ++ block_reward_abi
     }
+
+    :ets.insert(@table_name,
+      staking_contract: %{abi: staking_abi, address: staking_contract_address},
+      validator_set_contract: %{abi: validator_set_abi, address: validator_set_contract_address},
+      block_reward_contract: %{abi: block_reward_abi, address: block_reward_contract_address}
+    )
 
     {:ok, state, {:continue, []}}
   end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4055,7 +4055,7 @@ defmodule Explorer.ChainTest do
 
       options = %PagingOptions{page_size: 20, page_number: 1}
 
-      assert [gotten_validator] = Chain.staking_pools(:validator, options)
+      assert [%{pool: gotten_validator}] = Chain.staking_pools(:validator, options)
       assert inserted_validator.staking_address_hash == gotten_validator.staking_address_hash
     end
 
@@ -4065,7 +4065,7 @@ defmodule Explorer.ChainTest do
 
       options = %PagingOptions{page_size: 20, page_number: 1}
 
-      assert [gotten_pool] = Chain.staking_pools(:active, options)
+      assert [%{pool: gotten_pool}] = Chain.staking_pools(:active, options)
       assert inserted_pool.staking_address_hash == gotten_pool.staking_address_hash
     end
 
@@ -4075,7 +4075,7 @@ defmodule Explorer.ChainTest do
 
       options = %PagingOptions{page_size: 20, page_number: 1}
 
-      assert [gotten_pool] = Chain.staking_pools(:inactive, options)
+      assert [%{pool: gotten_pool}] = Chain.staking_pools(:inactive, options)
       assert inserted_pool.staking_address_hash == gotten_pool.staking_address_hash
     end
   end


### PR DESCRIPTION
1. Refresh list of pools on account change and show correct buttons.
AsyncLoadStore is improved to allow sending additional dynamic data from redux state, as well as refreshing currently displayed page. This allows showing table rows specifically for currently logged-in account with properly selected row buttons.

2. Make status modals generic and add modal utilities.
`open{Error,Warning,Success}Modal` methods just open corresponding modals.
`openQuestionModal` allows changing button titles and callbacks. It also automatically blocks UI for non-default callback.

3. Load contract ABIs after signing in, add `makeContractCall` utility.
After user signs in using MetaMask for the first time, the contract addresses and ABIs are pushed throught the websocket. They are saved in the state for making calls to MetaMask API.
`makeContractCall` utility is added for that purpose: it makes a call, shows success/error message from API, and shows error if 15s timeout passes.
Token information is passed as well for calculations, comparisons and alerts.

4. Render stakes progress template on server.
The stakes progress component is shown in some staking modals and contains basic information about currently selected pool. Client-side initialization utility `setupChart` is added as well.