### PR TITLE
remove rewards from getminedblocks rpc response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#2497](https://github.com/poanetwork/blockscout/pull/2497) - Add generic Ordered Cache behaviour and implementation
 
 ### Fixes
+- [#2613](https://github.com/poanetwork/blockscout/pull/2613) - fix getminedblocks rpc endpoint
 - [#2592](https://github.com/poanetwork/blockscout/pull/2592) - process new metadata format for whisper
 - [#2572](https://github.com/poanetwork/blockscout/pull/2572) - Ease non-critical css
 - [#2570](https://github.com/poanetwork/blockscout/pull/2570) - Network icons preload

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -713,11 +713,6 @@ defmodule BlockScoutWeb.Etherscan do
         type: "timestamp",
         definition: "When the block was collated.",
         example: ~s("1480072029")
-      },
-      blockReward: %{
-        type: "block reward",
-        definition: "The reward given to the miner of a block.",
-        example: ~s("5003251945421042780")
       }
     }
   }

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -157,8 +157,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
   defp prepare_block(block) do
     %{
       "blockNumber" => to_string(block.number),
-      "timeStamp" => to_string(block.timestamp),
-      "blockReward" => to_string(block.reward.value)
+      "timeStamp" => to_string(block.timestamp)
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -2266,7 +2266,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     end
 
     test "returns all the required fields", %{conn: conn} do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block = insert(:block, number: Enum.random(Range.new(range.from, range.to)))
 
@@ -2274,17 +2274,10 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       |> insert(gas_price: 1)
       |> with_block(block, gas_used: 1)
 
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(1))
-        |> Wei.from(:wei)
-
       expected_result = [
         %{
           "blockNumber" => to_string(block.number),
-          "timeStamp" => to_string(block.timestamp),
-          "blockReward" => to_string(expected_reward.value)
+          "timeStamp" => to_string(block.timestamp)
         }
       ]
 
@@ -2306,19 +2299,13 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     end
 
     test "with a block with one transaction", %{conn: conn} do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block = insert(:block, number: Enum.random(Range.new(range.from, range.to)))
 
       :transaction
       |> insert(gas_price: 1)
       |> with_block(block, gas_used: 1)
-
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(1))
-        |> Wei.from(:wei)
 
       params = %{
         "module" => "account",
@@ -2329,8 +2316,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       expected_result = [
         %{
           "blockNumber" => to_string(block.number),
-          "timeStamp" => to_string(block.timestamp),
-          "blockReward" => to_string(expected_reward.value)
+          "timeStamp" => to_string(block.timestamp)
         }
       ]
 
@@ -2346,7 +2332,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     end
 
     test "with pagination options", %{conn: conn} do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block_numbers = Range.new(range.from, range.to)
 
@@ -2361,12 +2347,6 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       |> insert(gas_price: 2)
       |> with_block(block2, gas_used: 2)
 
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(4))
-        |> Wei.from(:wei)
-
       params = %{
         "module" => "account",
         "action" => "getminedblocks",
@@ -2380,8 +2360,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       expected_result = [
         %{
           "blockNumber" => to_string(block2.number),
-          "timeStamp" => to_string(block2.timestamp),
-          "blockReward" => to_string(expected_reward.value)
+          "timeStamp" => to_string(block2.timestamp)
         }
       ]
 
@@ -2683,7 +2662,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     })
   end
 
