### PR TITLE
rewrite token updater

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2916,8 +2916,10 @@ defmodule Explorer.Chain do
           reducer :: (entry :: Hash.Address.t(), accumulator -> accumulator)
         ) :: {:ok, accumulator}
         when accumulator: term()
-  def stream_cataloged_token_contract_address_hashes(initial, reducer) when is_function(reducer, 2) do
-    Token.cataloged_tokens()
+  def stream_cataloged_token_contract_address_hashes(initial, reducer, hours_ago_updated \\ 48)
+      when is_function(reducer, 2) do
+    hours_ago_updated
+    |> Token.cataloged_tokens()
     |> order_by(asc: :updated_at)
     |> Repo.stream_reduce(initial, reducer)
   end

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -103,7 +103,7 @@ defmodule Explorer.Chain.Token do
   @doc """
   Builds an `Ecto.Query` to fetch the cataloged tokens.
 
-  These are tokens with cataloged field set to true.
+  These are tokens with cataloged field set to true and updated_at is earlier or equal than an hour ago.
   """
   def cataloged_tokens(hours \\ 48) do
     date_now = DateTime.utc_now()

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -105,11 +105,14 @@ defmodule Explorer.Chain.Token do
 
   These are tokens with cataloged field set to true.
   """
-  def cataloged_tokens do
+  def cataloged_tokens(hours \\ 48) do
+    date_now = DateTime.utc_now()
+    hours_ago_date = DateTime.add(date_now, -:timer.hours(hours), :millisecond)
+
     from(
       token in __MODULE__,
       select: token.contract_address_hash,
-      where: token.cataloged == true
+      where: token.cataloged == true and token.updated_at <= ^hours_ago_date
     )
   end
 end

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -134,20 +134,23 @@ defmodule Explorer.Token.MetadataRetriever do
 
     updated_at = DateTime.utc_now()
 
-    requests
-    |> Reader.query_contracts(@contract_abi)
-    |> Enum.chunk_every(4)
-    |> Enum.zip(hashes)
-    |> Enum.map(fn {result, hash} ->
-      formatted_result =
-        ["decimals", "name", "symbol", "totalSupply"]
-        |> Enum.zip(result)
-        |> format_contract_functions_result(hash)
+    fetched_result =
+      requests
+      |> Reader.query_contracts(@contract_abi)
+      |> Enum.chunk_every(4)
+      |> Enum.zip(hashes)
+      |> Enum.map(fn {result, hash} ->
+        formatted_result =
+          ["decimals", "name", "symbol", "totalSupply"]
+          |> Enum.zip(result)
+          |> format_contract_functions_result(hash)
 
-      formatted_result
-      |> Map.put(:contract_address_hash, hash)
-      |> Map.put(:updated_at, updated_at)
-    end)
+        formatted_result
+        |> Map.put(:contract_address_hash, hash)
+        |> Map.put(:updated_at, updated_at)
+      end)
+
+    {:ok, fetched_result}
   end
 
   @spec get_functions_of(Hash.t()) :: Map.t()

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -120,8 +120,7 @@ defmodule Explorer.Token.MetadataRetriever do
   It will retry to fetch each function in the Smart Contract according to :token_functions_reader_max_retries
   configured in the application env case one of them raised error.
   """
-
-  @spec get_functions_of([String.t()]) :: [Map.t()]
+  @spec get_functions_of([String.t()] | Hash.t() | String.t()) :: Map.t() | {:ok, [Map.t()]}
   def get_functions_of(hashes) when is_list(hashes) do
     requests =
       hashes
@@ -153,14 +152,12 @@ defmodule Explorer.Token.MetadataRetriever do
     {:ok, fetched_result}
   end
 
-  @spec get_functions_of(Hash.t()) :: Map.t()
   def get_functions_of(%Hash{byte_count: unquote(Hash.Address.byte_count())} = address) do
     address_string = Hash.to_string(address)
 
     get_functions_of(address_string)
   end
 
-  @spec get_functions_of(String.t()) :: Map.t()
   def get_functions_of(contract_address_hash) when is_binary(contract_address_hash) do
     contract_address_hash
     |> fetch_functions_from_contract(@contract_functions)

