### PR TITLE
Show Stake modal instead of Become a Candidate for existing pools

### DIFF
--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -52,11 +52,7 @@ async function becomeCandidate ($modal, store, msg) {
       return false
     }
 
-    if (msg.pool_exists) {
-      makeContractCall(stakingContract.methods.stake(store.getState().account, stake.toString()), store)
-    } else {
-      makeContractCall(stakingContract.methods.addPool(stake.toString(), miningAddress), store)
-    }
+    makeContractCall(stakingContract.methods.addPool(stake.toString(), miningAddress), store)
   } catch (err) {
     openErrorModal('Error', err.message)
   }

--- a/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
@@ -10,7 +10,7 @@ export function openMakeStakeModal (event, store) {
     return
   }
 
-  const address = $(event.target).closest('[data-address]').data('address')
+  const address = $(event.target).closest('[data-address]').data('address') || store.getState().account
 
   store.getState().channel
     .push('render_make_stake', { address })

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -77,7 +77,6 @@ defmodule BlockScoutWeb.StakesChannel do
   end
 
   def handle_in("render_become_candidate", _, socket) do
-    pool = Chain.staking_pool(socket.assigns.account)
     min_candidate_stake = ContractState.get(:min_candidate_stake)
     token = ContractState.get(:token)
     balance = Chain.fetch_last_token_balance(socket.assigns.account, token.contract_address_hash)
@@ -86,15 +85,13 @@ defmodule BlockScoutWeb.StakesChannel do
       View.render_to_string(StakesView, "_stakes_modal_become_candidate.html",
         min_candidate_stake: min_candidate_stake,
         balance: balance,
-        token: token,
-        pool: pool
+        token: token
       )
 
     result = %{
       html: html,
       balance: balance,
-      min_candidate_stake: min_candidate_stake,
-      pool_exists: not is_nil(pool)
+      min_candidate_stake: min_candidate_stake
     }
 
     {:reply, {:ok, result}, socket}

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
@@ -9,7 +9,7 @@
         <form>
           <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "candidate-stake", classes: "form-group", input_classes: "form-control n-b-r", attributes: "candidate-stake", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol %>
 
-          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "mining-address", classes: "form-group", input_classes: "form-control", attributes: "mining-address", type: "text", placeholder: gettext("Your Mining Address"), value: @pool && @pool.mining_address_hash, disabled: @pool %>
+          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "mining-address", classes: "form-group", input_classes: "form-control", attributes: "mining-address", type: "text", placeholder: gettext("Your Mining Address") %>
           <p class="form-p m-b-0">Minimum Stake:
             <span class="text-dark">
               <%= format_according_to_decimals(@min_candidate_stake, @token.decimals) %> <%= @token.symbol %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_top.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_top.html.eex
@@ -13,9 +13,16 @@
           <% end %>
         <% else %>
           <%=
+            button_class =
+              if @account[:pool] do
+                "js-make-stake"
+              else
+                "js-become-candidate"
+              end
+
             render BlockScoutWeb.CommonComponentsView, "_btn_add_full.html",
               text: gettext("Become a Candidate"),
-              extra_class: "js-become-candidate",
+              extra_class: button_class,
               disabled: @account[:pool] && @account.pool.is_banned
           %>
         <% end %>


### PR DESCRIPTION
Reinstating a pool is essentially staking something to it, so we reuse the existing Stake modal window with all of its checks and pool state chart.
