### PR TITLE
Separate Claim Withdrawal button from Withdraw

### DIFF
--- a/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
@@ -114,7 +114,6 @@ $stakes-stats-item-border-color: #fff !default;
 }
 
 .stakes-control-icon {
-  margin-right: 10px;
   path {
     fill: $stakes-control-color;
   }

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -13,6 +13,7 @@ import { openRemovePoolModal } from './stakes/remove_pool'
 import { openMakeStakeModal } from './stakes/make_stake'
 import { openMoveStakeModal } from './stakes/move_stake'
 import { openWithdrawStakeModal } from './stakes/withdraw_stake'
+import { openClaimWithdrawalModal } from './stakes/claim_withdrawal'
 
 export const initialState = {
   channel: null,
@@ -138,6 +139,7 @@ if ($stakesPage.length) {
     .on('click', '.js-make-stake', event => openMakeStakeModal(event, store))
     .on('click', '.js-move-stake', event => openMoveStakeModal(event, store))
     .on('click', '.js-withdraw-stake', event => openWithdrawStakeModal(event, store))
+    .on('click', '.js-claim-withdrawal', event => openClaimWithdrawalModal(event, store))
 
   $stakesPage
     .on('change', '[pool-filter-banned]', () => updateFilters(store))

--- a/apps/block_scout_web/assets/js/pages/stakes/claim_withdrawal.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/claim_withdrawal.js
@@ -1,0 +1,27 @@
+import $ from 'jquery'
+import { openModal, lockModal } from '../../lib/modals'
+import { makeContractCall, setupChart } from './utils'
+
+export function openClaimWithdrawalModal (event, store) {
+  const address = $(event.target).closest('[data-address]').data('address')
+
+  store.getState().channel
+    .push('render_claim_withdrawal', { address })
+    .receive('ok', msg => {
+      const $modal = $(msg.html)
+      setupChart($modal.find('.js-stakes-progress'), msg.self_staked_amount, msg.staked_amount)
+      $modal.find('form').submit(() => {
+        claimWithdraw($modal, address, store)
+        return false
+      })
+      openModal($modal)
+    })
+}
+
+function claimWithdraw ($modal, address, store) {
+  lockModal($modal)
+
+  const stakingContract = store.getState().stakingContract
+
+  makeContractCall(stakingContract.methods.claimOrderedWithdraw(address), store)
+}

--- a/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
@@ -1,6 +1,6 @@
 import $ from 'jquery'
 import { BigNumber } from 'bignumber.js'
-import { openModal, openErrorModal, openQuestionModal, lockModal } from '../../lib/modals'
+import { openModal, openErrorModal, lockModal } from '../../lib/modals'
 import { setupValidation } from '../../lib/validation'
 import { makeContractCall, setupChart } from './utils'
 
@@ -9,30 +9,7 @@ export function openWithdrawStakeModal (event, store) {
 
   store.getState().channel
     .push('render_withdraw_stake', { address })
-    .receive('ok', msg => {
-      if (msg.claim_html && msg.withdraw_html) {
-        openQuestionModal(
-          'Claim or order', 'Do you want withdraw or claim ordered withdraw?',
-          () => setupClaimWithdrawModal(address, store, msg),
-          () => setupWithdrawStakeModal(address, store, msg),
-          'Claim', 'Withdraw'
-        )
-      } else if (msg.claim_html) {
-        setupClaimWithdrawModal(address, store, msg)
-      } else {
-        setupWithdrawStakeModal(address, store, msg)
-      }
-    })
-}
-
-function setupClaimWithdrawModal (address, store, msg) {
-  const $modal = $(msg.claim_html)
-  setupChart($modal.find('.js-stakes-progress'), msg.self_staked_amount, msg.staked_amount)
-  $modal.find('form').submit(() => {
-    claimWithdraw($modal, address, store)
-    return false
-  })
-  openModal($modal)
+    .receive('ok', msg => setupWithdrawStakeModal (address, store, msg))
 }
 
 function setupWithdrawStakeModal (address, store, msg) {
@@ -71,13 +48,6 @@ function setupWithdrawStakeModal (address, store, msg) {
     return false
   })
   openModal($modal)
-}
-
-function claimWithdraw ($modal, address, store) {
-  lockModal($modal)
-
-  const stakingContract = store.getState().stakingContract
-  makeContractCall(stakingContract.methods.claimOrderedWithdraw(address), store)
 }
 
 function withdrawStake ($modal, address, store, msg) {

--- a/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
@@ -95,7 +95,8 @@ defmodule BlockScoutWeb.StakesController do
           buttons: %{
             stake: stake_allowed?(pool, delegator),
             move: move_allowed?(delegator),
-            withdraw: withdraw_allowed?(delegator, epoch_number)
+            withdraw: withdraw_allowed?(delegator),
+            claim: claim_allowed?(delegator, epoch_number)
           }
         )
       end)
@@ -145,12 +146,17 @@ defmodule BlockScoutWeb.StakesController do
     Decimal.positive?(delegator.max_withdraw_allowed)
   end
 
-  defp withdraw_allowed?(nil, _epoch_number), do: false
+  defp withdraw_allowed?(nil), do: false
 
-  defp withdraw_allowed?(delegator, epoch_number) do
+  defp withdraw_allowed?(delegator) do
     Decimal.positive?(delegator.max_withdraw_allowed) or
       Decimal.positive?(delegator.max_ordered_withdraw_allowed) or
-      Decimal.positive?(delegator.ordered_withdraw) or
-      (Decimal.positive?(delegator.ordered_withdraw) and delegator.ordered_withdraw_epoch < epoch_number)
+      Decimal.positive?(delegator.ordered_withdraw)
+  end
+
+  defp claim_allowed?(nil, _epoch_number), do: false
+
+  defp claim_allowed?(delegator, epoch_number) do
+    Decimal.positive?(delegator.ordered_withdraw) and delegator.ordered_withdraw_epoch < epoch_number
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
@@ -41,6 +41,9 @@
         <%= if @buttons.move do %>
           <%= render BlockScoutWeb.StakesView, "_stakes_control_move.html", address: @pool.staking_address_hash %>
         <% end %>
+        <%= if @buttons.claim do %>
+          <%= render BlockScoutWeb.StakesView, "_stakes_control_claim.html", address: @pool.staking_address_hash %>
+        <% end %>
         <%= if @buttons.withdraw do %>
           <%= render BlockScoutWeb.StakesView, "_stakes_control_withdraw.html", address: @pool.staking_address_hash %>
         <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_control_claim.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_control_claim.html.eex
@@ -1,0 +1,5 @@
+<span class="stakes-control js-claim-withdrawal <%= if assigns[:extra_class] do @extra_class end %>" data-address="<%= to_string(@address) %>" data-placement="top" data-toggle="tooltip" title="Claim Withdrawal">
+    <svg class="stakes-control-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+        <path fill-rule="evenodd" d="M15 16H1a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1zm-1-3H2v1h12v-1zm-3.235-8.312c-.008.008-.019.01-.027.018L9.722 5.718c-.008.009-.01.019-.018.027L6.765 8.674a1.036 1.036 0 0 1-1.156.207 1.008 1.008 0 0 1-.394-.236L2.294 5.734a1.027 1.027 0 0 1 0-1.455 1.036 1.036 0 0 1 1.46 0l2.241 2.234 2.24-2.232c.008-.008.019-.01.027-.018l1.016-1.012c.007-.008.01-.019.018-.027L12.235.295a1.042 1.042 0 0 1 1.469 0c.406.404.406 1.06 0 1.464l-2.939 2.929z"/>
+    </svg>
+</span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_control_move.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_control_move.html.eex
@@ -1,6 +1,5 @@
-<span class="stakes-control js-move-stake <%= if assigns[:extra_class] do @extra_class end %>" data-address="<%= to_string(@address) %>">
+<span class="stakes-control js-move-stake <%= if assigns[:extra_class] do @extra_class end %>" data-address="<%= to_string(@address) %>" data-placement="top" data-toggle="tooltip" title="Move">
     <svg class="stakes-control-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
         <path fill-rule="evenodd" d="M15 16H1a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h4.347l1.778 2H2v1h12v-1H8.875l1.778-2H15a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1zm0-11H9v3.532l1.252-1.253a1.028 1.028 0 1 1 1.455 1.456l-2.909 2.91c-.038.038-.087.054-.129.085a.945.945 0 0 1-.653.27h-.032a.971.971 0 0 1-.713-.315c-.006-.005-.013-.006-.018-.011L4.326 8.745A1.036 1.036 0 0 1 5.79 7.281L7 8.492V5H1a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1zm-1-3H2v1h12V2z"/>
     </svg>
-    <span class="stakes-control-text">Move Stake</span>
 </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_control_stake.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_control_stake.html.eex
@@ -1,6 +1,5 @@
-<span class="stakes-control js-make-stake <%= if assigns[:extra_class] do @extra_class end %>" data-address="<%= to_string(@address) %>">
+<span class="stakes-control js-make-stake <%= if assigns[:extra_class] do @extra_class end %>" data-address="<%= to_string(@address) %>" data-placement="top" data-toggle="tooltip" title="Stake">
     <svg class="stakes-control-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
         <path fill-rule="evenodd" d="M15 16H1a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1zm-1-3H2v1h12v-1zM8.785 8.675c-.114.114-.25.187-.394.237-.007.003-.012.01-.02.013a1.035 1.035 0 0 1-1.136-.221L4.296 5.765a1.038 1.038 0 1 1 1.469-1.469L7 5.531V1a1 1 0 0 1 2 0v4.54l1.246-1.246a1.033 1.033 0 0 1 1.46 1.46L8.785 8.675z"/>
     </svg>
-    <span class="stakes-control-text">Stake</span>
 </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_control_withdraw.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_control_withdraw.html.eex
@@ -1,6 +1,5 @@
-<span class="stakes-control js-withdraw-stake <%= if assigns[:extra_class] do @extra_class end %>" data-address="<%= to_string(@address) %>">
+<span class="stakes-control js-withdraw-stake <%= if assigns[:extra_class] do @extra_class end %>" data-address="<%= to_string(@address) %>" data-placement="top" data-toggle="tooltip" title="Withdraw">
     <svg class="stakes-control-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
         <path fill-rule="evenodd" d="M15 16H1a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1zm-1-3H2v1h12v-1zm-3.754-8.279L9 3.479V8a1 1 0 0 1-2 0V3.488L5.765 4.719a1.042 1.042 0 0 1-1.469 0 1.032 1.032 0 0 1 0-1.464L7.235.326a1.04 1.04 0 0 1 1.137-.22c.007.003.012.01.019.013.144.049.28.122.394.236l2.921 2.911a1.027 1.027 0 0 1 0 1.455 1.036 1.036 0 0 1-1.46 0z"/>
     </svg>
-    <span class="stakes-control-text">Withdraw</span>
 </span>


### PR DESCRIPTION
**Problem:** putting both _Withdraw_ and _Claim_ functionality on one button is confusing and requires an additional question modal.

**Solution:** add a separate _Claim_ button that appears when there is an ordered amount available for claiming. To save space in the table, all button titles are moved into tooltips.
