### PR TITLE
add log index to logs view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#2619](https://github.com/poanetwork/blockscout/pull/2619) - Enforce DB transaction's order to prevent deadlocks
 
 ### Chore
+- [#2708](https://github.com/poanetwork/blockscout/pull/2708) - add log index to logs view
 
 
 ## 2.0.4-beta

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_logs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_logs.html.eex
@@ -185,5 +185,13 @@
         </div>
       <% end %>
     </dd>
+    <dt class="col-md-2">
+      <%= gettext "Log Index" %>
+    </dt>
+    <dd class="col-md-10">
+      <div class="text-dark raw-transaction-log-index">
+        <%= @log.index %>
+      </div>
+    </dd>
   </dl>
 </div>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1841,3 +1841,8 @@ msgstr ""
 #: lib/block_scout_web/views/address_contract_view.ex:22
 msgid "true"
 msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:189
+msgid "Log Index"
+msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1841,3 +1841,8 @@ msgstr ""
 #: lib/block_scout_web/views/address_contract_view.ex:22
 msgid "true"
 msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction_log/_logs.html.eex:189
+msgid "Log Index"
+msgstr ""


### PR DESCRIPTION

![log_index](https://user-images.githubusercontent.com/6567687/65154331-fcbddf80-da33-11e9-9007-3df41801be72.png)

resolves https://github.com/poanetwork/blockscout/issues/2686

## Changelog

- add log index to logs view