### PR TITLE
Cut and ellipsize token amounts

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
@@ -14,8 +14,8 @@
     <%=
     render BlockScoutWeb.CommonComponentsView,
     "_progress_from_to.html",
-    from: format_according_to_decimals(@pool.self_staked_amount, @token.decimals),
-    to: format_according_to_decimals(@pool.staked_amount, @token.decimals),
+    from: format_token_amount(@pool.self_staked_amount, @token, digits: 0, ellipsize: false, symbol: false),
+    to: format_token_amount(@pool.staked_amount, @token, digits: 0, ellipsize: false, symbol: false),
     progress: amount_ratio(@pool)
     %>
   </td>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
@@ -12,12 +12,12 @@
           <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "mining-address", classes: "form-group", input_classes: "form-control", attributes: "mining-address", type: "text", placeholder: gettext("Your Mining Address") %>
           <p class="form-p m-b-0">Minimum Stake:
             <span class="text-dark">
-              <%= format_according_to_decimals(@min_candidate_stake, @token.decimals) %> <%= @token.symbol %>
+              <%= format_token_amount(@min_candidate_stake, @token) %>
             </span>
           </p>
           <p class="form-p">Your Balance:
             <span class="text-dark">
-              <%= format_according_to_decimals(@balance, @token.decimals) %> <%= @token.symbol %>
+              <%= format_token_amount(@balance, @token) %>
             </span>
           </p>
           <div class="form-buttons"><%= render BlockScoutWeb.CommonComponentsView, "_btn_add_full.html", text: gettext("Become a Candidate"), extra_class: "full-width" %></div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_claim.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_claim.html.eex
@@ -12,7 +12,7 @@
               <p class="form-p">Your ordered amount</p>
               <p class="form-p">
                 <span class="text-dark">
-                  <%= format_according_to_decimals(@delegator.ordered_withdraw, @token.decimals) %> <%= @token.symbol %>
+                  <%= format_token_amount(@delegator.ordered_withdraw, @token) %>
                 </span>
               </p>
               <div class="form-buttons">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
@@ -50,7 +50,7 @@
                     <% end %>
                   </div>
                 </td>
-                <td class="stakes-td"><%= format_according_to_decimals(delegator.stake_amount, @token.decimals) %></td>
+                <td class="stakes-td"><%= format_token_amount(delegator.stake_amount, @token, symbol: false) %></td>
                 <td class="stakes-td"><%= if delegator.reward_ratio do "#{delegator.reward_ratio}%" else "-" end %></td>
               </tr>
             <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
@@ -15,7 +15,7 @@
               <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "move-amount", classes: "form-group", input_classes: "form-control n-b-r", attributes: "move-amount", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol, value: @amount %>
               <p class="form-p">You Staked:
                 <span class="text-dark">
-                  <%= format_according_to_decimals(@delegator_from.stake_amount, @token.decimals) %> <%= @token.symbol %>
+                  <%= format_token_amount(@delegator_from.stake_amount, @token) %>
                 </span>
               </p>
               <div class="input-group form-group">
@@ -36,13 +36,13 @@
               <%= if @delegator_to && Decimal.positive?(@delegator_to.stake_amount) do %>
                 <p class="form-p m-b-0">Current stake:
                   <span class="text-dark">
-                    <%= format_according_to_decimals(@delegator_to.stake_amount, @token.decimals) %> <%= @token.symbol %>
+                    <%= format_token_amount(@delegator_to.stake_amount, @token) %>
                   </span>
                 </p>
               <% end %>
               <p class="form-p">Max Amount to Move:
                 <span class="text-dark">
-                  <%= format_according_to_decimals(@delegator_from.max_withdraw_allowed, @token.decimals) %> <%= @token.symbol %>
+                  <%= format_token_amount(@delegator_from.max_withdraw_allowed, @token) %>
                 </span>
               </p>
               <div class="form-buttons">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex
