### PR TITLE
add an index on block_number for token transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#2497](https://github.com/poanetwork/blockscout/pull/2497) - Add generic Ordered Cache behaviour and implementation
 
 ### Fixes
+- [#2654](https://github.com/poanetwork/blockscout/pull/2654) - add an index on block_number for token transfers
 - [#2640](https://github.com/poanetwork/blockscout/pull/2640) - SVG network icons
 - [#2635](https://github.com/poanetwork/blockscout/pull/2635) - optimize ERC721 inventory query
 - [#2626](https://github.com/poanetwork/blockscout/pull/2626) - Fixing 2 Mobile UI Issues

--- a/apps/explorer/priv/repo/migrations/20190830134512_add_index_on_block_number_for_token_transfers.exs
+++ b/apps/explorer/priv/repo/migrations/20190830134512_add_index_on_block_number_for_token_transfers.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.AddIndexOnBlockNumberForTokenTransfers do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(index(:token_transfers, [:block_number]))
+  end
+end


### PR DESCRIPTION
block_number is used for pagination and `order_by`
clauses in a couple of queries. For example, in
`address_to_unique_tokens` for ERC721 inventory tab

part of https://github.com/poanetwork/blockscout/issues/2644

## Changelog

- add an index on block_number for token transfers