### PR TITLE
Dark theme import to the end of sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#2403](https://github.com/poanetwork/blockscout/pull/2403) - Return gasPrice field at the result of gettxinfo method
 
 ### Fixes
+- [#2553](https://github.com/poanetwork/blockscout/pull/2553) - Dark theme import to the end of sass
 - [#2549](https://github.com/poanetwork/blockscout/pull/2549) - Fix wrong colour of tooltip
 - [#2548](https://github.com/poanetwork/blockscout/pull/2548) - CSS preload support in Firefox
 - [#2547](https://github.com/poanetwork/blockscout/pull/2547) - do not show eth value if it's zero on the transaction overview page

--- a/apps/block_scout_web/assets/css/app.scss
+++ b/apps/block_scout_web/assets/css/app.scss
@@ -75,9 +75,6 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "components/table";
 @import "components/navbar";
 @import "components/alerts";
-
-@import "theme/dark-theme";
-
 @import "components/animations";
 @import "components/card";
 @import "components/tile";
@@ -115,6 +112,8 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "components/new_smart_contract";
 @import "components/radio_big";
 @import "components/btn_no_border";
+
+@import "theme/dark-theme";
 
 :export {
   dashboardBannerChartAxisFontColor: $dashboard-banner-chart-axis-font-color;


### PR DESCRIPTION
## Motivation

![Screenshot 2019-08-12 at 16 27 25](https://user-images.githubusercontent.com/4341812/62868349-19bd0f80-bd1e-11e9-97f4-378ffed733d4.png)


## Changelog

### Bug Fixes

Dark theme import should be at the end of sass file in order to apply it to all styles. Unintentionally changed before in this commit https://github.com/poanetwork/blockscout/pull/2514/commits/77b7d34d50225ad68b47cd0565ec972e33decc3e#diff-5cbc16d38bf2aa42b4b2ac22b572ceb7R78

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
  - [ ] If I added/changed/removed ENV var, I should update the list of env vars in https://github.com/poanetwork/blockscout/blob/master/docs/env-variables.md to reflect changes in the table here https://poanetwork.github.io/blockscout/#/env-variables?id=blockscout-env-variables. I've set `master` in the `Version` column.
  - [ ] If I add new indices into DB, I checked, that they don't redundant with PGHero or other tools
