### PR TITLE
Revert "Filter pending logs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@
 - [#2679](https://github.com/poanetwork/blockscout/pull/2679) - added fixed height for card chain blocks and card chain transactions 
 - [#2678](https://github.com/poanetwork/blockscout/pull/2678) - fixed dashboard banner height bug
 - [#2672](https://github.com/poanetwork/blockscout/pull/2672) - added new theme for xUSDT
+- [#2663](https://github.com/poanetwork/blockscout/pull/2663) - Fetch address counters in parallel
 
 ### Fixes
 - [#2684](https://github.com/poanetwork/blockscout/pull/2684) - do not filter pending logs
 - [#2682](https://github.com/poanetwork/blockscout/pull/2682) - Use Task.start instead of Task.async in caches
-- [#2663](https://github.com/poanetwork/blockscout/pull/2663) - Fetch address counters in parallel
-
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ### Features
 - [#2678](https://github.com/poanetwork/blockscout/pull/2678) - fixed dashboard banner height bug
-- [#2672](https://github.com/poanetwork/blockscout/pull/2672) - added new theme for xUSDT 
+- [#2672](https://github.com/poanetwork/blockscout/pull/2672) - added new theme for xUSDT
 
 ### Fixes
+- [#2684](https://github.com/poanetwork/blockscout/pull/2684) - do not filter pending logs
 
 ### Chore
 
@@ -232,6 +233,7 @@
 - [#2123](https://github.com/poanetwork/blockscout/pull/2123) - fix coins percentage view
 - [#2119](https://github.com/poanetwork/blockscout/pull/2119) - fix map logging
 - [#2130](https://github.com/poanetwork/blockscout/pull/2130) - fix navigation
+- [#2148](https://github.com/poanetwork/blockscout/pull/2148) - filter pending logs
 - [#2147](https://github.com/poanetwork/blockscout/pull/2147) - add rsk format of checksum
 - [#2149](https://github.com/poanetwork/blockscout/pull/2149) - remove pending transaction count
 - [#2177](https://github.com/poanetwork/blockscout/pull/2177) - remove duplicate entries from UncleBlock's Fetcher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,7 +232,6 @@
 - [#2123](https://github.com/poanetwork/blockscout/pull/2123) - fix coins percentage view
 - [#2119](https://github.com/poanetwork/blockscout/pull/2119) - fix map logging
 - [#2130](https://github.com/poanetwork/blockscout/pull/2130) - fix navigation
-- [#2148](https://github.com/poanetwork/blockscout/pull/2148) - filter pending logs
 - [#2147](https://github.com/poanetwork/blockscout/pull/2147) - add rsk format of checksum
 - [#2149](https://github.com/poanetwork/blockscout/pull/2149) - remove pending transaction count
 - [#2177](https://github.com/poanetwork/blockscout/pull/2177) - remove duplicate entries from UncleBlock's Fetcher

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipts.ex
@@ -61,9 +61,7 @@ defmodule EthereumJSONRPC.Receipts do
   """
   @spec elixir_to_logs(elixir) :: Logs.elixir()
   def elixir_to_logs(elixir) when is_list(elixir) do
-    elixir
-    |> Enum.flat_map(&Receipt.elixir_to_logs/1)
-    |> Enum.filter(&(Map.get(&1, "type") != "pending"))
+    Enum.flat_map(elixir, &Receipt.elixir_to_logs/1)
   end
 
   @doc """

--- a/apps/indexer/test/indexer/block/fetcher/receipts_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher/receipts_test.exs
@@ -84,18 +84,6 @@ defmodule Indexer.Block.Fetcher.ReceiptsTest do
                      "transactionIndex" => "0x0",
                      "transactionLogIndex" => "0x0",
                      "type" => "mined"
-                   },
-                   %{
-                     "address" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415c",
-                     "blockHash" => nil,
-                     "blockNumber" => nil,
-                     "data" => "0x000000000000000000000000862d67cb0773ee3f8ce7ea89b328ffea861ab3ef",
-                     "logIndex" => "0x1",
-                     "topics" => ["0x600bcf04a13e752d1e3670a5a9f1c21177ca2a93c6f5391d4f1298d098097c22"],
-                     "transactionHash" => "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5",
-                     "transactionIndex" => "0x0",
-                     "transactionLogIndex" => "0x0",
-                     "type" => "pending"
                    }
                  ],
                  "logsBloom" =>
@@ -158,8 +146,6 @@ defmodule Indexer.Block.Fetcher.ReceiptsTest do
                log[:transaction_hash] == "0x43bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5" &&
                  log[:block_number] == 46147
              end)
-
-      refute Enum.find(logs, fn log -> log[:type] == "pending" end)
     end
   end
 end


### PR DESCRIPTION
Reverts poanetwork/blockscout#2148
We started having missing token transfers and logs. For new blocks parity returns pending logs. Logs are used for token transfers and token balances update. I think it's better to fail a couple of times before parity start returning normal logs
PR 2148 just skips pending logs that's why we have missing token transfers and token balances