### PR TITLE
do not update fetched_coin_balance with nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#2663](https://github.com/poanetwork/blockscout/pull/2663) - Fetch address counters in parallel
 
 ### Fixes
+- [#2696](https://github.com/poanetwork/blockscout/pull/2696) - do not update fetched_coin_balance with nil
 - [#2687](https://github.com/poanetwork/blockscout/pull/2687) - remove non-consensus token transfers, logs when inserting new consensus blocks
 - [#2684](https://github.com/poanetwork/blockscout/pull/2684) - do not filter pending logs
 - [#2682](https://github.com/poanetwork/blockscout/pull/2682) - Use Task.start instead of Task.async in caches

--- a/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
@@ -104,13 +104,15 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
           fetched_coin_balance:
             fragment(
               """
-              CASE WHEN EXCLUDED.fetched_coin_balance_block_number IS NOT NULL AND
-                        (? IS NULL OR
+              CASE WHEN EXCLUDED.fetched_coin_balance_block_number IS NOT NULL
+                    AND EXCLUDED.fetched_coin_balance IS NOT NULL AND
+                        (? IS NULL OR ? IS NULL OR
                          EXCLUDED.fetched_coin_balance_block_number >= ?) THEN
                           EXCLUDED.fetched_coin_balance
                    ELSE ?
               END
               """,
+              address.fetched_coin_balance,
               address.fetched_coin_balance_block_number,
               address.fetched_coin_balance_block_number,
               address.fetched_coin_balance

--- a/apps/explorer/test/explorer/chain/import/runner/addresses_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/addresses_test.exs
@@ -1,0 +1,69 @@
+defmodule Explorer.Chain.Import.Runner.AddressesTest do
+  use Explorer.DataCase
+
+  alias Ecto.Multi
+  alias Explorer.Chain.{Address, Wei}
+  alias Explorer.Chain.Import.Runner.Addresses
+  alias Explorer.Repo
+
+  describe "run/1" do
+    test "does not update fetched_coin_balance if original value is not nil but new value is nil" do
+      block_number = 5
+      original_address = insert(:address, fetched_coin_balance: 5, fetched_coin_balance_block_number: block_number)
+
+      new_params = %{
+        fetched_coin_balance: nil,
+        fetched_coin_balance_block_number: block_number,
+        hash: to_string(original_address.hash)
+      }
+
+      changeset = Address.balance_changeset(%Address{}, new_params)
+
+      wei = original_address.fetched_coin_balance
+
+      assert {:ok,
+              %{
+                addresses: [
+                  %Address{
+                    fetched_coin_balance: ^wei,
+                    fetched_coin_balance_block_number: 5
+                  }
+                ]
+              }} = run([changeset.changes])
+    end
+
+    test "updates fetched_coin_balance if original value is nil and new value is not nil" do
+      block_number = 5
+      original_address = insert(:address, fetched_coin_balance: nil, fetched_coin_balance_block_number: block_number)
+
+      new_params = %{
+        fetched_coin_balance: 5,
+        fetched_coin_balance_block_number: block_number,
+        hash: to_string(original_address.hash)
+      }
+
+      changeset = Address.balance_changeset(%Address{}, new_params)
+
+      wei = %Wei{value: Decimal.new(new_params.fetched_coin_balance)}
+
+      assert {:ok,
+              %{
+                addresses: [
+                  %Address{
+                    fetched_coin_balance: ^wei,
+                    fetched_coin_balance_block_number: 5
+                  }
+                ]
+              }} = run([changeset.changes])
+    end
+  end
+
+  defp run(changes) do
+    timestamp = DateTime.utc_now()
+    options = %{timestamps: %{inserted_at: timestamp, updated_at: timestamp}}
+
+    Multi.new()
+    |> Addresses.run(changes, options)
+    |> Repo.transaction()
+  end
+end

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -7,9 +7,8 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
   alias Ecto.Multi
   alias Explorer.Chain.Import.Runner.{Blocks, Transactions}
-  alias Explorer.Chain.{Address, Block, Log, Transaction, TokenTransfer}
-  alias Explorer.Chain
-  alias Explorer.Repo
+  alias Explorer.Chain.{Address, Block, Log, TokenTransfer, Transaction}
+  alias Explorer.{Chain, Repo}
 
   describe "run/1" do
     setup do


### PR DESCRIPTION
Currently, we update `fetched_coin_balance` field of an address
to nil, if changes have `fetched_coin_balance_block_number` bigger than
the current value in the DB.

https://github.com/poanetwork/blockscout/issues/2685


## Changelog

- do not update fetched_coin_balance with nil