### PR TITLE
Add ETS-based cache for accounts page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#2667](https://github.com/poanetwork/blockscout/pull/2667) - Add ETS-based cache for accounts page
 - [#2679](https://github.com/poanetwork/blockscout/pull/2679) - added fixed height for card chain blocks and card chain transactions
 - [#2678](https://github.com/poanetwork/blockscout/pull/2678) - fixed dashboard banner height bug
 - [#2672](https://github.com/poanetwork/blockscout/pull/2672) - added new theme for xUSDT

--- a/apps/block_scout_web/test/support/conn_case.ex
+++ b/apps/block_scout_web/test/support/conn_case.ex
@@ -42,6 +42,8 @@ defmodule BlockScoutWeb.ConnCase do
 
     Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Transactions.child_id())
     Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Transactions.child_id())
+    Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Accounts.child_id())
+    Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Accounts.child_id())
 
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end

--- a/apps/block_scout_web/test/support/feature_case.ex
+++ b/apps/block_scout_web/test/support/feature_case.ex
@@ -29,6 +29,8 @@ defmodule BlockScoutWeb.FeatureCase do
 
     Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Transactions.child_id())
     Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Transactions.child_id())
+    Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Accounts.child_id())
+    Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Accounts.child_id())
 
     metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(Explorer.Repo, self())
     {:ok, session} = Wallaby.start_session(metadata: metadata)

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -136,6 +136,10 @@ config :explorer, Explorer.Chain.Cache.Transactions,
   ttl_check_interval: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(1), else: false),
   global_ttl: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(5))
 
+config :explorer, Explorer.Chain.Cache.Accounts,
+  ttl_check_interval: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(1), else: false),
+  global_ttl: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(5))
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -8,6 +8,7 @@ defmodule Explorer.Application do
   alias Explorer.Admin
 
   alias Explorer.Chain.Cache.{
+    Accounts,
     BlockCount,
     BlockNumber,
     Blocks,
@@ -49,7 +50,8 @@ defmodule Explorer.Application do
       BlockNumber,
       con_cache_child_spec(MarketHistoryCache.cache_name()),
       con_cache_child_spec(RSK.cache_name(), ttl_check_interval: :timer.minutes(1), global_ttl: :timer.minutes(30)),
-      Transactions
+      Transactions,
+      Accounts
     ]
 
     children = base_children ++ configurable_children()

--- a/apps/explorer/lib/explorer/chain/cache/accounts.ex
+++ b/apps/explorer/lib/explorer/chain/cache/accounts.ex
@@ -1,0 +1,73 @@
+defmodule Explorer.Chain.Cache.Accounts do
+  @moduledoc """
+  Caches the top Addresses
+  """
+
+  alias Explorer.Chain.Address
+
+  use Explorer.Chain.OrderedCache,
+    name: :accounts,
+    max_size: 51,
+    preload: :names,
+    ttl_check_interval: Application.get_env(:explorer, __MODULE__)[:ttl_check_interval],
+    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl]
+
+  @type element :: Address.t()
+
+  @type id :: {non_neg_integer(), non_neg_integer()}
+
+  def element_to_id(%Address{fetched_coin_balance: fetched_coin_balance, hash: hash}) do
+    {fetched_coin_balance, hash}
+  end
+
+  def prevails?({fetched_coin_balance_a, hash_a}, {fetched_coin_balance_b, hash_b}) do
+    # same as a query's `order_by: [desc: :fetched_coin_balance, asc: :hash]`
+    if fetched_coin_balance_a == fetched_coin_balance_b do
+      hash_a < hash_b
+    else
+      fetched_coin_balance_a > fetched_coin_balance_b
+    end
+  end
+
+  def drop(nil), do: :ok
+
+  def drop([]), do: :ok
+
+  def drop(addresses) when is_list(addresses) do
+    # This has to be used by the Indexer insead of `update`.
+    # The reason being that addresses already in the cache can change their balance
+    # value and removing or updating them will result into a potentially invalid
+    # cache status, that would not even get corrected with time.
+    # The only thing we can safely do when an address in the cache changes its
+    # `fetched_coin_balance` is to invalidate the whole cache and wait for it
+    # to be filled again (by the query that it takes the place of when full).
+    ConCache.update(cache_name(), ids_list_key(), fn ids ->
+      if drop_needed?(ids, addresses) do
+        # Remove the addresses immediately
+        Enum.each(ids, &ConCache.delete(cache_name(), &1))
+
+        {:ok, []}
+      else
+        {:ok, ids}
+      end
+    end)
+  end
+
+  def drop(address), do: drop([address])
+
+  defp drop_needed?(ids, _addresses) when is_nil(ids), do: false
+
+  defp drop_needed?([], _addresses), do: false
+
+  defp drop_needed?(ids, addresses) do
+    ids_map = Map.new(ids, fn {balance, hash} -> {hash, balance} end)
+
+    # Result it `true` only when the address is present in the cache already,
+    # but with a different `fetched_coin_balance`
+    Enum.find_value(addresses, false, fn address ->
+      stored_address_balance = Map.get(ids_map, address.hash)
+
+      stored_address_balance && stored_address_balance != address.fetched_coin_balance
+    end)
+  end
+end

