### PR TITLE
do not show eth value if it's zero on the transaction overview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#2403](https://github.com/poanetwork/blockscout/pull/2403) - Return gasPrice field at the result of gettxinfo method
 
 ### Fixes
+- [#2547](https://github.com/poanetwork/blockscout/pull/2547) - do not show eth value if it's zero on the transaction overview page
 - [#2543](https://github.com/poanetwork/blockscout/pull/2543) - do not hide search input during logs search
 - [#2524](https://github.com/poanetwork/blockscout/pull/2524) - fix dark theme validator data styles
 - [#2532](https://github.com/poanetwork/blockscout/pull/2532) - don't show empty token transfers on the transaction overview page

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -175,7 +175,7 @@
         <!-- Value -->
         <div class="card card-background-1 flex-grow-1">
           <div class="card-body card-body-flex-column-space-between">
-            <%= if @transaction.value.value != 0 do %>
+            <%= if @transaction.value && @transaction.value.value != Decimal.new(0) do %>
               <h2 class="card-title balance-card-title"><%= gettext "Ether" %> <%= gettext "Value" %></h2>
               <div class="text-right">
                 <h3 class="address-balance-text">


### PR DESCRIPTION
fixes https://github.com/poanetwork/blockscout/issues/2544

## Changelog
- do not show eth value if it's zero on the transaction overview page