### PR TITLE
Add temporary indexer to trigger refetching of blocks with missing token transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#2699](https://github.com/poanetwork/blockscout/pull/2699) - Add temporary indexer to trigger refetching of blocks with missing token transfers
 - [#2733](https://github.com/poanetwork/blockscout/pull/2733) - Add cache for first page of uncles
 - [#2735](https://github.com/poanetwork/blockscout/pull/2735) - Add pending transactions cache
 - [#2726](https://github.com/poanetwork/blockscout/pull/2726) - Remove internal_transaction block_number setting from blocks runner

--- a/apps/explorer/priv/repo/migrations/20190919171316_find_blocks_with_missing_tokens.exs
+++ b/apps/explorer/priv/repo/migrations/20190919171316_find_blocks_with_missing_tokens.exs
@@ -1,0 +1,32 @@
+defmodule Explorer.Repo.Migrations.FindBlocksWithMissingTokens do
+  @moduledoc """
+  Use `priv/repo/migrations/scripts/20190919171316_find_blocks_with_missing_tokens.sql`
+  to find all the block number with missing tokens *before* running this migration.
+
+  ```sh
+  mix ecto.migrate
+  psql -d $DATABASE -a -f priv/repo/migrations/scripts/20181108205650_additional_internal_transaction_constraints.sql
+  ```
+
+  NOTE: if the script above is not run, all the existing numbers will be refetched.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    create_if_not_exists table(:blocks_to_invalidate_missing_tt, primary_key: false) do
+      add(:block_number, :bigint)
+      add(:refetched, :boolean)
+    end
+
+    execute("""
+    INSERT INTO blocks_to_invalidate_missing_tt
+    SELECT DISTINCT number FROM blocks
+    WHERE NOT EXISTS (SELECT * FROM blocks_to_invalidate_missing_tt);
+    """)
+  end
+
+  def down do
+    drop_if_exists(table(:blocks_to_invalidate_missing_tt))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/scripts/20190919171316_find_blocks_with_missing_tokens.sql
+++ b/apps/explorer/priv/repo/migrations/scripts/20190919171316_find_blocks_with_missing_tokens.sql
@@ -1,0 +1,85 @@
+-- This script finds all the block numbers with missing token transfers in a given
+-- range and puts them into a table (blocks_to_invalidate_missing_tt)
+-- To check the progress it is advised to run this in a `tmux` session or save
+-- the output to a file.
+
+DO $$
+DECLARE
+  batch_size  integer := 1000; -- HOW MANY ITEMS WILL BE UPDATED AT A TIME
+  max_number_to_check bigint; -- WILL CHECK ONLY TRANSACTIONS FOLLOWING THIS HASH (DESC)
+  min_number_to_check bigint; -- WILL CHECK ONLY TRANSACTIONS FOLLOWING THIS HASH (DESC)
+  min_batch_number bigint;
+BEGIN
+  RAISE NOTICE 'STARTING SCRIPT';
+  CREATE TABLE IF NOT EXISTS blocks_to_invalidate_missing_tt(block_number bigint, refetched boolean);
+
+  -- IF max_number_to_check IS NOT SET IT WILL RESUME FROM THE LAST RUN
+  IF max_number_to_check IS NULL THEN
+    SELECT INTO max_number_to_check block_number
+    FROM blocks_to_invalidate_missing_tt
+    ORDER BY block_number ASC LIMIT 1;
+  END IF;
+
+  -- IF THERE WAS NO LAST RUN AND max_number_to_check IS NOT SET THEN IT WILL BE THE HIGHEST block number
+  IF max_number_to_check IS NULL THEN
+    SELECT INTO max_number_to_check number
+    FROM blocks
+    ORDER BY number DESC LIMIT 1;
+  END IF;
+
+  -- IF min_number_to_check IS NOT SET IT IS SET TO BE 0
+  IF min_number_to_check IS NULL THEN
+    SELECT INTO min_number_to_check 0;
+  END IF;
+
+  RAISE NOTICE 'Starting first batch from % (DESC)', max_number_to_check;
+
+  LOOP
+    RAISE NOTICE 'Checking new batch of % block numbers', batch_size;
+
+    -- UPDATE min_batch_number
+    SELECT INTO min_batch_number GREATEST(max_number_to_check - batch_size + 1, min_number_to_check);
+
+    INSERT INTO blocks_to_invalidate_missing_tt
+    SELECT * FROM generate_series(max_number_to_check, min_batch_number, -1) AS s (block_number)
+    WHERE EXISTS(
+      SELECT 1 FROM transactions t
+      WHERE t.block_number = s.block_number
+      AND NOT EXISTS (
+        SELECT 1 FROM token_transfers tt
+        WHERE tt.transaction_hash = t.hash
+        )
+      AND (
+        EXISTS (
+          SELECT 1 FROM internal_transactions i
+          WHERE i.transaction_hash = t.hash
+          AND encode(i.input::bytea, 'hex') LIKE 'a9059%'
+          AND i.error IS NULL
+          )
+        OR EXISTS (
+          SELECT 1 FROM logs l
+          WHERE l.transaction_hash = t.hash
+          AND l.first_topic LIKE '0xddf252ad%'
+          AND (
+            (l.second_topic IS NOT NULL AND l.third_topic IS NOT NULL)
+            OR
+            (l.second_topic IS NULL AND l.third_topic IS NULL)
+            )
+          )
+        )
+      )
+    ;
+
+    -- COMMIT THE BATCH
+    CHECKPOINT;
+    RAISE NOTICE 'Last batch completed, last block number checked: %', min_batch_number;
+
+    -- EXIT IF ALL blocks HAVE BEEN CHECKED ALREADY
+    EXIT WHEN min_batch_number = min_number_to_check;
+
+    -- UPDATE max_number_to_check TO START THE NEXT BATCH
+    SELECT INTO max_number_to_check (min_batch_number - 1);
+  END LOOP;
+
+  RAISE NOTICE 'SCRIPT FINISHED, all affected block numbers have been inseted into table: blocks_to_invalidate_missing_tt';
+END $$;

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -17,7 +17,8 @@ defmodule Indexer.Block.Catchup.Fetcher do
       async_import_tokens: 1,
       async_import_token_balances: 1,
       async_import_uncles: 1,
-      fetch_and_import_range: 2
+      fetch_and_import_range: 2,
+      numbers_to_ranges: 1
     ]
 
   alias Ecto.Changeset
@@ -285,27 +286,6 @@ defmodule Indexer.Block.Catchup.Fetcher do
   end
 
   defp block_error_to_number(%{data: %{number: number}}) when is_integer(number), do: number
-
-  defp numbers_to_ranges([]), do: []
-
-  defp numbers_to_ranges(numbers) when is_list(numbers) do
-    numbers
-    |> Enum.sort()
-    |> Enum.chunk_while(
-      nil,
-      fn
-        number, nil ->
-          {:cont, number..number}
-
-        number, first..last when number == last + 1 ->
-          {:cont, first..number}
-
-        number, range ->
-          {:cont, range, number..number}
-      end,
-      fn range -> {:cont, range} end
-    )
-  end
 
   defp put_memory_monitor(sequence_options, %__MODULE__{memory_monitor: nil}) when is_list(sequence_options),
     do: sequence_options

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -26,6 +26,7 @@ defmodule Indexer.Supervisor do
 
   alias Indexer.Temporary.{
     BlocksTransactionsMismatch,
+    MissingTokenTransfers,
     UncatalogedTokenTransfers,
     UnclesWithoutIndex
   }
@@ -130,6 +131,8 @@ defmodule Indexer.Supervisor do
         {UnclesWithoutIndex.Supervisor,
          [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
         {BlocksTransactionsMismatch.Supervisor,
+         [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+        {MissingTokenTransfers.Supervisor,
          [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]}
       ],
       strategy: :one_for_one

--- a/apps/indexer/lib/indexer/temporary/missing_token_transfers.ex
+++ b/apps/indexer/lib/indexer/temporary/missing_token_transfers.ex
@@ -1,0 +1,232 @@
+defmodule Indexer.Temporary.MissingTokenTransfers do
+  @moduledoc """
+  Looks for a table `blocks_to_invalidate_missing_tt` specifing the number of
+  blocks that need to be refetched. For each of them:
+  - removes consensus from the block
+  - deletes logs and token transfers of its transactions
+  - refetches and imports the block
+  """
+
+  use Indexer.Fetcher
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL
+  alias Ecto.Multi
+  alias Explorer.Repo
+  alias Explorer.Chain.{Block, Hash, Log, TokenTransfer, Transaction}
+  alias Indexer.Block.Fetcher, as: BlockFetcher
+  alias Indexer.BufferedTask
+  alias Indexer.Temporary.MissingTokenTransfers
+
+  @behaviour BufferedTask
+
+  @defaults [
+    flush_interval: :timer.seconds(3),
+    max_batch_size: 10,
+    max_concurrency: 5,
+    task_supervisor: Indexer.Temporary.MissingTokenTransfers.TaskSupervisor,
+    metadata: [fetcher: :missing_token_transfers]
+  ]
+
+  @doc false
+  # credo:disable-for-next-line Credo.Check.Design.DuplicatedCode
+  def child_spec([init_options, gen_server_options]) when is_list(init_options) do
+    {json_rpc_named_arguments, mergeable_init_options} = Keyword.pop(init_options, :json_rpc_named_arguments)
+
+    unless json_rpc_named_arguments do
+      raise ArgumentError,
+            ":json_rpc_named_arguments must be provided to `#{__MODULE__}.child_spec " <>
+              "to allow for json_rpc calls when running."
+    end
+
+    block_fetcher = %BlockFetcher{
+      broadcast: false,
+      # for simplicity use the `import` function of catchup fetcher
+      callback_module: Indexer.Block.Catchup.Fetcher,
+      json_rpc_named_arguments: json_rpc_named_arguments
+    }
+
+    merged_init_options =
+      @defaults
+      |> Keyword.merge(mergeable_init_options)
+      |> Keyword.put(:state, block_fetcher)
+
+    Supervisor.child_spec({BufferedTask, [{__MODULE__, merged_init_options}, gen_server_options]}, id: __MODULE__)
+  end
+
+  @impl BufferedTask
+  def init(initial, reducer, _) do
+    query =
+      from(
+        s in MissingTokenTransfers.Schema,
+        where: is_nil(s.refetched) or not s.refetched,
+        where: not is_nil(s.block_number),
+        # goes from latest to newest
+        order_by: [desc: s.block_number],
+        select: s.block_number
+      )
+
+    {:ok, final} = Repo.stream_reduce(query, initial, &reducer.(&1, &2))
+
+    drop_table_when_finished(query)
+
+    final
+  rescue
+    postgrex_error in Postgrex.Error ->
+      # if the table does not exist it just does no work
+      case postgrex_error do
+        %{postgres: %{code: :undefined_table}} -> {0, []}
+        _ -> raise postgrex_error
+      end
+  end
+
+  # sobelow_skip ["SQL.Query"]
+  defp drop_table_when_finished(query) do
+    unless Repo.exists?(query) do
+      SQL.query!(Repo, "DROP TABLE blocks_to_invalidate_missing_tt", [])
+    end
+  end
+
+  def clean_affected_data(block_numbers) do
+    # Enforce ShareLocks tables order (see docs: sharelocks.md)
+    multi =
+      Multi.new()
+      |> Multi.run(:transaction_hashes, fn repo, _ ->
+        query =
+          from(
+            t in Transaction,
+            where: t.block_number in ^block_numbers,
+            select: t.hash
+          )
+
+        hashes =
+          query
+          |> repo.all()
+          |> Enum.map(fn h ->
+            {:ok, hash_bytes} = Hash.Full.dump(h)
+            hash_bytes
+          end)
+
+        {:ok, hashes}
+      end)
+      |> Multi.run(:remove_blocks_consensus, fn repo, _ ->
+        query =
+          from(
+            block in Block,
+            where: block.number in ^block_numbers,
+            # Enforce Block ShareLocks order (see docs: sharelocks.md)
+            order_by: [asc: block.hash],
+            lock: "FOR UPDATE"
+          )
+
+        {_num, result} =
+          repo.update_all(
+            from(b in Block, join: s in subquery(query), on: b.hash == s.hash),
+            set: [consensus: false]
+          )
+
+        {:ok, result}
+      end)
+      |> Multi.run(:remove_logs, fn repo, %{transaction_hashes: hashes} ->
+        query =
+          from(
+            log in Log,
+            join: t in fragment("(SELECT unnest(?::bytea[]) as hash)", ^hashes),
+            on: t.hash == log.transaction_hash,
+            # Enforce Log ShareLocks order (see docs: sharelocks.md)
+            order_by: [asc: log.transaction_hash, asc: log.index],
+            lock: "FOR UPDATE OF l0"
+          )
+
+        {_num, result} =
+          repo.delete_all(from(l in Log, join: s in subquery(query), on: l.transaction_hash == s.transaction_hash))
+
+        {:ok, result}
+      end)
+      |> Multi.run(:remove_token_transfers, fn repo, %{transaction_hashes: hashes} ->
+        query =
+          from(
+            transfer in TokenTransfer,
+            join: t in fragment("(SELECT unnest(?::bytea[]) as hash)", ^hashes),
+            on: t.hash == transfer.transaction_hash,
+            # Enforce TokenTransfer ShareLocks order (see docs: sharelocks.md)
+            order_by: [asc: transfer.transaction_hash, asc: transfer.log_index],
+            lock: "FOR UPDATE OF t0"
+          )
+
+        {_num, result} =
+          repo.delete_all(
+            from(tt in TokenTransfer, join: s in subquery(query), on: tt.transaction_hash == s.transaction_hash)
+          )
+
+        {:ok, result}
+      end)
+      |> Multi.run(:update_schema_entries, fn repo, _ ->
+        query =
+          from(
+            s in MissingTokenTransfers.Schema,
+            where: s.block_number in ^block_numbers,
+            order_by: [desc: s.block_number],
+            lock: "FOR UPDATE"
+          )
+
+        {num, _res} =
+          repo.update_all(
+            from(dtt in MissingTokenTransfers.Schema, join: s in subquery(query), on: dtt.block_number == s.block_number),
+            set: [refetched: true]
+          )
+
+        {:ok, num}
+      end)
+
+    Repo.transaction(multi, timeout: :infinity)
+  end
+
+  @impl BufferedTask
+  def run(block_numbers, block_fetcher) do
+    block_numbers
+    |> clean_affected_data()
+    |> case do
+      {:ok, _res} ->
+        BlockFetcher.refetch_and_import_blocks(block_numbers, block_fetcher)
+
+      {:error, error} ->
+        Logger.error(fn -> ["Error while handling missing token transfers: ", inspect(error)] end)
+        {:retry, block_numbers}
+    end
+  rescue
+    postgrex_error in Postgrex.Error ->
+      Logger.error(fn -> ["Error while handling missing token transfers: ", inspect(postgrex_error)] end)
+      {:retry, block_numbers}
+  end
+
+  defmodule Schema do
+    @moduledoc """
+    Schema for the table `blocks_to_invalidate_missing_tt`, used by the refetcher
+    """
+
+    use Explorer.Schema
+
+    alias Explorer.Chain.Block
+
+    @type t :: %__MODULE__{
+            block_number: Block.block_number(),
+            refetched: boolean() | nil
+          }
+
+    @primary_key false
+    schema "blocks_to_invalidate_missing_tt" do
+      field(:block_number, :integer)
+      field(:refetched, :boolean)
+    end
+
+    def changeset(%__MODULE__{} = with_missing_tt, attrs) do
+      with_missing_tt
+      |> cast(attrs, [:block_number, :refetched])
+      |> validate_required(:block_number)
+    end
+  end
+end

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -717,6 +717,18 @@ defmodule Indexer.Block.FetcherTest do
     end
   end
 
+  describe "numbers_to_ranges/1" do
+    test "returns an empty list when the list of number is empty" do
+      assert [] == Indexer.Block.Fetcher.numbers_to_ranges([])
+    end
+
+    test "returns one range when the numbers in the list follow each other" do
+      range = 1..15
+
+      assert [range] == Indexer.Block.Fetcher.numbers_to_ranges(Enum.to_list(range))
+    end
+  end
+
   defp wait_until(timeout, producer) do
     parent = self()
     ref = make_ref()

--- a/apps/indexer/test/indexer/temporary/missing_token_transfers_test.exs
+++ b/apps/indexer/test/indexer/temporary/missing_token_transfers_test.exs
@@ -1,0 +1,68 @@
+defmodule Indexer.Temporary.MissingTokenTransfersTest do
+  use Explorer.DataCase
+
+  alias Explorer.Chain.{Block, Log, TokenTransfer}
+  alias Indexer.Temporary.MissingTokenTransfers
+
+  describe "clean_affected_data/2" do
+    setup do
+      # we need to know that the table exists or the DB transactions will fail
+      Ecto.Adapters.SQL.query!(
+        Repo,
+        "CREATE TABLE IF NOT EXISTS blocks_to_invalidate_missing_tt (block_number integer, refetched boolean);"
+      )
+
+      :ok
+    end
+
+    test "removes consensus from blocks" do
+      block = insert(:block)
+      block_number = block.number
+
+      MissingTokenTransfers.clean_affected_data([block_number])
+
+      assert %{consensus: false} = from(b in Block, where: b.number == ^block_number) |> Repo.one()
+    end
+
+    test "deletes logs from transactions of blocks" do
+      block = insert(:block)
+      transaction = insert(:transaction) |> with_block(block)
+      insert(:token_transfer, transaction: transaction)
+      insert(:token_transfer, transaction: transaction)
+
+      insert(:log, transaction: transaction)
+      insert(:log, transaction: transaction)
+
+      assert 2 =
+               from(l in Log, where: l.transaction_hash == ^transaction.hash)
+               |> Repo.aggregate(:count, :transaction_hash)
+
+      block_number = block.number
+
+      MissingTokenTransfers.clean_affected_data([block_number])
+
+      assert 0 =
+               from(l in Log, where: l.transaction_hash == ^transaction.hash)
+               |> Repo.aggregate(:count, :transaction_hash)
+    end
+
+    test "deletes token_transfers from transactions of blocks" do
+      block = insert(:block)
+      transaction = insert(:transaction) |> with_block(block)
+      insert(:token_transfer, transaction: transaction)
+      insert(:token_transfer, transaction: transaction)
+
+      assert 2 =
+               from(t in TokenTransfer, where: t.transaction_hash == ^transaction.hash)
+               |> Repo.aggregate(:count, :transaction_hash)
+
+      block_number = block.number
+
+      MissingTokenTransfers.clean_affected_data([block_number])
+
+      assert 0 =
+               from(t in TokenTransfer, where: t.transaction_hash == ^transaction.hash)
+               |> Repo.aggregate(:count, :transaction_hash)
+    end
+  end
+end


### PR DESCRIPTION
Part of #2689

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
  - [x] If I added/changed/removed ENV var, I should update the list of env vars in https://github.com/poanetwork/blockscout/blob/master/docs/env-variables.md to reflect changes in the table here https://poanetwork.github.io/blockscout/#/env-variables?id=blockscout-env-variables. I've set `master` in the `Version` column.
  - [x] If I add new indices into DB, I checked, that they don't redundant with PGHero or other tools