-  defp resolve_schema(result \\ %{}) do
+  defp resolve_schema(result) do
     %{
       "type" => "object",
       "properties" => %{

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -8,8 +8,7 @@ defmodule Explorer.Etherscan do
   alias Explorer.Etherscan.Logs
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Address.TokenBalance
-  alias Explorer.Chain.{Block, Hash, InternalTransaction, Transaction, Wei}
-  alias Explorer.Chain.Block.EmissionReward
+  alias Explorer.Chain.{Block, Hash, InternalTransaction, Transaction}
 
   @default_options %{
     order_by_direction: :asc,
@@ -187,22 +186,15 @@ defmodule Explorer.Etherscan do
     query =
       from(
         b in Block,
-        left_join: t in assoc(b, :transactions),
-        inner_join: r in EmissionReward,
-        on: fragment("? <@ ?", b.number, r.block_range),
         where: b.miner_hash == ^address_hash,
         order_by: [desc: b.number],
         group_by: b.number,
         group_by: b.timestamp,
-        group_by: r.reward,
         limit: ^merged_options.page_size,
         offset: ^offset(merged_options),
         select: %{
           number: b.number,
-          timestamp: b.timestamp,
-          reward: %Wei{
-            value: fragment("coalesce(sum(? * ?), 0) + ?", t.gas_used, t.gas_price, r.reward)
-          }
+          timestamp: b.timestamp
         }
       )
 

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -4,7 +4,7 @@ defmodule Explorer.EtherscanTest do
   import Explorer.Factory
 
   alias Explorer.{Etherscan, Chain}
-  alias Explorer.Chain.{Transaction, Wei}
+  alias Explorer.Chain.Transaction
 
   describe "list_transactions/2" do
     test "with empty db" do
@@ -1170,7 +1170,7 @@ defmodule Explorer.EtherscanTest do
 
   describe "list_blocks/1" do
     test "it returns all required fields" do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block = insert(:block, number: Enum.random(Range.new(range.from, range.to)))
 
@@ -1181,17 +1181,10 @@ defmodule Explorer.EtherscanTest do
       |> insert(gas_price: 1)
       |> with_block(block, gas_used: 1)
 
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(1))
-        |> Wei.from(:wei)
-
       expected = [
         %{
           number: block.number,
-          timestamp: block.timestamp,
-          reward: expected_reward
+          timestamp: block.timestamp
         }
       ]
 
@@ -1199,32 +1192,14 @@ defmodule Explorer.EtherscanTest do
     end
 
     test "with block containing multiple transactions" do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block = insert(:block, number: Enum.random(Range.new(range.from, range.to)))
-
-      # irrelevant transaction
-      insert(:transaction)
-
-      :transaction
-      |> insert(gas_price: 1)
-      |> with_block(block, gas_used: 1)
-
-      :transaction
-      |> insert(gas_price: 1)
-      |> with_block(block, gas_used: 2)
-
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(3))
-        |> Wei.from(:wei)
 
       expected = [
         %{
           number: block.number,
-          timestamp: block.timestamp,
-          reward: expected_reward
+          timestamp: block.timestamp
         }
       ]
 
@@ -1232,7 +1207,7 @@ defmodule Explorer.EtherscanTest do
     end
 
     test "with block without transactions" do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block = insert(:block, number: Enum.random(Range.new(range.from, range.to)))
 
@@ -1242,8 +1217,7 @@ defmodule Explorer.EtherscanTest do
       expected = [
         %{
           number: block.number,
-          timestamp: block.timestamp,
-          reward: emission_reward.reward
+          timestamp: block.timestamp
         }
       ]
 
@@ -1251,7 +1225,7 @@ defmodule Explorer.EtherscanTest do
     end
 
     test "with multiple blocks" do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block_numbers = Range.new(range.from, range.to)
 
@@ -1262,47 +1236,14 @@ defmodule Explorer.EtherscanTest do
       block1 = insert(:block, number: block_number1, miner: address)
       block2 = insert(:block, number: block_number2, miner: address)
 
-      # irrelevant transaction
-      insert(:transaction)
-
-      :transaction
-      |> insert(gas_price: 2)
-      |> with_block(block1, gas_used: 2)
-
-      :transaction
-      |> insert(gas_price: 2)
-      |> with_block(block1, gas_used: 2)
-
-      :transaction
-      |> insert(gas_price: 3)
-      |> with_block(block2, gas_used: 3)
-
-      :transaction
-      |> insert(gas_price: 3)
-      |> with_block(block2, gas_used: 3)
-
-      expected_reward_block1 =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(8))
-        |> Wei.from(:wei)
-
-      expected_reward_block2 =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(18))
-        |> Wei.from(:wei)
-
       expected = [
         %{
           number: block2.number,
-          timestamp: block2.timestamp,
-          reward: expected_reward_block2
+          timestamp: block2.timestamp
         },
         %{
           number: block1.number,
-          timestamp: block1.timestamp,
-          reward: expected_reward_block1
+          timestamp: block1.timestamp
         }
       ]
 
@@ -1310,7 +1251,7 @@ defmodule Explorer.EtherscanTest do
     end
 
     test "with pagination options" do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block_numbers = Range.new(range.from, range.to)
 
@@ -1321,29 +1262,17 @@ defmodule Explorer.EtherscanTest do
       block1 = insert(:block, number: block_number1, miner: address)
       block2 = insert(:block, number: block_number2, miner: address)
 
-      :transaction
-      |> insert(gas_price: 2)
-      |> with_block(block1, gas_used: 2)
-
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(4))
-        |> Wei.from(:wei)
-
       expected1 = [
         %{
           number: block2.number,
-          timestamp: block2.timestamp,
-          reward: emission_reward.reward
+          timestamp: block2.timestamp
         }
       ]
 
       expected2 = [
         %{
           number: block1.number,
-          timestamp: block1.timestamp,
-          reward: expected_reward
+          timestamp: block1.timestamp
         }
       ]
 


### PR DESCRIPTION
fixes https://github.com/poanetwork/blockscout/issues/2493

Reward calculation is a heavy operation since it joins
`rewards` and `transactions` tables with `blocks`.
`transactions` is one of the largest tables in the DB.

So that was a reason for a request timeout. Removing rewards
fixed the issue. From this point rewards should be fetched
with `getblockreward` rpc.

Pagination is already implemented.

## Changelog
- remove rewards from getminedblocks rpc response