### PR TITLE
Use Task.start instead of Task.async in caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2672](https://github.com/poanetwork/blockscout/pull/2672) - added new theme for xUSDT 
 
 ### Fixes
+- [#2682](https://github.com/poanetwork/blockscout/pull/2682) - Use Task.start instead of Task.async in caches
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain/cache/block_count.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block_count.ex
@@ -28,8 +28,8 @@ defmodule Explorer.Chain.Cache.BlockCount do
   defp handle_fallback(:async_task) do
     # If this gets called it means an async task was requested, but none exists
     # so a new one needs to be launched
-    task =
-      Task.async(fn ->
+    {:ok, task} =
+      Task.start(fn ->
         try do
           result = Chain.fetch_count_consensus_block()
 

--- a/apps/explorer/lib/explorer/chain/cache/transaction_count.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction_count.ex
@@ -29,8 +29,8 @@ defmodule Explorer.Chain.Cache.TransactionCount do
   defp handle_fallback(:async_task) do
     # If this gets called it means an async task was requested, but none exists
     # so a new one needs to be launched
-    task =
-      Task.async(fn ->
+    {:ok, task} =
+      Task.start(fn ->
         try do
           result = Repo.aggregate(Transaction, :count, :hash, timeout: :infinity)
 


### PR DESCRIPTION
# Motivation

Using `Task.async` in caches causes problems because their result gets sent to the `ConCache.Owner` of the respective cache, that does not handle the call.

## Changelog

### Enhancements

### Bug Fixes
`Task.start` can be used instead of `Task.async`

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
  - [x] If I added/changed/removed ENV var, I should update the list of env vars in https://github.com/poanetwork/blockscout/blob/master/docs/env-variables.md to reflect changes in the table here https://poanetwork.github.io/blockscout/#/env-variables?id=blockscout-env-variables. I've set `master` in the `Version` column.
  - [x] If I add new indices into DB, I checked, that they don't redundant with PGHero or other tools