--- a/apps/explorer/test/explorer/chain/cache/accounts_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/accounts_test.exs
@@ -1,0 +1,42 @@
+defmodule Explorer.Chain.Cache.AccountsTest do
+  use Explorer.DataCase
+
+  alias Explorer.Chain.Cache.Accounts
+  alias Explorer.Repo
+
+  describe "drop/1" do
+    test "does not drop the cache if the address fetched_coin_balance has not changed" do
+      address =
+        insert(:address, fetched_coin_balance: 100_000, fetched_coin_balance_block_number: 1)
+        |> preload_names()
+
+      Accounts.update(address)
+
+      assert Accounts.take(1) == [address]
+
+      Accounts.drop(address)
+
+      assert Accounts.take(1) == [address]
+    end
+
+    test "drops the cache if an address was in the cache with a different fetched_coin_balance" do
+      address =
+        insert(:address, fetched_coin_balance: 100_000, fetched_coin_balance_block_number: 1)
+        |> preload_names()
+
+      Accounts.update(address)
+
+      assert Accounts.take(1) == [address]
+
+      updated_address = %{address | fetched_coin_balance: 100_001}
+
+      Accounts.drop(updated_address)
+
+      assert Accounts.take(1) == []
+    end
+  end
+
+  defp preload_names(address) do
+    Repo.preload(address, [:names])
+  end
+end

--- a/apps/explorer/test/support/data_case.ex
+++ b/apps/explorer/test/support/data_case.ex
@@ -45,6 +45,8 @@ defmodule Explorer.DataCase do
     Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Blocks.child_id())
     Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Transactions.child_id())
     Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Transactions.child_id())
+    Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Accounts.child_id())
+    Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Accounts.child_id())
 
     :ok
   end

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -13,7 +13,7 @@ defmodule Indexer.Block.Fetcher do
   alias Explorer.Chain
   alias Explorer.Chain.{Address, Block, Hash, Import, Transaction}
   alias Explorer.Chain.Cache.Blocks, as: BlocksCache