--- a/apps/explorer/test/explorer/chain/token_test.exs
+++ b/apps/explorer/test/explorer/chain/token_test.exs
@@ -16,7 +16,7 @@ defmodule Explorer.Chain.TokenTest do
       assert Repo.all(Token.cataloged_tokens()) == [token.contract_address_hash]
     end
 
-    test "filter tokens by updated_at filed" do
+    test "filter tokens by updated_at field" do
       {:ok, date} = DateTime.now("Etc/UTC")
       hours_ago_date = DateTime.add(date, -:timer.hours(60), :millisecond)
 

--- a/apps/explorer/test/explorer/chain/token_test.exs
+++ b/apps/explorer/test/explorer/chain/token_test.exs
@@ -3,14 +3,27 @@ defmodule Explorer.Chain.TokenTest do
 
   import Explorer.Factory
 
-  alias Explorer.Chain
+  alias Explorer.Chain.Token
+  alias Explorer.Repo
 
   describe "cataloged_tokens/0" do
     test "filters only cataloged tokens" do
-      token = insert(:token, cataloged: true)
+      {:ok, date} = DateTime.now("Etc/UTC")
+      hours_ago_date = DateTime.add(date, -:timer.hours(60), :millisecond)
+      token = insert(:token, cataloged: true, updated_at: hours_ago_date)
       insert(:token, cataloged: false)
 
-      assert Repo.all(Chain.Token.cataloged_tokens()) == [token.contract_address_hash]
+      assert Repo.all(Token.cataloged_tokens()) == [token.contract_address_hash]
+    end
+
+    test "filter tokens by updated_at filed" do
+      {:ok, date} = DateTime.now("Etc/UTC")
+      hours_ago_date = DateTime.add(date, -:timer.hours(60), :millisecond)
+
+      token = insert(:token, cataloged: true, updated_at: hours_ago_date)
+      insert(:token, cataloged: true)
+
+      assert Repo.all(Token.cataloged_tokens()) == [token.contract_address_hash]
     end
   end
 end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -3522,24 +3522,27 @@ defmodule Explorer.ChainTest do
 
   describe "stream_cataloged_token_contract_address_hashes/2" do
     test "reduces with given reducer and accumulator" do
-      %Token{contract_address_hash: catalog_address} = insert(:token, cataloged: true)
+      today = DateTime.utc_now()
+      yesterday = Timex.shift(today, days: -1)
+      %Token{contract_address_hash: catalog_address} = insert(:token, cataloged: true, updated_at: yesterday)
       insert(:token, cataloged: false)
-      assert Chain.stream_cataloged_token_contract_address_hashes([], &[&1 | &2]) == {:ok, [catalog_address]}
+      assert Chain.stream_cataloged_token_contract_address_hashes([], &[&1 | &2], 1) == {:ok, [catalog_address]}
     end
 
     test "sorts the tokens by updated_at in ascending order" do
       today = DateTime.utc_now()
       yesterday = Timex.shift(today, days: -1)
+      two_days_ago = Timex.shift(today, days: -2)
 
-      token1 = insert(:token, %{cataloged: true, updated_at: today})
-      token2 = insert(:token, %{cataloged: true, updated_at: yesterday})
+      token1 = insert(:token, %{cataloged: true, updated_at: yesterday})
+      token2 = insert(:token, %{cataloged: true, updated_at: two_days_ago})
 
       expected_response =
         [token1, token2]
         |> Enum.sort(&(Timex.to_unix(&1.updated_at) < Timex.to_unix(&2.updated_at)))
         |> Enum.map(& &1.contract_address_hash)
 
-      assert Chain.stream_cataloged_token_contract_address_hashes([], &(&2 ++ [&1])) == {:ok, expected_response}
+      assert Chain.stream_cataloged_token_contract_address_hashes([], &(&2 ++ [&1]), 12) == {:ok, expected_response}
     end
   end
 

--- a/apps/explorer/test/explorer/token/metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/metadata_retriever_test.exs
@@ -59,6 +59,61 @@ defmodule Explorer.Token.MetadataRetrieverTest do
       assert MetadataRetriever.get_functions_of(token.contract_address_hash) == expected
     end
 
