### PR TITLE
Changed text color for all error messages boxes for coin_balances page to the required one / Main Blockscout page banner height bug fix and new changes / New tooltips for Block Details page added / Token image added to the Token instance page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#2538](https://github.com/poanetwork/blockscout/pull/2538) - fetch the last not empty coin balance records
 
 ### Chore
+- [#2617](https://github.com/poanetwork/blockscout/pull/2617) - skip cache update if there are no blocks inserted
 - [#2594](https://github.com/poanetwork/blockscout/pull/2594) - do not start genesis data fetching periodically
 - [#2590](https://github.com/poanetwork/blockscout/pull/2590) - restore backward compatablity with old releases
 - [#2574](https://github.com/poanetwork/blockscout/pull/2574) - limit request body in json rpc error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#2538](https://github.com/poanetwork/blockscout/pull/2538) - fetch the last not empty coin balance records
 
 ### Chore
+- [#2611](https://github.com/poanetwork/blockscout/pull/2611) - fix js dependency vulnerabilities
 - [#2617](https://github.com/poanetwork/blockscout/pull/2617) - skip cache update if there are no blocks inserted
 - [#2594](https://github.com/poanetwork/blockscout/pull/2594) - do not start genesis data fetching periodically
 - [#2590](https://github.com/poanetwork/blockscout/pull/2590) - restore backward compatablity with old releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#2596](https://github.com/poanetwork/blockscout/pull/2596) - support AuRa's empty step reward type
 - [#2561](https://github.com/poanetwork/blockscout/pull/2561) - Add token's type to the response of tokenlist method
 - [#2499](https://github.com/poanetwork/blockscout/pull/2499) - import emission reward ranges
 - [#2497](https://github.com/poanetwork/blockscout/pull/2497) - Add generic Ordered Cache behaviour and implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2497](https://github.com/poanetwork/blockscout/pull/2497) - Add generic Ordered Cache behaviour and implementation
 
 ### Fixes
+- [#2613](https://github.com/poanetwork/blockscout/pull/2613) - fix getminedblocks rpc endpoint
 - [#2592](https://github.com/poanetwork/blockscout/pull/2592) - process new metadata format for whisper
 - [#2572](https://github.com/poanetwork/blockscout/pull/2572) - Ease non-critical css
 - [#2570](https://github.com/poanetwork/blockscout/pull/2570) - Network icons preload

--- a/apps/block_scout_web/assets/package-lock.json
+++ b/apps/block_scout_web/assets/package-lock.json
@@ -2678,8 +2678,7 @@
         "esprima": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "is-svg": {
           "version": "3.0.0",
@@ -2688,16 +2687,6 @@
           "dev": true,
           "requires": {
             "html-comment-regex": "^1.1.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
           }
         },
         "mdn-data": {
@@ -3638,24 +3627,13 @@
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
         },
         "globals": {
           "version": "11.7.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
           "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
           "dev": true
-        },
-        "js-yaml": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -3811,12 +3789,6 @@
         "acorn": "^5.5.0",
         "acorn-jsx": "^3.0.0"
       }
-    },
-    "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -3980,9 +3952,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extend-shallow": {
@@ -4293,6 +4265,16 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -4375,9 +4357,7 @@
         "chownr": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-          "dev": true,
-          "optional": true
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -4442,8 +4422,6 @@
           "version": "1.2.5",
           "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-          "dev": true,
-          "optional": true,
           "requires": {
             "minipass": "^2.2.1"
           }
@@ -4577,7 +4555,6 @@
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-          "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -4588,8 +4565,6 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
-          "dev": true,
-          "optional": true,
           "requires": {
             "minipass": "^2.2.1"
           }
@@ -4799,7 +4774,6 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
           "optional": true
         },
         "safer-buffer": {
@@ -4876,22 +4850,6 @@
           "dev": true,
           "optional": true
         },
-        "tar": {
-          "version": "4.4.1",
-          "resolved": false,
-          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
-          }
-        },
         "util-deprecate": {
           "version": "1.0.2",
           "resolved": false,
@@ -4920,15 +4878,14 @@
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
           "optional": true
         }
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -5158,15 +5115,23 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "neo-async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+          "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+          "dev": true
+        }
       }
     },
     "har-schema": {
@@ -6024,7 +5989,7 @@
         },
         "callsites": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         },
@@ -6226,7 +6191,7 @@
             },
             "jest-get-type": {
               "version": "22.4.3",
-              "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
               "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
               "dev": true
             },
@@ -6774,13 +6739,21 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-      "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
+        "esprima": "^4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        }
       }
     },
     "jsbn": {
@@ -6988,9 +6961,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -7017,9 +6990,9 @@
       "dev": true
     },
     "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "lodash.sortby": {
@@ -7422,6 +7395,36 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "mississippi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
@@ -7608,6 +7611,31 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
+        },
+        "tar": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+          "dev": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.12",
+            "inherits": "2"
+          },
+          "dependencies": {
+            "fstream": {
+              "version": "1.0.12",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+              "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+              }
+            }
+          }
         }
       }
     },
