### PR TITLE
Add temporary indexer to trigger refetching of blocks where internal transactions number doesn't match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#2697](https://github.com/poanetwork/blockscout/pull/2697) - Add temporary indexer to trigger refetching of blocks where internal transactions number doesn't match
 - [#2733](https://github.com/poanetwork/blockscout/pull/2733) - Add cache for first page of uncles
 - [#2735](https://github.com/poanetwork/blockscout/pull/2735) - Add pending transactions cache
 - [#2726](https://github.com/poanetwork/blockscout/pull/2726) - Remove internal_transaction block_number setting from blocks runner

--- a/apps/explorer/priv/repo/migrations/20190919183121_add_table_to_track_wrong_int_txs_collation.exs
+++ b/apps/explorer/priv/repo/migrations/20190919183121_add_table_to_track_wrong_int_txs_collation.exs
@@ -1,0 +1,25 @@
+defmodule Explorer.Repo.Migrations.AddTableToTrackWrongIntTxsCollation do
+  @moduledoc """
+  IMPORTANT: if the table `blocks_to_invalidate_wrong_int_txs_collation` does not
+  exists when this migration is run all the existing block numbers will be refetched.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    create_if_not_exists table(:blocks_to_invalidate_wrong_int_txs_collation, primary_key: false) do
+      add(:block_number, :bigint)
+      add(:refetched, :boolean)
+    end
+
+    execute("""
+    INSERT INTO blocks_to_invalidate_wrong_int_txs_collation
+    SELECT DISTINCT number FROM blocks
+    WHERE NOT EXISTS (SELECT * FROM blocks_to_invalidate_wrong_int_txs_collation);
+    """)
+  end
+
+  def down do
+    drop_if_exists(table(:blocks_to_invalidate_wrong_int_txs_collation))
+  end
+end

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -17,7 +17,8 @@ defmodule Indexer.Block.Catchup.Fetcher do
       async_import_tokens: 1,
       async_import_token_balances: 1,
       async_import_uncles: 1,
-      fetch_and_import_range: 2
+      fetch_and_import_range: 2,
+      numbers_to_ranges: 1
     ]
 
   alias Ecto.Changeset
@@ -285,27 +286,6 @@ defmodule Indexer.Block.Catchup.Fetcher do
   end
 
   defp block_error_to_number(%{data: %{number: number}}) when is_integer(number), do: number
-
-  defp numbers_to_ranges([]), do: []
-
-  defp numbers_to_ranges(numbers) when is_list(numbers) do
-    numbers
-    |> Enum.sort()
-    |> Enum.chunk_while(
-      nil,
-      fn
-        number, nil ->
-          {:cont, number..number}
-
-        number, first..last when number == last + 1 ->
-          {:cont, first..number}
-
-        number, range ->
-          {:cont, range, number..number}
-      end,
-      fn range -> {:cont, range} end
-    )
-  end
 
   defp put_memory_monitor(sequence_options, %__MODULE__{memory_monitor: nil}) when is_list(sequence_options),
     do: sequence_options

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -26,6 +26,7 @@ defmodule Indexer.Supervisor do
 
   alias Indexer.Temporary.{
     BlocksTransactionsMismatch,
+    InternalTransactionsBlockNumber,
     UncatalogedTokenTransfers,
     UnclesWithoutIndex
   }
@@ -130,6 +131,8 @@ defmodule Indexer.Supervisor do
         {UnclesWithoutIndex.Supervisor,
          [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
         {BlocksTransactionsMismatch.Supervisor,
+         [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+        {InternalTransactionsBlockNumber.Supervisor,
          [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]}
       ],
       strategy: :one_for_one

--- a/apps/indexer/lib/indexer/temporary/internal_transactions_block_number.ex
+++ b/apps/indexer/lib/indexer/temporary/internal_transactions_block_number.ex
@@ -1,0 +1,184 @@
+defmodule Indexer.Temporary.InternalTransactionsBlockNumber do
+  @moduledoc """
+  Looks for a table `blocks_to_invalidate_wrong_int_txs_collation` specifing
+  the `number` of blocks that need to be refetched, removes their consensus and
+  refetches and imports them.
+  """
+
+  use Indexer.Fetcher
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL
+  alias Ecto.Multi
+  alias Explorer.Chain.Block
+  alias Explorer.Repo
+  alias Indexer.Block.Fetcher, as: BlockFetcher
+  alias Indexer.BufferedTask
+  alias Indexer.Temporary.InternalTransactionsBlockNumber
+
+  @behaviour BufferedTask
+
+  @defaults [
+    flush_interval: :timer.seconds(3),
+    max_batch_size: 50,
+    max_concurrency: 2,
+    task_supervisor: Indexer.Temporary.InternalTransactionsBlockNumber.TaskSupervisor,
+    metadata: [fetcher: :internal_transactions_block_number]
+  ]
+
+  @doc false
+  # credo:disable-for-next-line Credo.Check.Design.DuplicatedCode
+  def child_spec([init_options, gen_server_options]) when is_list(init_options) do
+    {json_rpc_named_arguments, mergeable_init_options} = Keyword.pop(init_options, :json_rpc_named_arguments)
+
+    unless json_rpc_named_arguments do
+      raise ArgumentError,
+            ":json_rpc_named_arguments must be provided to `#{__MODULE__}.child_spec " <>
+              "to allow for json_rpc calls when running."
+    end
+
+    block_fetcher = %BlockFetcher{
+      # for simplicity use the `import` function of catchup fetcher
+      callback_module: Indexer.Block.Catchup.Fetcher,
+      json_rpc_named_arguments: json_rpc_named_arguments
+    }
+
+    merged_init_options =
+      @defaults
+      |> Keyword.merge(mergeable_init_options)
+      |> Keyword.put(:state, block_fetcher)
+
+    Supervisor.child_spec({BufferedTask, [{__MODULE__, merged_init_options}, gen_server_options]}, id: __MODULE__)
+  end
+
+  @impl BufferedTask
+  def init(initial, reducer, _) do
+    query =
+      from(
+        s in InternalTransactionsBlockNumber.Schema,
+        where: is_nil(s.refetched) or not s.refetched,
+        where: not is_nil(s.block_number),
+        # goes from latest to newest
+        order_by: [desc: s.block_number],
+        select: s.block_number
+      )
+
+    {:ok, final} = Repo.stream_reduce(query, initial, &reducer.(&1, &2))
+
+    drop_table_when_finished(query)
+
+    final
+  rescue
+    postgrex_error in Postgrex.Error ->
+      # if the table does not exist it just does no work
+      case postgrex_error do
+        %{postgres: %{code: :undefined_table}} -> {0, []}
+        _ -> raise postgrex_error
+      end
+  end
+
+  # sobelow_skip ["SQL.Query"]
+  defp drop_table_when_finished(query) do
+    unless Repo.exists?(query) do
+      SQL.query!(Repo, "DROP TABLE blocks_to_invalidate_wrong_int_txs_collation", [])
+    end
+  end
+
+  def clean_affected_data(block_numbers) do
+    # Enforce ShareLocks tables order (see docs: sharelocks.md)
+    multi =
+      Multi.new()
+      |> Multi.run(:remove_block_consensus, fn repo, _ ->
+        query =
+          from(
+            block in Block,
+            where: block.number in ^block_numbers,
+            # Enforce Block ShareLocks order (see docs: sharelocks.md)
+            order_by: [asc: block.hash],
+            lock: "FOR UPDATE"
+          )
+
+        {_num, result} =
+          repo.update_all(
+            from(b in Block, join: s in subquery(query), on: b.hash == s.hash),
+            set: [consensus: false]
+          )
+
+        {:ok, result}
+      end)
+      |> Multi.run(:update_schema_entries, fn repo, _ ->
+        query =
+          from(
+            s in InternalTransactionsBlockNumber.Schema,
+            where: s.block_number in ^block_numbers,
+            order_by: [desc: s.block_number],
+            lock: "FOR UPDATE"
+          )
+
+        {num, _res} =
+          repo.update_all(
+            from(dtt in InternalTransactionsBlockNumber.Schema,
+              join: s in subquery(query),
+              on: dtt.block_number == s.block_number
+            ),
+            set: [refetched: true]
+          )
+
+        {:ok, num}
+      end)
+
+    Repo.transaction(multi, timeout: :infinity)
+  end
+
+  @impl BufferedTask
+  def run(block_numbers, block_fetcher) do
+    block_numbers
+    |> clean_affected_data()
+    |> case do
+      {:ok, _res} ->
+        BlockFetcher.refetch_and_import_blocks(block_numbers, block_fetcher)
+
+      {:error, error} ->
+        Logger.error(fn ->
+          ["Error while handling internal_transactions with wrong block number: ", inspect(error)]
+        end)
+
+        {:retry, block_numbers}
+    end
+  rescue
+    postgrex_error in Postgrex.Error ->
+      Logger.error(fn ->
+        ["Error while handling internal_transactions with wrong block number: ", inspect(postgrex_error)]
+      end)
+
+      {:retry, block_numbers}
+  end
+
+  defmodule Schema do
+    @moduledoc """
+    Schema for the table `blocks_to_invalidate_wrong_int_txs_collation`, used by the refetcher
+    """
+
+    use Explorer.Schema
+
+    @type t :: %__MODULE__{
+            block_number: Block.block_number(),
+            refetched: boolean() | nil
+          }
+
+    @primary_key false
+    schema "blocks_to_invalidate_wrong_int_txs_collation" do
+      field(:block_number, :integer)
+      field(:refetched, :boolean)
+    end
+
+    def changeset(%__MODULE__{} = with_wrong_int_txs, attrs) do
+      with_wrong_int_txs
+      |> cast(attrs, [:block_number, :refetched])
+      |> validate_required(:block_number)
+    end
+  end
+end

--- a/apps/indexer/test/indexer/temporary/internal_transactions_block_number_test.exs
+++ b/apps/indexer/test/indexer/temporary/internal_transactions_block_number_test.exs
@@ -1,0 +1,33 @@
+defmodule Indexer.Temporary.InternalTransactionsBlockNumberTest do
+  use Explorer.DataCase
+
+  alias Explorer.Chain.Block
+  alias Indexer.Temporary.InternalTransactionsBlockNumber
+
+  @fetcher_name :internal_transactions_block_number
+
+  describe "clean_affected_data/2" do
+    setup do
+      # we need to know that the table exists or the DB transactions will fail
+      Ecto.Adapters.SQL.query!(
+        Repo,
+        "CREATE TABLE IF NOT EXISTS blocks_to_invalidate_wrong_int_txs_collation (block_number integer, refetched boolean);"
+      )
+
+      :ok
+    end
+
+    test "removes consensus from blocks" do
+      block = insert(:block)
+      transaction = insert(:transaction) |> with_block(block)
+
+      block_number = block.number
+
+      insert(:internal_transaction, transaction: transaction, block_number: block_number + 1, index: 0)
+
+      InternalTransactionsBlockNumber.clean_affected_data([block_number])
+
+      assert %{consensus: false} = from(b in Block, where: b.number == ^block_number) |> Repo.one()
+    end
+  end
+end


### PR DESCRIPTION
Closes: #2694 

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
  - [x] If I added/changed/removed ENV var, I should update the list of env vars in https://github.com/poanetwork/blockscout/blob/master/docs/env-variables.md to reflect changes in the table here https://poanetwork.github.io/blockscout/#/env-variables?id=blockscout-env-variables. I've set `master` in the `Version` column.
  - [x] If I add new indices into DB, I checked, that they don't redundant with PGHero or other tools
