### PR TITLE
 Validate input data in staking modals in real time

### DIFF
--- a/apps/block_scout_web/assets/css/components/_form.scss
+++ b/apps/block_scout_web/assets/css/components/_form.scss
@@ -44,6 +44,32 @@ $form-control-border-color: #e2e5ec !default;
   }
 }
 
+.input-group.input-status-error  {
+  input {
+    border-color: #FF7884 !important;
+    border-radius: 2px 2px 0 0;
+  }
+
+  .input-group-prepend {
+    margin-right: 0;
+  }
+
+  .input-group-prepend.last {
+    .input-group-text {
+      border-color: #FF7884;
+      border-radius: 0 2px 0 0;
+    }
+  }
+
+  .input-group-message {
+    width: 100%;
+    padding: 10px;
+    color: white;
+    background: #FF7884;
+    border-radius: 0 0 2px 2px;
+  }
+}
+
 .form-buttons {
   [class*="btn-"] {
     margin-bottom: 20px;

--- a/apps/block_scout_web/assets/js/lib/validation.js
+++ b/apps/block_scout_web/assets/js/lib/validation.js
@@ -1,0 +1,42 @@
+import $ from 'jquery'
+
+export function updateValidation (validation, errors, input) {
+  if (validation.state === false) {
+    errors.set($(input).prop('id'), input)
+    displayInputError(input, validation.message)
+    return errors
+  }
+
+  if (validation.state !== null) {
+    errors.delete($(input).prop('id'))
+  }
+
+  hideInputError(input)
+  return errors
+}
+
+export function displayInputError (input, message) {
+  const group = $(input).parent('.input-group')
+
+  group.addClass('input-status-error')
+  group.find('.input-group-message').html(message)
+}
+
+export function hideInputError (input) {
+  const group = $(input).parent('.input-group')
+
+  group.removeClass('input-status-error')
+  group.find('.input-group-message').html('')
+}
+
+export function updateSubmit ($form, errors) {
+  if (errors.size) {
+    disableSubmit($form, true)
+  } else {
+    disableSubmit($form, false)
+  }
+}
+
+export function disableSubmit ($form, disabled) {
+  $form.find('button').prop('disabled', disabled)
+}

--- a/apps/block_scout_web/assets/js/lib/validation.js
+++ b/apps/block_scout_web/assets/js/lib/validation.js
@@ -13,6 +13,9 @@ export function setupValidation ($form, validators, $submit) {
       .ready(() => {
         validateInput($input, callback, errors)
         updateSubmit($submit, errors)
+        if (errors[key]) {
+          displayInputError($input, errors[key])
+        }
       })
       .blur(() => {
         if (errors[key]) {

--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -45,9 +45,9 @@ async function becomeCandidate ($modal, store, msg) {
   try {
     if (!await stakingContract.methods.areStakeAndWithdrawAllowed().call()) {
       if (await blockRewardContract.methods.isSnapshotting().call()) {
-        openErrorModal('Error', 'Stakes are not allowed at the moment. Please try again in a few blocks')
+        openErrorModal('Error', 'Staking actions are temporarily restricted. Please try again in a few blocks.')
       } else {
-        openErrorModal('Error', 'Current staking epoch is finishing now, you will be able to place a stake during the next staking epoch. Please try again in a few blocks')
+        openErrorModal('Error', 'The current staking epoch is ending, and staking actions are temporarily restricted. Please try again when the new epoch starts.')
       }
       return false
     }
@@ -69,11 +69,11 @@ function isCandidateStakeValid (value, store, msg) {
   const stake = new BigNumber(value.replace(',', '.').trim()).shiftedBy(decimals).integerValue()
 
   if (!stake.isPositive()) {
-    return 'Invalid stake amount entered'
+    return 'Invalid amount'
   } else if (stake.isLessThan(minStake)) {
-    return `You cannot stake less than ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol}`
+    return `Minimum candidate stake is ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol}`
   } else if (stake.isGreaterThan(balance)) {
-    return 'Not enough funds'
+    return 'Insufficient funds'
   }
 
   return true
@@ -84,7 +84,7 @@ function isMiningAddressValid (value, store) {
   const miningAddress = value.trim().toLowerCase()
 
   if (miningAddress === store.getState().account || !web3.utils.isAddress(miningAddress)) {
-    return 'Invalid Mining Address'
+    return 'Invalid mining address'
   }
 
   return true

--- a/apps/block_scout_web/assets/js/pages/stakes/move_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/move_stake.js
@@ -1,6 +1,7 @@
 import $ from 'jquery'
 import { BigNumber } from 'bignumber.js'
-import { openModal, openErrorModal, lockModal } from '../../lib/modals'
+import { openModal, lockModal } from '../../lib/modals'
+import { setupValidation } from '../../lib/validation'
 import { makeContractCall, setupChart } from './utils'
 
 export function openMoveStakeModal (event, store) {
@@ -19,6 +20,14 @@ function setupModal ($modal, fromAddress, store, msg) {
   setupChart($modal.find('.js-pool-from-progress'), msg.from.self_staked_amount, msg.from.staked_amount)
   if (msg.to) {
     setupChart($modal.find('.js-pool-to-progress'), msg.to.self_staked_amount, msg.to.staked_amount)
+
+    setupValidation(
+      $modal.find('form'),
+      {
+        'move-amount': value => isMoveAmountValid(value, store, msg)
+      },
+      $modal.find('form button')
+    )
   }
 
   $modal.find('form').submit(() => {
@@ -44,29 +53,30 @@ function moveStake ($modal, fromAddress, store, msg) {
 
   const stakingContract = store.getState().stakingContract
   const decimals = store.getState().tokenDecimals
-
-  const minFromStake = new BigNumber(msg.from.min_stake)
-  const minToStake = new BigNumber(msg.to.min_stake)
-  const currentFromStake = new BigNumber(msg.from.stake_amount)
-  const currentToStake = new BigNumber(msg.to.stake_amount)
-  const maxAllowed = new BigNumber(msg.max_withdraw_allowed)
   const stake = new BigNumber($modal.find('[move-amount]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
-
-  if (!stake.isPositive() || stake.plus(currentToStake).isLessThan(minToStake)) {
-    openErrorModal('Error', `You cannot move less than ${minToStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} to this pool`)
-    return false
-  }
-
-  if (stake.isGreaterThan(maxAllowed)) {
-    openErrorModal('Error', `You cannot move more than ${maxAllowed.shiftedBy(-decimals)} ${store.getState().tokenSymbol} right now`)
-    return false
-  }
-
-  if (stake.isLessThan(currentFromStake) && currentFromStake.minus(stake).isLessThan(minFromStake)) {
-    openErrorModal('Error', `You can't leave less than ${minFromStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} in the source pool`)
-    return false
-  }
 
   const toAddress = $modal.find('[pool-select]').val()
   makeContractCall(stakingContract.methods.moveStake(fromAddress, toAddress, stake.toString()), store)
+}
+
+function isMoveAmountValid (value, store, msg) {
+  const decimals = store.getState().tokenDecimals
+  const minFromStake = new BigNumber(msg.from.min_stake)
+  const minToStake = (msg.to) ? new BigNumber(msg.to.min_stake) : null
+  const maxAllowed = new BigNumber(msg.max_withdraw_allowed)
+  const currentFromStake = new BigNumber(msg.from.stake_amount)
+  const currentToStake = (msg.to) ? new BigNumber(msg.to.stake_amount) : null
+  const stake = new BigNumber(value.replace(',', '.').trim()).shiftedBy(decimals).integerValue()
+
+  if (!stake.isPositive()) {
+    return 'Invalid amount'
+  } else if (stake.plus(currentToStake).isLessThan(minToStake)) {
+    return `You must move at least ${minToStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} to the selected pool`
+  } else if (stake.isGreaterThan(maxAllowed)) {
+    return `You have ${maxAllowed.shiftedBy(-decimals)} ${store.getState().tokenSymbol} available to move`
+  } else if (stake.isLessThan(currentFromStake) && currentFromStake.minus(stake).isLessThan(minFromStake)) {
+    return `A minimum of ${minFromStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} is required to remain in the current pool, or move the entire amount to leave this pool`
+  }
+
+  return true
 }

--- a/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
@@ -1,6 +1,7 @@
 import $ from 'jquery'
 import { BigNumber } from 'bignumber.js'
 import { openModal, openErrorModal, openQuestionModal, lockModal } from '../../lib/modals'
+import { setupValidation } from '../../lib/validation'
 import { makeContractCall, setupChart } from './utils'
 
 export function openWithdrawStakeModal (event, store) {
@@ -37,6 +38,30 @@ function setupClaimWithdrawModal (address, store, msg) {
 function setupWithdrawStakeModal (address, store, msg) {
   const $modal = $(msg.withdraw_html)
   setupChart($modal.find('.js-stakes-progress'), msg.self_staked_amount, msg.staked_amount)
+  setupValidation(
+    $modal.find('form'),
+    {
+      'amount': value => isAmountValid(value, store, msg)
+    },
+    $modal.find('form button')
+  )
+
+  setupValidation(
+    $modal.find('form'),
+    {
+      'amount': value => isWithdrawAmountValid(value, store, msg)
+    },
+    $modal.find('form button.withdraw')
+  )
+
+  setupValidation(
+    $modal.find('form'),
+    {
+      'amount': value => isOrderWithdrawAmountValid(value, store, msg)
+    },
+    $modal.find('form button.order-withdraw')
+  )
+
   $modal.find('.btn-full-primary.withdraw').click(() => {
     withdrawStake($modal, address, store, msg)
     return false
@@ -52,7 +77,6 @@ function claimWithdraw ($modal, address, store) {
   lockModal($modal)
 
   const stakingContract = store.getState().stakingContract
-
   makeContractCall(stakingContract.methods.claimOrderedWithdraw(address), store)
 }
 
@@ -61,21 +85,7 @@ function withdrawStake ($modal, address, store, msg) {
 
   const stakingContract = store.getState().stakingContract
   const decimals = store.getState().tokenDecimals
-  const minStake = new BigNumber(msg.min_stake)
-  const currentStake = new BigNumber(msg.delegator_staked)
-  const maxAllowed = new BigNumber(msg.max_withdraw_allowed)
-
   const amount = new BigNumber($modal.find('[amount]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
-
-  if (!amount.isPositive() || amount.isGreaterThan(maxAllowed)) {
-    openErrorModal('Error', `You cannot withdraw more than ${maxAllowed.shiftedBy(-decimals)} ${store.getState().tokenSymbol} from this pool`)
-    return false
-  }
-
-  if (amount.isLessThan(currentStake) && currentStake.minus(amount).isLessThan(minStake)) {
-    openErrorModal('Error', `You can't leave less than ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} in the pool`)
-    return false
-  }
 
   makeContractCall(stakingContract.methods.withdraw(address, amount.toString()), store)
 }
@@ -85,27 +95,67 @@ function orderWithdraw ($modal, address, store, msg) {
 
   const stakingContract = store.getState().stakingContract
   const decimals = store.getState().tokenDecimals
-  const minStake = new BigNumber(msg.min_stake)
-  const currentStake = new BigNumber(msg.delegator_staked)
   const orderedWithdraw = new BigNumber(msg.ordered_withdraw)
-  const maxAllowed = new BigNumber(msg.max_ordered_withdraw_allowed)
-
   const amount = new BigNumber($modal.find('[amount]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
-
-  if (amount.isGreaterThan(maxAllowed)) {
-    openErrorModal('Error', `You cannot withdraw more than ${maxAllowed.shiftedBy(-decimals)} ${store.getState().tokenSymbol} from this pool`)
-    return false
-  }
 
   if (amount.isLessThan(orderedWithdraw.negated())) {
     openErrorModal('Error', `You cannot reduce withdrawal by more than ${orderedWithdraw.shiftedBy(-decimals)} ${store.getState().tokenSymbol}`)
     return false
   }
 
-  if (amount.isLessThan(currentStake) && currentStake.minus(amount).isLessThan(minStake)) {
-    openErrorModal('Error', `You can't leave less than ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} in the pool`)
-    return false
+  makeContractCall(stakingContract.methods.orderWithdraw(address, amount.toString()), store)
+}
+
+function isAmountValid (value, store, msg) {
+  const decimals = store.getState().tokenDecimals
+  const minStake = new BigNumber(msg.min_stake)
+  const currentStake = new BigNumber(msg.delegator_staked)
+  const amount = new BigNumber(value.replace(',', '.').trim()).shiftedBy(decimals).integerValue()
+
+  if (!amount.isPositive()) {
+    return 'Invalid amount'
+  } else if (amount.isLessThan(currentStake) && currentStake.minus(amount).isLessThan(minStake)) {
+    return `A minimum of ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} is required to remain in the pool, or withdraw the entire amount to leave this pool`
   }
 
-  makeContractCall(stakingContract.methods.orderWithdraw(address, amount.toString()), store)
+  return true
+}
+
+function isWithdrawAmountValid (value, store, msg) {
+  const decimals = store.getState().tokenDecimals
+  const minStake = new BigNumber(msg.min_stake)
+  const currentStake = new BigNumber(msg.delegator_staked)
+  const maxAllowed = new BigNumber(msg.max_withdraw_allowed)
+  const amount = new BigNumber(value.replace(',', '.').trim()).shiftedBy(decimals).integerValue()
+
+  if (!amount.isPositive()) {
+    return null
+  } else if (amount.isLessThan(currentStake) && currentStake.minus(amount).isLessThan(minStake)) {
+    return null
+  } else if (!amount.isPositive() || amount.isGreaterThan(maxAllowed)) {
+    return null
+  }
+
+  return true
+}
+
+function isOrderWithdrawAmountValid (value, store, msg) {
+  const decimals = store.getState().tokenDecimals
+  const minStake = new BigNumber(msg.min_stake)
+  const currentStake = new BigNumber(msg.delegator_staked)
+  const orderedWithdraw = new BigNumber(msg.ordered_withdraw)
+  const maxAllowed = new BigNumber(msg.max_ordered_withdraw_allowed)
+  const amount = new BigNumber(value.replace(',', '.').trim()).shiftedBy(decimals).integerValue()
+
+  if (!amount.isPositive()) {
+    return null
+  } else if (amount.isLessThan(currentStake) && currentStake.minus(amount).isLessThan(minStake)) {
+    return null
+  } else if (amount.isGreaterThan(maxAllowed)) {
+    return null
+  } else if (amount.isLessThan(orderedWithdraw.negated())) {
+    return null
+  }
+
+  return true
 }

--- a/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
@@ -112,7 +112,7 @@ function isAmountValid (value, store, msg) {
   const currentStake = new BigNumber(msg.delegator_staked)
   const amount = new BigNumber(value.replace(',', '.').trim()).shiftedBy(decimals).integerValue()
 
-  if (!amount.isPositive()) {
+  if (!amount.isPositive() && !amount.isNegative()) {
     return 'Invalid amount'
   } else if (amount.isLessThan(currentStake) && currentStake.minus(amount).isLessThan(minStake)) {
     return `A minimum of ${minStake.shiftedBy(-decimals)} ${store.getState().tokenSymbol} is required to remain in the pool, or withdraw the entire amount to leave this pool`
@@ -147,7 +147,7 @@ function isOrderWithdrawAmountValid (value, store, msg) {
   const maxAllowed = new BigNumber(msg.max_ordered_withdraw_allowed)
   const amount = new BigNumber(value.replace(',', '.').trim()).shiftedBy(decimals).integerValue()
 
-  if (!amount.isPositive()) {
+  if (!amount.isPositive() && !amount.isNegative()) {
     return null
   } else if (amount.isLessThan(currentStake) && currentStake.minus(amount).isLessThan(minStake)) {
     return null

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_input_group.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_input_group.html.eex
@@ -1,0 +1,16 @@
+<div class="input-group <%= if assigns[:classes] do @classes end %>">
+  <input
+    <%= if assigns[:attributes] do @attributes end %>
+    type="<%= if assigns[:type] do @type end %>"
+    class="<%= if assigns[:input_classes] do @input_classes end %>"
+    placeholder="<%= if assigns[:placeholder] do @placeholder end %>"
+    value="<%= if assigns[:value] do @value end %>"
+    <%= if assigns[:disabled] do "disabled" end %>
+  />
+  <%= if assigns[:prepend] do %>
+    <div class="input-group-prepend last">
+      <div class="input-group-text"><%= @prepend %></div>
+    </div>
+  <% end %>
+  <div class="input-group-message"><%= if assigns[:message] do @message end %></div>
+</div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_input_group.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_input_group.html.eex
@@ -1,5 +1,6 @@
 <div class="input-group <%= if assigns[:classes] do @classes end %>">
   <input
+    id="<%= if assigns[:id] do @id end %>"
     <%= if assigns[:attributes] do @attributes end %>
     type="<%= if assigns[:type] do @type end %>"
     class="<%= if assigns[:input_classes] do @input_classes end %>"

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
@@ -7,22 +7,9 @@
       <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
       <div class="modal-body">
         <form>
-          <div class="input-group form-group">
-            <input candidate-stake type="text" class="form-control n-b-r" placeholder="<%= gettext("Amount") %>">
-            <div class="input-group-prepend last">
-              <div class="input-group-text"><%= @token.symbol %></div>
-            </div>
-          </div>
-          <div class="form-group">
-            <input
-              mining-address
-              type="text"
-              class="form-control"
-              placeholder="<%= gettext("Your Mining Address") %>"
-              value="<%= @pool && @pool.mining_address_hash %>"
-              <%= if @pool do "disabled" end %>
-            />
-          </div>
+          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", classes: "form-group", input_classes: "form-control n-b-r", attributes: "candidate-stake", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol %>
+
+          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", classes: "form-group", input_classes: "form-control", attributes: "mining-address", type: "text", placeholder: gettext("Your Mining Address"), value: @pool && @pool.mining_address_hash, disabled: @pool %>
           <p class="form-p m-b-0">Minimum Stake:
             <span class="text-dark">
               <%= format_according_to_decimals(@min_candidate_stake, @token.decimals) %> <%= @token.symbol %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
@@ -7,9 +7,9 @@
       <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
       <div class="modal-body">
         <form>
-          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", classes: "form-group", input_classes: "form-control n-b-r", attributes: "candidate-stake", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol %>
+          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "candidate-stake", classes: "form-group", input_classes: "form-control n-b-r", attributes: "candidate-stake", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol %>
 
-          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", classes: "form-group", input_classes: "form-control", attributes: "mining-address", type: "text", placeholder: gettext("Your Mining Address"), value: @pool && @pool.mining_address_hash, disabled: @pool %>
+          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "mining-address", classes: "form-group", input_classes: "form-control", attributes: "mining-address", type: "text", placeholder: gettext("Your Mining Address"), value: @pool && @pool.mining_address_hash, disabled: @pool %>
           <p class="form-p m-b-0">Minimum Stake:
             <span class="text-dark">
               <%= format_according_to_decimals(@min_candidate_stake, @token.decimals) %> <%= @token.symbol %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
@@ -12,12 +12,7 @@
           </div>
           <div class="modal-body">
             <form>
-              <div class="input-group form-group">
-                <input move-amount type="text" class="form-control n-b-r" placeholder="<%= gettext("Amount") %>" value="<%= @amount %>">
-                <div class="input-group-prepend last">
-                  <div class="input-group-text"><%= @token.symbol %></div>
-                </div>
-              </div>
+              <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "move-amount", classes: "form-group", input_classes: "form-control n-b-r", attributes: "move-amount", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol, value: @amount %>
               <p class="form-p">You Staked:
                 <span class="text-dark">
                   <%= format_according_to_decimals(@delegator_from.stake_amount, @token.decimals) %> <%= @token.symbol %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex
@@ -9,12 +9,8 @@
           </div>
           <div class="modal-body">
             <form>
-              <div class="input-group form-group">
-                <input delegator-stake type="text" class="form-control n-b-r" placeholder="<%= gettext("Amount") %>">
-                <div class="input-group-prepend last">
-                  <div class="input-group-text"><%= @token.symbol %></div>
-                </div>
-              </div>
+              <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "delegator-stake", classes: "form-group", input_classes: "form-control n-b-r", attributes: "delegator-stake", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol %>
+
               <%= if @delegator && Decimal.positive?(@delegator.stake_amount) do %>
                 <p class="form-p m-b-0">Current stake:
                   <span class="text-dark">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
@@ -9,12 +9,7 @@
           </div>
           <div class="modal-body">
             <form>
-              <div class="input-group form-group">
-                <input amount type="text" class="form-control n-b-r" placeholder="<%= gettext("Amount") %>">
-                <div class="input-group-prepend last">
-                  <div class="input-group-text"><%= @token.symbol %></div>
-                </div>
-              </div>
+              <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "amount", classes: "form-group", input_classes: "form-control n-b-r", attributes: "amount", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol %>
               <p class="form-p m-b-0">You Staked:
                 <span class="text-dark">
                   <%= format_according_to_decimals(@delegator.stake_amount, @token.decimals) %> <%= @token.symbol %>


### PR DESCRIPTION
Part of #2573

## Motivation
Currently, in case invalid data is entered in any of the modals related to staking, an error modal is displayed, and after it is closed, a user has to open it again and enter all the data from scratch.
Instead, the project designer has drawn inline error messages, which would be displayed immediately.

## Changelog
- New template component - Input Group added
- Raw HTML inputs replaced Input Group component in _stakes_modal_become_candidate.html
- Error state styles added for Input Group
- Some on submit validations replaced with on input blur (unfocus) validations for Become Candidate modal 
- Added functionality to disable submit button in case of invalid entries for Become Candidate modal