### PR TITLE
Validate staking contract calls in JS and allow adding <1 POA to existing stake

### DIFF
--- a/apps/block_scout_web/assets/css/components/_form.scss
+++ b/apps/block_scout_web/assets/css/components/_form.scss
@@ -44,6 +44,32 @@ $form-control-border-color: #e2e5ec !default;
   }
 }
 
+.input-group.input-status-error  {
+  input {
+    border-color: #FF7884 !important;
+    border-radius: 2px 2px 0 0;
+  }
+
+  .input-group-prepend {
+    margin-right: 0;
+  }
+
+  .input-group-prepend.last {
+    .input-group-text {
+      border-color: #FF7884;
+      border-radius: 0 2px 0 0;
+    }
+  }
+
+  .input-group-message {
+    width: 100%;
+    padding: 10px;
+    color: white;
+    background: #FF7884;
+    border-radius: 0 0 2px 2px;
+  }
+}
+
 .form-buttons {
   [class*="btn-"] {
     margin-bottom: 20px;

--- a/apps/block_scout_web/assets/js/lib/validation.js
+++ b/apps/block_scout_web/assets/js/lib/validation.js
@@ -1,0 +1,64 @@
+import $ from 'jquery'
+
+export function setupValidation ($form, validators, $submit) {
+  const errors = {}
+
+  updateSubmit($submit, errors)
+
+  for (let [key, callback] of Object.entries(validators)) {
+    const $input = $form.find('[' + key + ']')
+    errors[key] = null
+
+    $input
+      .ready(() => {
+        validateInput($input, callback, errors)
+        updateSubmit($submit, errors)
+        if (errors[key]) {
+          displayInputError($input, errors[key])
+        }
+      })
+      .blur(() => {
+        if (errors[key]) {
+          displayInputError($input, errors[key])
+        }
+      })
+      .on('input', () => {
+        hideInputError($input)
+        validateInput($input, callback, errors)
+        updateSubmit($submit, errors)
+      })
+  }
+}
+
+function validateInput ($input, callback, errors) {
+  if (!$input.val()) {
+    errors[$input.prop('id')] = null
+    return
+  }
+
+  const validation = callback($input.val())
+  if (validation === true) {
+    delete errors[$input.prop('id')]
+    return
+  }
+
+  errors[$input.prop('id')] = validation
+}
+
+function updateSubmit ($submit, errors) {
+  $submit.prop('disabled', !$.isEmptyObject(errors))
+}
+
+function displayInputError ($input, message) {
+  const group = $input.parent('.input-group')
+
+  group.addClass('input-status-error')
+  group.find('.input-group-message').html(message)
+}
+
+function hideInputError ($input) {
+  const group = $input.parent('.input-group')
+
+  group.removeClass('input-status-error')
+  group.find('.input-group-message').html('')
+}

--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -1,6 +1,7 @@
 import $ from 'jquery'
 import { BigNumber } from 'bignumber.js'
 import { openModal, openErrorModal, openWarningModal, lockModal } from '../../lib/modals'
+import { setupValidation } from '../../lib/validation'
 import { makeContractCall } from './utils'
 
 export function openBecomeCandidateModal (store) {
@@ -13,10 +14,21 @@ export function openBecomeCandidateModal (store) {
     .push('render_become_candidate')
     .receive('ok', msg => {
       const $modal = $(msg.html)
+
+      setupValidation(
+        $modal.find('form'),
+        {
+          'candidate-stake': value => isCandidateStakeValid(value, store, msg),
+          'mining-address': value => isMiningAddressValid(value, store)
+        },
+        $modal.find('form button')
+      )
+
       $modal.find('form').submit(() => {
         becomeCandidate($modal, store, msg)
         return false
       })
+
       openModal($modal)
     })
 }
@@ -24,34 +36,18 @@ export function openBecomeCandidateModal (store) {
 async function becomeCandidate ($modal, store, msg) {
   lockModal($modal)
 
-  const web3 = store.getState().web3
   const stakingContract = store.getState().stakingContract
   const blockRewardContract = store.getState().blockRewardContract
   const decimals = store.getState().tokenDecimals
-
-  const minStake = new BigNumber(msg.min_candidate_stake)
-  const balance = new BigNumber(msg.balance)
   const stake = new BigNumber($modal.find('[candidate-stake]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
-  if (!stake.isPositive() || stake.isLessThan(minStake)) {
-    openErrorModal('Error', `You cannot stake less than ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol}`)
-    return false
-  } else if (stake.isGreaterThan(balance)) {
-    openErrorModal('Error', `You cannot stake more than ${balance.shiftedBy(-decimals)} ${store.getState().tokenSymbol}`)
-    return false
-  }
-
   const miningAddress = $modal.find('[mining-address]').val().trim().toLowerCase()
-  if (miningAddress === store.getState().account || !web3.utils.isAddress(miningAddress)) {
-    openErrorModal('Error', 'Invalid Mining Address')
-    return false
-  }
 
   try {
     if (!await stakingContract.methods.areStakeAndWithdrawAllowed().call()) {
       if (await blockRewardContract.methods.isSnapshotting().call()) {
-        openErrorModal('Error', 'Stakes are not allowed at the moment. Please try again in a few blocks')
+        openErrorModal('Error', 'Staking actions are temporarily restricted. Please try again in a few blocks.')
       } else {
-        openErrorModal('Error', 'Current staking epoch is finishing now, you will be able to place a stake during the next staking epoch. Please try again in a few blocks')
+        openErrorModal('Error', 'The current staking epoch is ending, and staking actions are temporarily restricted. Please try again when the new epoch starts.')
       }
       return false
     }
@@ -64,4 +60,32 @@ async function becomeCandidate ($modal, store, msg) {
   } catch (err) {
     openErrorModal('Error', err.message)
   }
+}
+
+function isCandidateStakeValid (value, store, msg) {
+  const decimals = store.getState().tokenDecimals
+  const minStake = new BigNumber(msg.min_candidate_stake)
+  const balance = new BigNumber(msg.balance)
+  const stake = new BigNumber(value.replace(',', '.').trim()).shiftedBy(decimals).integerValue()
+
+  if (!stake.isPositive()) {
+    return 'Invalid amount'
+  } else if (stake.isLessThan(minStake)) {
+    return `Minimum candidate stake is ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol}`
+  } else if (stake.isGreaterThan(balance)) {
+    return 'Insufficient funds'
+  }
+
+  return true
+}
+
+function isMiningAddressValid (value, store) {
+  const web3 = store.getState().web3
+  const miningAddress = value.trim().toLowerCase()
+
+  if (miningAddress === store.getState().account || !web3.utils.isAddress(miningAddress)) {
+    return 'Invalid mining address'
+  }
+
+  return true
 }

--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -30,13 +30,17 @@ async function becomeCandidate ($modal, store, msg) {
   const decimals = store.getState().tokenDecimals
 
   const minStake = new BigNumber(msg.min_candidate_stake)
+  const balance = new BigNumber(msg.balance)
   const stake = new BigNumber($modal.find('[candidate-stake]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
   if (!stake.isPositive() || stake.isLessThan(minStake)) {
     openErrorModal('Error', `You cannot stake less than ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol}`)
     return false
+  } else if (stake.isGreaterThan(balance)) {
+    openErrorModal('Error', `You cannot stake more than ${balance.shiftedBy(-decimals)} ${store.getState().tokenSymbol}`)
+    return false
   }
 
-  const miningAddress = $modal.find('[mining-address]').val().toLowerCase()
+  const miningAddress = $modal.find('[mining-address]').val().trim().toLowerCase()
   if (miningAddress === store.getState().account || !web3.utils.isAddress(miningAddress)) {
     openErrorModal('Error', 'Invalid Mining Address')
     return false

--- a/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
@@ -30,11 +30,16 @@ function makeStake ($modal, address, store, msg) {
   const stakingContract = store.getState().stakingContract
   const decimals = store.getState().tokenDecimals
 
-  const minStake = new BigNumber(msg.min_delegator_stake)
+  const minStake = new BigNumber(msg.min_stake)
+  const currentStake = new BigNumber(msg.delegator_staked)
+  const balance = new BigNumber(msg.balance)
   const stake = new BigNumber($modal.find('[delegator-stake]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
 
-  if (!stake.isPositive() || stake.isLessThan(minStake)) {
+  if (!stake.isPositive() || stake.plus(currentStake).isLessThan(minStake)) {
     openErrorModal('Error', `You cannot stake less than ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol}`)
+    return false
+  } else if (stake.isGreaterThan(balance)) {
+    openErrorModal('Error', `You cannot stake more than ${balance.shiftedBy(-decimals)} ${store.getState().tokenSymbol}`)
     return false
   }
 

--- a/apps/block_scout_web/assets/js/pages/stakes/move_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/move_stake.js
@@ -1,6 +1,7 @@
 import $ from 'jquery'
 import { BigNumber } from 'bignumber.js'
-import { openModal, openErrorModal, lockModal } from '../../lib/modals'
+import { openModal, lockModal } from '../../lib/modals'
+import { setupValidation } from '../../lib/validation'
 import { makeContractCall, setupChart } from './utils'
 
 export function openMoveStakeModal (event, store) {
@@ -19,6 +20,14 @@ function setupModal ($modal, fromAddress, store, msg) {
   setupChart($modal.find('.js-pool-from-progress'), msg.from.self_staked_amount, msg.from.staked_amount)
   if (msg.to) {
     setupChart($modal.find('.js-pool-to-progress'), msg.to.self_staked_amount, msg.to.staked_amount)
+
+    setupValidation(
+      $modal.find('form'),
+      {
+        'move-amount': value => isMoveAmountValid(value, store, msg)
+      },
+      $modal.find('form button')
+    )
   }
 
   $modal.find('form').submit(() => {
@@ -44,29 +53,30 @@ function moveStake ($modal, fromAddress, store, msg) {
 
   const stakingContract = store.getState().stakingContract
   const decimals = store.getState().tokenDecimals
-
-  const minFromStake = new BigNumber(msg.from.min_stake)
-  const minToStake = new BigNumber(msg.to.min_stake)
-  const currentFromStake = new BigNumber(msg.from.stake_amount)
-  const currentToStake = new BigNumber(msg.to.stake_amount)
-  const maxAllowed = new BigNumber(msg.max_withdraw_allowed)
   const stake = new BigNumber($modal.find('[move-amount]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
-
-  if (!stake.isPositive() || stake.plus(currentToStake).isLessThan(minToStake)) {
-    openErrorModal('Error', `You cannot move less than ${minToStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} to this pool`)
-    return false
-  }
-
-  if (stake.isGreaterThan(maxAllowed)) {
-    openErrorModal('Error', `You cannot move more than ${maxAllowed.shiftedBy(-decimals)} ${store.getState().tokenSymbol} right now`)
-    return false
-  }
-
-  if (stake.isLessThan(currentFromStake) && currentFromStake.minus(stake).isLessThan(minFromStake)) {
-    openErrorModal('Error', `You can't leave less than ${minFromStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} in the source pool`)
-    return false
-  }
 
   const toAddress = $modal.find('[pool-select]').val()
   makeContractCall(stakingContract.methods.moveStake(fromAddress, toAddress, stake.toString()), store)
+}
+
+function isMoveAmountValid (value, store, msg) {
+  const decimals = store.getState().tokenDecimals
+  const minFromStake = new BigNumber(msg.from.min_stake)
+  const minToStake = (msg.to) ? new BigNumber(msg.to.min_stake) : null
+  const maxAllowed = new BigNumber(msg.max_withdraw_allowed)
+  const currentFromStake = new BigNumber(msg.from.stake_amount)
+  const currentToStake = (msg.to) ? new BigNumber(msg.to.stake_amount) : null
+  const stake = new BigNumber(value.replace(',', '.').trim()).shiftedBy(decimals).integerValue()
+
+  if (!stake.isPositive()) {
+    return 'Invalid amount'
+  } else if (stake.plus(currentToStake).isLessThan(minToStake)) {
+    return `You must move at least ${minToStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} to the selected pool`
+  } else if (stake.isGreaterThan(maxAllowed)) {
+    return `You have ${maxAllowed.shiftedBy(-decimals)} ${store.getState().tokenSymbol} available to move`
+  } else if (stake.isLessThan(currentFromStake) && currentFromStake.minus(stake).isLessThan(minFromStake)) {
+    return `A minimum of ${minFromStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} is required to remain in the current pool, or move the entire amount to leave this pool`
+  }
+
+  return true
 }

--- a/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
@@ -1,6 +1,6 @@
 import $ from 'jquery'
 import { BigNumber } from 'bignumber.js'
-import { openModal, openQuestionModal, lockModal } from '../../lib/modals'
+import { openModal, openErrorModal, openQuestionModal, lockModal } from '../../lib/modals'
 import { makeContractCall, setupChart } from './utils'
 
 export function openWithdrawStakeModal (event, store) {
@@ -9,13 +9,15 @@ export function openWithdrawStakeModal (event, store) {
   store.getState().channel
     .push('render_withdraw_stake', { address })
     .receive('ok', msg => {
-      if (msg.claim_html) {
+      if (msg.claim_html && msg.withdraw_html) {
         openQuestionModal(
           'Claim or order', 'Do you want withdraw or claim ordered withdraw?',
           () => setupClaimWithdrawModal(address, store, msg),
           () => setupWithdrawStakeModal(address, store, msg),
           'Claim', 'Withdraw'
         )
+      } else if (msg.claim_html) {
+        setupClaimWithdrawModal(address, store, msg)
       } else {
         setupWithdrawStakeModal(address, store, msg)
       }
@@ -33,14 +35,14 @@ function setupClaimWithdrawModal (address, store, msg) {
 }
 
 function setupWithdrawStakeModal (address, store, msg) {
-  const $modal = $(msg.html)
+  const $modal = $(msg.withdraw_html)
   setupChart($modal.find('.js-stakes-progress'), msg.self_staked_amount, msg.staked_amount)
   $modal.find('.btn-full-primary.withdraw').click(() => {
-    withdrawStake($modal, address, store)
+    withdrawStake($modal, address, store, msg)
     return false
   })
   $modal.find('.btn-full-primary.order-withdraw').click(() => {
-    orderWithdraw($modal, address, store)
+    orderWithdraw($modal, address, store, msg)
     return false
   })
   openModal($modal)
@@ -54,24 +56,56 @@ function claimWithdraw ($modal, address, store) {
   makeContractCall(stakingContract.methods.claimOrderedWithdraw(address), store)
 }
 
-function withdrawStake ($modal, address, store) {
-  lockModal($modal)
+function withdrawStake ($modal, address, store, msg) {
+  lockModal($modal, $modal.find('.btn-full-primary.withdraw'))
 
   const stakingContract = store.getState().stakingContract
   const decimals = store.getState().tokenDecimals
+  const minStake = new BigNumber(msg.min_stake)
+  const currentStake = new BigNumber(msg.delegator_staked)
+  const maxAllowed = new BigNumber(msg.max_withdraw_allowed)
 
   const amount = new BigNumber($modal.find('[amount]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
+
+  if (!amount.isPositive() || amount.isGreaterThan(maxAllowed)) {
+    openErrorModal('Error', `You cannot withdraw more than ${maxAllowed.shiftedBy(-decimals)} ${store.getState().tokenSymbol} from this pool`)
+    return false
+  }
+
+  if (amount.isLessThan(currentStake) && currentStake.minus(amount).isLessThan(minStake)) {
+    openErrorModal('Error', `You can't leave less than ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} in the pool`)
+    return false
+  }
 
   makeContractCall(stakingContract.methods.withdraw(address, amount.toString()), store)
 }
 
-function orderWithdraw ($modal, address, store) {
-  lockModal($modal)
+function orderWithdraw ($modal, address, store, msg) {
+  lockModal($modal, $modal.find('.btn-full-primary.order-withdraw'))
 
   const stakingContract = store.getState().stakingContract
   const decimals = store.getState().tokenDecimals
+  const minStake = new BigNumber(msg.min_stake)
+  const currentStake = new BigNumber(msg.delegator_staked)
+  const orderedWithdraw = new BigNumber(msg.ordered_withdraw)
+  const maxAllowed = new BigNumber(msg.max_ordered_withdraw_allowed)
 
   const amount = new BigNumber($modal.find('[amount]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
+
+  if (amount.isGreaterThan(maxAllowed)) {
+    openErrorModal('Error', `You cannot withdraw more than ${maxAllowed.shiftedBy(-decimals)} ${store.getState().tokenSymbol} from this pool`)
+    return false
+  }
+
+  if (amount.isLessThan(orderedWithdraw.negated())) {
+    openErrorModal('Error', `You cannot reduce withdrawal by more than ${orderedWithdraw.shiftedBy(-decimals)} ${store.getState().tokenSymbol}`)
+    return false
+  }
+
+  if (amount.isLessThan(currentStake) && currentStake.minus(amount).isLessThan(minStake)) {
+    openErrorModal('Error', `You can't leave less than ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} in the pool`)
+    return false
+  }
 
   makeContractCall(stakingContract.methods.orderWithdraw(address, amount.toString()), store)
 }

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -138,9 +138,23 @@ defmodule BlockScoutWeb.StakesChannel do
     pool_from = Chain.staking_pool(from_address)
     pool_to = to_address && Chain.staking_pool(to_address)
     pools = Chain.staking_pools(:active, :all)
-    delegator = Chain.staking_pool_delegator(from_address, socket.assigns.account)
-    min_delegator_stake = ContractState.get(:min_delegator_stake)
+    delegator_from = Chain.staking_pool_delegator(from_address, socket.assigns.account)
+    delegator_to = to_address && Chain.staking_pool_delegator(to_address, socket.assigns.account)
     token = ContractState.get(:token)
+
+    min_from_stake =
+      if delegator_from.delegator_address_hash == delegator_from.pool_address_hash do
+        ContractState.get(:min_candidate_stake)
+      else
+        ContractState.get(:min_delegator_stake)
+      end
+
+    min_to_stake =
+      if to_address == socket.assigns.account do
+        ContractState.get(:min_candidate_stake)
+      else
+        ContractState.get(:min_delegator_stake)
+      end
 
     html =
       View.render_to_string(StakesView, "_stakes_modal_move.html",
@@ -148,18 +162,29 @@ defmodule BlockScoutWeb.StakesChannel do
         pools: pools,
         pool_from: pool_from,
         pool_to: pool_to,
-        delegator: delegator,
+        delegator_from: delegator_from,
+        delegator_to: delegator_to,
         amount: amount
       )
 
     result = %{
       html: html,
-      min_delegator_stake: min_delegator_stake,
-      max_withdraw_allowed: delegator.max_withdraw_allowed,
-      from_self_staked_amount: pool_from.self_staked_amount,
-      from_staked_amount: pool_from.staked_amount,
-      to_self_staked_amount: pool_to && pool_to.self_staked_amount,
-      to_staked_amount: pool_to && pool_to.staked_amount
+      max_withdraw_allowed: delegator_from.max_withdraw_allowed,
+      from: %{
+        stake_amount: delegator_from.stake_amount,
+        min_stake: min_from_stake,
+        self_staked_amount: pool_from.self_staked_amount,
+        staked_amount: pool_from.staked_amount
+      },
+      to:
+        if pool_to do
+          %{
+            stake_amount: (delegator_to && delegator_to.stake_amount) || 0,
+            min_stake: min_to_stake,
+            self_staked_amount: pool_to.self_staked_amount,
+            staked_amount: pool_to.staked_amount
+          }
+        end
     }
 
     {:reply, {:ok, result}, socket}

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -196,6 +196,13 @@ defmodule BlockScoutWeb.StakesChannel do
     delegator = Chain.staking_pool_delegator(staking_address, socket.assigns.account)
     epoch_number = ContractState.get(:epoch_number, 0)
 
+    min_stake =
+      if delegator.delegator_address_hash == delegator.pool_address_hash do
+        ContractState.get(:min_candidate_stake)
+      else
+        ContractState.get(:min_delegator_stake)
+      end
+
     claim_html =
       if Decimal.positive?(delegator.ordered_withdraw) and delegator.ordered_withdraw_epoch < epoch_number do
         View.render_to_string(StakesView, "_stakes_modal_claim.html",
@@ -205,18 +212,27 @@ defmodule BlockScoutWeb.StakesChannel do
         )
       end
 
-    html =
-      View.render_to_string(StakesView, "_stakes_modal_withdraw.html",
-        token: token,
-        delegator: delegator,
-        pool: pool
-      )
+    withdraw_html =
+      if Decimal.positive?(delegator.ordered_withdraw) or
+           Decimal.positive?(delegator.max_withdraw_allowed) or
+           Decimal.positive?(delegator.max_ordered_withdraw_allowed) do
+        View.render_to_string(StakesView, "_stakes_modal_withdraw.html",
+          token: token,
+          delegator: delegator,
+          pool: pool
+        )
+      end
 
     result = %{
       claim_html: claim_html,
-      html: html,
+      withdraw_html: withdraw_html,
       self_staked_amount: pool.self_staked_amount,
-      staked_amount: pool.staked_amount
+      staked_amount: pool.staked_amount,
+      delegator_staked: delegator.stake_amount,
+      ordered_withdraw: delegator.ordered_withdraw,
+      max_withdraw_allowed: delegator.max_withdraw_allowed,
+      max_ordered_withdraw_allowed: delegator.max_ordered_withdraw_allowed,
+      min_stake: min_stake
     }
 
     {:reply, {:ok, result}, socket}

--- a/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
@@ -142,7 +142,7 @@ defmodule BlockScoutWeb.StakesController do
   defp move_allowed?(nil), do: false
 
   defp move_allowed?(delegator) do
-    delegator.is_active and Decimal.positive?(delegator.max_withdraw_allowed)
+    Decimal.positive?(delegator.max_withdraw_allowed)
   end
 
   defp withdraw_allowed?(nil, _epoch_number), do: false

--- a/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
@@ -148,8 +148,9 @@ defmodule BlockScoutWeb.StakesController do
   defp withdraw_allowed?(nil, _epoch_number), do: false
 
   defp withdraw_allowed?(delegator, epoch_number) do
-    (delegator.is_active and Decimal.positive?(delegator.max_withdraw_allowed)) or
-      (delegator.is_active and Decimal.positive?(delegator.max_ordered_withdraw_allowed)) or
+    Decimal.positive?(delegator.max_withdraw_allowed) or
+      Decimal.positive?(delegator.max_ordered_withdraw_allowed) or
+      Decimal.positive?(delegator.ordered_withdraw) or
       (Decimal.positive?(delegator.ordered_withdraw) and delegator.ordered_withdraw_epoch < epoch_number)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_input_group.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_input_group.html.eex
@@ -1,0 +1,17 @@
+<div class="input-group <%= if assigns[:classes] do @classes end %>">
+  <input
+    id="<%= if assigns[:id] do @id end %>"
+    <%= if assigns[:attributes] do @attributes end %>
+    type="<%= if assigns[:type] do @type end %>"
+    class="<%= if assigns[:input_classes] do @input_classes end %>"
+    placeholder="<%= if assigns[:placeholder] do @placeholder end %>"
+    value="<%= if assigns[:value] do @value end %>"
+    <%= if assigns[:disabled] do "disabled" end %>
+  />
+  <%= if assigns[:prepend] do %>
+    <div class="input-group-prepend last">
+      <div class="input-group-text"><%= @prepend %></div>
+    </div>
+  <% end %>
+  <div class="input-group-message"><%= if assigns[:message] do @message end %></div>
+</div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
@@ -7,22 +7,9 @@
       <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
       <div class="modal-body">
         <form>
-          <div class="input-group form-group">
-            <input candidate-stake type="text" class="form-control n-b-r" placeholder="<%= gettext("Amount") %>">
-            <div class="input-group-prepend last">
-              <div class="input-group-text"><%= @token.symbol %></div>
-            </div>
-          </div>
-          <div class="form-group">
-            <input
-              mining-address
-              type="text"
-              class="form-control"
-              placeholder="<%= gettext("Your Mining Address") %>"
-              value="<%= @pool && @pool.mining_address_hash %>"
-              <%= if @pool do "disabled" end %>
-            />
-          </div>
+          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "candidate-stake", classes: "form-group", input_classes: "form-control n-b-r", attributes: "candidate-stake", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol %>
+
+          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "mining-address", classes: "form-group", input_classes: "form-control", attributes: "mining-address", type: "text", placeholder: gettext("Your Mining Address"), value: @pool && @pool.mining_address_hash, disabled: @pool %>
           <p class="form-p m-b-0">Minimum Stake:
             <span class="text-dark">
               <%= format_according_to_decimals(@min_candidate_stake, @token.decimals) %> <%= @token.symbol %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
@@ -12,12 +12,7 @@
           </div>
           <div class="modal-body">
             <form>
-              <div class="input-group form-group">
-                <input move-amount type="text" class="form-control n-b-r" placeholder="<%= gettext("Amount") %>" value="<%= @amount %>">
-                <div class="input-group-prepend last">
-                  <div class="input-group-text"><%= @token.symbol %></div>
-                </div>
-              </div>
+              <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "move-amount", classes: "form-group", input_classes: "form-control n-b-r", attributes: "move-amount", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol, value: @amount %>
               <p class="form-p">You Staked:
                 <span class="text-dark">
                   <%= format_according_to_decimals(@delegator_from.stake_amount, @token.decimals) %> <%= @token.symbol %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
@@ -20,7 +20,7 @@
               </div>
               <p class="form-p">You Staked:
                 <span class="text-dark">
-                  <%= format_according_to_decimals(@delegator.stake_amount, @token.decimals) %> <%= @token.symbol %>
+                  <%= format_according_to_decimals(@delegator_from.stake_amount, @token.decimals) %> <%= @token.symbol %>
                 </span>
               </p>
               <div class="input-group form-group">
@@ -28,7 +28,7 @@
                   <option disabled <%= unless @pool_to do "selected" end %>><%= gettext("Choose Pool") %></option>
                   <%= for %{pool: pool} <- @pools,
                         pool.staking_address_hash != @pool_from.staking_address_hash,
-                        Decimal.positive?(pool.self_staked_amount) or pool.staking_address_hash == @delegator.delegator_address_hash do %>
+                        Decimal.positive?(pool.self_staked_amount) or pool.staking_address_hash == @delegator_from.delegator_address_hash do %>
                     <option
                       value="<%= pool.staking_address_hash %>"
                       <%= if @pool_to && pool.staking_address_hash == @pool_to.staking_address_hash do "selected" end %>
@@ -38,9 +38,16 @@
                   <% end %>
                 </select>
               </div>
+              <%= if @delegator_to && Decimal.positive?(@delegator_to.stake_amount) do %>
+                <p class="form-p m-b-0">Current stake:
+                  <span class="text-dark">
+                    <%= format_according_to_decimals(@delegator_to.stake_amount, @token.decimals) %> <%= @token.symbol %>
+                  </span>
+                </p>
+              <% end %>
               <p class="form-p">Max Amount to Move:
                 <span class="text-dark">
-                  <%= format_according_to_decimals(@delegator.max_withdraw_allowed, @token.decimals) %> <%= @token.symbol %>
+                  <%= format_according_to_decimals(@delegator_from.max_withdraw_allowed, @token.decimals) %> <%= @token.symbol %>
                 </span>
               </p>
               <div class="form-buttons">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex
@@ -15,18 +15,35 @@
                   <div class="input-group-text"><%= @token.symbol %></div>
                 </div>
               </div>
-              <p class="form-p m-b-0">Minimum Stake:
-                <span class="text-dark">
-                  <%= format_according_to_decimals(@min_delegator_stake, @token.decimals) %> <%= @token.symbol %>
-                </span>
-              </p>
+              <%= if @delegator && Decimal.positive?(@delegator.stake_amount) do %>
+                <p class="form-p m-b-0">Current stake:
+                  <span class="text-dark">
+                    <%= format_according_to_decimals(@delegator.stake_amount, @token.decimals) %> <%= @token.symbol %>
+                  </span>
+                </p>
+              <% else %>
+                <p class="form-p m-b-0">Minimum Stake:
+                  <span class="text-dark">
+                    <%= format_according_to_decimals(@min_stake, @token.decimals) %> <%= @token.symbol %>
+                  </span>
+                </p>
+              <% end %>
               <p class="form-p">Your Balance:
                 <span class="text-dark">
                   <%= format_according_to_decimals(@balance, @token.decimals) %> <%= @token.symbol %>
                 </span>
               </p>
               <div class="form-buttons">
-                <%= render BlockScoutWeb.StakesView, "_stakes_btn_stake.html", text: gettext("Stake More"), extra_class: "full-width btn-add-full" %>
+                <%=
+                  label =
+                    if @delegator && Decimal.positive?(@delegator.stake_amount) do
+                      gettext("Stake More")
+                    else
+                      gettext("Place stake")
+                    end
+
+                  render BlockScoutWeb.StakesView, "_stakes_btn_stake.html", text: label, extra_class: "full-width btn-add-full"
+                %>
               </div>
             </form>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex
@@ -9,12 +9,8 @@
           </div>
           <div class="modal-body">
             <form>
-              <div class="input-group form-group">
-                <input delegator-stake type="text" class="form-control n-b-r" placeholder="<%= gettext("Amount") %>">
-                <div class="input-group-prepend last">
-                  <div class="input-group-text"><%= @token.symbol %></div>
-                </div>
-              </div>
+              <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "delegator-stake", classes: "form-group", input_classes: "form-control n-b-r", attributes: "delegator-stake", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol %>
+
               <%= if @delegator && Decimal.positive?(@delegator.stake_amount) do %>
                 <p class="form-p m-b-0">Current stake:
                   <span class="text-dark">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
@@ -15,29 +15,44 @@
                   <div class="input-group-text"><%= @token.symbol %></div>
                 </div>
               </div>
-              <p class="form-p">You Staked:
+              <p class="form-p m-b-0">You Staked:
                 <span class="text-dark">
                   <%= format_according_to_decimals(@delegator.stake_amount, @token.decimals) %> <%= @token.symbol %>
                 </span>
               </p>
-              <div class="form-buttons">
+              <%= if Decimal.positive?(@delegator.ordered_withdraw) do %>
+                <p class="form-p m-b-0">Already ordered:
+                  <span class="text-dark">
+                    <%= format_according_to_decimals(@delegator.ordered_withdraw, @token.decimals) %> <%= @token.symbol %>
+                  </span>
+                </p>
+              <% end %>
+              <%= if Decimal.positive?(@delegator.max_withdraw_allowed) do %>
+                <p class="form-p m-b-0">Available now:
+                  <span class="text-dark">
+                    <%= format_according_to_decimals(@delegator.max_withdraw_allowed, @token.decimals) %> <%= @token.symbol %>
+                  </span>
+                </p>
                 <%=
-                  if Decimal.positive?(@delegator.max_withdraw_allowed) do
-                    render BlockScoutWeb.StakesView,
-                    "_stakes_btn_withdraw.html",
-                    text: gettext("Withdraw Now"),
-                    extra_class: "full-width btn-add-full withdraw"
-                  end
+                  render BlockScoutWeb.StakesView,
+                  "_stakes_btn_withdraw.html",
+                  text: gettext("Withdraw Now"),
+                  extra_class: "full-width btn-add-full withdraw"
                 %>
+              <% end %>
+              <%= if Decimal.positive?(@delegator.max_ordered_withdraw_allowed) or Decimal.positive?(@delegator.ordered_withdraw) do %>
+                <p class="form-p m-b-0">Available after the current epoch:
+                  <span class="text-dark">
+                    <%= format_according_to_decimals(@delegator.max_ordered_withdraw_allowed, @token.decimals) %> <%= @token.symbol %>
+                  </span>
+                </p>
                 <%=
-                  if Decimal.positive?(@delegator.max_ordered_withdraw_allowed) do
-                    render BlockScoutWeb.StakesView,
-                    "_stakes_btn_withdraw.html",
-                    text: gettext("Order Withdrawal"),
-                    extra_class: "full-width btn-add-full order-withdraw"
-                  end
+                  render BlockScoutWeb.StakesView,
+                  "_stakes_btn_withdraw.html",
+                  text: gettext("Order Withdrawal"),
+                  extra_class: "full-width btn-add-full order-withdraw"
                 %>
-              </div>
+              <% end %>
             </form>
           </div>
           <%= render BlockScoutWeb.CommonComponentsView, "_modal_bottom_disclaimer.html", text: "Lorem ipsum dolor sit amet, consect adipiscing elit, sed do eiusmod temp incididunt ut labore et dolore magna. Sed do eiusmod temp incididunt ut.", extra_class: "b-b-r-0" %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
@@ -9,12 +9,7 @@
           </div>
           <div class="modal-body">
             <form>
-              <div class="input-group form-group">
-                <input amount type="text" class="form-control n-b-r" placeholder="<%= gettext("Amount") %>">
-                <div class="input-group-prepend last">
-                  <div class="input-group-text"><%= @token.symbol %></div>
-                </div>
-              </div>
+              <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "amount", classes: "form-group", input_classes: "form-control n-b-r", attributes: "amount", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol %>
               <p class="form-p m-b-0">You Staked:
                 <span class="text-dark">
                   <%= format_according_to_decimals(@delegator.stake_amount, @token.decimals) %> <%= @token.symbol %>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1935,7 +1935,7 @@ msgid "Stake"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex:29
+#: lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex:40
 msgid "Stake More"
 msgstr ""
 
@@ -1979,4 +1979,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex:26
 msgid "Ordered"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex:42
+msgid "Place stake"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1915,7 +1915,7 @@ msgid "Next epoch in"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:36
+#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:45
 msgid "Order Withdrawal"
 msgstr ""
 
@@ -1966,7 +1966,7 @@ msgid "Withdraw"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:28
+#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:32
 msgid "Withdraw Now"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1905,7 +1905,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex:11
-#: lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex:50
+#: lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex:57
 msgid "Move Stake"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1916,7 +1916,7 @@ msgid "Next epoch in"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:36
+#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:45
 msgid "Order Withdrawal"
 msgstr ""
 
@@ -1967,7 +1967,7 @@ msgid "Withdraw"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:28
+#: lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex:32
 msgid "Withdraw Now"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1936,7 +1936,7 @@ msgid "Stake"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex:29
+#: lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex:40
 msgid "Stake More"
 msgstr ""
 
@@ -1980,4 +1980,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex:26
 msgid "Ordered"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex:42
+msgid "Place stake"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1906,7 +1906,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex:11
-#: lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex:50
+#: lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex:57
 msgid "Move Stake"
 msgstr ""
 


### PR DESCRIPTION
As contract calls don't give very descriptive errors, we need to check preconditions in JS ourselves.
This PR adds these checks and tidies them up in general.

Also, `MIN_DELEGATOR_STAKE` defines minimal _total_ stake on particular pool.
Thus, we now allow adding less than that amount for existing stakes.

- [x] Become a Candidate
- [x] Make Stake
- [x] Move Stake
- [x] Withdraw stake
- [x] Order withdraw
- [x] Claim ordered withdraw