### PR TITLE
optimize addresses page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#2663](https://github.com/poanetwork/blockscout/pull/2663) - Fetch address counters in parallel
 
 ### Fixes
+- [#2745](https://github.com/poanetwork/blockscout/pull/2745) - optimize addresses page
 - [#2737](https://github.com/poanetwork/blockscout/pull/2737) - switched hardcoded subnetwork value to elixir expression for mobile menu
 - [#2736](https://github.com/poanetwork/blockscout/pull/2736) - do not update cache if no blocks were inserted
 - [#2731](https://github.com/poanetwork/blockscout/pull/2731) - fix library verification

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
@@ -44,8 +44,7 @@ defmodule BlockScoutWeb.AddressController do
           index: index,
           exchange_rate: exchange_rate,
           total_supply: total_supply,
-          tx_count: tx_count,
-          validation_count: validation_count(address.hash)
+          tx_count: tx_count
         )
       end)
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tile.html.eex
@@ -29,11 +29,6 @@
       <span data-test="transaction_count">
         <%= @tx_count %>
       </span> <%= gettext "Transactions sent" %>
-      <% if validator?(@address) do %>
-        <span data-test="validation_count">
-          <%= @validation_count %>
-        </span> <%= gettext "Validations" %>
-      <% end %>
     </span>
   </td>
 </tr>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1677,11 +1677,6 @@ msgid "Validated Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tile.html.eex:35
-msgid "Validations"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:30
 msgid "Validator Creation Date"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1677,11 +1677,6 @@ msgid "Validated Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tile.html.eex:35
-msgid "Validations"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:30
 msgid "Validator Creation Date"
 msgstr ""


### PR DESCRIPTION
the longest part of addresses page loading was fetching validation
count for every address.

addresses are loaded from cache. it takes less than a second but
fetching validation count takes more than 5 seconds.

Moreover, validation_count is not used.

## Changelog

- optimize addresses page