### PR TITLE
remove duplicate token transfers

### DIFF
--- a/apps/explorer/priv/repo/migrations/20190902094749_add_unique_index_on_log_index_and_transaction_hash_for_token_transfers.exs
+++ b/apps/explorer/priv/repo/migrations/20190902094749_add_unique_index_on_log_index_and_transaction_hash_for_token_transfers.exs
@@ -1,0 +1,26 @@
+defmodule Explorer.Repo.Migrations.AddUniqueIndexOnLogIndexAndTransactionHashForTokenTransfers do
+  use Ecto.Migration
+
+  alias Ecto.Adapters.SQL
+  alias Explorer.Repo
+
+  def change do
+    drop_if_exists(index(:token_transfers, [:transaction_hash, :log_index]))
+
+    remove_duplicate_token_transfers()
+
+    create_if_not_exists(unique_index(:token_transfers, [:transaction_hash, :log_index]))
+  end
+
+  defp remove_duplicate_token_transfers do
+    query = """
+      DELETE FROM token_transfers
+        WHERE ctid NOT IN (
+          SELECT MIN(ctid)
+          FROM token_transfers
+          GROUP BY transaction_hash, log_index, block_number)
+    """
+
+    SQL.query!(Repo, query, [], timeout: :infinity)
+  end
+end


### PR DESCRIPTION
Recently it was found that blockscout
sometimes imports multiple duplicated
token transfers. This PR adds unique index
on transaction_hash and log_index to prevent this from
happening.

fixes https://github.com/poanetwork/blockscout/pull/2631

## Changelog
- remove duplicate token transfers