@@ -14,19 +14,19 @@
               <%= if @delegator && Decimal.positive?(@delegator.stake_amount) do %>
                 <p class="form-p m-b-0">Current stake:
                   <span class="text-dark">
-                    <%= format_according_to_decimals(@delegator.stake_amount, @token.decimals) %> <%= @token.symbol %>
+                    <%= format_token_amount(@delegator.stake_amount, @token) %>
                   </span>
                 </p>
               <% else %>
                 <p class="form-p m-b-0">Minimum Stake:
                   <span class="text-dark">
-                    <%= format_according_to_decimals(@min_stake, @token.decimals) %> <%= @token.symbol %>
+                    <%= format_token_amount(@min_stake, @token) %>
                   </span>
                 </p>
               <% end %>
               <p class="form-p">Your Balance:
                 <span class="text-dark">
-                  <%= format_according_to_decimals(@balance, @token.decimals) %> <%= @token.symbol %>
+                  <%= format_token_amount(@balance, @token) %>
                 </span>
               </p>
               <div class="form-buttons">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_validator_info.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_validator_info.html.eex
@@ -16,13 +16,13 @@
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
           title: "Candidate’s Staked Amount",
-          value: "#{format_according_to_decimals(@validator.self_staked_amount, @token.decimals)} #{@token.symbol}"
+          value: format_token_amount(@validator.self_staked_amount, @token)
         %>
         <%=
           render BlockScoutWeb.StakesView,
           "_stakes_validator_info_item.html",
           title: "Delegators’ Staked Amount",
-          value: "#{format_according_to_decimals(Decimal.sub(@validator.staked_amount, @validator.self_staked_amount), @token.decimals)} #{@token.symbol}"
+          value: format_token_amount(Decimal.sub(@validator.staked_amount, @validator.self_staked_amount), @token)
         %>
         <%=
           render BlockScoutWeb.StakesView,

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_withdraw.html.eex
@@ -12,20 +12,20 @@
               <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "amount", classes: "form-group", input_classes: "form-control n-b-r", attributes: "amount", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol %>
               <p class="form-p m-b-0">You Staked:
                 <span class="text-dark">
-                  <%= format_according_to_decimals(@delegator.stake_amount, @token.decimals) %> <%= @token.symbol %>
+                  <%= format_token_amount(@delegator.stake_amount, @token) %>
                 </span>
               </p>
               <%= if Decimal.positive?(@delegator.ordered_withdraw) do %>
                 <p class="form-p m-b-0">Already ordered:
                   <span class="text-dark">
-                    <%= format_according_to_decimals(@delegator.ordered_withdraw, @token.decimals) %> <%= @token.symbol %>
+                    <%= format_token_amount(@delegator.ordered_withdraw, @token) %>
                   </span>
                 </p>
               <% end %>
               <%= if Decimal.positive?(@delegator.max_withdraw_allowed) do %>
                 <p class="form-p m-b-0">Available now:
                   <span class="text-dark">
-                    <%= format_according_to_decimals(@delegator.max_withdraw_allowed, @token.decimals) %> <%= @token.symbol %>
+                    <%= format_token_amount(@delegator.max_withdraw_allowed, @token) %>
                   </span>
                 </p>
                 <%=
@@ -38,7 +38,7 @@
               <%= if Decimal.positive?(@delegator.max_ordered_withdraw_allowed) or Decimal.positive?(@delegator.ordered_withdraw) do %>
                 <p class="form-p m-b-0">Available after the current epoch:
                   <span class="text-dark">
-                    <%= format_according_to_decimals(@delegator.max_ordered_withdraw_allowed, @token.decimals) %> <%= @token.symbol %>
+                    <%= format_token_amount(@delegator.max_ordered_withdraw_allowed, @token) %>
                   </span>
                 </p>
                 <%=

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_progress.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_progress.html.eex
@@ -7,10 +7,10 @@
     ></canvas>
     <div class="stakes-progress-data">
       <div class="stakes-progress-data-progress js-stakes-progress-data-progress">
