### PR TITLE
Enforce DB transaction's order to prevent deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#2684](https://github.com/poanetwork/blockscout/pull/2684) - do not filter pending logs
 - [#2682](https://github.com/poanetwork/blockscout/pull/2682) - Use Task.start instead of Task.async in caches
 - [#2671](https://github.com/poanetwork/blockscout/pull/2671) - fixed buttons color at smart contract section
+- [#2619](https://github.com/poanetwork/blockscout/pull/2619) - Enforce DB transaction's order to prevent deadlocks
 
 ### Chore
 
@@ -31,7 +32,6 @@
 - [#2497](https://github.com/poanetwork/blockscout/pull/2497) - Add generic Ordered Cache behaviour and implementation
 
 ### Fixes
-- [#2619](https://github.com/poanetwork/blockscout/pull/2619) - Enforce DB transaction's order to prevent deadlocks
 - [#2659](https://github.com/poanetwork/blockscout/pull/2659) - Multipurpose front-end part update
 - [#2640](https://github.com/poanetwork/blockscout/pull/2640) - SVG network icons
 - [#2635](https://github.com/poanetwork/blockscout/pull/2635) - optimize ERC721 inventory query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [#2497](https://github.com/poanetwork/blockscout/pull/2497) - Add generic Ordered Cache behaviour and implementation
 
 ### Fixes
+- [#2619](https://github.com/poanetwork/blockscout/pull/2619) - Enforce DB transaction's order to prevent deadlocks
 - [#2659](https://github.com/poanetwork/blockscout/pull/2659) - Multipurpose front-end part update
 - [#2640](https://github.com/poanetwork/blockscout/pull/2640) - SVG network icons
 - [#2635](https://github.com/poanetwork/blockscout/pull/2635) - optimize ERC721 inventory query

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -8,6 +8,7 @@ defmodule Explorer.Chain do
       from: 2,
       join: 4,
       limit: 2,
+      lock: 2,
       order_by: 2,
       order_by: 3,
       offset: 2,
@@ -2924,14 +2925,20 @@ defmodule Explorer.Chain do
         ]) :: {integer(), nil | [term()]}
   def find_and_update_replaced_transactions(transactions, timeout \\ :infinity) do
     query =
-      Enum.reduce(transactions, Transaction, fn %{hash: hash, nonce: nonce, from_address_hash: from_address_hash},
-                                                query ->
-        from(t in query,
-          or_where:
-            t.nonce == ^nonce and t.from_address_hash == ^from_address_hash and t.hash != ^hash and
-              not is_nil(t.block_number)
-        )
-      end)
+      transactions
+      |> Enum.reduce(
+        Transaction,
+        fn %{hash: hash, nonce: nonce, from_address_hash: from_address_hash}, query ->
+          from(t in query,
+            or_where:
+              t.nonce == ^nonce and t.from_address_hash == ^from_address_hash and t.hash != ^hash and
+                not is_nil(t.block_number)
+          )
+        end
+      )
+      # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
+      |> order_by(asc: :hash)
+      |> lock("FOR UPDATE")
 
     hashes = Enum.map(transactions, & &1.hash)
 
@@ -2974,10 +2981,15 @@ defmodule Explorer.Chain do
             or_where: t.nonce == ^nonce and t.from_address_hash == ^from_address and is_nil(t.block_hash)
           )
         end)
+        # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
+        |> order_by(asc: :hash)
+        |> lock("FOR UPDATE")
 
-      update_query = from(t in query, update: [set: [status: ^:error, error: "dropped/replaced"]])
-
-      Repo.update_all(update_query, [], timeout: timeout)
+      Repo.update_all(
+        from(t in Transaction, join: s in subquery(query), on: t.hash == s.hash),
+        [set: [error: "dropped/replaced", status: :error]],
+        timeout: timeout
+      )
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/contract_method.ex
+++ b/apps/explorer/lib/explorer/chain/contract_method.ex
@@ -46,7 +46,10 @@ defmodule Explorer.Chain.ContractMethod do
       end)
     end
 
-    Repo.insert_all(__MODULE__, successes, on_conflict: :nothing, conflict_target: [:identifier, :abi])
+    # Enforce ContractMethod ShareLocks order (see docs: sharelocks.md)
+    ordered_successes = Enum.sort_by(successes, &{&1.identifier, &1.abi})
+
+    Repo.insert_all(__MODULE__, ordered_successes, on_conflict: :nothing, conflict_target: [:identifier, :abi])
   end
 
   def import_all do

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -10,7 +10,9 @@ defmodule Explorer.Chain.Import do
 
   @stages [
     Import.Stage.Addresses,
-    Import.Stage.AddressReferencing
+    Import.Stage.AddressReferencing,
+    Import.Stage.BlockReferencing,
+    Import.Stage.BlockFollowing
   ]
 
   # in order so that foreign keys are inserted before being referenced

--- a/apps/explorer/lib/explorer/chain/import/runner/address/coin_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/coin_balances.ex
@@ -71,7 +71,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CoinBalances do
   defp insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
-    # order so that row ShareLocks are grabbed in a consistent order
+    # Enforce CoinBalance ShareLocks order (see docs: sharelocks.md)
     ordered_changes_list = Enum.sort_by(changes_list, &{&1.address_hash, &1.block_number})
 
     {:ok, _} =

--- a/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
@@ -59,7 +59,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
   def insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
-    # order so that row ShareLocks are grabbed in a consistent order
+    # Enforce TokenBalance ShareLocks order (see docs: sharelocks.md)
     ordered_changes_list =
       Enum.sort_by(changes_list, &{&1.address_hash, &1.token_contract_address_hash, &1.block_number})
 

--- a/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
@@ -80,7 +80,7 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
   defp insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
-    # order so that row ShareLocks are grabbed in a consistent order
+    # Enforce Address ShareLocks order (see docs: sharelocks.md)
     ordered_changes_list = sort_changes_list(changes_list)
 
     Import.insert_changes_list(
@@ -153,13 +153,18 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
       query =
         from(t in Transaction,
           where: t.created_contract_address_hash in ^ordered_created_contract_hashes,
-          update: [
-            set: [created_contract_code_indexed_at: ^timestamps.updated_at]
-          ]
+          # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
+          order_by: t.hash,
+          lock: "FOR UPDATE"
         )
 
       try do
-        {_, result} = repo.update_all(query, [], timeout: timeout)
+        {_, result} =
+          repo.update_all(
+            from(t in Transaction, join: s in subquery(query), on: t.hash == s.hash),
+            [set: [created_contract_code_indexed_at: timestamps.updated_at]],
+            timeout: timeout
+          )
 
         {:ok, result}
       rescue

--- a/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
@@ -52,7 +52,7 @@ defmodule Explorer.Chain.Import.Runner.Block.Rewards do
        when is_list(changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
-    # order so that row ShareLocks are grabbed in a consistent order
+    # Enforce Reward ShareLocks order (see docs: sharelocks.md)
     ordered_changes_list = Enum.sort_by(changes_list, &{&1.address_hash, &1.address_type, &1.block_hash})
 
     Import.insert_changes_list(

--- a/apps/explorer/lib/explorer/chain/import/runner/block/second_degree_relations.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/block/second_degree_relations.ex
@@ -62,7 +62,7 @@ defmodule Explorer.Chain.Import.Runner.Block.SecondDegreeRelations do
   defp insert(repo, changes_list, %{timeout: timeout} = options) when is_atom(repo) and is_list(changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
-    # order so that row ShareLocks are grabbed in a consistent order
+    # Enforce SeconDegreeRelation ShareLocks order (see docs: sharelocks.md)
     ordered_changes_list = Enum.sort_by(changes_list, &{&1.nephew_hash, &1.uncle_hash})
 
     Import.insert_changes_list(repo, ordered_changes_list,

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -5,9 +5,8 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
   require Ecto.Query
 
-  import Ecto.Query, only: [from: 2, select: 2, subquery: 1, update: 2]
+  import Ecto.Query, only: [from: 2, lock: 2, order_by: 2, subquery: 1]
 
-  alias Ecto.Adapters.SQL
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.{Address, Block, Hash, Import, InternalTransaction, Log, TokenTransfer, Transaction}
   alias Explorer.Chain.Block.Reward
@@ -131,76 +130,60 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         }
       )
     end)
-    |> Multi.run(
-      :internal_transaction_transaction_block_number,
-      fn repo, %{blocks: blocks} ->
-        blocks_hashes = Enum.map(blocks, & &1.hash)
-
-        query =
-          from(
-            internal_transaction in InternalTransaction,
-            join: transaction in Transaction,
-            on: internal_transaction.transaction_hash == transaction.hash,
-            join: block in Block,
-            on: block.hash == transaction.block_hash,
-            where: block.hash in ^blocks_hashes,
-            update: [
-              set: [
-                block_number: block.number
-              ]
-            ]
-          )
-
-        {total, _} = repo.update_all(query, [])
-
-        {:ok, total}
-      end
-    )
+    |> Multi.run(:internal_transaction_transaction_block_number, fn repo, %{blocks: blocks} when is_list(blocks) ->
+      update_internal_transaction_block_number(repo, blocks)
+    end)
   end
 
   @impl Runner
   def timeout, do: @timeout
 
-  # sobelow_skip ["SQL.Query"]
   defp derive_transaction_forks(%{
          repo: repo,
          timeout: timeout,
          timestamps: %{inserted_at: inserted_at, updated_at: updated_at},
          where_forked: where_forked
        }) do
-    query =
-      from(transaction in where_forked,
-        select: [
-          transaction.block_hash,
-          transaction.index,
-          transaction.hash,
-          type(^inserted_at, transaction.inserted_at),
-          type(^updated_at, transaction.updated_at)
-        ],
-        # order so that row ShareLocks are grabbed in a consistent order with
-        # `Explorer.Chain.Import.Runner.Transactions.insert`
-        order_by: transaction.hash
-      )
+    multi =
+      Multi.new()
+      |> Multi.run(:get_forks, fn repo, _ ->
+        query =
+          from(transaction in where_forked,
+            select: %{
+              uncle_hash: transaction.block_hash,
+              index: transaction.index,
+              hash: transaction.hash,
+              inserted_at: type(^inserted_at, transaction.inserted_at),
+              updated_at: type(^updated_at, transaction.updated_at)
+            }
+          )
 
-    {select_sql, parameters} = SQL.to_sql(:all, repo, query)
+        transactions = repo.all(query)
+        {:ok, transactions}
+      end)
+      |> Multi.run(:insert_transaction_forks, fn repo, %{get_forks: transactions} ->
+        # Enforce Fork ShareLocks order (see docs: sharelocks.md)
+        ordered_forks = Enum.sort_by(transactions, &{&1.uncle_hash, &1.index})
 
-    insert_sql = """
-    INSERT INTO transaction_forks (uncle_hash, index, hash, inserted_at, updated_at)
-    #{select_sql}
-    ON CONFLICT (uncle_hash, index)
-    DO UPDATE SET hash = EXCLUDED.hash
-    WHERE EXCLUDED.hash <> transaction_forks.hash
-    RETURNING uncle_hash, hash
-    """
+        {_total, result} =
+          repo.insert_all(
+            Transaction.Fork,
+            ordered_forks,
+            conflict_target: [:uncle_hash, :index],
+            on_conflict:
+              from(
+                transaction_fork in Transaction.Fork,
+                update: [set: [hash: fragment("EXCLUDED.hash")]],
+                where: fragment("EXCLUDED.hash <> ?", transaction_fork.hash)
+              ),
+            returning: [:uncle_hash, :hash]
+          )
 
-    with {:ok, %Postgrex.Result{columns: ["uncle_hash", "hash"], command: :insert, rows: rows}} <-
-           SQL.query(
-             repo,
-             insert_sql,
-             parameters,
-             timeout: timeout
-           ) do
-      derived_transaction_forks = Enum.map(rows, fn [uncle_hash, hash] -> %{uncle_hash: uncle_hash, hash: hash} end)
+        {:ok, result}
+      end)
+
+    with {:ok, %{insert_transaction_forks: rows}} <- repo.transaction(multi, timeout: timeout) do
+      derived_transaction_forks = Enum.map(rows, &Map.take(&1, [:uncle_hash, :hash]))
 
       {:ok, derived_transaction_forks}
     end
@@ -214,23 +197,32 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
        }) do
     query =
       where_forked
-      |> update(
-        set: [
-          block_hash: nil,
-          block_number: nil,
-          gas_used: nil,
-          cumulative_gas_used: nil,
-          index: nil,
-          internal_transactions_indexed_at: nil,
-          status: nil,
-          error: nil,
-          updated_at: ^updated_at
-        ]
+      # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
+      |> order_by(asc: :hash)
+      |> lock("FOR UPDATE")
+
+    update_query =
+      from(t in Transaction,
+        join: s in subquery(query),
+        on: t.hash == s.hash,
+        update: [
+          set: [
+            block_hash: nil,
+            block_number: nil,
+            gas_used: nil,
+            cumulative_gas_used: nil,
+            index: nil,
+            internal_transactions_indexed_at: nil,
+            status: nil,
+            error: nil,
+            updated_at: ^updated_at
+          ]
+        ],
+        select: t.hash
       )
-      |> select([:hash])
 
     try do
-      {_, result} = repo.update_all(query, [], timeout: timeout)
+      {_, result} = repo.update_all(update_query, [], timeout: timeout)
 
       {:ok, result}
     rescue
@@ -247,8 +239,8 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   defp insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
-    # order so that row ShareLocks are grabbed in a consistent order
-    ordered_changes_list = Enum.sort_by(changes_list, &{&1.number, &1.hash})
+    # Enforce Block ShareLocks order (see docs: sharelocks.md)
+    ordered_changes_list = Enum.sort_by(changes_list, & &1.hash)
 
     Import.insert_changes_list(
       repo,
@@ -316,17 +308,18 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
       from(
         block in Block,
         where: block.number in ^ordered_consensus_block_number,
-        update: [
-          set: [
-            consensus: false,
-            updated_at: ^updated_at
-          ]
-        ],
-        select: [:hash, :number]
+        # Enforce Block ShareLocks order (see docs: sharelocks.md)
+        order_by: [asc: block.hash],
+        lock: "FOR UPDATE"
       )
 
     try do
-      {_, result} = repo.update_all(query, [], timeout: timeout)
+      {_, result} =
+        repo.update_all(
+          from(b in Block, join: s in subquery(query), on: b.hash == s.hash, select: [:hash, :number]),
+          [set: [consensus: false, updated_at: updated_at]],
+          timeout: timeout
+        )
 
       {:ok, result}
     rescue
@@ -342,17 +335,18 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     query =
       from(
         block in where_invalid_neighbour,
-        update: [
-          set: [
-            consensus: false,
-            updated_at: ^updated_at
-          ]
-        ],
-        select: [:hash, :number]
+        # Enforce Block ShareLocks order (see docs: sharelocks.md)
+        order_by: [asc: block.hash],
+        lock: "FOR UPDATE"
       )
 
     try do
-      {_, result} = repo.update_all(query, [], timeout: timeout)
+      {_, result} =
+        repo.update_all(
+          from(b in Block, join: s in subquery(query), on: b.hash == s.hash, select: [:hash, :number]),
+          [set: [consensus: false, updated_at: updated_at]],
+          timeout: timeout
+        )
 
       {:ok, result}
     rescue
@@ -498,13 +492,12 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
       from(address_token_balance in Address.TokenBalance,
         where: address_token_balance.block_number in ^ordered_consensus_block_numbers,
         select: map(address_token_balance, [:address_hash, :token_contract_address_hash, :block_number]),
-        # MUST match order in `Explorer.Chain.Import.Runner.Address.TokenBalances.insert` to prevent ShareLock ordering deadlocks.
+        # Enforce TokenBalance ShareLocks order (see docs: sharelocks.md)
         order_by: [
           address_token_balance.address_hash,
           address_token_balance.token_contract_address_hash,
           address_token_balance.block_number
         ],
-        # ensures rows remains locked while outer query is joining to it
         lock: "FOR UPDATE"
       )
 
@@ -536,12 +529,11 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
       from(address_current_token_balance in Address.CurrentTokenBalance,
         where: address_current_token_balance.block_number in ^ordered_consensus_block_numbers,
         select: map(address_current_token_balance, [:address_hash, :token_contract_address_hash]),
-        # MUST match order in `Explorer.Chain.Import.Runner.Address.CurrentTokenBalances.insert` to prevent ShareLock ordering deadlocks.
+        # Enforce CurrentTokenBalance ShareLocks order (see docs: sharelocks.md)
         order_by: [
           address_current_token_balance.address_hash,
           address_current_token_balance.token_contract_address_hash
         ],
-        # ensures row remains locked while outer query is joining to it
         lock: "FOR UPDATE"
       )
 
@@ -575,7 +567,6 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
   defp derive_address_current_token_balances(_, [], _), do: {:ok, []}
 
-  # sobelow_skip ["SQL.Query"]
   defp derive_address_current_token_balances(repo, deleted_address_current_token_balances, %{timeout: timeout})
        when is_list(deleted_address_current_token_balances) do
     initial_query =
@@ -609,54 +600,51 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
           address_token_balance.address_hash == new_current_token_balance.address_hash and
             address_token_balance.token_contract_address_hash == new_current_token_balance.token_contract_address_hash and
             address_token_balance.block_number == new_current_token_balance.block_number,
-        select: {
-          new_current_token_balance.address_hash,
-          new_current_token_balance.token_contract_address_hash,
-          new_current_token_balance.block_number,
-          address_token_balance.value,
-          over(min(address_token_balance.inserted_at), :w),
-          over(max(address_token_balance.updated_at), :w)
+        select: %{
+          address_hash: new_current_token_balance.address_hash,
+          token_contract_address_hash: new_current_token_balance.token_contract_address_hash,
+          block_number: new_current_token_balance.block_number,
+          value: address_token_balance.value,
+          inserted_at: over(min(address_token_balance.inserted_at), :w),
+          updated_at: over(max(address_token_balance.updated_at), :w)
         },
-        # Prevent ShareLock deadlock by matching order of `Explorer.Chain.Import.Runner.Address.CurrentTokenBalances.insert`
-        order_by: [new_current_token_balance.address_hash, new_current_token_balance.token_contract_address_hash],
         windows: [
           w: [partition_by: [address_token_balance.address_hash, address_token_balance.token_contract_address_hash]]
         ]
       )
 
-    {select_sql, parameters} = SQL.to_sql(:all, repo, new_current_token_balance_query)
+    multi =
+      Multi.new()
+      |> Multi.run(:new_current_token_balance, fn repo, _ ->
+        new_current_token_balances = repo.all(new_current_token_balance_query)
+        {:ok, new_current_token_balances}
+      end)
+      |> Multi.run(
+        :insert_new_current_token_balance,
+        fn repo, %{new_current_token_balance: new_current_token_balance} ->
+          # Enforce CurrentTokenBalance ShareLocks order (see docs: sharelocks.md)
+          ordered_current_token_balance =
+            Enum.sort_by(
+              new_current_token_balance,
+              &{&1.address_hash, &1.token_contract_address_hash}
+            )
 
-    # No `ON CONFLICT` because `delete_address_current_token_balances` should have removed any conflicts.
-    insert_sql = """
-    INSERT INTO address_current_token_balances (address_hash, token_contract_address_hash, block_number, value, inserted_at, updated_at)
-    #{select_sql}
-    RETURNING address_hash, token_contract_address_hash, block_number, value
-    """
+          {_total, result} =
+            repo.insert_all(
+              Address.CurrentTokenBalance,
+              ordered_current_token_balance,
+              # No `ON CONFLICT` because `delete_address_current_token_balances`
+              # should have removed any conflicts.
+              returning: [:address_hash, :token_contract_address_hash, :block_number, :value]
+            )
 
-    with {:ok,
-          %Postgrex.Result{
-            columns: [
-              "address_hash",
-              "token_contract_address_hash",
-              "block_number",
-              # needed for `update_tokens_holder_count`
-              "value"
-            ],
-            command: :insert,
-            rows: rows
-          }} <- SQL.query(repo, insert_sql, parameters, timeout: timeout) do
+          {:ok, result}
+        end
+      )
+
+    with {:ok, %{insert_new_current_token_balance: rows}} <- repo.transaction(multi, timeout: timeout) do
       derived_address_current_token_balances =
-        Enum.map(rows, fn [address_hash_bytes, token_contract_address_hash_bytes, block_number, value] ->
-          {:ok, address_hash} = Hash.Address.load(address_hash_bytes)
-          {:ok, token_contract_address_hash} = Hash.Address.load(token_contract_address_hash_bytes)
-
-          %{
-            address_hash: address_hash,
-            token_contract_address_hash: token_contract_address_hash,
-            block_number: block_number,
-            value: value
-          }
-        end)
+        Enum.map(rows, &Map.take(&1, [:address_hash, :token_contract_address_hash, :block_number, :value]))
 
       {:ok, derived_address_current_token_balances}
     end
@@ -677,11 +665,24 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     query =
       from(reward in Reward,
         inner_join: block in assoc(reward, :block),
-        where: block.hash in ^hashes or block.number in ^numbers
+        where: block.hash in ^hashes or block.number in ^numbers,
+        # Enforce Reward ShareLocks order (see docs: sharelocks.md)
+        order_by: [asc: :address_hash, asc: :address_type, asc: :block_hash],
+        # NOTE: find a better way to know the alias that ecto gives to token
+        lock: "FOR UPDATE OF b0"
+      )
+
+    delete_query =
+      from(r in Reward,
+        join: s in subquery(query),
+        on:
+          r.address_hash == s.address_hash and
+            r.address_type == s.address_type and
+            r.block_hash == s.block_hash
       )
 
     try do
-      {count, nil} = repo.delete_all(query, timeout: timeout)
+      {count, nil} = repo.delete_all(delete_query, timeout: timeout)
 
       {:ok, count}
     rescue
@@ -692,30 +693,71 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
   defp update_block_second_degree_relations(repo, blocks, %{timeout: timeout, timestamps: %{updated_at: updated_at}})
        when is_list(blocks) do
-    ordered_uncle_hashes =
+    uncle_hashes =
       blocks
       |> MapSet.new(& &1.hash)
-      |> Enum.sort()
+      |> MapSet.to_list()
 
     query =
       from(
         bsdr in Block.SecondDegreeRelation,
-        where: bsdr.uncle_hash in ^ordered_uncle_hashes,
-        update: [
-          set: [
-            uncle_fetched_at: ^updated_at
-          ]
-        ]
+        where: bsdr.uncle_hash in ^uncle_hashes,
+        # Enforce SeconDegreeRelation ShareLocks order (see docs: sharelocks.md)
+        order_by: [asc: :nephew_hash, asc: :uncle_hash],
+        lock: "FOR UPDATE"
+      )
+
+    update_query =
+      from(
+        b in Block.SecondDegreeRelation,
+        join: s in subquery(query),
+        on: b.nephew_hash == s.nephew_hash and b.uncle_hash == s.uncle_hash,
+        update: [set: [uncle_fetched_at: ^updated_at]]
       )
 
     try do
-      {_, result} = repo.update_all(query, [], timeout: timeout)
+      {_, result} = repo.update_all(update_query, [], timeout: timeout)
 
       {:ok, result}
     rescue
       postgrex_error in Postgrex.Error ->
-        {:error, %{exception: postgrex_error, uncle_hashes: ordered_uncle_hashes}}
+        {:error, %{exception: postgrex_error, uncle_hashes: uncle_hashes}}
     end
+  end
+
+  defp update_internal_transaction_block_number(repo, blocks) when is_list(blocks) do
+    blocks_hashes = Enum.map(blocks, & &1.hash)
+
+    query =
+      from(
+        internal_transaction in InternalTransaction,
+        join: transaction in Transaction,
+        on: internal_transaction.transaction_hash == transaction.hash,
+        join: block in Block,
+        on: block.hash == transaction.block_hash,
+        where: block.hash in ^blocks_hashes,
+        select: %{
+          transaction_hash: internal_transaction.transaction_hash,
+          index: internal_transaction.index,
+          block_number: block.number
+        },
+        # Enforce InternalTransaction ShareLocks order (see docs: sharelocks.md)
+        order_by: [asc: :transaction_hash, asc: :index],
+        # NOTE: find a better way to know the alias that ecto gives to internal_transaction
+        lock: "FOR UPDATE OF i0"
+      )
+
+    update_query =
+      from(
+        i in InternalTransaction,
+        join: s in subquery(query),
+        on: i.transaction_hash == s.transaction_hash and i.index == s.index,
+        update: [set: [block_number: s.block_number]]
+      )
+
+    {total, _} = repo.update_all(update_query, [])
+
+    {:ok, total}
   end
 
   defp where_forked(blocks_changes) when is_list(blocks_changes) do

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions_indexed_at_blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions_indexed_at_blocks.ex
@@ -49,36 +49,36 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsIndexedAtBlocks do
 
   defp update_blocks(_repo, [], %{}), do: {:ok, []}
 
-  defp update_blocks(repo, block_numbers, %{
+  defp update_blocks(repo, changes_list, %{
          timeout: timeout,
          timestamps: timestamps
        })
-       when is_list(block_numbers) do
-    ordered_block_numbers =
-      block_numbers
-      |> Enum.map(fn %{number: number} -> number end)
-      |> Enum.sort()
+       when is_list(changes_list) do
+    block_numbers = Enum.map(changes_list, fn %{number: number} -> number end)
 
     query =
       from(
         b in Block,
-        where: b.number in ^ordered_block_numbers and b.consensus,
-        update: [
-          set: [
-            internal_transactions_indexed_at: ^timestamps.updated_at
-          ]
-        ]
+        where: b.number in ^block_numbers and b.consensus,
+        # Enforce Block ShareLocks order (see docs: sharelocks.md)
+        order_by: [asc: b.hash],
+        lock: "FOR UPDATE"
       )
 
-    block_count = Enum.count(ordered_block_numbers)
+    block_count = Enum.count(block_numbers)
 
     try do
-      {^block_count, result} = repo.update_all(query, [], timeout: timeout)
+      {^block_count, result} =
+        repo.update_all(
+          from(b in Block, join: s in subquery(query), on: b.hash == s.hash),
+          [set: [internal_transactions_indexed_at: timestamps.updated_at]],
+          timeout: timeout
+        )
 
       {:ok, result}
     rescue
       postgrex_error in Postgrex.Error ->
-        {:error, %{exception: postgrex_error, block_numbers: ordered_block_numbers}}
+        {:error, %{exception: postgrex_error, block_numbers: block_numbers}}
     end
   end
 end

--- a/apps/explorer/lib/explorer/chain/import/runner/logs.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/logs.ex
@@ -58,7 +58,7 @@ defmodule Explorer.Chain.Import.Runner.Logs do
   defp insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
-    # order so that row ShareLocks are grabbed in a consistent order
+    # Enforce Log ShareLocks order (see docs: sharelocks.md)
     ordered_changes_list = Enum.sort_by(changes_list, &{&1.transaction_hash, &1.index})
 
     {:ok, _} =

--- a/apps/explorer/lib/explorer/chain/import/runner/staking_pools_delegators.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/staking_pools_delegators.ex
@@ -59,10 +59,13 @@ defmodule Explorer.Chain.Import.Runner.StakingPoolsDelegators do
   defp insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
+    # Enforce StackingPoolDelegator ShareLocks order (see docs: sharelocks.md)
+    ordered_changes_list = Enum.sort_by(changes_list, &{&1.delegator_address_hash, &1.pool_address_hash})
+
     {:ok, _} =
       Import.insert_changes_list(
         repo,
-        changes_list,
+        ordered_changes_list,
         conflict_target: [:pool_address_hash, :delegator_address_hash],
         on_conflict: on_conflict,
         for: StakingPoolsDelegator,

--- a/apps/explorer/lib/explorer/chain/import/runner/token_transfers.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/token_transfers.ex
@@ -54,7 +54,7 @@ defmodule Explorer.Chain.Import.Runner.TokenTransfers do
   def insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
-    # order so that row ShareLocks are grabbed in a consistent order
+    # Enforce TokenTransfer ShareLocks order (see docs: sharelocks.md)
     ordered_changes_list = Enum.sort_by(changes_list, &{&1.transaction_hash, &1.log_index})
 
     {:ok, _} =

--- a/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
@@ -7,7 +7,6 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
 
   import Ecto.Query, only: [from: 2]
 
-  alias Ecto.Adapters.SQL
   alias Ecto.{Multi, Repo}
   alias Explorer.Chain.{Hash, Import, Token}
 
@@ -22,10 +21,59 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
   @type holder_count :: non_neg_integer()
   @type token_holder_count :: %{contract_address_hash: Hash.Address.t(), count: holder_count()}
 
-  def update_holder_counts_with_deltas(repo, token_holder_count_deltas, options) do
-    parameters = token_holder_count_deltas_to_parameters(token_holder_count_deltas)
+  def update_holder_counts_with_deltas(repo, token_holder_count_deltas, %{
+        timeout: timeout,
+        timestamps: %{updated_at: updated_at}
+      }) do
+    {hashes, deltas} =
+      token_holder_count_deltas
+      |> Enum.map(fn %{contract_address_hash: contract_address_hash, delta: delta} ->
+        {:ok, contract_address_hash_bytes} = Hash.Address.dump(contract_address_hash)
+        {contract_address_hash_bytes, delta}
+      end)
+      |> Enum.unzip()
 
-    update_holder_counts_with_parameters(repo, parameters, options)
+    query =
+      from(
+        token in Token,
+        join:
+          deltas in fragment(
+            "(SELECT unnest(?::bytea[]) as contract_address_hash, unnest(?::bigint[]) as delta)",
+            ^hashes,
+            ^deltas
+          ),
+        on: token.contract_address_hash == deltas.contract_address_hash,
+        select: %{
+          contract_address_hash: token.contract_address_hash,
+          delta: deltas.delta
+        },
+        where: not is_nil(token.holder_count),
+        # Enforce Token ShareLocks order (see docs: sharelocks.md)
+        order_by: token.contract_address_hash,
+        # NOTE: find a better way to know the alias that ecto gives to token
+        lock: "FOR UPDATE OF t0"
+      )
+
+    update_query =
+      from(
+        t in Token,
+        join: s in subquery(query),
+        on: t.contract_address_hash == s.contract_address_hash,
+        update: [
+          set: [
+            holder_count: t.holder_count + s.delta,
+            updated_at: ^updated_at
+          ]
+        ],
+        select: %{
+          contract_address_hash: t.contract_address_hash,
+          holder_count: t.holder_count
+        }
+      )
+
+    {_total, result} = repo.update_all(update_query, [], timeout: timeout)
+
+    {:ok, result}
   end
 
   @impl Import.Runner
@@ -71,7 +119,7 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
       changes_list
       # brand new tokens start with no holders
       |> Stream.map(&Map.put_new(&1, :holder_count, 0))
-      # order so that row ShareLocks are grabbed in a consistent order
+      # Enforce Token ShareLocks order (see docs: sharelocks.md)
       |> Enum.sort_by(& &1.contract_address_hash)
 
     {:ok, _} =
@@ -116,70 +164,5 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
           token.cataloged
         )
     )
-  end
-
-  defp token_holder_count_deltas_to_parameters(token_holder_count_deltas) when is_list(token_holder_count_deltas) do
-    Enum.flat_map(token_holder_count_deltas, fn
-      %{contract_address_hash: contract_address_hash, delta: delta} ->
-        {:ok, contract_address_hash_bytes} = Hash.Address.dump(contract_address_hash)
-        [contract_address_hash_bytes, delta]
-    end)
-  end
-
-  defp update_holder_counts_with_parameters(_, [], _), do: {:ok, []}
-
-  # sobelow_skip ["SQL.Query"]
-  defp update_holder_counts_with_parameters(repo, parameters, %{timeout: timeout, timestamps: %{updated_at: updated_at}})
-       when is_list(parameters) do
-    update_sql = update_holder_counts_sql(parameters)
-
-    with {:ok, %Postgrex.Result{columns: ["contract_address_hash", "holder_count"], command: :update, rows: rows}} <-
-           SQL.query(repo, update_sql, [updated_at | parameters], timeout: timeout) do
-      update_token_holder_counts =
-        Enum.map(rows, fn [contract_address_hash_bytes, holder_count] ->
-          {:ok, contract_address_hash} = Hash.Address.cast(contract_address_hash_bytes)
-          %{contract_address_hash: contract_address_hash, holder_count: holder_count}
-        end)
-
-      {:ok, update_token_holder_counts}
-    end
-  end
-
-  defp update_holder_counts_sql(parameters) when is_list(parameters) do
-    parameters
-    |> Enum.count()
-    |> div(2)
-    |> update_holder_counts_sql()
-  end
-
-  defp update_holder_counts_sql(row_count) when is_integer(row_count) do
-    parameters_sql =
-      update_holder_counts_parameters_sql(
-        row_count,
-        # skip $1 as it is used for the common `updated_at` timestamp
-        2
-      )
-
-    """
-    UPDATE tokens
-    SET holder_count = holder_count + holder_counts.delta,
-        updated_at = $1
-    FROM (
-        VALUES
-          #{parameters_sql}
-      ) AS holder_counts(contract_address_hash, delta)
-    WHERE tokens.contract_address_hash = holder_counts.contract_address_hash AND
-          holder_count IS NOT NULL
-    RETURNING tokens.contract_address_hash, tokens.holder_count
-    """
-  end
-
-  defp update_holder_counts_parameters_sql(row_count, start) when is_integer(row_count) do
-    Enum.map_join(0..(row_count - 1), ",\n      ", fn i ->
-      contract_address_hash_parameter_number = 2 * i + start
-      holder_count_number = contract_address_hash_parameter_number + 1
-
-      "($#{contract_address_hash_parameter_number}::bytea, $#{holder_count_number}::bigint)"
-    end)
   end
 end

--- a/apps/explorer/lib/explorer/chain/import/runner/transaction/forks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transaction/forks.ex
@@ -58,8 +58,8 @@ defmodule Explorer.Chain.Import.Runner.Transaction.Forks do
   defp insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
-    # order so that row ShareLocks are grabbed in a consistent order
-    ordered_changes_list = Enum.sort_by(changes_list, &{&1.uncle_hash, &1.hash})
+    # Enforce Fork ShareLocks order (see docs: sharelocks.md)
+    ordered_changes_list = Enum.sort_by(changes_list, &{&1.uncle_hash, &1.index})
 
     Import.insert_changes_list(
       repo,

--- a/apps/explorer/lib/explorer/chain/import/stage.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage.ex
@@ -47,4 +47,24 @@ defmodule Explorer.Chain.Import.Stage do
       runner.run(Multi.new(), changes_chunk, options)
     end)
   end
+
+  @spec single_multi([Runner.t()], runner_to_changes_list, %{optional(atom()) => term()}) ::
+          {Multi.t(), runner_to_changes_list}
+  def single_multi(runners, runner_to_changes_list, options) do
+    runners
+    |> Enum.reduce({Multi.new(), runner_to_changes_list}, fn runner, {multi, remaining_runner_to_changes_list} ->
+      {changes_list, new_remaining_runner_to_changes_list} = Map.pop(remaining_runner_to_changes_list, runner)
+
+      new_multi =
+        case changes_list do
+          nil ->
+            multi
+
+          _ ->
+            runner.run(multi, changes_list, options)
+        end
+
+      {new_multi, new_remaining_runner_to_changes_list}
+    end)
+  end
 end

--- a/apps/explorer/lib/explorer/chain/import/stage/address_referencing.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/address_referencing.ex
@@ -4,7 +4,6 @@ defmodule Explorer.Chain.Import.Stage.AddressReferencing do
   `Explorer.Chain.Import.Stage.Addresses`.
   """
 
-  alias Ecto.Multi
   alias Explorer.Chain.Import.{Runner, Stage}
 
   @behaviour Stage
@@ -14,17 +13,6 @@ defmodule Explorer.Chain.Import.Stage.AddressReferencing do
     do: [
       Runner.Address.CoinBalances,
       Runner.Blocks,
-      Runner.Block.Rewards,
-      Runner.Block.SecondDegreeRelations,
-      Runner.Transactions,
-      Runner.Transaction.Forks,
-      Runner.InternalTransactions,
-      Runner.InternalTransactionsIndexedAtBlocks,
-      Runner.Logs,
-      Runner.Tokens,
-      Runner.TokenTransfers,
-      Runner.Address.CurrentTokenBalances,
-      Runner.Address.TokenBalances,
       Runner.StakingPools,
       Runner.StakingPoolsDelegators
     ]
@@ -32,21 +20,7 @@ defmodule Explorer.Chain.Import.Stage.AddressReferencing do
   @impl Stage
   def multis(runner_to_changes_list, options) do
     {final_multi, final_remaining_runner_to_changes_list} =
-      runners()
-      |> Enum.reduce({Multi.new(), runner_to_changes_list}, fn runner, {multi, remaining_runner_to_changes_list} ->
-        {changes_list, new_remaining_runner_to_changes_list} = Map.pop(remaining_runner_to_changes_list, runner)
-
-        new_multi =
-          case changes_list do
-            nil ->
-              multi
-
-            _ ->
-              runner.run(multi, changes_list, options)
-          end
-
-        {new_multi, new_remaining_runner_to_changes_list}
-      end)
+      Stage.single_multi(runners(), runner_to_changes_list, options)
 
     {[final_multi], final_remaining_runner_to_changes_list}
   end

--- a/apps/explorer/lib/explorer/chain/import/stage/block_following.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/block_following.ex
@@ -1,0 +1,30 @@
+defmodule Explorer.Chain.Import.Stage.BlockFollowing do
+  @moduledoc """
+  Imports any tables that follows and cannot be imported at the same time as
+  those imported by `Explorer.Chain.Import.Stage.Addresses`,
+  `Explorer.Chain.Import.Stage.AddressReferencing` and
+  `Explorer.Chain.Import.Stage.BlockReferencing`
+  """
+
+  alias Explorer.Chain.Import.{Runner, Stage}
+
+  @behaviour Stage
+
+  @impl Stage
+  def runners,
+    do: [
+      Runner.InternalTransactionsIndexedAtBlocks,
+      Runner.Block.SecondDegreeRelations,
+      Runner.Block.Rewards,
+      Runner.InternalTransactions,
+      Runner.Address.CurrentTokenBalances
+    ]
+
+  @impl Stage
+  def multis(runner_to_changes_list, options) do
+    {final_multi, final_remaining_runner_to_changes_list} =
+      Stage.single_multi(runners(), runner_to_changes_list, options)
+
+    {[final_multi], final_remaining_runner_to_changes_list}
+  end
+end

--- a/apps/explorer/lib/explorer/chain/import/stage/block_referencing.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/block_referencing.ex
@@ -1,0 +1,30 @@
+defmodule Explorer.Chain.Import.Stage.BlockReferencing do
+  @moduledoc """
+  Imports any tables that reference `t:Explorer.Chain.Block.t/0` and that were
+  imported by `Explorer.Chain.Import.Stage.Addresses` and
+  `Explorer.Chain.Import.Stage.AddressReferencing`.
+  """
+
+  alias Explorer.Chain.Import.{Runner, Stage}
+
+  @behaviour Stage
+
+  @impl Stage
+  def runners,
+    do: [
+      Runner.Transactions,
+      Runner.Transaction.Forks,
+      Runner.Logs,
+      Runner.Tokens,
+      Runner.TokenTransfers,
+      Runner.Address.TokenBalances
+    ]
+
+  @impl Stage
+  def multis(runner_to_changes_list, options) do
+    {final_multi, final_remaining_runner_to_changes_list} =
+      Stage.single_multi(runners(), runner_to_changes_list, options)
+
+    {[final_multi], final_remaining_runner_to_changes_list}
+  end
+end

--- a/apps/explorer/lib/explorer/market/market.ex
+++ b/apps/explorer/lib/explorer/market/market.ex
@@ -41,9 +41,12 @@ defmodule Explorer.Market do
   @doc false
   def bulk_insert_history(records) do
     records_without_zeroes =
-      Enum.reject(records, fn item ->
+      records
+      |> Enum.reject(fn item ->
         Decimal.equal?(item.closing_price, 0) && Decimal.equal?(item.opening_price, 0)
       end)
+      # Enforce MarketHistory ShareLocks order (see docs: sharelocks.md)
+      |> Enum.sort_by(& &1.date)
 
     Repo.insert_all(MarketHistory, records_without_zeroes, on_conflict: :nothing, conflict_target: [:date])
   end

--- a/apps/explorer/lib/explorer/validator/metadata_importer.ex
+++ b/apps/explorer/lib/explorer/validator/metadata_importer.ex
@@ -8,7 +8,10 @@ defmodule Explorer.Validator.MetadataImporter do
   import Ecto.Query, only: [from: 2]
 
   def import_metadata(metadata_maps) do
-    Repo.transaction(fn -> Enum.each(metadata_maps, &upsert_validator_metadata(&1)) end)
+    # Enforce Name ShareLocks order (see docs: sharelocks.md)
+    ordered_metadata_maps = Enum.sort_by(metadata_maps, &{&1.address_hash, &1.name})
+
+    Repo.transaction(fn -> Enum.each(ordered_metadata_maps, &upsert_validator_metadata(&1)) end)
   end
 
   defp upsert_validator_metadata(validator_changeset) do

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -116,7 +116,7 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
       assert count(Address.CurrentTokenBalance) == count
     end
 
-    test "remove_nonconsensus_data deletes token transfer rows with matching block number when new consensus block is inserted",
+    test "remove_nonconsensus_token_transfers deletes token transfer rows with matching block number when new consensus block is inserted",
          %{consensus_block: %{number: block_number} = block, options: options} do
       insert(:block, number: block_number, consensus: true)
 
@@ -127,17 +127,15 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
       assert {:ok,
               %{
-                remove_nonconsensus_data: %{
-                  token_transfers: [
-                    %{transaction_hash: ^transaction_hash, log_index: ^log_index}
-                  ]
-                }
+                remove_nonconsensus_token_transfers: [
+                  %{transaction_hash: ^transaction_hash, log_index: ^log_index}
+                ]
               }} = run_block_consensus_change(block, true, options)
 
       assert count(TokenTransfer) == 0
     end
 
-    test "remove_nonconsensus_data does not delete token transfer rows with matching block number when new consensus block wasn't inserted",
+    test "remove_nonconsensus_token_transfers does not delete token transfer rows with matching block number when new consensus block wasn't inserted",
          %{consensus_block: %{number: block_number} = block, options: options} do
       insert(:token_transfer, block_number: block_number, transaction: insert(:transaction))
 
@@ -145,17 +143,12 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
       assert count(TokenTransfer) == count
 
-      assert {:ok,
-              %{
-                remove_nonconsensus_data: %{
-                  token_transfers: []
-                }
-              }} = run_block_consensus_change(block, false, options)
+      assert {:ok, %{remove_nonconsensus_token_transfers: []}} = run_block_consensus_change(block, false, options)
 
       assert count(TokenTransfer) == count
     end
 
-    test "remove_nonconsensus_data deletes nonconsensus logs", %{
+    test "remove_nonconsensus_logs deletes nonconsensus logs", %{
       consensus_block: %{number: block_number} = block,
       options: options
     } do
@@ -165,19 +158,13 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
       assert count(Log) == 1
 
-      assert {:ok,
-              %{
-                remove_nonconsensus_data: %{
-                  logs: [
-                    %{transaction_hash: ^hash, index: ^index}
-                  ]
-                }
-              }} = run_block_consensus_change(block, true, options)
+      assert {:ok, %{remove_nonconsensus_logs: [%{transaction_hash: ^hash, index: ^index}]}} =
+               run_block_consensus_change(block, true, options)
 
       assert count(Log) == 0
     end
 
-    test "remove_nonconsensus_data deletes nonconsensus internal transactions", %{
+    test "remove_nonconsensus_internal_transactions deletes nonconsensus internal transactions", %{
       consensus_block: %{number: block_number} = block,
       options: options
     } do
@@ -189,14 +176,8 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
       assert count(InternalTransaction) == 1
 
-      assert {:ok,
-              %{
-                remove_nonconsensus_data: %{
-                  internal_transactions: [
-                    %{transaction_hash: ^hash, index: ^index}
-                  ]
-                }
-              }} = run_block_consensus_change(block, true, options)
+      assert {:ok, %{remove_nonconsensus_internal_transactions: [%{transaction_hash: ^hash, index: ^index}]}} =
+               run_block_consensus_change(block, true, options)
 
       assert count(InternalTransaction) == 0
     end

--- a/docs/sharelocks.md
+++ b/docs/sharelocks.md
@@ -1,0 +1,88 @@
+<!--sharelocks.md -->
+
+## ShareLocks
+
+ShareLock is the row-level locking mechanism used internally by PostgreSQL.
+
+### Deadlocks and prevention
+
+When several DB transactions are acting on multiple rows of the same table, it's
+possible to incur in a deadlock and so into an error.
+This can be prevented by enforcing the same consistent order of lock aquisition
+on *all* the transactions performing `INSERT`, `UPDATE` or `DELETE` on a given table.
+
+### Imposing the lock acquisition order with Ecto
+
+When `INSERT`ing a list of rows Postgres will respect the order in which they
+appear in the query, so the reordering can happen beforehand.
+
+For example, this will work:
+```elixir
+entries = [...]
+
+ordered_entries = Enum.sort_by(entries, & &1.id)
+
+Repo.insert_all(__MODULE__, ordered_entries)
+```
+
+Performing `UPDATE`s is trickier because there is no `ORDER BY` clause.
+The solution to this is to `JOIN` on a subquery that `SELECT`s with the option `FOR UPDATE`.
+
+Using Ecto this can be done, for example, like this:
+```elixir
+query =
+  from(
+    entry in Entry,
+    where: not is_nil(entry.value),
+    order_by: entry.id,
+    lock: "FOR UPDATE"
+  )
+
+Repo.update_all(
+  from(e in Entry, join: s in subquery(query), on: e.id == s.id),
+  [set: [value: nil]],
+  timeout: timeout)
+```
+
+`DELETE` has the same quircks as `UPDATE` and it is too solved in the same way.
+
+For example:
+```elixir
+query =
+  from(
+    entry in Entry,
+    where: is_nil(entry.value),
+    order_by: entry.id,
+    lock: "FOR UPDATE"
+  )
+
+Repo.delete_all(from(e in Entry, join: s in subquery(query), on: e.id == s.id))
+```
+
+### Order used in Explorer's tables
+
+This is a complete list of the ordering currently in use on each table.
+Note that this should always be enforced because as long as there is one DB
+transaction performing in a different order there is the possibility of a deadlock.
+
+| schema module | table name | ordered by |
+|---------------|------------|------------|
+| Explorer.Chain.Address | addresses | asc: :hash |
+| Explorer.Chain.Address.CoinBalance | address_coin_balances | [asc: :address_hash, asc: :block_number] |
+| Explorer.Chain.Address.CurrentTokenBalance | address_current_token_balances | [asc: :address_hash, asc: :token_contract_address_hash] |
+| Explorer.Chain.Address.Name | address_names | [asc: :address_hash, asc: :name] |
+| Explorer.Chain.Address.TokenBalance | address_token_balances | [asc: :address_hash, asc: :token_contract_address_hash, asc: :block_number] |
+| Explorer.Chain.Block | blocks | asc: :hash |
+| Explorer.Chain.Block.EmissionReward | emission_rewards | asc: :block_range |
+| Explorer.Chain.Block.Reward | block_rewards | [asc: :address_hash, asc: :address_type, asc: :block_hash] |
+| Explorer.Chain.Block.SecondDegreeRelation | block_second_degree_relations | [asc: :nephew_hash, asc: :uncle_hash] |
+| Explorer.Chain.ContractMethod | contract_methods | [asc: :identified, asc: :abi]
+| Explorer.Chain.InternalTransaction | internal_transactions | [asc: :transaction_hash, asc: :index] |
+| Explorer.Chain.Log | logs | [asc: :transaction_hash, asc: :index] |
+| Explorer.Chain.StakingPool | staking_pools | :staking_address_hash |
+| Explorer.Chain.StakingPoolsDelegator | staking_pools_delegators | [asc: :delegator_address_hash, asc: :pool_address_hash] |
+| Explorer.Chain.Token | tokens | asc: :contract_address_hash |
+| Explorer.Chain.TokenTransfer | token_transfers | [asc: :transaction_hash, asc: :log_index]|
+| Explorer.Chain.Transaction | transactions | asc: :hash |
+| Explorer.Chain.Transaction.Fork | transaction_forks | [asc: :uncle_hash, asc: :index] |
+| Explorer.Market.MarketHistory | market_history | asc: :date |

--- a/docs/sharelocks.md
+++ b/docs/sharelocks.md
@@ -11,7 +11,13 @@ possible to incur in a deadlock and so into an error.
 This can be prevented by enforcing the same consistent order of lock aquisition
 on *all* the transactions performing `INSERT`, `UPDATE` or `DELETE` on a given table.
 
-### Imposing the lock acquisition order with Ecto
+On top of this, if multiple DB transactions act on multiple tables a deadlock
+will occur, even if they follow the order on each table described above, if they
+acquire locks on said tables in a different order.
+This can also be prevented by using a consisten order of lock acquisition *between*
+different tables.
+
+### Imposing the lock acquisition order on a table with Ecto
 
 When `INSERT`ing a list of rows Postgres will respect the order in which they
 appear in the query, so the reordering can happen beforehand.
@@ -59,30 +65,73 @@ query =
 Repo.delete_all(from(e in Entry, join: s in subquery(query), on: e.id == s.id))
 ```
 
-### Order used in Explorer's tables
+### Imposing the lock acquisition order between tables with Ecto
+
+When using an `Ecto.Multi` to perform `INSERT`, `UPDATE` or `DELETE` on multiple
+tables the order to keep is between different operation.
+For example, supposing `EntryA` was established to be modified before `EntryB`,
+this is not correct:
+```elixir
+Multi.new()
+|> Multi.run(:update_b, fn repo, _ ->
+  # operations with ordered locks on `EntryB`
+end)
+|> Multi.run(:update_a, fn repo, _ ->
+  # operations with ordered locks on `EntryA`
+end)
+|> Repo.transaction()
+```
+
+When possible, the simple solution is to move `:update_a` to be before `:update_b`.
+When not possible, for instance if `:update_a` depends on the result of `:update_b`,
+this can be solved by acquiring the locks in a separate operation.
+
+For example:
+```elixir
+Multi.new()
+|> Multi.run(:acquire_a, fn repo, _ ->
+  # acquire locks in order on `EntryA`
+end)
+|> Multi.run(:update_b, fn repo, _ ->
+  # operations with ordered locks on `EntryB`
+end)
+|> Multi.run(:update_a, fn repo, %{acquire_a: values} ->
+  # operations (no need to enforce order again) on `EntryA`
+end)
+|> Repo.transaction()
+```
+
+Note also that for the same reasons multiple operations on the same table in the
+same transaction are not safe to perform if they each acquire locks in order,
+because locks are not released until the transaction is committed.
+
+### Order used for Explorer's tables
 
 This is a complete list of the ordering currently in use on each table.
+It also specifies the order between tables in the same transaction: locks for a
+table on top need to be acquired before those from a table on the bottom.
+
 Note that this should always be enforced because as long as there is one DB
 transaction performing in a different order there is the possibility of a deadlock.
 
 | schema module | table name | ordered by |
 |---------------|------------|------------|
 | Explorer.Chain.Address | addresses | asc: :hash |
-| Explorer.Chain.Address.CoinBalance | address_coin_balances | [asc: :address_hash, asc: :block_number] |
-| Explorer.Chain.Address.CurrentTokenBalance | address_current_token_balances | [asc: :address_hash, asc: :token_contract_address_hash] |
 | Explorer.Chain.Address.Name | address_names | [asc: :address_hash, asc: :name] |
-| Explorer.Chain.Address.TokenBalance | address_token_balances | [asc: :address_hash, asc: :token_contract_address_hash, asc: :block_number] |
+| Explorer.Chain.Address.CoinBalance | address_coin_balances | [asc: :address_hash, asc: :block_number] |
 | Explorer.Chain.Block | blocks | asc: :hash |
-| Explorer.Chain.Block.EmissionReward | emission_rewards | asc: :block_range |
-| Explorer.Chain.Block.Reward | block_rewards | [asc: :address_hash, asc: :address_type, asc: :block_hash] |
 | Explorer.Chain.Block.SecondDegreeRelation | block_second_degree_relations | [asc: :nephew_hash, asc: :uncle_hash] |
-| Explorer.Chain.ContractMethod | contract_methods | [asc: :identified, asc: :abi]
-| Explorer.Chain.InternalTransaction | internal_transactions | [asc: :transaction_hash, asc: :index] |
-| Explorer.Chain.Log | logs | [asc: :transaction_hash, asc: :index] |
-| Explorer.Chain.StakingPool | staking_pools | :staking_address_hash |
-| Explorer.Chain.StakingPoolsDelegator | staking_pools_delegators | [asc: :delegator_address_hash, asc: :pool_address_hash] |
-| Explorer.Chain.Token | tokens | asc: :contract_address_hash |
-| Explorer.Chain.TokenTransfer | token_transfers | [asc: :transaction_hash, asc: :log_index]|
+| Explorer.Chain.Block.Reward | block_rewards | [asc: :address_hash, asc: :address_type, asc: :block_hash] |
+| Explorer.Chain.Block.EmissionReward | emission_rewards | asc: :block_range |
 | Explorer.Chain.Transaction | transactions | asc: :hash |
 | Explorer.Chain.Transaction.Fork | transaction_forks | [asc: :uncle_hash, asc: :index] |
+| Explorer.Chain.Log | logs | [asc: :transaction_hash, asc: :index] |
+| Explorer.Chain.InternalTransaction | internal_transactions | [asc: :transaction_hash, asc: :index] |
+| Explorer.Chain.Token | tokens | asc: :contract_address_hash |
+| Explorer.Chain.TokenTransfer | token_transfers | [asc: :transaction_hash, asc: :log_index]|
+| Explorer.Chain.Address.TokenBalance | address_token_balances | [asc: :address_hash, asc: :token_contract_address_hash, asc: :block_number] |
+| Explorer.Chain.Address.CurrentTokenBalance | address_current_token_balances | [asc: :address_hash, asc: :token_contract_address_hash] |
+| Explorer.Chain.StakingPool | staking_pools | :staking_address_hash |
+| Explorer.Chain.StakingPoolsDelegator | staking_pools_delegators | [asc: :delegator_address_hash, asc: :pool_address_hash] |
+| Explorer.Chain.ContractMethod | contract_methods | [asc: :identified, asc: :abi]
 | Explorer.Market.MarketHistory | market_history | asc: :date |


### PR DESCRIPTION
fixes: #2587 

## Motivation

Due to the ShareLock mechanism used by PostgreSQL when there are several DB transactions are acting on multiple rows of the same table, it's possible to incur in a deadlock and so into an error.

## Changelog

This PR enforces a consistent order of ShareLock acquisition in all the relevant transaction.
It also adds a clear documentation that should help in the future.

### Bug Fixes

This is the list of functions that had to be modified and for what reason: 

Updates that were performed without ordering:
- Explorer.Chain.find_and_update_replaced_transactions
- Explorer.Chain.update_replaced_transactions
- Explorer.Chain.Import.Runner.Addresses.update_transactions
- Explorer.Chain.Import.Runner.Blocks.update_internal_transaction_block_number
- Explorer.Chain.Import.Runner.Blocks.fork_transactions
- Explorer.Chain.Import.Runner.Blocks.lose_consensus
- Explorer.Chain.Import.Runner.Blocks.lose_invalid_neighbour_consensus
- Explorer.Chain.Import.Runner.Blocks.update_block_second_degree_relations
- Indexer.Temporary.BlocksTransactionsMismatch.run_blocks

Updates that were incorrectly ordered (e.g. postgres does not respect the order of a list to match)
- Explorer.Chain.Import.Runner.InternalTransactions.update_transactions
- Explorer.Chain.Import.Runner.InternalTransactionsIndexedAtBlocks.update_blocks
- Explorer.Chain.Import.Runner.Transactions.discard_blocks_for_recollated_transactions
- Explorer.Chain.Import.Runner.Blocks.derive_transaction_forks

Deletes without order
- Explorer.ChainSpec.Parity.Importer.import_emission_rewards
- Explorer.Chain.Import.Runner.Blocks.delete_rewards

Ordering that did not exist at all (and the functions that now use them):
- StakingPool - staking_address_hash
  - Explorer.Chain.Import.Runner.StakingPools.mark_as_deleted
  - Explorer.Chain.Import.Runner.StakingPools.insert
- EmissionReward - block_range
  - Explorer.ChainSpec.Parity.Importer.import_emission_rewards
- StakingPoolsDelegators delegator_address_hash, pool_address_hash
  - Explorer.Chain.Import.Runner.StakingPoolsDelegators.insert
- MarketHistory - date
  - Explorer.Market.bulk_insert_history
- Address.Name - address_hash
  - Explorer.Validator.MetadataImporter.import_metadata
- ContractMethod - {identifier, abi}
  - Explorer.Chain.ContractMethod.upsert_from_abi

SQL.query calls where refactored for clarity and ordering was added where necessary:
- Explorer.Chain.Import.Runner.Blocks.derive_transaction_forks
- Explorer.Chain.Import.Runner.Blocks.derive_address_current_token_balances
- Explorer.Chain.Import.Runner.Tokens.update_holder_counts_with_deltas

#### Modified ordering

These are orderings that were found to be inconsistent. All the functions that use them (including those corrected in the list above), have been changed to use the new ones.
The modified ones are:
- for `Block`, from `number, hash` to `hash`
- for `Transaction.Fork`,  from `uncle_hash, hash` to `uncle_hash, index`
- for `Address.Name`, from `address_hash` to `address_hash, name`

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
  - [x] If I added/changed/removed ENV var, I should update the list of env vars in https://github.com/poanetwork/blockscout/blob/master/docs/env-variables.md to reflect changes in the table here https://poanetwork.github.io/blockscout/#/env-variables?id=blockscout-env-variables. I've set `master` in the `Version` column.
  - [x] If I add new indices into DB, I checked, that they don't redundant with PGHero or other tools
