### PR TITLE
allow enabling internal transactions for simple token transfers txs

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -15,7 +15,9 @@ config :explorer,
       "homestead,tangerineWhistle,spuriousDragon,byzantium,constantinople,petersburg,default",
   include_uncles_in_average_block_time:
     if(System.get_env("UNCLES_IN_AVERAGE_BLOCK_TIME") == "true", do: true, else: false),
-  healthy_blocks_period: System.get_env("HEALTHY_BLOCKS_PERIOD") || :timer.minutes(5)
+  healthy_blocks_period: System.get_env("HEALTHY_BLOCKS_PERIOD") || :timer.minutes(5),
+  index_internal_transactions_for_token_transfers:
+    if(System.get_env("INTERNAL_TRANSACTIONOS_FOR_TOKEN_TRANSFERS") == "true", do: true, else: false)
 
 average_block_period =
   case Integer.parse(System.get_env("AVERAGE_BLOCK_CACHE_PERIOD", "")) do

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -155,12 +155,20 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
     )
   end
 
-  defp put_internal_transactions_indexed_at(changes_list, timestamp, token_transfer_transaction_hash_set)
+  defp put_internal_transactions_indexed_at(changes_list, timestamp, token_transfer_transaction_hash_set) do
+    if Application.get_env(:explorer, :index_internal_transactions_for_token_transfers) do
+      changes
+    else
+      do_put_internal_transactions_indexed_at(changes_list, timestamp, token_transfer_transaction_hash_set)
+    end
+  end
+
+  defp do_put_internal_transactions_indexed_at(changes_list, timestamp, token_transfer_transaction_hash_set)
        when is_list(changes_list) do
     Enum.map(changes_list, &put_internal_transactions_indexed_at(&1, timestamp, token_transfer_transaction_hash_set))
   end
 
-  defp put_internal_transactions_indexed_at(%{hash: hash} = changes, timestamp, token_transfer_transaction_hash_set) do
+  defp do_put_internal_transactions_indexed_at(%{hash: hash} = changes, timestamp, token_transfer_transaction_hash_set) do
     token_transfer? = to_string(hash) in token_transfer_transaction_hash_set
 
     if put_internal_transactions_indexed_at?(changes, token_transfer?) do

--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -69,3 +69,4 @@ $ export NETWORK=POA
 | `COIN_GECKO_ID` | | CoinGecko coin id required for fetching an exchange rate | poa-network | v2.0.4+ | | master |
 | `EMISSION_FORMAT` | | Should be set to `POA` if you have block emission indentical to POA Network. This env var is used only if `CHAIN_SPEC_PATH` is set | `STANDARD` | v2.0.4+ | | |
 | `REWARDS_CONTRACT_ADDRESS` | | Emission rewards contract address. This env var is used only if `EMISSION_FORMAT` is set to `POA` | `0xeca443e8e1ab29971a45a9c57a6a9875701698a5` | v2.0.4+ | | |
+| `INTERNAL_TRANSACTIONOS_FOR_TOKEN_TRANSFERS` | | Does not applicable for parity because we fetch all transactions for it. If set to true fetches internal transactions for simple token transfers transactions. It's disabled by default to increase internal transactions indexing speed | `false` | master | | |


### PR DESCRIPTION
it was disabled in https://github.com/poanetwork/blockscout/pull/1305.
Note that it's not applicable for parity. Because we fetch internal
transactions for it block by block so all internal transactions are
fetched.

fixes https://github.com/poanetwork/blockscout/issues/2743


## Changelog
- allow enabling internal transactions for simple token transfers txs