@@ -8026,18 +8054,7 @@
         "esprima": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "parse-json": {
           "version": "4.0.0",
@@ -10720,14 +10737,35 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.5",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+          "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+          "dev": true,
+          "optional": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "terser": {

--- a/apps/block_scout_web/assets/package.json
+++ b/apps/block_scout_web/assets/package.json
@@ -30,7 +30,7 @@
     "highlightjs-solidity": "^1.0.6",
     "humps": "^2.0.1",
     "jquery": "^3.3.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "moment": "^2.22.1",
     "nanomorph": "^5.1.3",
     "numeral": "^2.0.6",

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -713,11 +713,6 @@ defmodule BlockScoutWeb.Etherscan do
         type: "timestamp",
         definition: "When the block was collated.",
         example: ~s("1480072029")
-      },
-      blockReward: %{
-        type: "block reward",
-        definition: "The reward given to the miner of a block.",
-        example: ~s("5003251945421042780")
       }
     }
   }

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -157,8 +157,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
   defp prepare_block(block) do
     %{
       "blockNumber" => to_string(block.number),
-      "timeStamp" => to_string(block.timestamp),
-      "blockReward" => to_string(block.reward.value)
+      "timeStamp" => to_string(block.timestamp)
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -2266,7 +2266,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     end
 
     test "returns all the required fields", %{conn: conn} do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block = insert(:block, number: Enum.random(Range.new(range.from, range.to)))
 
@@ -2274,17 +2274,10 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       |> insert(gas_price: 1)
       |> with_block(block, gas_used: 1)
 
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(1))
-        |> Wei.from(:wei)
-
       expected_result = [
         %{
           "blockNumber" => to_string(block.number),
-          "timeStamp" => to_string(block.timestamp),
-          "blockReward" => to_string(expected_reward.value)
+          "timeStamp" => to_string(block.timestamp)
         }
       ]
 
@@ -2306,19 +2299,13 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     end
 
     test "with a block with one transaction", %{conn: conn} do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block = insert(:block, number: Enum.random(Range.new(range.from, range.to)))
 
       :transaction
       |> insert(gas_price: 1)
       |> with_block(block, gas_used: 1)
-
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(1))
-        |> Wei.from(:wei)
 
       params = %{
         "module" => "account",
@@ -2329,8 +2316,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       expected_result = [
         %{
           "blockNumber" => to_string(block.number),
-          "timeStamp" => to_string(block.timestamp),
-          "blockReward" => to_string(expected_reward.value)
+          "timeStamp" => to_string(block.timestamp)
         }
       ]
 
@@ -2346,7 +2332,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     end
 
     test "with pagination options", %{conn: conn} do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block_numbers = Range.new(range.from, range.to)
 
@@ -2361,12 +2347,6 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       |> insert(gas_price: 2)
       |> with_block(block2, gas_used: 2)
 
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(4))
-        |> Wei.from(:wei)
-
       params = %{
         "module" => "account",
         "action" => "getminedblocks",
@@ -2380,8 +2360,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       expected_result = [
         %{
           "blockNumber" => to_string(block2.number),
-          "timeStamp" => to_string(block2.timestamp),
-          "blockReward" => to_string(expected_reward.value)
+          "timeStamp" => to_string(block2.timestamp)
         }
       ]
 
@@ -2683,7 +2662,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     })
   end
 