+    test "returns results for multiple coins" do
+      token = insert(:token, contract_address: build(:contract_address))
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        1,
+        fn requests, _opts ->
+          {:ok,
+           Enum.map(requests, fn
+             %{id: id, method: "eth_call", params: [%{data: "0x313ce567", to: _}, "latest"]} ->
+               %{
+                 id: id,
+                 result: "0x0000000000000000000000000000000000000000000000000000000000000012"
+               }
+
+             %{id: id, method: "eth_call", params: [%{data: "0x06fdde03", to: _}, "latest"]} ->
+               %{
+                 id: id,
+                 result:
+                   "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000642616e636f720000000000000000000000000000000000000000000000000000"
+               }
+
+             %{id: id, method: "eth_call", params: [%{data: "0x95d89b41", to: _}, "latest"]} ->
+               %{
+                 id: id,
+                 result:
+                   "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003424e540000000000000000000000000000000000000000000000000000000000"
+               }
+
+             %{id: id, method: "eth_call", params: [%{data: "0x18160ddd", to: _}, "latest"]} ->
+               %{
+                 id: id,
+                 result: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
+               }
+           end)}
+        end
+      )
+
+      assert [
+               %{
+                 name: "Bancor",
+                 symbol: "BNT",
+                 total_supply: 1_000_000_000_000_000_000,
+                 decimals: 18
+               },
+               %{
+                 name: "Bancor",
+                 symbol: "BNT",
+                 total_supply: 1_000_000_000_000_000_000,
+                 decimals: 18
+               }
+             ] = MetadataRetriever.get_functions_of([token.contract_address_hash, token.contract_address_hash])
+    end
+
     test "returns only the functions that were read without error" do
       token = insert(:token, contract_address: build(:contract_address))
 

--- a/apps/explorer/test/explorer/token/metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/metadata_retriever_test.exs
@@ -98,20 +98,21 @@ defmodule Explorer.Token.MetadataRetrieverTest do
         end
       )
 
-      assert [
-               %{
-                 name: "Bancor",
-                 symbol: "BNT",
-                 total_supply: 1_000_000_000_000_000_000,
-                 decimals: 18
-               },
-               %{
-                 name: "Bancor",
-                 symbol: "BNT",
-                 total_supply: 1_000_000_000_000_000_000,
-                 decimals: 18
-               }
-             ] = MetadataRetriever.get_functions_of([token.contract_address_hash, token.contract_address_hash])
+      assert {:ok,
+              [
+                %{
+                  name: "Bancor",
+                  symbol: "BNT",
+                  total_supply: 1_000_000_000_000_000_000,
+                  decimals: 18
+                },
+                %{
+                  name: "Bancor",
+                  symbol: "BNT",
+                  total_supply: 1_000_000_000_000_000_000,
+                  decimals: 18
+                }
+              ]} = MetadataRetriever.get_functions_of([token.contract_address_hash, token.contract_address_hash])
     end
 
     test "returns only the functions that were read without error" do

--- a/apps/indexer/lib/indexer/fetcher/token_updater.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_updater.ex
@@ -7,8 +7,7 @@ defmodule Indexer.Fetcher.TokenUpdater do
   require Logger
 
   alias Explorer.Chain
-  alias Explorer.Chain.Hash
-  alias Explorer.Chain.Token
+  alias Explorer.Chain.{Hash, Token}
   alias Explorer.Token.MetadataRetriever
   alias Indexer.BufferedTask
 
@@ -59,6 +58,13 @@ defmodule Indexer.Fetcher.TokenUpdater do
     |> case do
       {:ok, params} ->
         update_metadata(params)
+
+      other ->
+        Logger.error(fn -> ["failed to update tokens: ", inspect(other)] end,
+          error_count: Enum.count(entries)
+        )
+
+        {:retry, entries}
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/token_updater.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_updater.ex
@@ -43,7 +43,10 @@ defmodule Indexer.Fetcher.TokenUpdater do
 
   @impl BufferedTask
   def init(initial, reducer, _) do
-    {:ok, tokens} = Chain.stream_cataloged_token_contract_address_hashes(initial, reducer)
+    metadata_updater_inverval = Application.get_env(:indexer, :metadata_updater_seconds_interval)
+    hour_interval = Kernel.round(metadata_updater_inverval / (60 * 60))
+
+    {:ok, tokens} = Chain.stream_cataloged_token_contract_address_hashes(initial, reducer, hour_interval)
 
     tokens
   end