-  alias Explorer.Chain.Cache.{BlockNumber, Transactions}
+  alias Explorer.Chain.Cache.{Accounts, BlockNumber, Transactions}
   alias Indexer.Block.Fetcher.Receipts
 
   alias Indexer.Fetcher.{
@@ -176,6 +176,7 @@ defmodule Indexer.Block.Fetcher do
       result = {:ok, %{inserted: inserted, errors: blocks_errors}}
       update_block_cache(inserted[:blocks])
       update_transactions_cache(inserted[:transactions])
+      update_addresses_cache(inserted[:addresses])
       result
     else
       {step, {:error, reason}} -> {:error, {step, reason}}
@@ -196,6 +197,8 @@ defmodule Indexer.Block.Fetcher do
   defp update_transactions_cache(transactions) do
     Transactions.update(transactions)
   end
+
+  defp update_addresses_cache(addresses), do: Accounts.drop(addresses)
 
   def import(
         %__MODULE__{broadcast: broadcast, callback_module: callback_module} = state,

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -27,6 +27,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
   alias Ecto.Changeset
   alias EthereumJSONRPC.{FetchedBalances, Subscription}
   alias Explorer.Chain
+  alias Explorer.Chain.Cache.Accounts
   alias Explorer.Counters.AverageBlockTime
   alias Indexer.{Block, Tracer}
   alias Indexer.Block.Realtime.TaskSupervisor
@@ -196,6 +197,8 @@ defmodule Indexer.Block.Realtime.Fetcher do
         %{block_rewards: %{errors: block_reward_errors}},
         json_rpc_named_arguments
       )
+
+      Accounts.drop(imported[:addresses])
 
       ok
     end

--- a/apps/indexer/lib/indexer/fetcher/block_reward.ex
+++ b/apps/indexer/lib/indexer/fetcher/block_reward.ex
@@ -17,6 +17,7 @@ defmodule Indexer.Fetcher.BlockReward do
   alias EthereumJSONRPC.FetchedBeneficiaries
   alias Explorer.Chain
   alias Explorer.Chain.{Block, Wei}
+  alias Explorer.Chain.Cache.Accounts
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Fetcher.BlockReward.Supervisor, as: BlockRewardSupervisor
   alias Indexer.Fetcher.CoinBalance
@@ -130,7 +131,9 @@ defmodule Indexer.Fetcher.BlockReward do
         |> add_gas_payments()
         |> import_block_reward_params()
         |> case do
-          {:ok, %{address_coin_balances: address_coin_balances}} ->
+          {:ok, %{address_coin_balances: address_coin_balances, addresses: addresses}} ->
+            Accounts.drop(addresses)
+
             CoinBalance.async_fetch_balances(address_coin_balances)
 
             retry_errors(errors)

--- a/apps/indexer/lib/indexer/fetcher/coin_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance.ex
@@ -14,6 +14,7 @@ defmodule Indexer.Fetcher.CoinBalance do
   alias EthereumJSONRPC.FetchedBalances
   alias Explorer.Chain
   alias Explorer.Chain.{Block, Hash}
+  alias Explorer.Chain.Cache.Accounts
   alias Indexer.{BufferedTask, Tracer}
 
   @behaviour BufferedTask
@@ -136,7 +137,9 @@ defmodule Indexer.Fetcher.CoinBalance do
   end
 
   defp run_fetched_balances(%FetchedBalances{errors: errors} = fetched_balances, _) do
-    {:ok, _} = import_fetched_balances(fetched_balances)
+    {:ok, imported} = import_fetched_balances(fetched_balances)
+
+    Accounts.drop(imported[:addresses])
 
     retry(errors)
   end

--- a/apps/indexer/lib/indexer/fetcher/coin_balance_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance_on_demand.ex
@@ -19,7 +19,7 @@ defmodule Indexer.Fetcher.CoinBalanceOnDemand do
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Address
   alias Explorer.Chain.Address.CoinBalance
-  alias Explorer.Chain.Cache.BlockNumber
+  alias Explorer.Chain.Cache.{Accounts, BlockNumber}
   alias Explorer.Counters.AverageBlockTime
   alias Indexer.Fetcher.CoinBalance, as: CoinBalanceFetcher
   alias Timex.Duration
@@ -71,7 +71,11 @@ defmodule Indexer.Fetcher.CoinBalanceOnDemand do
   end
 
   def handle_cast({:fetch_and_update, block_number, address}, state) do
-    fetch_and_update(block_number, address, state.json_rpc_named_arguments)
+    result = fetch_and_update(block_number, address, state.json_rpc_named_arguments)
+
+    with {:ok, %{addresses: addresses}} <- result do
+      Accounts.drop(addresses)
+    end
 
     {:noreply, state}
   end

--- a/apps/indexer/lib/indexer/fetcher/contract_code.ex
+++ b/apps/indexer/lib/indexer/fetcher/contract_code.ex
@@ -12,6 +12,7 @@ defmodule Indexer.Fetcher.ContractCode do
 
   alias Explorer.Chain
   alias Explorer.Chain.{Block, Hash}
+  alias Explorer.Chain.Cache.Accounts
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Transform.Addresses
 
@@ -126,7 +127,8 @@ defmodule Indexer.Fetcher.ContractCode do
                addresses: %{params: merged_addresses_params},
                timeout: :infinity
              }) do
