### PR TITLE
Fixed menu hovers in dark mode desktop view

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.9.1-otp-22
-erlang 22.0
+elixir 1.9.0
+erlang 21.0
 nodejs 10.11.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.9.0
-erlang 21.0
+elixir 1.9.1-otp-22
+erlang 22.0
 nodejs 10.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - [#2663](https://github.com/poanetwork/blockscout/pull/2663) - Fetch address counters in parallel
 
 ### Fixes
+- [#2742](https://github.com/poanetwork/blockscout/pull/2742) -
+fixed menu hovers in dark mode desktop view
 - [#2737](https://github.com/poanetwork/blockscout/pull/2737) - switched hardcoded subnetwork value to elixir expression for mobile menu
 - [#2736](https://github.com/poanetwork/blockscout/pull/2736) - do not update cache if no blocks were inserted
 - [#2731](https://github.com/poanetwork/blockscout/pull/2731) - fix library verification

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -792,7 +792,7 @@ $labels-dark: #8a8dba; // header nav, labels
 .dark-theme-applied .dropdown-item.active, .dark-theme-applied .dropdown-item:hover, .dark-theme-applied .dropdown-item:focus {
     background-image: none;
     width: 100%;
-    background-color: #35335d!important;
+    background-color: #3f426c!important;
 }
 @media (max-width: 991.98px) {
 	.dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link:hover,

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -794,16 +794,6 @@ $labels-dark: #8a8dba; // header nav, labels
     width: 100%;
     background-color: #35335d!important;
 }
- .dark-theme-applied .dropdown-item:hover:before {
-	content: "|";
-    height: 50px;
-    width: 50%;
-    opacity: 1;
-    background: none;
-    right: 17%;
-    color: $dark-primary;
-    position: relative;
-}
 @media (max-width: 991.98px) {
 	.dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link:hover,
 	.dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link.activeLink,
@@ -814,6 +804,16 @@ $labels-dark: #8a8dba; // header nav, labels
 		color: white;
 		border: none;
 	  }
+	  .dark-theme-applied .dropdown-item:hover:before {
+		content: "|";
+		height: 50px;
+		width: 50%;
+		opacity: 1;
+		background: none;
+		right: 17%;
+		color: $dark-primary;
+		position: relative;
+	}
 	  .dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link:hover:before
 	   {
 		content: "|";

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -804,23 +804,25 @@ $labels-dark: #8a8dba; // header nav, labels
     color: $dark-primary;
     position: relative;
 }
-.dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link:hover,
-.dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link.activeLink,
-.dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link:focus {
-	background-image: none;
-    width: 100%;
-	background-color: #35335d!important;
-	color: white;
-	border: none;
-  }
-  .dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link:hover:before
-   {
-	content: "|";
-    height: 50px;
-    width: 50%;
-    opacity: 1;
-    background: none;
-    left: 24%;
-    top: 14%;
-	color: $dark-primary;
-	}
+@media (max-width: 991.98px) {
+	.dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link:hover,
+	.dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link.activeLink,
+	.dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link:focus {
+		background-image: none;
+		width: 100%;
+		background-color: #35335d!important;
+		color: white;
+		border: none;
+	  }
+	  .dark-theme-applied .navbar.navbar-primary .navbar-nav .nav-link:hover:before
+	   {
+		content: "|";
+		height: 50px;
+		width: 50%;
+		opacity: 1;
+		background: none;
+		left: 24%;
+		top: 14%;
+		color: $dark-primary;
+		}
+		}


### PR DESCRIPTION
Fixed hovers for blockscout menu in dark mode desktop view. 

## Motivation

Menu hovers in dark mode desktop view were broken (i've created new hovers for new mobile menu, but they appeared in desktop view too.)

## Changelog
### Bug Fixes
Added media query for mobile menu hovers, and issue was fixed.

https://www.loom.com/share/b4306e240cd24f06a2986c3ed4cc2245

## Checklist for your PR

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  you must be able to justify that.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
  - [ ] If I added/changed/removed ENV var, I should update the list of env vars in https://github.com/poanetwork/blockscout/blob/master/docs/env-variables.md to reflect changes in the table here https://poanetwork.github.io/blockscout/#/env-variables?id=blockscout-env-variables. I've set `master` in the `Version` column.
  - [ ] If I add new indices into DB, I checked, that they don't redundant with PGHero or other tools