-        <%= format_according_to_decimals(@pool.self_staked_amount, @token.decimals) %>
+        <%= format_token_amount(@pool.self_staked_amount, @token, symbol: false, digits: 2) %>
       </div>
       <div class="stakes-progress-data-total js-stakes-progress-data-total">
-        <%= format_according_to_decimals(@pool.staked_amount, @token.decimals) %>
+        <%= format_token_amount(@pool.staked_amount, @token, symbol: false, digits: 2) %>
       </div>
     </div>
   </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex
@@ -17,14 +17,14 @@
   </span>
   <span class="stakes-top-stats-label">
     <span class="stakes-top-stats-label-item"><%= gettext "Balance" %>:
-      <%= format_according_to_decimals(@account[:balance], @token.decimals) %> <%= @token.symbol %>
+      <%= format_token_amount(@account[:balance], @token) %>
     </span>
     <span class="stakes-top-stats-label-item"><%= gettext "Staked" %>:
-      <%= format_according_to_decimals(@account[:stake_amount], @token.decimals) %> <%= @token.symbol %>
+      <%= format_token_amount(@account[:stake_amount], @token) %>
     </span>
     <%= if @account[:ordered_withdraw] && @account[:ordered_withdraw] > 0 do %>
       <span class="stakes-top-stats-label-item"><%= gettext "Ordered" %>:
-        <%= format_according_to_decimals(@account[:ordered_withdraw], @token.decimals) %> <%= @token.symbol %>
+        <%= format_token_amount(@account[:ordered_withdraw], @token) %>
       </span>
     <% end %>
   </span>

--- a/apps/block_scout_web/lib/block_scout_web/views/stakes_helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/stakes_helpers.ex
@@ -2,7 +2,10 @@ defmodule BlockScoutWeb.StakesHelpers do
   @moduledoc """
   Helpers for staking templates
   """
+  alias BlockScoutWeb.CldrHelper.Number
   alias Explorer.Chain.Cache.BlockNumber
+  alias Explorer.Chain.Token
+  alias Phoenix.HTML
   alias Timex.Duration
 
   def amount_ratio(pool) do
@@ -37,4 +40,31 @@ defmodule BlockScoutWeb.StakesHelpers do
   def list_title(:validator), do: "Validators"
   def list_title(:active), do: "Active Pools"
   def list_title(:inactive), do: "Inactive Pools"
+
+  def format_token_amount(amount, token, options \\ [])
+  def format_token_amount(nil, _token, _options), do: "-"
+
+  def format_token_amount(%Decimal{} = amount, %Token{} = token, options) do
+    symbol = if Keyword.get(options, :symbol, true), do: " #{token.symbol}"
+    digits = Keyword.get(options, :digits, 5)
+    ellipsize = Keyword.get(options, :ellipsize, true)
+
+    reduced =
+      amount.sign
+      |> Decimal.new(amount.coef, amount.exp - Decimal.to_integer(token.decimals))
+      |> Decimal.reduce()
+
+    if digits >= -reduced.exp or not ellipsize do
+      "#{Number.to_string!(reduced, fractional_digits: min(digits, -reduced.exp))}#{symbol}"
+    else
+      HTML.raw(~s"""
+        <span
+          data-placement="top"
+          data-toggle="tooltip"
+          title="#{Number.to_string!(reduced, fractional_digits: -reduced.exp)}#{symbol}">
+          #{Number.to_string!(reduced, fractional_digits: digits)}...#{symbol}
+        </span>
+      """)
+    end
+  end
 end


### PR DESCRIPTION
**Problem:** fractional token amounts are too long and break page layout.

**Solution:** add token amount formatting function that cuts and ellipsizes token amounts according to token settings and passed parameters.

By default, amounts are cut to 5 fractional digits, "..." with tooltip is added if needed, and token symbol is attached. This can be changed by passing additional list of parameters.