-          {:ok, _} ->
+          {:ok, imported} ->
+            Accounts.drop(imported[:addresses])
             :ok
 
           {:error, step, reason, _changes_so_far} ->

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -14,6 +14,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   alias Explorer.Chain
   alias Explorer.Chain.{Block, Hash}
+  alias Explorer.Chain.Cache.Accounts
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Transform.Addresses
 
@@ -218,6 +219,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
     case imports do
       {:ok, imported} ->
+        Accounts.drop(imported[:addreses])
+
         async_import_coin_balances(imported, %{
           address_hash_to_fetched_balance_block_number: address_hash_to_block_number
         })

--- a/apps/indexer/lib/indexer/fetcher/pending_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/pending_transaction.ex
@@ -14,6 +14,7 @@ defmodule Indexer.Fetcher.PendingTransaction do
 
   alias Ecto.Changeset
   alias Explorer.Chain
+  alias Explorer.Chain.Cache.Accounts
   alias Indexer.Fetcher.PendingTransaction
   alias Indexer.Transform.Addresses
 
@@ -148,7 +149,8 @@ defmodule Indexer.Fetcher.PendingTransaction do
            broadcast: :realtime,
            transactions: %{params: transactions_params, on_conflict: :nothing}
          }) do
-      {:ok, _} ->
+      {:ok, imported} ->
+        Accounts.drop(imported[:addresses])
         :ok
 
       {:error, [%Changeset{} | _] = changesets} ->

--- a/apps/indexer/lib/indexer/fetcher/uncle_block.ex
+++ b/apps/indexer/lib/indexer/fetcher/uncle_block.ex
@@ -12,6 +12,7 @@ defmodule Indexer.Fetcher.UncleBlock do
   alias Ecto.Changeset
   alias EthereumJSONRPC.Blocks
   alias Explorer.Chain
+  alias Explorer.Chain.Cache.Accounts
   alias Explorer.Chain.Hash
   alias Indexer.{Block, BufferedTask, Tracer}
   alias Indexer.Fetcher.UncleBlock
@@ -126,7 +127,8 @@ defmodule Indexer.Fetcher.UncleBlock do
            block_second_degree_relations: %{params: block_second_degree_relations_params},
            transactions: %{params: transactions_params, on_conflict: :nothing}
          }) do
-      {:ok, _} ->
+      {:ok, imported} ->
+        Accounts.drop(imported[:addresses])
         retry(errors)
 
       {:error, {:import = step, [%Changeset{} | _] = changesets}} ->


### PR DESCRIPTION
Closes #2428 

NOTE: the cache is already set up to work without the Indexer, but it will only work after #2612 is merged.

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
  - [x] If I added/changed/removed ENV var, I should update the list of env vars in https://github.com/poanetwork/blockscout/blob/master/docs/env-variables.md to reflect changes in the table here https://poanetwork.github.io/blockscout/#/env-variables?id=blockscout-env-variables. I've set `master` in the `Version` column.
  - [x] If I add new indices into DB, I checked, that they don't redundant with PGHero or other tools
