### PR TITLE
Improve speed of nonconsensus data removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#2717](https://github.com/poanetwork/blockscout/pull/2717) - Improve speed of nonconsensus data removal
 - [#2679](https://github.com/poanetwork/blockscout/pull/2679) - added fixed height for card chain blocks and card chain transactions
 - [#2678](https://github.com/poanetwork/blockscout/pull/2678) - fixed dashboard banner height bug
 - [#2672](https://github.com/poanetwork/blockscout/pull/2672) - added new theme for xUSDT

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -117,10 +117,12 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
     test "remove_nonconsensus_token_transfers deletes token transfer rows with matching block number when new consensus block is inserted",
          %{consensus_block: %{number: block_number} = block, options: options} do
-      insert(:block, number: block_number, consensus: true)
+      consensus_block = insert(:block, number: block_number, consensus: true)
+
+      transaction = insert(:transaction) |> with_block(consensus_block)
 
       %TokenTransfer{transaction_hash: transaction_hash, log_index: log_index} =
-        insert(:token_transfer, block_number: block_number, transaction: insert(:transaction))
+        insert(:token_transfer, block_number: block_number, transaction: transaction)
 
       assert count(TokenTransfer) == 1
 
@@ -136,7 +138,11 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
     test "remove_nonconsensus_token_transfers does not delete token transfer rows with matching block number when new consensus block wasn't inserted",
          %{consensus_block: %{number: block_number} = block, options: options} do
-      insert(:token_transfer, block_number: block_number, transaction: insert(:transaction))
+      consensus_block = insert(:block, number: block_number, consensus: true)
+
+      transaction = insert(:transaction) |> with_block(consensus_block)
+
+      insert(:token_transfer, block_number: block_number, transaction: transaction)
 
       count = 1
 


### PR DESCRIPTION
## Motivation

The recently introduction of non-consensus block's data removal is not efficient enough to keep the pace with block creation.

## Changelog

### Enhancements
This PR changes the logic to remove only data of blocks that lose consensus because they are being overridden (as opposed to also for blocks that are invalid neighbors) and changes the queries to perform.

## Checklist for your PR

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so if necessary
  - [x] If I added/changed/removed ENV var, I should update the list of env vars in https://github.com/poanetwork/blockscout/blob/master/docs/env-variables.md to reflect changes in the table here https://poanetwork.github.io/blockscout/#/env-variables?id=blockscout-env-variables. I've set `master` in the `Version` column.
  - [x] If I add new indices into DB, I checked, that they don't redundant with PGHero or other tools
