### PR TITLE
Separate ordered withdrawals from active stakes

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
@@ -23,12 +23,13 @@ defmodule BlockScoutWeb.StakesController do
 
     account =
       if account_address = conn.assigns[:account] do
-        %{
+        account_address
+        |> Chain.get_total_staked()
+        |> Map.merge(%{
           address: account_address,
           balance: Chain.fetch_last_token_balance(account_address, token.contract_address_hash),
-          staked: Chain.get_total_staked(account_address),
           pool: Chain.staking_pool(account_address)
-        }
+        })
       end
 
     View.render_to_string(StakesView, "_stakes_top.html",

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex
@@ -20,7 +20,12 @@
       <%= format_according_to_decimals(@account[:balance], @token.decimals) %> <%= @token.symbol %>
     </span>
     <span class="stakes-top-stats-label-item"><%= gettext "Staked" %>:
-      <%= format_according_to_decimals(@account[:staked], @token.decimals) %> <%= @token.symbol %>
+      <%= format_according_to_decimals(@account[:stake_amount], @token.decimals) %> <%= @token.symbol %>
     </span>
+    <%= if @account[:ordered_withdraw] && @account[:ordered_withdraw] > 0 do %>
+      <span class="stakes-top-stats-label-item"><%= gettext "Ordered" %>:
+        <%= format_according_to_decimals(@account[:ordered_withdraw], @token.decimals) %> <%= @token.symbol %>
+      </span>
+    <% end %>
   </span>
 </div>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1975,3 +1975,8 @@ msgstr ""
 #: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:17
 msgid "Your Mining Address"
 msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex:26
+msgid "Ordered"
+msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1976,3 +1976,8 @@ msgstr ""
 #: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:17
 msgid "Your Mining Address"
 msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex:26
+msgid "Ordered"
+msgstr ""

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3290,7 +3290,9 @@ defmodule Explorer.Chain do
       if delegator_address_hash do
         base_query
         |> join(:left, [p], pd in StakingPoolsDelegator,
-          on: p.staking_address_hash == pd.pool_address_hash and pd.delegator_address_hash == ^delegator_address_hash
+          on:
+            p.staking_address_hash == pd.pool_address_hash and pd.delegator_address_hash == ^delegator_address_hash and
+              not pd.is_deleted
         )
         |> select([p, pd], %{pool: p, delegator: pd})
       else
@@ -3372,19 +3374,19 @@ defmodule Explorer.Chain do
   def staking_pool_delegator(pool_address_hash, delegator_address_hash) do
     Repo.get_by(StakingPoolsDelegator,
       pool_address_hash: pool_address_hash,
-      delegator_address_hash: delegator_address_hash
+      delegator_address_hash: delegator_address_hash,
+      is_deleted: false
     )
   end
 
   def get_total_staked(address_hash) do
-    staked_query =
-      from(
-        delegator in StakingPoolsDelegator,
-        where: delegator.delegator_address_hash == ^address_hash and delegator.is_active,
-        select: sum(delegator.stake_amount)
-      )
-
-    Repo.one(staked_query) || Decimal.new(0)
+    StakingPoolsDelegator
+    |> where([delegator], delegator.delegator_address_hash == ^address_hash and not delegator.is_deleted)
+    |> select([delegator], %{
+      stake_amount: coalesce(sum(delegator.stake_amount), 0),
+      ordered_withdraw: coalesce(sum(delegator.ordered_withdraw), 0)
+    })
+    |> Repo.one()
   end
 
   defp with_decompiled_code_flag(query, _hash, false), do: query

--- a/apps/explorer/lib/explorer/staking/contract_reader.ex
+++ b/apps/explorer/lib/explorer/staking/contract_reader.ex
@@ -47,7 +47,7 @@ defmodule Explorer.Staking.ContractReader do
 
   def delegator_requests(pool_address, delegator_address) do
     [
-      stake_amount: {:staking, "stakeAmount", [pool_address, delegator_address]},
+      stake_amount: {:staking, "stakeAmountMinusOrderedWithdraw", [pool_address, delegator_address]},
       ordered_withdraw: {:staking, "orderedWithdrawAmount", [pool_address, delegator_address]},
       max_withdraw_allowed: {:staking, "maxWithdrawAllowed", [pool_address, delegator_address]},
       max_ordered_withdraw_allowed: {:staking, "maxWithdrawOrderAllowed", [pool_address, delegator_address]},


### PR DESCRIPTION
Result of `stakeAmount` getter includes ordered withdrawals, which should not actually be displayed as part of stake from user's standpoint.
Thus, we now use `stakeAmountMinusOrderedWithdraw` getter for that amount and start showing the total amount of ordered withdrawals in top panel.

In addition, a couple of missing `is_deleted` filters is added.

Addresses [issue 18](https://github.com/poanetwork/blockscout/pull/2292#issuecomment-522098750).