### PR TITLE
Allow connection only to authorized chain networks

### DIFF
--- a/apps/block_scout_web/assets/js/lib/modals.js
+++ b/apps/block_scout_web/assets/js/lib/modals.js
@@ -72,7 +72,7 @@ export function openErrorModal (title, text) {
 export function openWarningModal (title, text) {
   const $modal = $('#warningStatusModal')
   $modal.find('.modal-status-title').text(title)
-  $modal.find('.modal-status-text').text(text)
+  $modal.find('.modal-status-text').html(text)
   openModal($modal)
 }
 

--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -2,13 +2,15 @@ import $ from 'jquery'
 import { BigNumber } from 'bignumber.js'
 import { openModal, openErrorModal, openWarningModal, lockModal } from '../../lib/modals'
 import { setupValidation } from '../../lib/validation'
-import { makeContractCall } from './utils'
+import { makeContractCall, isSupportedNetwork } from './utils'
 
 export function openBecomeCandidateModal (store) {
   if (!store.getState().account) {
     openWarningModal('Unauthorized', 'Please login with MetaMask')
     return
   }
+
+  if (!isSupportedNetwork(store)) return
 
   store.getState().channel
     .push('render_become_candidate')

--- a/apps/block_scout_web/assets/js/pages/stakes/claim_withdrawal.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/claim_withdrawal.js
@@ -1,8 +1,10 @@
 import $ from 'jquery'
 import { openModal, lockModal } from '../../lib/modals'
-import { makeContractCall, setupChart } from './utils'
+import { makeContractCall, setupChart, isSupportedNetwork } from './utils'
 
 export function openClaimWithdrawalModal (event, store) {
+  if (!isSupportedNetwork(store)) return
+
   const address = $(event.target).closest('[data-address]').data('address')
 
   store.getState().channel

--- a/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
@@ -2,13 +2,15 @@ import $ from 'jquery'
 import { BigNumber } from 'bignumber.js'
 import { openModal, openWarningModal, lockModal } from '../../lib/modals'
 import { setupValidation } from '../../lib/validation'
-import { makeContractCall, setupChart } from './utils'
+import { makeContractCall, setupChart, isSupportedNetwork } from './utils'
 
 export function openMakeStakeModal (event, store) {
   if (!store.getState().account) {
     openWarningModal('Unauthorized', 'Please login with MetaMask')
     return
   }
+
+  if (!isSupportedNetwork(store)) return
 
   const address = $(event.target).closest('[data-address]').data('address') || store.getState().account
 

--- a/apps/block_scout_web/assets/js/pages/stakes/move_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/move_stake.js
@@ -2,9 +2,11 @@ import $ from 'jquery'
 import { BigNumber } from 'bignumber.js'
 import { openModal, lockModal } from '../../lib/modals'
 import { setupValidation } from '../../lib/validation'
-import { makeContractCall, setupChart } from './utils'
+import { makeContractCall, setupChart, isSupportedNetwork } from './utils'
 
 export function openMoveStakeModal (event, store) {
+  if (!isSupportedNetwork(store)) return
+
   const fromAddress = $(event.target).closest('[data-address]').data('address')
 
   store.getState().channel

--- a/apps/block_scout_web/assets/js/pages/stakes/remove_pool.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/remove_pool.js
@@ -1,7 +1,8 @@
 import { openQuestionModal } from '../../lib/modals'
-import { makeContractCall } from './utils'
+import { makeContractCall, isSupportedNetwork } from './utils'
 
 export function openRemovePoolModal (store) {
+  if (!isSupportedNetwork(store)) return
   openQuestionModal('Remove my Pool', 'Do you really want to remove your pool?', () => removePool(store))
 }
 

--- a/apps/block_scout_web/assets/js/pages/stakes/utils.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/utils.js
@@ -1,7 +1,7 @@
 import $ from 'jquery'
 import Chart from 'chart.js'
 import { refreshPage } from '../../lib/async_listing_load'
-import { openErrorModal, openSuccessModal } from '../../lib/modals'
+import { openErrorModal, openSuccessModal, openWarningModal } from '../../lib/modals'
 
 export async function makeContractCall (call, store) {
   let gas, timeout
@@ -81,4 +81,14 @@ export function setupChart ($canvas, self, total) {
       }
     }
   })
+}
+
+export function isSupportedNetwork (store) {
+  if (store.getState().network.authorized) {
+    return true
+  }
+
+  openWarningModal('Unauthorized', 'Connect to the xDai Chain for staking.<br /> <a href="https://docs.xdaichain.com" target="_blank">Instructions</a>')
+
+  return false
 }

--- a/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
@@ -2,9 +2,11 @@ import $ from 'jquery'
 import { BigNumber } from 'bignumber.js'
 import { openModal, openErrorModal, lockModal } from '../../lib/modals'
 import { setupValidation } from '../../lib/validation'
-import { makeContractCall, setupChart } from './utils'
+import { makeContractCall, setupChart, isSupportedNetwork } from './utils'
 
 export function openWithdrawStakeModal (event, store) {
+  if (!isSupportedNetwork(store)) return
+
   const address = $(event.target).closest('[data-address]').data('address')
 
   store.getState().channel


### PR DESCRIPTION
## Motivation
As an additional requirement, we want to restrict connection only to authorized chain network. For now it's xDai (id: 100) and posdao-test network (id: 101)
Requirement: https://github.com/poanetwork/blockscout/pull/2292#issuecomment-532163749

## Changelog
- [x] Save network id to js storage
- [x] Check on app initialization if the network is not allowed and show Alert Modal
- [x] Check on "Become Candidate" action if the network is not allowed and show Alert Modal
- [x] Check on "Make Stake" action if the network is not allowed and show Alert Modal