### PR TITLE
Fix staking Theme colors UI issues (from #2292)

### DIFF
--- a/apps/block_scout_web/assets/css/_mixins.scss
+++ b/apps/block_scout_web/assets/css/_mixins.scss
@@ -157,6 +157,7 @@
   }
 
   path {
+    transition: $transition-cont;
     fill: $text-color;
   }
 

--- a/apps/block_scout_web/assets/css/components/_check.scss
+++ b/apps/block_scout_web/assets/css/components/_check.scss
@@ -26,6 +26,7 @@ $check-dimensions: 14px !default;
   }
 
   .check-icon {
+    top: -1px;
     border: 1px solid $base-border-color;
     flex-grow: 0;
     flex-shrink: 0;

--- a/apps/block_scout_web/assets/css/components/_form.scss
+++ b/apps/block_scout_web/assets/css/components/_form.scss
@@ -1,4 +1,5 @@
 $form-control-border-color: #e2e5ec !default;
+$form-control-border-color-active: $primary !default;
 
 .form-control {
   border-color: $form-control-border-color;
@@ -10,7 +11,7 @@ $form-control-border-color: #e2e5ec !default;
   }
 
   &:focus {
-    border-color: $secondary;
+    border-color: $form-control-border-color-active;
     box-shadow: none;
   }
 
@@ -43,6 +44,13 @@ $form-control-border-color: #e2e5ec !default;
     font-size: 14px;
   }
 }
+
+.form-control:focus ~ .input-group-prepend.last {
+  .input-group-text {
+    border-color: $form-control-border-color-active;
+  }
+}
+
 
 .input-group.input-status-error  {
   input {

--- a/apps/block_scout_web/assets/css/components/_form.scss
+++ b/apps/block_scout_web/assets/css/components/_form.scss
@@ -42,6 +42,7 @@ $form-control-border-color-active: $primary !default;
     border-left: none;
     color: #a3a9b5;
     font-size: 14px;
+    transition: $input-transition;
   }
 }
 

--- a/apps/block_scout_web/assets/css/components/_i_tooltip.scss
+++ b/apps/block_scout_web/assets/css/components/_i_tooltip.scss
@@ -1,4 +1,5 @@
 $i-tooltip-background: #a3a9b5 !default;
