### PR TITLE
Show "Delegators List" modal window

### DIFF
--- a/apps/block_scout_web/assets/css/app.scss
+++ b/apps/block_scout_web/assets/css/app.scss
@@ -101,6 +101,7 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "components/stakes_table";
 @import "components/i_tooltip";
 @import "components/check_tooltip";
+@import "components/me_tooltip";
 @import "components/tooltip";
 @import "components/progress_from_to";
 @import "components/stakes_empty_content";

--- a/apps/block_scout_web/assets/css/components/_me_tooltip.scss
+++ b/apps/block_scout_web/assets/css/components/_me_tooltip.scss
@@ -1,0 +1,25 @@
+$me-tooltip-background: #f5f6fa !default;
+$me-tooltip-background-active: $primary !default;
+$me-tooltip-text: #a3a9b5 !default;
+$me-tooltip-text-active: #fff !default;
+
+.me-tooltip {
+  display: block;
+  height: 16px;
+  width: 24px;
+  border-radius: 8px;
+  background-color: $me-tooltip-background;
+  color: $me-tooltip-text;
+  cursor: pointer;
+  font-size: 10px;
+  line-height: 16px;
+  font-weight: bold;
+  text-align: center;
+  position: relative;
+  top: -1px;
+
+  &:hover {
+    background-color: $me-tooltip-background-active;
+    color: $me-tooltip-text-active;
+  }
+}

--- a/apps/block_scout_web/assets/css/components/_modal.scss
+++ b/apps/block_scout_web/assets/css/components/_modal.scss
@@ -61,3 +61,8 @@ $modal-gray-background: #f6f7f9 !default;
     }
   }
 }
