### PR TITLE
Fixed address alignment in logs decoded view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#2663](https://github.com/poanetwork/blockscout/pull/2663) - Fetch address counters in parallel
 
 ### Fixes
+- [#2746](https://github.com/poanetwork/blockscout/pull/2746) - fixed wrong alignment in logs decoded view
 - [#2737](https://github.com/poanetwork/blockscout/pull/2737) - switched hardcoded subnetwork value to elixir expression for mobile menu
 - [#2736](https://github.com/poanetwork/blockscout/pull/2736) - do not update cache if no blocks were inserted
 - [#2731](https://github.com/poanetwork/blockscout/pull/2731) - fix library verification

--- a/apps/block_scout_web/assets/css/_layout.scss
+++ b/apps/block_scout_web/assets/css/_layout.scss
@@ -8,3 +8,7 @@
     background-color: #fbfafc;
   }
 }
+
+.logs-hash {
+  line-height: 24px !important;
+}

--- a/apps/block_scout_web/assets/css/components/_address-overview.scss
+++ b/apps/block_scout_web/assets/css/components/_address-overview.scss
@@ -80,3 +80,7 @@
     margin-bottom: 0;
   }
 }
+
+.logs-decoded {
+  line-height: 25px;
+}

--- a/apps/block_scout_web/assets/css/components/_address-overview.scss
+++ b/apps/block_scout_web/assets/css/components/_address-overview.scss
@@ -82,5 +82,5 @@
 }
 
 .logs-decoded {
-  line-height: 25px;
+  line-height: 25px!important;
 }

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_logs/_logs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_logs/_logs.html.eex
@@ -17,7 +17,7 @@
   <dl class="row">
     <dt class="col-md-2"> <%= gettext "Transaction" %> </dt>
     <dd class="col-md-10">
-      <h3 class="">
+      <h3 class="logs-decoded">
         <%= link(
             @log.transaction,
             to: transaction_path(@conn, :show, @log.transaction),

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_logs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_logs.html.eex
@@ -18,7 +18,7 @@
   <dl class="row">
     <dt class="col-lg-2"> <%= gettext "Address" %> </dt>
     <dd class="col-lg-10">
-      <h3 class="">
+      <h3 class="logs-hash">
         <%= link(
             @log.address,
             to: address_path(@conn, :show, @log.address),


### PR DESCRIPTION
This PR is related to #2533 issue

## Motivation

Wrong alignment in logs entry

## Changelog


### Bug Fixes
Fixed wrong alignment in logs decoded view :

![Screenshot](https://user-images.githubusercontent.com/10085945/65959128-de0b1000-e459-11e9-971c-75ba9d84354b.png)


## Checklist for your PR

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  you must be able to justify that.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so if necessary
  - [ ] If I added/changed/removed ENV var, I should update the list of env vars in https://github.com/poanetwork/blockscout/blob/master/docs/env-variables.md to reflect changes in the table here https://poanetwork.github.io/blockscout/#/env-variables?id=blockscout-env-variables. I've set `master` in the `Version` column.
  - [ ] If I add new indices into DB, I checked, that they don't redundant with PGHero or other tools