-  defp resolve_schema(result \\ %{}) do
+  defp resolve_schema(result) do
     %{
       "type" => "object",
       "properties" => %{

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
@@ -182,4 +182,5 @@ defmodule EthereumJSONRPC.Parity.FetchedBeneficiaries do
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 10, do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "block", do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "uncle", do: :uncle
+  defp get_address_type(reward_type, _index) when reward_type == "emptyStep", do: :validator
 end

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -8,8 +8,7 @@ defmodule Explorer.Etherscan do
   alias Explorer.Etherscan.Logs
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Address.TokenBalance
-  alias Explorer.Chain.{Block, Hash, InternalTransaction, Transaction, Wei}
-  alias Explorer.Chain.Block.EmissionReward
+  alias Explorer.Chain.{Block, Hash, InternalTransaction, Transaction}
 
   @default_options %{
     order_by_direction: :asc,
@@ -187,22 +186,15 @@ defmodule Explorer.Etherscan do
     query =
       from(
         b in Block,
-        left_join: t in assoc(b, :transactions),
-        inner_join: r in EmissionReward,
-        on: fragment("? <@ ?", b.number, r.block_range),
         where: b.miner_hash == ^address_hash,
         order_by: [desc: b.number],
         group_by: b.number,
         group_by: b.timestamp,
-        group_by: r.reward,
         limit: ^merged_options.page_size,
         offset: ^offset(merged_options),
         select: %{
           number: b.number,
-          timestamp: b.timestamp,
-          reward: %Wei{
-            value: fragment("coalesce(sum(? * ?), 0) + ?", t.gas_used, t.gas_price, r.reward)
-          }
+          timestamp: b.timestamp
         }
       )
 

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -4,7 +4,7 @@ defmodule Explorer.EtherscanTest do
   import Explorer.Factory
 
   alias Explorer.{Etherscan, Chain}
-  alias Explorer.Chain.{Transaction, Wei}
+  alias Explorer.Chain.Transaction
 
   describe "list_transactions/2" do
     test "with empty db" do
@@ -1170,7 +1170,7 @@ defmodule Explorer.EtherscanTest do
 
   describe "list_blocks/1" do
     test "it returns all required fields" do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block = insert(:block, number: Enum.random(Range.new(range.from, range.to)))
 
@@ -1181,17 +1181,10 @@ defmodule Explorer.EtherscanTest do
       |> insert(gas_price: 1)
       |> with_block(block, gas_used: 1)
 
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(1))
-        |> Wei.from(:wei)
-
       expected = [
         %{
           number: block.number,
-          timestamp: block.timestamp,
-          reward: expected_reward
+          timestamp: block.timestamp
         }
       ]
 
@@ -1199,32 +1192,14 @@ defmodule Explorer.EtherscanTest do
     end
 
     test "with block containing multiple transactions" do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block = insert(:block, number: Enum.random(Range.new(range.from, range.to)))
-
-      # irrelevant transaction
-      insert(:transaction)
-
-      :transaction
-      |> insert(gas_price: 1)
-      |> with_block(block, gas_used: 1)
-
-      :transaction
-      |> insert(gas_price: 1)
-      |> with_block(block, gas_used: 2)
-
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(3))
-        |> Wei.from(:wei)
 
       expected = [
         %{
           number: block.number,
-          timestamp: block.timestamp,
-          reward: expected_reward
+          timestamp: block.timestamp
         }
       ]
 
@@ -1232,7 +1207,7 @@ defmodule Explorer.EtherscanTest do
     end
 
     test "with block without transactions" do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block = insert(:block, number: Enum.random(Range.new(range.from, range.to)))
 
@@ -1242,8 +1217,7 @@ defmodule Explorer.EtherscanTest do
       expected = [
         %{
           number: block.number,
-          timestamp: block.timestamp,
-          reward: emission_reward.reward
+          timestamp: block.timestamp
         }
       ]
 
@@ -1251,7 +1225,7 @@ defmodule Explorer.EtherscanTest do
     end
 
     test "with multiple blocks" do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block_numbers = Range.new(range.from, range.to)
 
@@ -1262,47 +1236,14 @@ defmodule Explorer.EtherscanTest do
       block1 = insert(:block, number: block_number1, miner: address)
       block2 = insert(:block, number: block_number2, miner: address)
 
-      # irrelevant transaction
-      insert(:transaction)
-
-      :transaction
-      |> insert(gas_price: 2)
-      |> with_block(block1, gas_used: 2)
-
-      :transaction
-      |> insert(gas_price: 2)
-      |> with_block(block1, gas_used: 2)
-
-      :transaction
-      |> insert(gas_price: 3)
-      |> with_block(block2, gas_used: 3)
-
-      :transaction
-      |> insert(gas_price: 3)
-      |> with_block(block2, gas_used: 3)
-
-      expected_reward_block1 =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(8))
-        |> Wei.from(:wei)
-
-      expected_reward_block2 =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(18))
-        |> Wei.from(:wei)
-
       expected = [
         %{
           number: block2.number,
-          timestamp: block2.timestamp,
-          reward: expected_reward_block2
+          timestamp: block2.timestamp
         },
         %{
           number: block1.number,
-          timestamp: block1.timestamp,
-          reward: expected_reward_block1
+          timestamp: block1.timestamp
         }
       ]
 
