### PR TITLE
add token instance images to inventory tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#2772](https://github.com/poanetwork/blockscout/pull/2772) - add token instance images to the token inventory tab
 - [#2733](https://github.com/poanetwork/blockscout/pull/2733) - Add cache for first page of uncles
 - [#2735](https://github.com/poanetwork/blockscout/pull/2735) - Add pending transactions cache
 - [#2726](https://github.com/poanetwork/blockscout/pull/2726) - Remove internal_transaction block_number setting from blocks runner

--- a/apps/block_scout_web/assets/css/app.scss
+++ b/apps/block_scout_web/assets/css/app.scss
@@ -116,6 +116,7 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "components/btn_no_border";
 @import "components/custom_tooltips_block_details";
 @import "components/_erc721_token_image_container";
+@import "components/_inventory_token_instance_image_container";
 
 @import "theme/dark-theme";
 

--- a/apps/block_scout_web/assets/css/components/_inventory_token_instance_image_container.scss
+++ b/apps/block_scout_web/assets/css/components/_inventory_token_instance_image_container.scss
@@ -1,0 +1,10 @@
+/* ERC721 image block */
+.inventory-erc721-image {
+    display: flex;
+    justify-content: center;
+}
+
+ .inventory-erc721-image img {
+    height: 50px;
+}
+/* ERC721 image block end */

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/_token.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/_token.html.eex
@@ -24,5 +24,12 @@
         </span>
       </span>
     </div>
+
+    <div class="pl-5 col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center">
+      <!-- substitute the span with <img class="tile-image" /> to token with images -->
+      <div class="inventory-erc721-image" >
+        <img src=<%=image_src(@token_transfer.instance)%> />
+      </div>
+    </div>
   </div>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/inventory_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/inventory_view.ex
@@ -1,5 +1,7 @@
 defmodule BlockScoutWeb.Tokens.InventoryView do
   use BlockScoutWeb, :view
 
+  import BlockScoutWeb.Tokens.Instance.OverviewView, only: [image_src: 1]
+
   alias BlockScoutWeb.Tokens.OverviewView
 end

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -278,11 +278,13 @@ defmodule Explorer.Chain.TokenTransfer do
   def address_to_unique_tokens(contract_address_hash) do
     from(
       tt in TokenTransfer,
-      where: tt.token_contract_address_hash == ^contract_address_hash,
+      left_join: instance in Instance,
+      on: tt.token_contract_address_hash == instance.token_contract_address_hash and tt.token_id == instance.token_id,
+      where: tt.token_contract_address_hash == ^contract_address_hash and tt.token_id == tt.token_id,
       order_by: [desc: tt.block_number],
       distinct: tt.token_id,
       preload: [:to_address],
-      select: tt
+      select: %{tt | instance: instance}
     )
   end
 end


### PR DESCRIPTION

![inventory](https://user-images.githubusercontent.com/6567687/66646197-2979a700-ec2e-11e9-8205-623576f88343.png)

resolves https://github.com/poanetwork/blockscout/issues/2668

## Changelog

- add token instance images to inventory tab