### PR TITLE
hide decoded row if event is not decoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#2425](https://github.com/poanetwork/blockscout/pull/2425) - Force to show address view for checksummed address even if it is not in DB
 
 ### Chore
+- [#2492](https://github.com/poanetwork/blockscout/pull/2492) - hide decoded row if event is not decoded
 - [#2432](https://github.com/poanetwork/blockscout/pull/2432) - bump credo version
 - [#2457](https://github.com/poanetwork/blockscout/pull/2457) - update mix.lock
 - [#2435](https://github.com/poanetwork/blockscout/pull/2435) - Replace deprecated extract-text-webpack-plugin with mini-css-extract-plugin

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_logs/_logs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_logs/_logs.html.eex
@@ -11,10 +11,10 @@
             ) %>
       </h3>
     </dd>
-    <dt class="col-md-2"><%= gettext "Decoded" %></dt>
-    <dd class="col-md-10">
       <%= case decode(@log, @log.transaction) do %>
         <% {:error, :contract_not_verified} -> %>
+          <dt class="col-md-2"><%= gettext "Decoded" %></dt>
+          <dd class="col-md-10">
           <div class="alert alert-info">
             <%= gettext "To see decoded input data, the contract must be verified." %>
             <%= case @log.transaction do %>
@@ -25,10 +25,16 @@
             <% end %>
           </div>
         <% {:error, :could_not_decode} -> %>
+          <dt class="col-md-2"><%= gettext "Decoded" %></dt>
+          <dd class="col-md-10">
           <div class="alert alert-danger">
             <%= gettext "Failed to decode log data." %>
           </div>
+        <% {:error, :no_matching_function} -> %>
+          <%= nil %>
         <% {:ok, method_id, text, mapping} -> %>
+          <dt class="col-md-2"><%= gettext "Decoded" %></dt>
+          <dd class="col-md-10">
           <table summary="Transaction Info" class="table thead-light table-bordered transaction-input-table">
             <tr>
               <td>Method Id</td>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_logs/_logs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_logs/_logs.html.eex
@@ -30,8 +30,6 @@
           <div class="alert alert-danger">
             <%= gettext "Failed to decode log data." %>
           </div>
-        <% {:error, :no_matching_function} -> %>
-          <%= nil %>
         <% {:ok, method_id, text, mapping} -> %>
           <dt class="col-md-2"><%= gettext "Decoded" %></dt>
           <dd class="col-md-10">
@@ -84,7 +82,7 @@
             <% end %>
          </table>
        </div>
-        <% _ -> %>
+       <% _ -> %>
           <%= nil %>
       <% end %>
     <dt class="col-md-2"><%= gettext "Topics" %></dt>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_logs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_logs.html.eex
@@ -11,10 +11,10 @@
           ) %>
       </h3>
     </dd>
-    <dt class="col-md-1"><%= gettext "Decoded" %></dt>
-    <dd class="col-md-11">
       <%= case decode(@log, @transaction) do %>
         <% {:error, :contract_not_verified} -> %>
+          <dt class="col-md-1"><%= gettext "Decoded" %></dt>
+          <dd class="col-md-11">
           <div class="alert alert-info">
             <%= gettext "To see decoded input data, the contract must be verified." %>
             <%= case @transaction do %>
@@ -25,10 +25,16 @@
             <% end %>
           </div>
         <% {:error, :could_not_decode} -> %>
+          <dt class="col-md-1"><%= gettext "Decoded" %></dt>
+          <dd class="col-md-11">
           <div class="alert alert-danger">
             <%= gettext "Failed to decode log data." %>
           </div>
+        <% {:error, :no_matching_function} -> %>
+          <%= nil %>
         <% {:ok, method_id, text, mapping} -> %>
+          <dt class="col-md-1"><%= gettext "Decoded" %></dt>
+          <dd class="col-md-11">
           <table summary="Transaction Info" class="table thead-light table-bordered transaction-input-table">
             <tr>
               <td>Method Id</td>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -547,7 +547,7 @@ msgid "Must be set to:"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:52
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:50
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:52
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:19
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:52
@@ -1110,7 +1110,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:16
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:28
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:36
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:34
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:16
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:28
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:36
@@ -1757,7 +1757,7 @@ msgid "Constructor Arguments"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:65
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:63
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:31
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:65
 msgid "Copy Value"
@@ -1769,8 +1769,8 @@ msgid "Create2"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:55
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:120
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:53
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:118
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:21
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:55
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:121
@@ -1784,13 +1784,13 @@ msgid "Failed to decode log data."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:54
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:52
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:54
 msgid "Indexed?"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:49
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:47
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:49
 msgid "Log Data"
 msgstr ""
@@ -1803,13 +1803,13 @@ msgid "Reward"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:90
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:88
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:91
 msgid "Topics"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:53
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:51
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:20
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:53
 msgid "Type"

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -547,10 +547,10 @@ msgid "Must be set to:"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:46
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:52
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:52
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:19
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:46
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:52
 msgid "Name"
 msgstr ""
 
@@ -1108,8 +1108,12 @@ msgid "Static Call"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:14
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:14
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:16
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:28
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:36
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:16
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:28
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:36
 msgid "Decoded"
 msgstr ""
 
@@ -1753,9 +1757,9 @@ msgid "Constructor Arguments"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:59
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:65
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:31
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:59
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:65
 msgid "Copy Value"
 msgstr ""
 
@@ -1765,29 +1769,29 @@ msgid "Create2"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:49
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:114
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:55
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:120
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:21
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:49
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:115
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:55
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:121
 msgid "Data"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:29
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:29
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:31
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:31
 msgid "Failed to decode log data."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:48
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:48
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:54
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:54
 msgid "Indexed?"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:43
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:43
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:49
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:49
 msgid "Log Data"
 msgstr ""
 
@@ -1799,14 +1803,14 @@ msgid "Reward"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:84
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:85
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:90
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:91
 msgid "Topics"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:47
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:53
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:20
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:47
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:53
 msgid "Type"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -547,7 +547,7 @@ msgid "Must be set to:"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:52
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:50
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:52
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:19
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:52
@@ -1110,7 +1110,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:16
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:28
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:36
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:34
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:16
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:28
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:36
@@ -1758,7 +1758,7 @@ msgid "Constructor Arguments"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:65
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:63
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:31
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:65
 msgid "Copy Value"
@@ -1770,8 +1770,8 @@ msgid "Create2"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:55
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:120
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:53
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:118
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:21
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:55
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:121
@@ -1785,13 +1785,13 @@ msgid "Failed to decode log data."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:54
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:52
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:54
 msgid "Indexed?"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:49
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:47
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:49
 msgid "Log Data"
 msgstr ""
@@ -1804,13 +1804,13 @@ msgid "Reward"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:90
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:88
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:91
 msgid "Topics"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:53
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:51
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:20
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:53
 msgid "Type"

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -547,10 +547,10 @@ msgid "Must be set to:"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:46
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:52
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:52
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:19
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:46
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:52
 msgid "Name"
 msgstr ""
 
@@ -1108,8 +1108,12 @@ msgid "Static Call"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:14
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:14
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:16
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:28
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:36
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:16
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:28
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:36
 msgid "Decoded"
 msgstr ""
 
@@ -1754,9 +1758,9 @@ msgid "Constructor Arguments"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:59
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:65
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:31
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:59
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:65
 msgid "Copy Value"
 msgstr ""
 
@@ -1766,29 +1770,29 @@ msgid "Create2"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:49
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:114
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:55
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:120
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:21
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:49
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:115
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:55
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:121
 msgid "Data"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:29
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:29
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:31
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:31
 msgid "Failed to decode log data."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:48
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:48
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:54
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:54
 msgid "Indexed?"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:43
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:43
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:49
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:49
 msgid "Log Data"
 msgstr ""
 
@@ -1800,14 +1804,14 @@ msgid "Reward"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:84
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:85
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:90
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:91
 msgid "Topics"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:47
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:53
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:20
-#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:47
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:53
 msgid "Type"
 msgstr ""


### PR DESCRIPTION
fixes https://github.com/poanetwork/blockscout/issues/2476

## Motivation

Some logs events can not be decoded because matching function is not found in the contract's abi.
For example https://blockscout.com/eth/mainnet/address/0x1c527e27aa092c566cdfcc537faf5acc74a62ea0/logs
the same is happening in etherscan https://etherscan.io/address/0x1C527e27aA092c566cdFCC537Faf5acC74A62Ea0#events

## Changelog
- hide decoded row if event is not decoded