### PR TITLE
add AuRa's empty step reward type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#2596](https://github.com/poanetwork/blockscout/pull/2596) - support AuRa's empty step reward type
 - [#2561](https://github.com/poanetwork/blockscout/pull/2561) - Add token's type to the response of tokenlist method
 - [#2499](https://github.com/poanetwork/blockscout/pull/2499) - import emission reward ranges
 - [#2497](https://github.com/poanetwork/blockscout/pull/2497) - Add generic Ordered Cache behaviour and implementation

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
@@ -182,4 +182,5 @@ defmodule EthereumJSONRPC.Parity.FetchedBeneficiaries do
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 10, do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "block", do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "uncle", do: :uncle
+  defp get_address_type(reward_type, _index) when reward_type == "emptyStep", do: :validator
 end


### PR DESCRIPTION
Instead of producing empty blocks nodes in Aura consensus protocol
broadcast an EmptyStep(step, parent_hash) message.
https://github.com/paritytech/wiki/blob/master/Aura.md#empty-steps

resolves https://github.com/poanetwork/blockscout/issues/2347

## Changelog

- add AuRa's empty step reward type