+$i-tooltip-info: #fff !default;
 $i-tooltip-background-active: $primary !default;
 
 .i-tooltip {
@@ -6,12 +7,16 @@ $i-tooltip-background-active: $primary !default;
   height: 16px;
   width: 16px;
 
-  path {
+  .i-tooltip-circle  {
     fill: $i-tooltip-background;
   }
 
+  .i-tooltip-info  {
+    fill: $i-tooltip-info;
+  }
+
   &:hover {
-    path {
+    .i-tooltip-circle {
       fill: $i-tooltip-background-active;
     }
   }

--- a/apps/block_scout_web/assets/css/components/_modal_status.scss
+++ b/apps/block_scout_web/assets/css/components/_modal_status.scss
@@ -76,6 +76,13 @@ $modal-status-graph-question: #329ae9 !default;
   .btn-line {
     flex-grow: 1;
     margin-right: 20px;
+    border-color: $primary;
+    color: $primary;
+
+    &:hover {
+      background-color: $primary;
+      color: $additional-font;
+    }
 
     &:last-child {
       margin-right: 0;

--- a/apps/block_scout_web/assets/css/components/_stakes_table.scss
+++ b/apps/block_scout_web/assets/css/components/_stakes_table.scss
@@ -1,5 +1,6 @@
 $stakes-table-th-background: #f5f6fa !default;
 $stakes-table-cell-separation: 25px !default;
+$stakes-link-color: $primary !default;
 
 .stakes-table-container {
   max-width: 100%;
@@ -88,6 +89,11 @@ $stakes-table-cell-separation: 25px !default;
   padding: 21px $stakes-table-cell-separation 21px 0;
   position: relative;
   z-index: 0;
+
+  .i-tooltip {
+    position: relative;
+    top: -2px;
+  }
 }
 
 .stakes-th-text {
@@ -130,7 +136,7 @@ $stakes-table-cell-separation: 25px !default;
 }
 
 .stakes-td-link-style {
-  color: $secondary;
+  color: $stakes-link-color;
   cursor: pointer;
 
   .stakes-tr-banned & {

--- a/apps/block_scout_web/assets/css/components/stakes/_modal_bottom_disclaimer.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_modal_bottom_disclaimer.scss
@@ -21,6 +21,10 @@
   .modal-bottom-disclaimer-graphic {
     flex-shrink: 0;
     padding-right: 15px;
+
+    svg {
+      fill: #333;
+    }
   }
 
   .modal-bottom-disclaimer-text {

--- a/apps/block_scout_web/assets/css/components/stakes/_modal_delegators_info.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_modal_delegators_info.scss
@@ -1,11 +1,11 @@
 .modal-delegators-info {
-  max-width: map-get($container-max-widths, "md");
-  min-width: map-get($container-max-widths, "md");
+  max-width: map-get($container-max-widths, "lg");
+  min-width: map-get($container-max-widths, "lg");
   width: 100%;
 
   .container {
-    @include media-breakpoint-down(sm) {
-      max-width: map-get($container-max-widths, "md");
+    @include media-breakpoint-down(md) {
+      max-width: map-get($container-max-widths, "lg");
     }
   }
 }

--- a/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
@@ -99,6 +99,11 @@ $stakes-stats-item-border-color: #fff !default;
     color: $stakes-address-color;
     cursor: pointer;
   }
+
+  .check-tooltip {
+		position: relative;
+		top: -1px;
+	}
 }
 
 .stakes-controls {

--- a/apps/block_scout_web/assets/css/components/stakes/_stakes_progress.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_stakes_progress.scss
@@ -1,3 +1,5 @@
+$stakes-progress-graph-color: $primary !default;
+
 .stakes-progress {
   .modal-stake-right & {
     border-left: 1px solid $base-border-color;
@@ -51,6 +53,10 @@
 .stakes-progress-graph-canvas {
   position: relative;
   z-index: 1;
+}
+
+.stakes-progress-graph-thing-for-getting-color {
+  color: $stakes-progress-graph-color;
 }
 
 .stakes-progress-data {

--- a/apps/block_scout_web/assets/css/components/stakes/_stakes_progress.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_stakes_progress.scss
@@ -39,7 +39,7 @@
 }
 
 .stakes-progress-info-link {
-  color: $secondary;
+  color: $primary;
   cursor: pointer;
 }
 

--- a/apps/block_scout_web/assets/css/theme/_dai_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_dai_variables.scss
@@ -33,6 +33,9 @@ $dashboard-banner-network-plain-container-background-color: #20446e; // stats bg
 // navigation
 .navbar { box-shadow: 0px 0px 30px 0px rgba(21, 53, 80, 0.12); } // header shadow
 
+// form
+$form-control-border-color-active: $secondary;
+
 // buttons
 $btn-line-bg: #fff; // button bg
 $btn-line-color: $secondary; // button border and font color && hover bg color
@@ -75,13 +78,7 @@ $progress-from-to-progress-background: $secondary;
 $stakes-stats-item-border-color: rgba(#fff, .5);
 $check-color: $secondary;
 $modal-status-graph-success: $secondary;
-.modal-content {
-	.form-control {
-		box-shadow: none !important;
-		outline: none !important;
-		border-color: #e2e5ec !important;
-	}
-}
+
 .stakes-table-th-content {
 	.i-tooltip {
 		position: relative;

--- a/apps/block_scout_web/assets/css/theme/_dai_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_dai_variables.scss
@@ -81,13 +81,6 @@ $modal-status-graph-success: $secondary;
 		outline: none !important;
 		border-color: #e2e5ec !important;
 	}
-	.btn-line {
-		border-color: $primary;
-		color: $primary;
-		&:hover {
-			background-color: $primary
-		}
-	}
 }
 .stakes-table-th-content {
 	.i-tooltip {

--- a/apps/block_scout_web/assets/css/theme/_dai_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_dai_variables.scss
@@ -74,23 +74,11 @@ $stakes-dashboard-copy-icon-color: $secondary;
 $btn-full-primary-bg: $secondary;
 $stakes-address-color: $secondary;
 $stakes-control-color: $secondary;
+$stakes-link-color: $secondary;
 $progress-from-to-progress-background: $secondary;
 $stakes-stats-item-border-color: rgba(#fff, .5);
 $check-color: $secondary;
 $modal-status-graph-success: $secondary;
-
-.stakes-table-th-content {
-	.i-tooltip {
-		position: relative;
-		top: -2px;
-	}
-}
-.stakes-address-container {
-	.check-tooltip {
-		position: relative;
-		top: -1px;
-	}
-}
 
 // Dark theme
 $dark-primary: #15bba6;

--- a/apps/block_scout_web/assets/css/theme/_dai_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_dai_variables.scss
@@ -79,6 +79,7 @@ $progress-from-to-progress-background: $secondary;
 $stakes-stats-item-border-color: rgba(#fff, .5);
 $check-color: $secondary;
 $modal-status-graph-success: $secondary;
+$stakes-progress-graph-color: $secondary;
 
 // Dark theme
 $dark-primary: #15bba6;

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -504,7 +504,7 @@ $labels-dark: #8a8dba; // header nav, labels
 		border-top-color: darken($labels-dark, 30);
 		border-bottom-color: darken($labels-dark, 30);
 	}
-	
+
 	// Form Controlls
 	.form-control {
 		background-color: $dark-light;
@@ -749,7 +749,17 @@ $labels-dark: #8a8dba; // header nav, labels
 			color: #fff;
 		}
 	}
-    
+
+	.modal-status .modal-status-button-wrapper .btn-line {
+		border-color: $dark-primary-alternate;
+		color: $dark-primary-alternate;
+
+		&:hover {
+			background-color: $dark-primary-alternate;
+			color: $additional-font;
+		}
+	}
+
 	// alerts
 	.alert-link {
 		color: $labels-dark;

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -830,6 +830,7 @@ $labels-dark: #8a8dba; // header nav, labels
 		}
 	}
 
+	//stakes
 	.modal-stake-right {
 		.stakes-progress {
 		  border-left-color: darken($labels-dark, 30);
@@ -842,6 +843,14 @@ $labels-dark: #8a8dba; // header nav, labels
 
 	.stakes-progress-data-progress, .stakes-progress-info-value {
 		color: #fff;
+	}
+
+	.stakes-empty-content-text {
+		color: $labels-dark;
+	}
+
+	.stakes-empty-content-pic-svg-path {
+		fill: $dark-primary;
 	}
 
 	.check-tooltip {

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -3,6 +3,7 @@ $dark-bg: #22223a; // hero shade
 $dark-light-bg: #282945; // pills bg shade
 $dark-light: #313355; // tile light top share
 $labels-dark: #8a8dba; // header nav, labels
+$dark-stakes-banned-background: #3e314c;
 
 // Switcher
 .dark-mode-changer {
@@ -298,6 +299,26 @@ $labels-dark: #8a8dba; // header nav, labels
 	.stakes-td {
 		border-bottom-color: darken($labels-dark, 30);
 	}
+
+	.stakes-tr-banned {
+		.stakes-td {
+			background-color: $dark-stakes-banned-background;
+			border-top: 1px solid $stakes-banned-color;
+			border-bottom-color: $stakes-banned-color;
+
+			.stakes-td-link-style {
+				color: $stakes-banned-color;
+			}
+		}
+
+	}
+
+	.modal-validator-alert {
+		background-color: $dark-stakes-banned-background;
+		border-top: 1px solid $stakes-banned-color;
+		border-bottom-color: $stakes-banned-color;
+	}
+
 	.table th, .table td {
 		border-top-color: darken($labels-dark, 30);
 	}

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -552,6 +552,8 @@ $dark-stakes-banned-background: #3e314c;
 		background-color: $dark-light;
 		border-color: $dark-light;
 		color: #fff;
+		transition: border-color 0.15s ease-in-out;
+
 		&::placeholder {
 			color: $labels-dark;
 		}
@@ -559,6 +561,14 @@ $dark-stakes-banned-background: #3e314c;
 			background-color: $dark-light;
 			border-color: $dark-primary;
 			color: #fff;
+		}
+
+		&:-webkit-autofill,
+		&:-webkit-autofill:hover,
+		&:-webkit-autofill:focus {
+			caret-color: #fff;
+			-webkit-text-fill-color: #fff;
+			-webkit-box-shadow: 0 0 0px 1000px $dark-light inset;
 		}
 	}
 

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -304,6 +304,18 @@ $labels-dark: #8a8dba; // header nav, labels
 		border-top-color: darken($labels-dark, 30);
 	}
 
+	.i-tooltip {
+		path {
+			fill: $labels-dark;
+		}
+
+		&:hover {
+			path {
+			  fill: $dark-primary;
+			}
+		}
+	}
+
 	// api's
 	.api-anchors-list {
 		background-color: $dark-light;
@@ -519,6 +531,21 @@ $labels-dark: #8a8dba; // header nav, labels
 			color: #fff;
 		}
 	}
+
+	.input-group:not(.input-status-error) .form-control:focus ~ .input-group-prepend.last {
+		.input-group-text {
+		  border-color: $dark-primary;
+		}
+	}
+
+	.input-group-prepend.last {
+		.input-group-text {
+			background: $dark-light;
+			border-color: $dark-light;
+			color: $labels-dark;
+		}
+	}
+
 	.radio-big .radio-icon {
 		border-color: $labels-dark;
 	}
@@ -750,13 +777,95 @@ $labels-dark: #8a8dba; // header nav, labels
 		}
 	}
 
-	.modal-status .modal-status-button-wrapper .btn-line {
-		border-color: $dark-primary-alternate;
-		color: $dark-primary-alternate;
+	.modal-status {
+		.modal-status-title {
+			color: #fff;
+		}
+
+		.modal-status-button-wrapper .btn-line {
+			border-color: $dark-primary-alternate;
+			color: $dark-primary-alternate;
+
+			&:hover {
+				background-color: $dark-primary-alternate;
+				color: $additional-font;
+			}
+		}
+	}
+
+	.modal-dialog {
+		.modal-title {
+			color: #fff;
+		}
+		.modal-content {
+			background-color: $dark-light-bg;
+		}
+
+		.modal-bottom-disclaimer {
+			background-color: $dark-light;
+
+			color: $labels-dark;
+		}
+
+		.modal-bottom-disclaimer-graphic svg {
+			fill: #fff;
+		}
+
+		.modal-header {
+			.modal-validator-info-item-title {
+				color: $labels-dark;
+			}
+
+			.modal-validator-info-item-value {
+				color: #fff;
+			}
+		}
+
+		.modal-validator-info-content {
+			background-color: $dark-light;
+
+			.modal-validator-info-item-value {
+				color: #fff;
+			}
+		}
+	}
+
+	.modal-stake-right {
+		.stakes-progress {
+		  border-left-color: darken($labels-dark, 30);
+		}
+	}
+
+	.modal-stake-middle {
+		border-left-color: darken($labels-dark, 30);
+	}
+
+	.stakes-progress-data-progress, .stakes-progress-info-value {
+		color: #fff;
+	}
+
+	.check-tooltip {
+		.check-tooltip-circle {
+			fill: $labels-dark;
+		}
+
+		.check-tooltip-check {
+			fill: $dark-light-bg;
+		}
 
 		&:hover {
-			background-color: $dark-primary-alternate;
-			color: $additional-font;
+			.check-tooltip-circle {
+			  fill: $dark-primary;
+			}
+		  }
+	}
+
+	.me-tooltip {
+		background-color: $labels-dark;
+		color: $dark-light-bg;
+
+		&:hover {
+			background-color: $dark-primary;
 		}
 	}
 
@@ -786,6 +895,14 @@ $labels-dark: #8a8dba; // header nav, labels
 			background: darken($dark-primary, 6);
 			border-color: darken($dark-primary, 6);
 			color: #fff;
+		}
+
+		&[disabled] {
+			&,
+			&:hover {
+			  background-color: $dark-primary;
+			  border-color: $dark-primary;
+			}
 		}
 	}
 }

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -294,6 +294,7 @@ $labels-dark: #8a8dba; // header nav, labels
 		background-color: $dark-light;
 		color: $labels-dark;
 	}
+
 	.stakes-td {
 		border-bottom-color: darken($labels-dark, 30);
 	}
@@ -305,13 +306,21 @@ $labels-dark: #8a8dba; // header nav, labels
 	}
 
 	.i-tooltip {
-		path {
+		.i-tooltip-circle {
 			fill: $labels-dark;
 		}
 
+		.i-tooltip-info {
+			fill: $dark-light-bg;
+		}
+
 		&:hover {
-			path {
+			.i-tooltip-circle {
 			  fill: $dark-primary;
+			}
+
+			.i-tooltip-info {
+				fill: #fff;
 			}
 		}
 	}
@@ -557,6 +566,10 @@ $labels-dark: #8a8dba; // header nav, labels
 	}
 	.radio-big .radio-text {
 		color: #fff;
+	}
+
+	.check input[type="checkbox"]:checked + .check-icon::before {
+		background: $dark-primary;
 	}
 
 	// Content loading placeholders
@@ -851,6 +864,26 @@ $labels-dark: #8a8dba; // header nav, labels
 
 	.stakes-empty-content-pic-svg-path {
 		fill: $dark-primary;
+	}
+
+	.stakes-address-container .stakes-address-active {
+		color: $dark-primary;
+	}
+
+	.stakes-td-link-style {
+		color: $dark-primary;
+	}
+
+	.stakes-control-icon path {
+		fill: $dark-primary;
+	}
+
+	.progress-from-to-value {
+		color: #fff;
+	}
+
+	.progress-from-to-background {
+		background-color: $dark-bg;
 	}
 
 	.check-tooltip {

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -102,7 +102,11 @@ if ($stakesPage.length) {
   store.dispatch({ type: 'CHANNEL_CONNECTED', channel })
 
   channel.on('staking_update', msg => {
-    $('.tooltip').hide()
+    // hide tooltip on tooltip triggering element reloading
+    // due to issues with bootstrap tooltips https://github.com/twbs/bootstrap/issues/13133
+    const stakesTopTooltipID = $('[aria-describedby]', $stakesTop).attr('aria-describedby')
+    $('#' + stakesTopTooltipID).hide()
+
     $stakesTop.html(msg.top_html)
 
     const state = store.getState()

--- a/apps/block_scout_web/assets/js/pages/stakes/utils.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/utils.js
@@ -47,7 +47,7 @@ export async function makeContractCall (call, store) {
 }
 
 export function setupChart ($canvas, self, total) {
-  const primaryColor = $('.btn-full-primary').css('background-color')
+  const primaryColor = $('.stakes-progress-graph-thing-for-getting-color').css('color')
   const backgroundColors = [
     primaryColor,
     'rgba(202, 199, 226, 0.5)'

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_i_tooltip.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_i_tooltip.html.eex
@@ -8,6 +8,7 @@
     title="<%= @text %>"
 >
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-        <path fill-rule="evenodd" d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM8 3a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm1 5a1 1 0 0 0-2 0v4a1 1 0 0 0 2 0V8z"/>
+        <path class="i-tooltip-circle" fill-rule="evenodd" d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0z"/>
+        <path class="i-tooltip-info" fill-rule="evenodd" d="M8 13a1 1 0 0 1-1-1V8a1 1 0 0 1 2 0v4a1 1 0 0 1-1 1zm0-8a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
     </svg>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_modal_bottom_disclaimer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_modal_bottom_disclaimer.html.eex
@@ -1,7 +1,7 @@
 <div class="modal-bottom-disclaimer <%= if assigns[:extra_class] do @extra_class end %>">
     <div class="modal-bottom-disclaimer-graphic">
         <svg xmlns="http://www.w3.org/2000/svg" width="10" height="16">
-            <path fill="#333" fill-rule="evenodd" d="M9 16H1a1 1 0 0 1 0-2h3V6H1a1 1 0 0 1 0-2h4a1 1 0 0 1 1 1v9h3a1 1 0 0 1 0 2zM5 2H4a1 1 0 0 1 0-2h1a1 1 0 0 1 0 2z"/>
+            <path fill-rule="evenodd" d="M9 16H1a1 1 0 0 1 0-2h3V6H1a1 1 0 0 1 0-2h4a1 1 0 0 1 1 1v9h3a1 1 0 0 1 0 2zM5 2H4a1 1 0 0 1 0-2h1a1 1 0 0 1 0 2z"/>
         </svg>
     </div>
     <div class="modal-bottom-disclaimer-text"><%= if assigns[:text] do @text end %></div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/index.html.eex
@@ -43,3 +43,4 @@
 
   </div>
 </section>
+<div class="stakes-progress-graph-thing-for-getting-color"></div>


### PR DESCRIPTION
## Motivation
This PR is made to fix remain UI issues related to the theme colors for POSDAO Staking DApp, directly https://github.com/poanetwork/blockscout/pull/2292#issuecomment-522098750
This is a more clean version of https://github.com/poanetwork/blockscout/pull/2618 , so should contain commits for each fix and remove some unnecessary logic. 

## Changelog
- [x] Fix button color in dark mode on Error Status modal (8)
- [x] Fix dark theme color in stake dialog modals (10)
- [x] Fix dark theme color for the empty state in stake pools list (11)
- [x] Fix dark theme color for the non-empty state in stake pools list
- [x] Fix delegators list modal width for inactive pools (Again 2)
- [x] Fix dark theme color for banned pools
- [x] Fix differences in transition speed for input prepend block (2700.3)
- [x] Fix dark theme color for input autofill (#2700.1)
- [x] Fix chart color in staking modals (#2700.2)