### PR TITLE
Fix staking UI issues (from #2292)

### DIFF
--- a/apps/block_scout_web/assets/css/components/_check_tooltip.scss
+++ b/apps/block_scout_web/assets/css/components/_check_tooltip.scss
@@ -7,6 +7,7 @@ $check-tooltip-check-active: #fff !default;
   display: block;
   height: 16px;
   width: 16px;
+  cursor: pointer;
 
   .check-tooltip-circle {
     fill: $check-tooltip-background;

--- a/apps/block_scout_web/assets/css/components/_stakes_table.scss
+++ b/apps/block_scout_web/assets/css/components/_stakes_table.scss
@@ -96,6 +96,7 @@ $stakes-table-cell-separation: 25px !default;
 }
 
 .stakes-td {
+  display: flex;
   border-bottom: 1px solid #f5f6fa;
   font-size: 14px;
   font-weight: normal;
@@ -103,7 +104,7 @@ $stakes-table-cell-separation: 25px !default;
   line-height: 1.2;
   padding-right: $stakes-table-cell-separation;
   text-align: left;
-  vertical-align: middle;
+  align-items: center;
   white-space: nowrap;
 
   &:last-child {

--- a/apps/block_scout_web/assets/css/components/stakes/_modal_become_candidate.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_modal_become_candidate.scss
@@ -1,6 +1,6 @@
 .modal-become-candidate {
-  max-width: 100%;
-  width: 280px;
+  max-width: 380px;
+  width: 100%;
 
   @include media-breakpoint-down(sm) {
     margin-left: auto;

--- a/apps/block_scout_web/assets/css/components/stakes/_modal_delegators_info.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_modal_delegators_info.scss
@@ -1,0 +1,24 @@
+.modal-delegators-info {
+  max-width: map-get($container-max-widths, "xl");
+  min-width: map-get($container-max-widths, "md");
+  width: 100%;
+
+  @include media-breakpoint-down(lg) {
+    max-width: map-get($container-max-widths, "lg");
+  }
+
+  @include media-breakpoint-down(md) {
+    max-width: map-get($container-max-widths, "md");
+  }
+
+  @include media-breakpoint-down(sm) {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .container {
+    @include media-breakpoint-down(sm) {
+      max-width: map-get($container-max-widths, "md");
+    }
+  }
+}

--- a/apps/block_scout_web/assets/css/components/stakes/_modal_delegators_info.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_modal_delegators_info.scss
@@ -1,20 +1,7 @@
 .modal-delegators-info {
-  max-width: map-get($container-max-widths, "xl");
+  max-width: map-get($container-max-widths, "md");
   min-width: map-get($container-max-widths, "md");
   width: 100%;
-
-  @include media-breakpoint-down(lg) {
-    max-width: map-get($container-max-widths, "lg");
-  }
-
-  @include media-breakpoint-down(md) {
-    max-width: map-get($container-max-widths, "md");
-  }
-
-  @include media-breakpoint-down(sm) {
-    margin-left: auto;
-    margin-right: auto;
-  }
 
   .container {
     @include media-breakpoint-down(sm) {

--- a/apps/block_scout_web/assets/css/components/stakes/_modal_stake.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_modal_stake.scss
@@ -13,8 +13,9 @@
 }
 
 .modal-stake-move {
-  max-width: 100%;
-  width: 680px;
+  max-width: 640px;
+  min-width: 640px;
+  width: 100%;
 
   @include media-breakpoint-down(sm) {
     margin-left: auto;
@@ -24,7 +25,6 @@
 
 .modal-stake-middle {
   border-left: 1px solid $base-border-color;
-
   height: 100%;
 }
 

--- a/apps/block_scout_web/assets/css/components/stakes/_modal_validator_info.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_modal_validator_info.scss
@@ -1,10 +1,14 @@
 .modal-validator-info {
-  max-width: 100%;
-  width: 660px;
+  max-width: 660px;
+  width: 100%;
 
   @include media-breakpoint-down(sm) {
     margin-left: auto;
     margin-right: auto;
+  }
+
+  .modal-title {
+    margin-bottom: 15px;
   }
 }
 

--- a/apps/block_scout_web/assets/css/components/stakes/_modal_validator_info.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_modal_validator_info.scss
@@ -8,7 +8,7 @@
   }
 
   .modal-title {
-    margin-bottom: 15px;
+    margin-bottom: 10px;
   }
 }
 

--- a/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
@@ -85,19 +85,19 @@ $stakes-stats-item-border-color: #fff !default;
 
 .stakes-address-container {
   display: flex;
-  cursor: pointer;
   justify-content: flex-start;
 
-  span {
-    margin-right: 10px;
-  }
-
   .stakes-address {
-    color: $stakes-address-color;
+    margin-right: 10px;
 
     .stakes-tr-banned & {
       color: $stakes-banned-color;
     }
+  }
+
+  .stakes-address-active {
+    color: $stakes-address-color;
+    cursor: pointer;
   }
 }
 

--- a/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
@@ -49,6 +49,7 @@ $stakes-stats-item-border-color: #fff !default;
   }
 
   .copy-icon {
+    min-width: 18px;
     margin-left: 20px;
     path {
       fill: $stakes-dashboard-copy-icon-color;
@@ -60,10 +61,17 @@ $stakes-stats-item-border-color: #fff !default;
   align-items: center;
   display: flex;
 
-  .stakes-top-stats-item-address & {
-    white-space: normal;
-    word-break: break-all;
+  div:nth-child(1) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
   }
+}
+
+.stakes-top-stats-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 .stakes-top-stats-login {
@@ -119,7 +127,17 @@ $stakes-stats-item-border-color: #fff !default;
   }
 }
 
+.stakes-top-stats-item {
+  min-width: 180px;
+
+  &.stakes-top-stats-item-address {
+    min-width: 390px;
+    width: 100%;
+  }
+}
+
 .stakes-top-buttons {
+  min-width: 180px;
   align-items: center;
   display: flex;
   justify-content: center;

--- a/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
@@ -88,9 +88,12 @@ $stakes-stats-item-border-color: #fff !default;
   cursor: pointer;
   justify-content: flex-start;
 
+  span {
+    margin-right: 10px;
+  }
+
   .stakes-address {
     color: $stakes-address-color;
-    margin-right: 10px;
 
     .stakes-tr-banned & {
       color: $stakes-banned-color;

--- a/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
@@ -134,7 +134,7 @@ $stakes-stats-item-border-color: #fff !default;
   min-width: 180px;
 
   &.stakes-top-stats-item-address {
-    min-width: 390px;
+    min-width: 260px;
     width: 100%;
   }
 }

--- a/apps/block_scout_web/assets/css/stakes.scss
+++ b/apps/block_scout_web/assets/css/stakes.scss
@@ -17,4 +17,5 @@
 @import "components/stakes/modal_stake";
 @import "components/stakes/modal_become_candidate";
 @import "components/stakes/modal_validator_info";
+@import "components/stakes/modal_delegators_info";
 @import "components/stakes/modal_bottom_disclaimer";

--- a/apps/block_scout_web/assets/js/app.js
+++ b/apps/block_scout_web/assets/js/app.js
@@ -39,7 +39,6 @@ import './pages/network-search'
 import './pages/layout'
 import './pages/verification_form'
 import './pages/dark-mode-switcher'
-import './pages/stakes'
 
 import './pages/admin/tasks.js'
 

--- a/apps/block_scout_web/assets/js/lib/list_morph.js
+++ b/apps/block_scout_web/assets/js/lib/list_morph.js
@@ -35,7 +35,7 @@ export default function (container, newElements, { key, horizontal } = {}) {
   const overlap = intersectionBy(newList, currentList, 'id').map(({ id, el }) => ({ id, el: updateAllAges($(el))[0] }))
   // remove old items
   const removals = differenceBy(currentList, newList, 'id')
-  let canAnimate = !horizontal && removals.length <= 1
+  let canAnimate = !horizontal && newList.length > 0
   removals.forEach(({ el }) => {
     if (!canAnimate) return el.remove()
     const $el = $(el)

--- a/apps/block_scout_web/assets/js/lib/list_morph.js
+++ b/apps/block_scout_web/assets/js/lib/list_morph.js
@@ -29,11 +29,10 @@ import { updateAllAges } from './from_now'
 //               animations
 export default function (container, newElements, { key, horizontal } = {}) {
   if (!container) return
-  const oldElements = $(container).children().get()
+  const oldElements = $(container).children().not('.shrink-out').get()
   let currentList = map(oldElements, (el) => ({ id: get(el, key), el }))
   const newList = map(newElements, (el) => ({ id: get(el, key), el }))
   const overlap = intersectionBy(newList, currentList, 'id').map(({ id, el }) => ({ id, el: updateAllAges($(el))[0] }))
-
   // remove old items
   const removals = differenceBy(currentList, newList, 'id')
   let canAnimate = !horizontal && removals.length <= 1
@@ -57,7 +56,6 @@ export default function (container, newElements, { key, horizontal } = {}) {
   finalList.forEach((el, i) => {
     if (el.parentElement) return
     if (!canAnimate) return container.insertBefore(el, get(finalList, `[${i - 1}]`))
-    canAnimate = false
     if (!get(finalList, `[${i - 1}]`)) return slideDownAppend($(container), el)
     slideDownBefore($(get(finalList, `[${i - 1}]`)), el)
   })

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -1,6 +1,7 @@
 import '../../css/stakes.scss'
 
 import $ from 'jquery'
+import 'bootstrap'
 import _ from 'lodash'
 import { subscribeChannel } from '../socket'
 import { connectElements } from '../lib/redux_helpers.js'

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -101,6 +101,7 @@ if ($stakesPage.length) {
   store.dispatch({ type: 'CHANNEL_CONNECTED', channel })
 
   channel.on('staking_update', msg => {
+    $('.tooltip').hide()
     $stakesTop.html(msg.top_html)
 
     const state = store.getState()

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
     <link rel="preload" href="/css/non-critical.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="/css/non-critical.css"></noscript>
+    <%= render_existing(@view_module, "styles.html", assigns) %>
 
     <link rel="apple-touch-icon" sizes="180x180" href="<%= static_path(@conn, "/apple-touch-icon.png") %>">
     <link rel="icon" type="image/png" sizes="32x32" href="<%= static_path(@conn, "/favicon-32x32.png") %>">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
@@ -1,6 +1,6 @@
-<tr data-identifier-pool="<%= @index %>" class=<%= if @pool.is_banned, do:  "stakes-tr-banned" %>>
-  <td class="stakes-td"><div class="stakes-td-order"><%= @index %></div></td>
-  <td class="stakes-td">
+<div data-identifier-pool="<%= @pool.staking_address_hash %>" class="row <%= if @pool.is_banned, do:  "stakes-tr-banned" %>">
+  <div class="col-1 stakes-td"><div class="stakes-td-order"><%= @index %></div></div>
+  <div class="col-2 stakes-td">
     <%=
     tooltip = if @pool.is_validator, do: "This is a validator", else: false
     render BlockScoutWeb.StakesView,
@@ -9,8 +9,8 @@
     tooltip: tooltip,
     index: @index
     %>
-  </td>
-  <td class="stakes-td">
+  </div>
+  <div class="col-2 stakes-td">
     <%=
     render BlockScoutWeb.CommonComponentsView,
     "_progress_from_to.html",
@@ -18,20 +18,20 @@
     to: format_token_amount(@pool.staked_amount, @token, digits: 0, ellipsize: false, symbol: false),
     progress: amount_ratio(@pool)
     %>
-  </td>
-  <td class="stakes-td">
+  </div>
+  <div class="col-2 stakes-td">
     <%= if @pools_type == :inactive do %>
       <%= if @pool.is_banned, do: "Yes", else: "No" %>
     <% else %>
       <%= if @pool.staked_ratio, do: "#{@pool.staked_ratio}%" %>
     <% end %>
-  </td>
-  <td class="stakes-td">
+  </div>
+  <div class="col-2 stakes-td">
     <span class="stakes-td-link-style js-delegators-list" data-address="<%= @pool.staking_address_hash %>">
       <%= @pool.delegators_count %>
     </span>
-  </td>
-  <td class="stakes-td">
+  </div>
+  <div class="col-3 stakes-td justify-content-end">
     <%= if @pool.is_banned do %>
       <span class="stakes-td-banned-info">
         Banned until block #<%= @pool.banned_until %> (<%= estimated_unban_day(@pool.banned_until, @average_block_time) %>)
@@ -52,5 +52,5 @@
         <% end %>
       </div>
     <% end %>
-  </td>
-</tr>
+  </div>
+</div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_address.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_address.html.eex
@@ -1,5 +1,5 @@
 <div class="stakes-address-container js-validator-info" data-address="<%= to_string(@address) %>">
-  <span class="stakes-address">
+  <span class="stakes-address stakes-address-active">
     <%= BlockScoutWeb.AddressView.trimmed_hash(@address) %>
   </span>
   <%= if @tooltip do %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
@@ -1,61 +1,61 @@
 <div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-validator-info" role="document">
+  <div class="modal-dialog modal-dialog-centered modal-delegators-info" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Delegators</h5>
       </div>
       <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
       <div class="modal-body">
-        <table class="modal-table">
-          <thead>
-            <tr>
-              <th class="stakes-table-th">&nbsp;</th>
+        <div class="container modal-table">
+          <div class="row stakes-table-th">
+            <div class="col-1"></div>
+            <div class="col-4">
               <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Staker's Address", tooltip: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut." %>
+            </div>
+            <div class="col-4">
               <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Total Stake Amount", tooltip: "Lorem ipsum dolor sit iusmod tempor incididunt ut." %>
+            </div>
+            <div class="col-3">
               <%=
                 title = if @pool.is_validator do "Reward Percent" else "Potential Reward Percent" end
-
                 render BlockScoutWeb.StakesView,
                   "_stakes_th.html",
                   title: title,
                   tooltip: "Lorem ipsum dolor sit iusmod tempor incididunt ut."
               %>
-            </tr>
-          </thead>
-
-          <tbody>
-            <%= for {delegator, index} <- Enum.with_index(@delegators, 1) do %>
-              <tr>
-                <td class="stakes-td"><div class="stakes-td-order"><%= index %></div></td>
-                <td class="stakes-td">
-                  <div class="stakes-address-container">
-                    <span class="stakes-address">
-                      <%= BlockScoutWeb.AddressView.trimmed_hash(delegator.delegator_address_hash) %>
-                    </span>
-                    <%= if delegator.delegator_address_hash == @pool.staking_address_hash and @pool.is_validator do %>
-                      <%= render BlockScoutWeb.CommonComponentsView, "_check_tooltip.html", text: "This is a validator" %>
-                    <% end %>
-                    <%= if to_string(delegator.delegator_address_hash) == @account do %>
-                      <div
-                          class="me-tooltip"
-                          data-boundary="window"
-                          data-container="body"
-                          data-html="true"
-                          data-placement="top"
-                          data-toggle="tooltip"
-                          title="It's me!"
-                      >
-                          ME
-                      </div>
-                    <% end %>
-                  </div>
-                </td>
-                <td class="stakes-td"><%= format_token_amount(delegator.stake_amount, @token, symbol: false) %></td>
-                <td class="stakes-td"><%= if delegator.reward_ratio do "#{delegator.reward_ratio}%" else "-" end %></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+            </div>
+          </div>
+          <%= for {delegator, index} <- Enum.with_index(@delegators, 1) do %>
+            <div class="row">
+              <div class="col-1 stakes-td"><div class="stakes-td-order"><%= index %></div></div>
+              <div class="col-4 stakes-td">
+                <div class="stakes-address-container">
+                  <span class="stakes-address">
+                    <%= BlockScoutWeb.AddressView.trimmed_hash(delegator.delegator_address_hash) %>
+                  </span>
+                  <%= if delegator.delegator_address_hash == @pool.staking_address_hash and @pool.is_validator do %>
+                    <%= render BlockScoutWeb.CommonComponentsView, "_check_tooltip.html", text: "This is a validator" %>
+                  <% end %>
+                  <%= if to_string(delegator.delegator_address_hash) == @account do %>
+                    <div
+                        class="me-tooltip"
+                        data-boundary="window"
+                        data-container="body"
+                        data-html="true"
+                        data-placement="top"
+                        data-toggle="tooltip"
+                        title="It's me!"
+                    >
+                        ME
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+              <div class="col-4 stakes-td"><%= format_token_amount(delegator.stake_amount, @token, symbol: false) %></div>
+              <div class="col-3 stakes-td"><%= if delegator.reward_ratio do "#{delegator.reward_ratio}%" else "-" end %></div>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
@@ -30,7 +30,7 @@
               <div class="col-1 stakes-td"><div class="stakes-td-order"><%= index %></div></div>
               <div class="col-4 stakes-td">
                 <div class="stakes-address-container">
-                  <span>
+                  <span class="stakes-address">
                     <%= BlockScoutWeb.AddressView.trimmed_hash(delegator.delegator_address_hash) %>
                   </span>
                   <%= if delegator.delegator_address_hash == @pool.staking_address_hash and @pool.is_validator do %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
@@ -30,7 +30,7 @@
               <div class="col-1 stakes-td"><div class="stakes-td-order"><%= index %></div></div>
               <div class="col-4 stakes-td">
                 <div class="stakes-address-container">
-                  <span class="stakes-address">
+                  <span>
                     <%= BlockScoutWeb.AddressView.trimmed_hash(delegator.delegator_address_hash) %>
                   </span>
                   <%= if delegator.delegator_address_hash == @pool.staking_address_hash and @pool.is_validator do %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_move.html.eex
@@ -1,5 +1,5 @@
 <div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered <%= if @pool_to do "modal-stake-move" end %>" role="document">
+  <div class="modal-dialog modal-dialog-centered <%= if @pool_to do "modal-stake-move" else "modal-stake" end %>" role="document">
     <div class="modal-content">
       <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
       <div class="modal-stake-two-cols">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_stats_item_account.html.eex
@@ -4,7 +4,7 @@
   <span class="stakes-top-stats-value">
     <%= if @account do %>
       <div data-placement="top" data-toggle="tooltip" title=<%= @account.address %>>
-        <%= binary_part(@account.address, 0, 13) %>...
+        <%= @account.address %>
       </div>
       <div class="copy-icon" data-clipboard-text="<%= @account.address %>">
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_table.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_table.html.eex
@@ -1,38 +1,32 @@
-<div class="stakes-table-container">
-  <table class="stakes-table">
-    <thead>
-      <tr>
-        <th class="stakes-table-th">&nbsp;</th>
-        <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Pool", tooltip: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut." %>
-        <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Staked Amount", tooltip: "Lorem ipsum dolor sit iusmod tempor incididunt ut." %>
-        <%= if @pools_type == :inactive do %>
-          <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Banned", tooltip: "Sed do eiusmod tempor incididunt ut." %>
-        <% else %>
-          <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Stakes Ratio", tooltip: "Sed do eiusmod tempor incididunt ut." %>
-        <% end %>
-        <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Delegators", tooltip: "Lorem ipsum dolor sit amet." %>
-        <th class="stakes-table-th">&nbsp;</th>
-      </tr>
-    </thead>
+<div class="container stakes-table-container">
+  <div class="row stakes-table-th">
+    <div class="col-1"></div>
+    <div class="col-2">
+      <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Pool", tooltip: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut." %>
+    </div>
+    <div class="col-2">
+      <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Staked Amount", tooltip: "Lorem ipsum dolor sit iusmod tempor incididunt ut." %>
+    </div>
+    <div class="col-2">
+      <%= if @pools_type == :inactive do %>
+        <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Banned", tooltip: "Sed do eiusmod tempor incididunt ut." %>
+      <% else %>
+        <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Stakes Ratio", tooltip: "Sed do eiusmod tempor incididunt ut." %>
+      <% end %>
+    </div>
+    <div class="col-2">
+      <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: "Delegators", tooltip: "Lorem ipsum dolor sit amet." %>
+    </div>
+    <div class="col-3"></div>
+  </div>
 
-    <tbody>
-      <tr>
-        <td colspan="6">
-          <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
-            <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
-          </button>
-        </td>
-      </tr>
-    </tbody>
+  <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+    <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
+  </button>
 
-    <tbody data-empty-response-message style="display: none;">
-      <tr>
-        <td colspan="6">
-          <%= render BlockScoutWeb.StakesView, "_stakes_empty_content.html" %>
-        </td>
-      </tr>
-    </tbody>
+  <div data-empty-response-message style="display: none;">
+    <%= render BlockScoutWeb.StakesView, "_stakes_empty_content.html" %>
+  </div>
 
-    <tbody data-items></tbody>
-  </table>
+  <div data-items></div>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/views/stakes_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/stakes_view.ex
@@ -1,4 +1,12 @@
 defmodule BlockScoutWeb.StakesView do
   use BlockScoutWeb, :view
   import BlockScoutWeb.StakesHelpers
+
+  def render("scripts.html", %{conn: conn}) do
+    render_scripts(conn, "stakes.js")
+  end
+
+  def render("styles.html", _) do
+    ~E(<link rel="stylesheet" href="/css/stakes.css">)
+  end
 end


### PR DESCRIPTION
## Motivation
This PR is made to fix remin WEB UI issues for POSDAO Staking DApp, directly https://github.com/poanetwork/blockscout/pull/2292#issuecomment-522098750
This is a more clean version of https://github.com/poanetwork/blockscout/pull/2618 , so should contain commits for each fix and remove some unnecessary logic. 
  
## Changelog
- [x] Fix items disappearing misbehavior of staking filters (5, 26)
- [x] Fix items disappearing animation of staking filters (7)
- [x] Fix not disappearing tooltip in stakes-top container on block number update (3)
- [x] Fix stakes top stats width to have fixed size on refresh (4)
- [x] Replace stakes table with flex boxes to fixate size of table header (6, 13)
- [x] Fix staking modals width (2, 12)

