### PR TITLE
fix logging for indexed chain when last block is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2456](https://github.com/poanetwork/blockscout/pull/2456) - fetch pending transactions for geth
 
 ### Fixes
+- [#2495](https://github.com/poanetwork/blockscout/pull/2495) - fix logs for indexed chain
 - [#2459](https://github.com/poanetwork/blockscout/pull/2459) - fix top addresses query
 - [#2425](https://github.com/poanetwork/blockscout/pull/2425) - Force to show address view for checksummed address even if it is not in DB
 

--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -185,7 +185,12 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
 
   def handle_info(
         {ref,
-         %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: false = shrunk}},
+         %{
+           first_block_number: first_block_number,
+           last_block_number: last_block_number,
+           missing_block_count: missing_block_count,
+           shrunk: false = shrunk
+         }},
         %__MODULE__{
           bound_interval: bound_interval,
           task: %Task{ref: ref}
@@ -197,7 +202,7 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
         0 ->
           Logger.info("Index already caught up.",
             first_block_number: first_block_number,
-            last_block_number: 0,
+            last_block_number: last_block_number,
             missing_block_count: 0,
             shrunk: shrunk
           )

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -123,7 +123,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
               Shrinkable.shrunk?(sequence)
           end
 
-        %{first_block_number: first, missing_block_count: missing_block_count, shrunk: shrunk}
+        %{first_block_number: first, last_block_number: last, missing_block_count: missing_block_count, shrunk: shrunk}
     end
   end
 


### PR DESCRIPTION
## Motivation

`last_block_number` is always 0 for indexed chain even if `LAST_BLOCK` is set

## Changelog

- fix logging for finished indexed with last block set