### PR TITLE
Add cache updating independently from Indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#2497](https://github.com/poanetwork/blockscout/pull/2497) - Add generic Ordered Cache behaviour and implementation
 
 ### Fixes
+- [#2612](https://github.com/poanetwork/blockscout/pull/2612) - Add cache updating independently from Indexer
 - [#2659](https://github.com/poanetwork/blockscout/pull/2659) - Multipurpose front-end part update
 - [#2468](https://github.com/poanetwork/blockscout/pull/2468) - fix confirmations for non consensus blocks
 - [#2610](https://github.com/poanetwork/blockscout/pull/2610) - use CoinGecko instead of CoinMarketcap for exchange rates

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -29,7 +29,10 @@ config :explorer, Explorer.Counters.AverageBlockTime,
 
 config :explorer, Explorer.ChainSpec.GenesisData, enabled: false, chain_spec_path: System.get_env("CHAIN_SPEC_PATH")
 
-config :explorer, Explorer.Chain.Cache.BlockNumber, enabled: true
+config :explorer, Explorer.Chain.Cache.BlockNumber,
+  enabled: true,
+  ttl_check_interval: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(1), else: false),
+  global_ttl: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(5))
 
 config :explorer, Explorer.ExchangeRates.Source.CoinGecko, coin_id: System.get_env("COIN_GECKO_ID", "poa-network")
 
@@ -122,6 +125,14 @@ market_history_cache_period =
   end
 
 config :explorer, Explorer.Market.MarketHistoryCache, period: market_history_cache_period
+
+config :explorer, Explorer.Chain.Cache.Blocks,
+  ttl_check_interval: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(1), else: false),
+  global_ttl: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(5))
+
+config :explorer, Explorer.Chain.Cache.Transactions,
+  ttl_check_interval: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(1), else: false),
+  global_ttl: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(5))
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -56,9 +56,7 @@ defmodule Explorer.Application do
 
     opts = [strategy: :one_for_one, name: Explorer.Supervisor]
 
-    res = Supervisor.start_link(children, opts)
-
-    res
+    Supervisor.start_link(children, opts)
   end
 
   defp configurable_children do

--- a/apps/explorer/lib/explorer/chain/cache/block_number.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block_number.ex
@@ -7,7 +7,9 @@ defmodule Explorer.Chain.Cache.BlockNumber do
 
   use Explorer.Chain.MapCache,
     name: :block_number,
-    keys: [:min, :max]
+    keys: [:min, :max],
+    ttl_check_interval: Application.get_env(:explorer, __MODULE__)[:ttl_check_interval],
+    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl]
 
   alias Explorer.Chain
 

--- a/apps/explorer/lib/explorer/chain/cache/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/cache/blocks.ex
@@ -11,7 +11,9 @@ defmodule Explorer.Chain.Cache.Blocks do
     ids_list_key: "block_numbers",
     preload: :transactions,
     preload: [miner: :names],
-    preload: :rewards
+    preload: :rewards,
+    ttl_check_interval: Application.get_env(:explorer, __MODULE__)[:ttl_check_interval],
+    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl]
 
   @type element :: Block.t()
 

--- a/apps/explorer/lib/explorer/chain/cache/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transactions.ex
@@ -16,7 +16,9 @@ defmodule Explorer.Chain.Cache.Transactions do
       token_transfers: :token,
       token_transfers: :from_address,
       token_transfers: :to_address
-    ]
+    ],
+    ttl_check_interval: Application.get_env(:explorer, __MODULE__)[:ttl_check_interval],
+    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl]
 
   @type element :: Transaction.t()
 

--- a/apps/explorer/test/explorer/chain/cache/block_number_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/block_number_test.exs
@@ -11,7 +11,7 @@ defmodule Explorer.Chain.Cache.BlockNumberTest do
     end)
   end
 
-  describe "get_max/1" do
+  describe "get_max/0" do
     test "returns max number" do
       insert(:block, number: 5)
 
@@ -19,7 +19,7 @@ defmodule Explorer.Chain.Cache.BlockNumberTest do
     end
   end
 
-  describe "get_min/1" do
+  describe "get_min/0" do
     test "returns min number" do
       insert(:block, number: 2)
 
@@ -27,7 +27,7 @@ defmodule Explorer.Chain.Cache.BlockNumberTest do
     end
   end
 
-  describe "get_all/1" do
+  describe "get_all/0" do
     test "returns min and max number" do
       insert(:block, number: 6)
 


### PR DESCRIPTION
Relates to https://github.com/poanetwork/blockscout/issues/2583

## Motivation

`Blocks`, `Transactions` and `BlockNumber` caches are updated by Indexer, but when Indexer runs separately from WebApp, caches aren't updated. So I added TTL for this caches to updating them without Indexer.

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
  - [ ] If I added/changed/removed ENV var, I should update the list of env vars in https://github.com/poanetwork/blockscout/blob/master/docs/env-variables.md to reflect changes in the table here https://poanetwork.github.io/blockscout/#/env-variables?id=blockscout-env-variables. I've set `master` in the `Version` column.
  - [ ] If I add new indices into DB, I checked, that they don't redundant with PGHero or other tools