--- a/apps/indexer/lib/indexer/fetcher/token_updater.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_updater.ex
@@ -7,7 +7,6 @@ defmodule Indexer.Fetcher.TokenUpdater do
   require Logger
 
   alias Explorer.Chain
-  alias Explorer.Chain.Token
   alias Explorer.Token.MetadataRetriever
   alias Indexer.BufferedTask
 

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -19,7 +19,6 @@ defmodule Indexer.Supervisor do
     StakingPools,
     Token,
     TokenBalance,
-    TokenUpdater,
     UncleBlock
   }
 

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -19,6 +19,7 @@ defmodule Indexer.Supervisor do
     StakingPools,
     Token,
     TokenBalance,
+    TokenUpdater,
     UncleBlock
   }
 
@@ -111,6 +112,8 @@ defmodule Indexer.Supervisor do
         {ContractCode.Supervisor,
          [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
         {TokenBalance.Supervisor,
+         [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+        {TokenUpdater.Supervisor,
          [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
         {ReplacedTransaction.Supervisor, [[memory_monitor: memory_monitor]]},
         {StakingPools.Supervisor, [[memory_monitor: memory_monitor]]},

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -72,8 +72,6 @@ defmodule Indexer.Supervisor do
       subscribe_named_arguments: subscribe_named_arguments
     } = named_arguments
 
-    metadata_updater_inverval = Application.get_env(:indexer, :metadata_updater_seconds_interval)
-
     block_fetcher =
       named_arguments
       |> Map.drop(~w(block_interval blocks_concurrency memory_monitor subscribe_named_arguments realtime_overrides)a)
@@ -120,7 +118,6 @@ defmodule Indexer.Supervisor do
 
         # Out-of-band fetchers
         {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
-        {TokenUpdater.Supervisor, [%{update_interval: metadata_updater_inverval}]},
 
         # Temporary workers
         {UncatalogedTokenTransfers.Supervisor, [[]]},

--- a/apps/indexer/test/indexer/fetcher/token_updater_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_updater_test.exs
@@ -11,7 +11,13 @@ defmodule Indexer.Fetcher.TokenUpdaterTest do
   setup :set_mox_global
 
   test "updates tokens metadata on start" do
-    insert(:token, name: nil, symbol: nil, decimals: 10, cataloged: true)
+    insert(:token,
+      name: nil,
+      symbol: nil,
+      decimals: 10,
+      cataloged: true,
+      updated_at: DateTime.add(DateTime.utc_now(), -:timer.hours(50), :millisecond)
+    )
 
     expect(
       EthereumJSONRPC.Mox,
@@ -49,7 +55,7 @@ defmodule Indexer.Fetcher.TokenUpdaterTest do
       end
     )
 
-    pid = start_supervised!({TokenUpdater, [%{update_interval: 1}, []]})
+    pid = TokenUpdater.Supervisor.Case.start_supervised!(json_rpc_named_arguments: [])
 
     wait_for_results(fn ->
       updated = Repo.one!(from(t in Token, where: t.cataloged == true and not is_nil(t.name), limit: 1))

--- a/apps/indexer/test/indexer/fetcher/token_updater_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_updater_test.exs
@@ -72,54 +72,14 @@ defmodule Indexer.Fetcher.TokenUpdaterTest do
     test "updates the metadata for a list of tokens" do
       token = insert(:token, name: nil, symbol: nil, decimals: 10)
 
-      expect(
-        EthereumJSONRPC.Mox,
-        :json_rpc,
-        1,
-        fn requests, _opts ->
-          {:ok,
-           Enum.map(requests, fn
-             %{id: id, method: "eth_call", params: [%{data: "0x313ce567", to: _}, "latest"]} ->
-               %{
-                 id: id,
-                 result: "0x0000000000000000000000000000000000000000000000000000000000000012"
-               }
+      params = %{name: "Bancor", symbol: "BNT", contract_address_hash: to_string(token.contract_address_hash)}
 
-             %{id: id, method: "eth_call", params: [%{data: "0x06fdde03", to: _}, "latest"]} ->
-               %{
-                 id: id,
-                 result:
-                   "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000642616e636f720000000000000000000000000000000000000000000000000000"
-               }
-
-             %{id: id, method: "eth_call", params: [%{data: "0x95d89b41", to: _}, "latest"]} ->
-               %{
-                 id: id,
-                 result:
-                   "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003424e540000000000000000000000000000000000000000000000000000000000"
-               }
-
-             %{id: id, method: "eth_call", params: [%{data: "0x18160ddd", to: _}, "latest"]} ->
-               %{
-                 id: id,
-                 result: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
-               }
-           end)}
-        end
-      )
-
-      TokenUpdater.update_metadata([token.contract_address_hash])
-
-      expected_supply = Decimal.new(1_000_000_000_000_000_000)
-
-      decimals_expected = Decimal.new(18)
+      TokenUpdater.update_metadata([params])
 
       assert {:ok,
               %Token{
                 name: "Bancor",
                 symbol: "BNT",
-                total_supply: ^expected_supply,
-                decimals: ^decimals_expected,
                 cataloged: true
               }} = Chain.token_from_address_hash(token.contract_address_hash)
     end

--- a/apps/indexer/test/support/indexer/fetcher/token_updater_supervisor_case.ex
+++ b/apps/indexer/test/support/indexer/fetcher/token_updater_supervisor_case.ex
@@ -1,0 +1,17 @@
+defmodule Indexer.Fetcher.TokenUpdater.Supervisor.Case do
+  alias Indexer.Fetcher.TokenUpdater
+
+  def start_supervised!(fetcher_arguments \\ []) when is_list(fetcher_arguments) do
+    merged_fetcher_arguments =
+      Keyword.merge(
+        fetcher_arguments,
+        flush_interval: 50,
+        max_batch_size: 1,
+        max_concurrency: 1
+      )
+
+    [merged_fetcher_arguments]
+    |> TokenUpdater.Supervisor.child_spec()
+    |> ExUnit.Callbacks.start_supervised!()
+  end
+end


### PR DESCRIPTION
More than 50% of requests that we're making to Ethereum node are `eth_call` requests that query token contracts for a name and a symbol

Example (data  starts with `0x313ce567`)
```
окт 02 10:21:26 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:26 UTC jsonrpc-eventloop-1 TRACE rpc  Request: [{"id":0,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0x313ce567"
окт 02 10:21:26 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:26 UTC jsonrpc-eventloop-1 DEBUG rpc  [None] Took 36ms
окт 02 10:21:26 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:26 UTC jsonrpc-eventloop-1 TRACE rpc  Request: [{"id":0,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0x313ce567"
окт 02 10:21:26 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:26 UTC jsonrpc-eventloop-1 DEBUG rpc  [None] Took 22ms
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-1 TRACE rpc  Request: [{"id":0,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0x313ce567"
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-1 DEBUG rpc  [None] Took 56ms
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-1 TRACE rpc  Request: [{"id":0,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0x313ce567"
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-1 TRACE rpc  Request: [{"id":0,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0x70a082310
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-1 DEBUG rpc  [None] Took 49ms
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-1 TRACE rpc  Request: {"jsonrpc":"2.0","method":"eth_blockNumber","params":null,"id":48}.
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-0 TRACE rpc  Request: {"jsonrpc":"2.0","method":"eth_blockNumber","params":null,"id":28}.
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-1 TRACE rpc  Request: {"jsonrpc":"2.0","method":"eth_accounts","params":null,"id":41}.
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-1 TRACE rpc  Request: [{"id":0,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0x313ce567"
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-1 DEBUG rpc  [None] Took 25ms
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-0 TRACE rpc  Request: {"jsonrpc":"2.0","method":"eth_accounts","params":null,"id":68}.
окт 02 10:21:27 ip-172-31-11-113.ec2.internal parity[24923]: 2019-10-02 10:21:27 UTC jsonrpc-eventloop-1 TRACE rpc  Request: [{"id":0,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0x313ce567"
```

## Motivation

These requests are not batched and sent one by one for all catalogued tokens on the blockscout startup and periodically. although they executed quickly (20 - 40 ms), the large number of them clogs rpc threads of an Ethereum node.

## Changelog

- rewrite token updater with batched requests