### PR TITLE
skip cache update if there are no blocks inserted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#2538](https://github.com/poanetwork/blockscout/pull/2538) - fetch the last not empty coin balance records
 
 ### Chore
+- [#2617](https://github.com/poanetwork/blockscout/pull/2617) - skip cache update if there are no blocks inserted
 - [#2594](https://github.com/poanetwork/blockscout/pull/2594) - do not start genesis data fetching periodically
 - [#2590](https://github.com/poanetwork/blockscout/pull/2590) - restore backward compatablity with old releases
 - [#2574](https://github.com/poanetwork/blockscout/pull/2574) - limit request body in json rpc error

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -183,7 +183,7 @@ defmodule Indexer.Block.Fetcher do
     end
   end
 
-  defp update_block_cache(blocks) do
+  defp update_block_cache(blocks) when is_list(blocks) do
     max_block = Enum.max_by(blocks, fn block -> block.number end)
     min_block = Enum.min_by(blocks, fn block -> block.number end)
 
@@ -191,6 +191,8 @@ defmodule Indexer.Block.Fetcher do
     BlockNumber.update(min_block.number)
     BlocksCache.update(blocks)
   end
+
+  defp update_block_cache(_), do: :ok
 
   defp update_transactions_cache(transactions) do
     Transactions.update(transactions)


### PR DESCRIPTION
Sometimes due to some error (mostly network) we may
not fetch any data when indexing block. If block cache update
is triggered it fails.

This PR checks if list is passed to cache update function.

## Changelog

- skip cache update if there are no blocks inserted