### PR TITLE
Improve UI for becoming a candidate for existing pools

### DIFF
--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -52,7 +52,11 @@ async function becomeCandidate ($modal, store, msg) {
       return false
     }
 
-    makeContractCall(stakingContract.methods.addPool(stake.toString(), miningAddress), store)
+    if (msg.pool_exists) {
+      makeContractCall(stakingContract.methods.stake(store.getState().account, stake.toString()), store)
+    } else {
+      makeContractCall(stakingContract.methods.addPool(stake.toString(), miningAddress), store)
+    }
   } catch (err) {
     openErrorModal('Error', err.message)
   }

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -77,6 +77,7 @@ defmodule BlockScoutWeb.StakesChannel do
   end
 
   def handle_in("render_become_candidate", _, socket) do
+    pool = Chain.staking_pool(socket.assigns.account)
     min_candidate_stake = ContractState.get(:min_candidate_stake)
     token = ContractState.get(:token)
     balance = Chain.fetch_last_token_balance(socket.assigns.account, token.contract_address_hash)
@@ -85,12 +86,15 @@ defmodule BlockScoutWeb.StakesChannel do
       View.render_to_string(StakesView, "_stakes_modal_become_candidate.html",
         min_candidate_stake: min_candidate_stake,
         balance: balance,
-        token: token
+        token: token,
+        pool: pool
       )
 
     result = %{
       html: html,
-      min_candidate_stake: min_candidate_stake
+      balance: balance,
+      min_candidate_stake: min_candidate_stake,
+      pool_exists: not is_nil(pool)
     }
 
     {:reply, {:ok, result}, socket}

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
@@ -14,7 +14,14 @@
             </div>
           </div>
           <div class="form-group">
-            <input mining-address type="text" class="form-control" placeholder="<%= gettext("Your Mining Address") %>">
+            <input
+              mining-address
+              type="text"
+              class="form-control"
+              placeholder="<%= gettext("Your Mining Address") %>"
+              value="<%= @pool && @pool.mining_address_hash %>"
+              <%= if @pool do "disabled" end %>
+            />
           </div>
           <p class="form-p m-b-0">Minimum Stake:
             <span class="text-dark">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_top.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_top.html.eex
@@ -12,7 +12,12 @@
             <%= render BlockScoutWeb.StakesView, "_stakes_btn_remove_pool.html", text: gettext("Remove My Pool"), extra_class: "js-remove-pool" %>
           <% end %>
         <% else %>
-          <%= render BlockScoutWeb.CommonComponentsView, "_btn_add_full.html", text: gettext("Become a Candidate"), extra_class: "js-become-candidate" %>
+          <%=
+            render BlockScoutWeb.CommonComponentsView, "_btn_add_full.html",
+              text: gettext("Become a Candidate"),
+              extra_class: "js-become-candidate",
+              disabled: @account[:pool] && @account.pool.is_banned
+          %>
         <% end %>
       </div>
     </div>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1862,8 +1862,8 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_empty_content.html.eex:14
 #: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:5
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:29
-#: lib/block_scout_web/templates/stakes/_stakes_top.html.eex:15
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:36
+#: lib/block_scout_web/templates/stakes/_stakes_top.html.eex:17
 msgid "Become a Candidate"
 msgstr ""
 
@@ -1972,7 +1972,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:17
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:21
 msgid "Your Mining Address"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1863,8 +1863,8 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_empty_content.html.eex:14
 #: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:5
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:29
-#: lib/block_scout_web/templates/stakes/_stakes_top.html.eex:15
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:36
+#: lib/block_scout_web/templates/stakes/_stakes_top.html.eex:17
 msgid "Become a Candidate"
 msgstr ""
 
@@ -1973,7 +1973,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:17
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:21
 msgid "Your Mining Address"
 msgstr ""
 


### PR DESCRIPTION
1. If an address has been a pool some time ago, but was deactivated since, we can't use `addPool()` method anymore due to limitations in the contract.
Instead, we fetch previously existing pool, provide unchangeable mining address, and use `stake()` method for reactivating the pool.

2. Banned pools can't become a candidate again, so the button is disabled. [Issue 13](https://github.com/poanetwork/blockscout/pull/2292#issuecomment-517391758).