### PR TITLE
do not fail block `internal_transactions_indexed_at` field update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [#2671](https://github.com/poanetwork/blockscout/pull/2671) - fixed buttons color at smart contract section
 - [#2660](https://github.com/poanetwork/blockscout/pull/2660) - set correct last value for coin balances chart data
 - [#2619](https://github.com/poanetwork/blockscout/pull/2619) - Enforce DB transaction's order to prevent deadlocks
+- [#2738](https://github.com/poanetwork/blockscout/pull/2738) - do not fail block `internal_transactions_indexed_at` field update
 
 ### Chore
 - [#2724](https://github.com/poanetwork/blockscout/pull/2724) - fix ci by commenting a line in hackney library

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions_indexed_at_blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions_indexed_at_blocks.ex
@@ -65,8 +65,6 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsIndexedAtBlocks do
         lock: "FOR UPDATE"
       )
 
-    block_count = Enum.count(block_numbers)
-
     try do
       {_, result} =
         repo.update_all(

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions_indexed_at_blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions_indexed_at_blocks.ex
@@ -68,7 +68,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsIndexedAtBlocks do
     block_count = Enum.count(block_numbers)
 
     try do
-      {^block_count, result} =
+      {_, result} =
         repo.update_all(
           from(b in Block, join: s in subquery(query), on: b.hash == s.hash),
           [set: [internal_transactions_indexed_at: timestamps.updated_at]],


### PR DESCRIPTION
this runner updates internal_transactions_index_at field in blocks
table. but before this, it checks if these blocks are consensus, some
blocks may lose consensus.

we just shouldn't check if the number of updated records is exactly
equal to the number of records that we want to insert.
blocks that lost consensus will be re-fetched

## Motivation

fixes
```
no match of right hand side value: {7, nil}
    (explorer) lib/explorer/chain/import/runner/internal_transactions_indexed_at_blocks.ex:71:
```

## Changelog

- do not fail block `internal_transactions_indexed_at` field update