### PR TITLE
fix empty total_supply in coin gecko response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#2663](https://github.com/poanetwork/blockscout/pull/2663) - Fetch address counters in parallel
 
 ### Fixes
+- [#2706](https://github.com/poanetwork/blockscout/pull/2706) - fix empty total_supply in coin gecko response
 - [#2701](https://github.com/poanetwork/blockscout/pull/2701) - Exclude nonconsensus blocks from avg block time calculation by default
 - [#2696](https://github.com/poanetwork/blockscout/pull/2696) - do not update fetched_coin_balance with nil
 - [#2693](https://github.com/poanetwork/blockscout/pull/2693) - remove non consensus internal transactions

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
@@ -26,7 +26,7 @@ defmodule Explorer.ExchangeRates.Source.CoinGecko do
     [
       %Token{
         available_supply: to_decimal(market_data["circulating_supply"]),
-        total_supply: to_decimal(market_data["total_supply"]),
+        total_supply: to_decimal(market_data["total_supply"]) || to_decimal(market_data["circulating_supply"]),
         btc_value: btc_value,
         id: json_data["id"],
         last_updated: last_updated,


### PR DESCRIPTION
#Motivation

It causes empty percentages on accounts page

## Changelog

- fix empty total_supply in coin gecko response