@@ -1310,7 +1251,7 @@ defmodule Explorer.EtherscanTest do
     end
 
     test "with pagination options" do
-      %{block_range: range} = emission_reward = insert(:emission_reward)
+      %{block_range: range} = insert(:emission_reward)
 
       block_numbers = Range.new(range.from, range.to)
 
@@ -1321,29 +1262,17 @@ defmodule Explorer.EtherscanTest do
       block1 = insert(:block, number: block_number1, miner: address)
       block2 = insert(:block, number: block_number2, miner: address)
 
-      :transaction
-      |> insert(gas_price: 2)
-      |> with_block(block1, gas_used: 2)
-
-      expected_reward =
-        emission_reward.reward
-        |> Wei.to(:wei)
-        |> Decimal.add(Decimal.new(4))
-        |> Wei.from(:wei)
-
       expected1 = [
         %{
           number: block2.number,
-          timestamp: block2.timestamp,
-          reward: emission_reward.reward
+          timestamp: block2.timestamp
         }
       ]
 
       expected2 = [
         %{
           number: block1.number,
-          timestamp: block1.timestamp,
-          reward: expected_reward
+          timestamp: block1.timestamp
         }
       ]
 

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -183,7 +183,7 @@ defmodule Indexer.Block.Fetcher do
     end
   end
 
-  defp update_block_cache(blocks) do
+  defp update_block_cache(blocks) when is_list(blocks) do
     max_block = Enum.max_by(blocks, fn block -> block.number end)
     min_block = Enum.min_by(blocks, fn block -> block.number end)
 
@@ -191,6 +191,8 @@ defmodule Indexer.Block.Fetcher do
     BlockNumber.update(min_block.number)
     BlocksCache.update(blocks)
   end
+
+  defp update_block_cache(_), do: :ok
 
   defp update_transactions_cache(transactions) do
     Transactions.update(transactions)


### PR DESCRIPTION
* Issues were introduced at
 * #2621
 * #1771 
 * #2541 
 * **This issue wasn't introduced yet** :   
  Fixed height issue with top-banner on the main Blockscout page.  

## Motivation

* #2621 - Error box text colors has different style.
* #1771 - New Tooltips were needed for the Block Details page. 
* #2541 - ERC-721 token instance page required some changes. I've added a new block with the image into the Total Supply container. As content is rendering dynamically - we still must add some additional logic for Total Supply container ( if token type ERC721 => return new created div with image and hide text info). As for tabs - still need similar logical solution ( if token type ERC721 => hide unnecessary tabs from the page).

* Top banner on the Blockscout home page is opening with the height bug now. I've added several changes in order to fix this issue (fixed height etc.) .

## Changelog

### Enhancements
*  Changed style for all error messages blocks to required one. Added "cursor: pointer" and switched "a href=" to "span" (let me know if it's not required) , as I guess all of the error messages of such a type should have the same style. (one error block has "a href=" another one - span).

* I've commented "display: none" for error messages block in devtools  just in order to show you performed changes and you can see both messages now on the following gif:

![Sokol-Testnet-Explorer-BlockScout](https://user-images.githubusercontent.com/10085945/63762961-73037200-c8cc-11e9-9c26-1dbb26b3c3cd.gif)
* #1771 - Added tooltips for the Block Details Page (Additional logic is required for Miner/Validator tooltip text and Block Rewards container. ) : 
![Block-10428651-Sokol-Testnet-Explorer-_6_](https://user-images.githubusercontent.com/10085945/63700315-54996a00-c82b-11e9-8678-7a8284307263.gif)

* #2541  - Added new container with the ERC721 token image, which should be rendered only if token type is ERC721. (Additional logic is required).
### Bug Fixes
Fixed height bug with top banner container on the main BlockScout Page:

* **Was:**

 ![Запись_экрана_2019-08-14_в_19 50 21](https://user-images.githubusercontent.com/10085945/63700823-59125280-c82c-11e9-9259-b61c2d852adc.gif)

* **Now:** 

![AwesomeScreenshot-2019-8-20-1566309626893](https://user-images.githubusercontent.com/10085945/63700788-4a2ba000-c82c-11e9-9775-91dd0491ed0c.gif)
## Checklist for your PR

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  you must be able to justify that.
-->

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
  - [ ] If I added/changed/removed ENV var, I should update the list of env vars in https://github.com/poanetwork/blockscout/blob/master/docs/env-variables.md to reflect changes in the table here https://poanetwork.github.io/blockscout/#/env-variables?id=blockscout-env-variables. I've set `master` in the `Version` column.
  - [ ] If I add new indices into DB, I checked, that they don't redundant with PGHero or other tools
