### PR TITLE
do not start genesis data fetching periodically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#2538](https://github.com/poanetwork/blockscout/pull/2538) - fetch the last not empty coin balance records
 
 ### Chore
+- [#2594](https://github.com/poanetwork/blockscout/pull/2594) - do not start genesis data fetching periodically
 - [#2590](https://github.com/poanetwork/blockscout/pull/2590) - restore backward compatablity with old releases
 - [#2574](https://github.com/poanetwork/blockscout/pull/2574) - limit request body in json rpc error
 - [#2566](https://github.com/poanetwork/blockscout/pull/2566) - upgrade absinthe phoenix

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -27,7 +27,7 @@ config :explorer, Explorer.Counters.AverageBlockTime,
   enabled: true,
   period: average_block_period
 
-config :explorer, Explorer.ChainSpec.GenesisData, enabled: true, chain_spec_path: System.get_env("CHAIN_SPEC_PATH")
+config :explorer, Explorer.ChainSpec.GenesisData, enabled: false, chain_spec_path: System.get_env("CHAIN_SPEC_PATH")
 
 config :explorer, Explorer.Chain.Cache.BlockNumber, enabled: true
 

--- a/apps/explorer/lib/explorer/chain_spec/genesis_data.ex
+++ b/apps/explorer/lib/explorer/chain_spec/genesis_data.ex
@@ -18,7 +18,6 @@ defmodule Explorer.ChainSpec.GenesisData do
 
   @impl GenServer
   def init(_) do
-    :timer.send_interval(@interval, :import)
     Process.send_after(self(), :import, @interval)
 
     {:ok, %{}}


### PR DESCRIPTION
## Motivation

From this point, genesis data fetching will start once and will
be retried on task failure. Also, this PR disables genesis
data fetcher process by default because most of our users won't
know that they should set chain spec for it.

## Changelog

- do not start genesis data fetching periodically