+
+.modal-table {
+  width: calc(100% + #{$modal-horizontal-padding} * 2);
+  margin: 0 -#{$modal-horizontal-padding} 0;
+}

--- a/apps/block_scout_web/assets/css/components/_stakes_table.scss
+++ b/apps/block_scout_web/assets/css/components/_stakes_table.scss
@@ -124,6 +124,7 @@ $stakes-table-cell-separation: 25px !default;
 
 .stakes-td-link-style {
   color: $secondary;
+  cursor: pointer;
 
   .stakes-tr-banned & {
     color: $stakes-banned-color;

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -5,6 +5,7 @@ import { connectElements } from '../lib/redux_helpers.js'
 import { createAsyncLoadStore, refreshPage } from '../lib/async_listing_load'
 import Web3 from 'web3'
 import { openValidatorInfoModal } from './stakes/validator_info'
+import { openDelegatorsListModal } from './stakes/delegators_list'
 import { openBecomeCandidateModal } from './stakes/become_candidate'
 import { openRemovePoolModal } from './stakes/remove_pool'
 import { openMakeStakeModal } from './stakes/make_stake'
@@ -83,6 +84,7 @@ if ($stakesPage.length) {
 
   $(document.body)
     .on('click', '.js-validator-info', event => openValidatorInfoModal(event, store))
+    .on('click', '.js-delegators-list', event => openDelegatorsListModal(event, store))
     .on('click', '.js-become-candidate', () => openBecomeCandidateModal(store))
     .on('click', '.js-remove-pool', () => openRemovePoolModal(store))
     .on('click', '.js-make-stake', event => openMakeStakeModal(event, store))

--- a/apps/block_scout_web/assets/js/pages/stakes/delegators_list.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/delegators_list.js
@@ -1,0 +1,10 @@
+import $ from 'jquery'
+import { openModal } from '../../lib/modals'
+
+export function openDelegatorsListModal (event, store) {
+  const address = $(event.target).closest('[data-address]').data('address')
+
+  store.getState().channel
+    .push('render_delegators_list', { address })
+    .receive('ok', msg => openModal($(msg.html)))
+}

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -40,6 +40,26 @@ defmodule BlockScoutWeb.StakesChannel do
     {:reply, {:ok, %{html: html}}, socket}
   end
 
+  def handle_in("render_delegators_list", %{"address" => staking_address}, socket) do
+    pool = Chain.staking_pool(staking_address)
+    token = ContractState.get(:token)
+
+    delegators =
+      staking_address
+      |> Chain.staking_pool_delegators()
+      |> Enum.sort_by(&(to_string(&1.delegator_address_hash) != socket.assigns[:account]))
+
+    html =
+      View.render_to_string(StakesView, "_stakes_modal_delegators_list.html",
+        account: socket.assigns[:account],
+        pool: pool,
+        delegators: delegators,
+        token: token
+      )
+
+    {:reply, {:ok, %{html: html}}, socket}
+  end
+
   def handle_in("render_become_candidate", _, socket) do
     min_candidate_stake = ContractState.get(:min_candidate_stake)
     token = ContractState.get(:token)

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
@@ -26,7 +26,11 @@
       <%= @pool.staked_ratio %>%
     <% end %>
   </td>
-  <td class="stakes-td"><span class="stakes-td-link-style"><%= @pool.delegators_count %></span></td>
+  <td class="stakes-td">
+    <span class="stakes-td-link-style js-delegators-list" data-address="<%= @pool.staking_address_hash %>">
+      <%= @pool.delegators_count %>
+    </span>
+  </td>
   <td class="stakes-td">
     <%= if @pool.is_banned do %>
       <span class="stakes-td-banned-info">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
@@ -1,0 +1,75 @@
+<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-validator-info" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Delegators</h5>
+      </div>
+      <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
+      <div class="modal-body">
+        <table class="modal-table">
+          <thead>
+            <tr>
+              <th class="stakes-table-th">&nbsp;</th>
+              <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Staker's Address", tooltip: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut." %>
+              <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Total Stake Amount", tooltip: "Lorem ipsum dolor sit iusmod tempor incididunt ut." %>
+              <%=
+                title = if @pool.is_validator do "Reward Percent" else "Potential Reward Percent" end
+
+                render BlockScoutWeb.StakesView,
+                  "_stakes_th.html",
+                  title: title,
+                  tooltip: "Lorem ipsum dolor sit iusmod tempor incididunt ut."
+              %>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr>
+              <td class="stakes-td"><div class="stakes-td-order">1</div></td>
+              <td class="stakes-td">
+                <%=
+                  tooltip = if @pool.is_validator do "This is a validator" else false end
+
+                  render BlockScoutWeb.StakesView,
+                    "_stakes_address.html",
+                    address: @pool.staking_address_hash,
+                    tooltip: tooltip
+                %>
+              </td>
+              <td class="stakes-td"><%= format_according_to_decimals(@pool.self_staked_amount, @token.decimals) %></td>
+              <td class="stakes-td"><%= @pool.block_reward_ratio %>%</td>
+            </tr>
+
+            <%= for {delegator, index} <- Enum.with_index(@delegators, 2) do %>
+              <tr>
+                <td class="stakes-td"><div class="stakes-td-order"><%= index %></div></td>
+                <td class="stakes-td">
+                  <div class="stakes-address-container">
+                    <span class="stakes-address">
+                      <%= BlockScoutWeb.AddressView.trimmed_hash(delegator.delegator_address_hash) %>
+                    </span>
+                    <%= if to_string(delegator.delegator_address_hash) == @account do %>
+                      <div
+                          class="me-tooltip"
+                          data-boundary="window"
+                          data-container="body"
+                          data-html="true"
+                          data-placement="top"
+                          data-toggle="tooltip"
+                          title="It's me!"
+                      >
+                          ME
+                      </div>
+                    <% end %>
+                  </div>
+                </td>
+                <td class="stakes-td"><%= format_according_to_decimals(delegator.stake_amount, @token.decimals) %></td>
+                <td class="stakes-td"><%= if delegator.reward_ratio do "#{delegator.reward_ratio}%" else "-" end %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3326,6 +3326,13 @@ defmodule Explorer.Chain do
     Repo.get_by(StakingPool, staking_address_hash: staking_address_hash)
   end
 
+  def staking_pool_delegators(staking_address_hash) do
+    StakingPoolsDelegator
+    |> where(pool_address_hash: ^staking_address_hash, is_active: true)
+    |> order_by(desc: :stake_amount)
+    |> Repo.all()
+  end
+
   def staking_pool_delegator(pool_address_hash, delegator_address_hash) do
     Repo.get_by(StakingPoolsDelegator,
       pool_address_hash: pool_address_hash,

--- a/apps/explorer/lib/explorer/chain/import/runner/staking_pools_delegators.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/staking_pools_delegators.ex
@@ -107,6 +107,7 @@ defmodule Explorer.Chain.Import.Runner.StakingPoolsDelegators do
           max_withdraw_allowed: fragment("EXCLUDED.max_withdraw_allowed"),
           max_ordered_withdraw_allowed: fragment("EXCLUDED.max_ordered_withdraw_allowed"),
           ordered_withdraw_epoch: fragment("EXCLUDED.ordered_withdraw_epoch"),
+          reward_ratio: fragment("EXCLUDED.reward_ratio"),
           inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", delegator.inserted_at),
           updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", delegator.updated_at),
           is_active: fragment("EXCLUDED.is_active"),

--- a/apps/explorer/lib/explorer/chain/staking_pools_delegator.ex
+++ b/apps/explorer/lib/explorer/chain/staking_pools_delegator.ex
@@ -18,8 +18,9 @@ defmodule Explorer.Chain.StakingPoolsDelegator do
           max_ordered_withdraw_allowed: Decimal.t(),
           max_withdraw_allowed: Decimal.t(),
           ordered_withdraw: Decimal.t(),
-          stake_amount: Decimal.t(),
           ordered_withdraw_epoch: integer(),
+          stake_amount: Decimal.t(),
+          reward_ratio: Decimal.t(),
           is_active: boolean(),
           is_deleted: boolean()
         }
@@ -27,7 +28,7 @@ defmodule Explorer.Chain.StakingPoolsDelegator do
   @attrs ~w(
     pool_address_hash delegator_address_hash max_ordered_withdraw_allowed
     max_withdraw_allowed ordered_withdraw stake_amount ordered_withdraw_epoch
-    is_active is_deleted
+    reward_ratio is_active is_deleted
   )a
 
   @req_attrs ~w(
@@ -42,6 +43,7 @@ defmodule Explorer.Chain.StakingPoolsDelegator do
     field(:ordered_withdraw, :decimal)
     field(:ordered_withdraw_epoch, :integer)
     field(:stake_amount, :decimal)
+    field(:reward_ratio, :decimal)
     field(:is_active, :boolean, default: true)
     field(:is_deleted, :boolean, default: false)
 

--- a/apps/explorer/lib/explorer/staking/contract_reader.ex
+++ b/apps/explorer/lib/explorer/staking/contract_reader.ex
@@ -28,7 +28,9 @@ defmodule Explorer.Staking.ContractReader do
       inactive_delegators: {:staking, "poolDelegatorsInactive", [staking_address]},
       staked_amount: {:staking, "stakeAmountTotalMinusOrderedWithdraw", [staking_address]},
       self_staked_amount: {:staking, "stakeAmountMinusOrderedWithdraw", [staking_address, staking_address]},
-      block_reward: {:block_reward, "validatorRewardPercent", [staking_address]}
+      block_reward: {:block_reward, "validatorRewardPercent", [staking_address]},
+      stakers: {:block_reward, "snapshotStakers", [staking_address]},
+      reward_percents: {:block_reward, "snapshotRewardPercents", [staking_address]}
     ]
   end
 

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -140,6 +140,11 @@ defmodule Explorer.Staking.ContractState do
           Enum.map(responses.inactive_delegators, &{pool_address, &1, false})
       end)
 
+    delegator_rewards =
+      Enum.into(pool_staking_responses, %{}, fn {pool_address, responses} ->
+        {pool_address, Enum.into(Enum.zip(responses.stakers, responses.reward_percents), %{})}
+      end)
+
     delegator_responses =
       delegators
       |> Enum.map(fn {pool_address, delegator_address, _} ->
@@ -189,10 +194,28 @@ defmodule Explorer.Staking.ContractState do
 
     delegator_entries =
       Enum.map(delegator_responses, fn {{pool_address, delegator_address, is_active}, response} ->
+        staking_response = pool_staking_responses[pool_address]
+        mining_response = pool_mining_responses[pool_address]
+
+        reward_ratio =
+          if mining_response.is_validator do
+            reward_ratio = delegator_rewards[pool_address][delegator_address]
+
+            if reward_ratio do
+              reward_ratio / 10_000
+            end
+          else
+            ratio(
+              response.stake_amount - response.ordered_withdraw,
+              staking_response.staked_amount - staking_response.self_staked_amount
+            ) * min(0.7, 1 - staking_response.block_reward / 1_000_000)
+          end
+
         Map.merge(response, %{
           delegator_address_hash: delegator_address,
           pool_address_hash: pool_address,
-          is_active: is_active
+          is_active: is_active,
+          reward_ratio: reward_ratio
         })
       end)
 

--- a/apps/explorer/priv/repo/migrations/20190731172720_add_reward_ratio_to_pool_delegators.exs
+++ b/apps/explorer/priv/repo/migrations/20190731172720_add_reward_ratio_to_pool_delegators.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddBlockRewardToPools do
+  use Ecto.Migration
+
+  def change do
+    alter table(:staking_pools_delegators) do
+      add(:reward_ratio, :decimal, precision: 5, scale: 2)
+    end
+  end
+end


### PR DESCRIPTION
**NB!** `staking-latest` branch is updated to include this PR.

Delegator's reward ratio field is added and calculated as follows:
  - if the pool is validator, `snapshotStakers` and `snapshotRewardPercents` arrays are fetched from contract, zipped and used for delegators' ratios.
  - if a delegator made a stake during this epoch, they won't be present in the arrays above, so they will have `nil` for reward ratio
  - if the pool is a candidate, _potential_ reward is calculated manually, while taking into account that pool always receives at least 30%.

The list of delegators is displayed in a modal window with the pool itself being added as the first row, and currently logged in user moved to top.

No paging is implemented for this table, as AsyncListingLoad component doesn't support more than one pageable table simultaneously.
Fixing that requires almost full component rewrite, and I think that should be done in a separate PR.

"Me" tooltip is emulated with text, but should be replaced with SVG image.
