### PR TITLE
remove non consensus internal transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#2663](https://github.com/poanetwork/blockscout/pull/2663) - Fetch address counters in parallel
 
 ### Fixes
+- [#2693](https://github.com/poanetwork/blockscout/pull/2693) - remove non consensus internal transactions
 - [#2687](https://github.com/poanetwork/blockscout/pull/2687) - remove non-consensus token transfers, logs when inserting new consensus blocks
 - [#2684](https://github.com/poanetwork/blockscout/pull/2684) - do not filter pending logs
 - [#2682](https://github.com/poanetwork/blockscout/pull/2682) - Use Task.start instead of Task.async in caches

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -131,6 +131,31 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         }
       )
     end)
+    |> Multi.run(
+      :internal_transaction_transaction_block_number,
+      fn repo, %{blocks: blocks} ->
+        blocks_hashes = Enum.map(blocks, & &1.hash)
+
+        query =
+          from(
+            internal_transaction in InternalTransaction,
+            join: transaction in Transaction,
+            on: internal_transaction.transaction_hash == transaction.hash,
+            join: block in Block,
+            on: block.hash == transaction.block_hash,
+            where: block.hash in ^blocks_hashes,
+            update: [
+              set: [
+                block_number: block.number
+              ]
+            ]
+          )
+
+        {total, _} = repo.update_all(query, [])
+
+        {:ok, total}
+      end
+    )
   end
 
   @impl Runner

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -131,31 +131,6 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         }
       )
     end)
-    |> Multi.run(
-      :internal_transaction_transaction_block_number,
-      fn repo, %{blocks: blocks} ->
-        blocks_hashes = Enum.map(blocks, & &1.hash)
-
-        query =
-          from(
-            internal_transaction in InternalTransaction,
-            join: transaction in Transaction,
-            on: internal_transaction.transaction_hash == transaction.hash,
-            join: block in Block,
-            on: block.hash == transaction.block_hash,
-            where: block.hash in ^blocks_hashes,
-            update: [
-              set: [
-                block_number: block.number
-              ]
-            ]
-          )
-
-        {total, _} = repo.update_all(query, [])
-
-        {:ok, total}
-      end
-    )
   end
 
   @impl Runner

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -368,8 +368,15 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
        ) do
     with {:ok, deleted_token_transfers} <-
            remove_nonconsensus_token_transfers(repo, nonconsensus_block_numbers, insert_options),
-         {:ok, deleted_logs} <- remove_nonconsensus_logs(repo, nonconsensus_block_numbers, insert_options) do
-      {:ok, %{token_transfers: deleted_token_transfers, logs: deleted_logs}}
+         {:ok, deleted_logs} <- remove_nonconsensus_logs(repo, nonconsensus_block_numbers, insert_options),
+         {:ok, deleted_internal_transactions} <-
+           remove_nonconsensus_internal_transactions(repo, nonconsensus_block_numbers, insert_options) do
+      {:ok,
+       %{
+         token_transfers: deleted_token_transfers,
+         logs: deleted_logs,
+         internal_transactions: deleted_internal_transactions
+       }}
     end
   end
 
@@ -400,6 +407,46 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
       {_count, deleted_token_transfers} = repo.delete_all(query, timeout: timeout)
 
       {:ok, deleted_token_transfers}
+    rescue
+      postgrex_error in Postgrex.Error ->
+        {:error, %{exception: postgrex_error, block_numbers: nonconsensus_block_numbers}}
+    end
+  end
+
+  defp remove_nonconsensus_internal_transactions(repo, nonconsensus_block_numbers, %{timeout: timeout}) do
+    transaction_query =
+      from(transaction in Transaction,
+        where: transaction.block_number in ^nonconsensus_block_numbers,
+        select: map(transaction, [:hash]),
+        order_by: transaction.hash
+      )
+
+    ordered_internal_transactions =
+      from(internal_transaction in InternalTransaction,
+        inner_join: transaction in subquery(transaction_query),
+        on: internal_transaction.transaction_hash == transaction.hash,
+        select: map(internal_transaction, [:transaction_hash, :index]),
+        # Enforce Log ShareLocks order (see docs: sharelocks.md)
+        order_by: [
+          internal_transaction.transaction_hash,
+          internal_transaction.index
+        ],
+        lock: "FOR UPDATE OF i0"
+      )
+
+    query =
+      from(internal_transaction in InternalTransaction,
+        select: map(internal_transaction, [:transaction_hash, :index]),
+        inner_join: ordered_internal_transaction in subquery(ordered_internal_transactions),
+        on:
+          ordered_internal_transaction.transaction_hash == internal_transaction.transaction_hash and
+            ordered_internal_transaction.index == internal_transaction.index
+      )
+
+    try do
+      {_count, deleted_internal_transactions} = repo.delete_all(query, timeout: timeout)
+
+      {:ok, deleted_internal_transactions}
     rescue
       postgrex_error in Postgrex.Error ->
         {:error, %{exception: postgrex_error, block_numbers: nonconsensus_block_numbers}}

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -426,7 +426,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         inner_join: transaction in subquery(transaction_query),
         on: internal_transaction.transaction_hash == transaction.hash,
         select: map(internal_transaction, [:transaction_hash, :index]),
-        # Enforce Log ShareLocks order (see docs: sharelocks.md)
+        # Enforce InternalTransaction ShareLocks order (see docs: sharelocks.md)
         order_by: [
           internal_transaction.transaction_hash,
           internal_transaction.index

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -7,7 +7,7 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
   alias Ecto.Multi
   alias Explorer.Chain.Import.Runner.{Blocks, Transactions}
-  alias Explorer.Chain.{Address, Block, Log, Transaction, TokenTransfer}
+  alias Explorer.Chain.{Address, Block, InternalTransaction, Log, Transaction, TokenTransfer}
   alias Explorer.Chain
   alias Explorer.Repo
 
@@ -175,6 +175,30 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
               }} = run_block_consensus_change(block, true, options)
 
       assert count(Log) == 0
+    end
+
+    test "remove_nonconsensus_date deletes nonconsensus internal transactions", %{
+      consensus_block: %{number: block_number} = block,
+      options: options
+    } do
+      old_block = insert(:block, number: block_number, consensus: true)
+      forked_transaction = :transaction |> insert() |> with_block(old_block)
+
+      %InternalTransaction{index: index, transaction_hash: hash} =
+        insert(:internal_transaction, index: 0, transaction: forked_transaction)
+
+      assert count(InternalTransaction) == 1
+
+      assert {:ok,
+              %{
+                remove_nonconsensus_data: %{
+                  internal_transactions: [
+                    %{transaction_hash: ^hash, index: ^index}
+                  ]
+                }
+              }} = run_block_consensus_change(block, true, options)
+
+      assert count(InternalTransaction) == 0
     end
 
     test "derive_address_current_token_balances inserts rows if there is an address_token_balance left for the rows deleted by delete_address_current_token_balances",

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -177,7 +177,7 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
       assert count(Log) == 0
     end
 
-    test "remove_nonconsensus_date deletes nonconsensus internal transactions", %{
+    test "remove_nonconsensus_data deletes nonconsensus internal transactions", %{
       consensus_block: %{number: block_number} = block,
       options: options
     } do


### PR DESCRIPTION
## Motivation

Transactions have duplicate internal transactions. The issue is caused by chain reorganisations.

## Changelog

- remove non consensus internal transactions