### PR TITLE
Dockerfile: use bitwalker/alpine-elixir-phoenix:latest for now

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-elixir-phoenix:1.9.0
+FROM bitwalker/alpine-elixir-phoenix:latest
 
 RUN apk --no-cache --update add alpine-sdk gmp-dev automake libtool inotify-tools autoconf python
 


### PR DESCRIPTION
It's better to run `:latest` to stick closer to 1.9.1 , as the `1.9.0` image is pinned to that build.

* Move to `alpine-elixir-phoenix:latest` since the 1.9.1 base image hasn't yet been released.