### PR TITLE
fetch token counters async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#2776](https://github.com/poanetwork/blockscout/pull/2776) - fetch token counters async
 - [#2772](https://github.com/poanetwork/blockscout/pull/2772) - add token instance images to the token inventory tab
 - [#2733](https://github.com/poanetwork/blockscout/pull/2733) - Add cache for first page of uncles
 - [#2735](https://github.com/poanetwork/blockscout/pull/2735) - Add pending transactions cache

--- a/apps/block_scout_web/assets/js/app.js
+++ b/apps/block_scout_web/assets/js/app.js
@@ -38,6 +38,7 @@ import './pages/favorites'
 import './pages/network-search'
 import './pages/layout'
 import './pages/verification_form'
+import './pages/token_counters'
 import './pages/dark-mode-switcher'
 
 import './pages/admin/tasks.js'

--- a/apps/block_scout_web/assets/js/pages/token_counters.js
+++ b/apps/block_scout_web/assets/js/pages/token_counters.js
@@ -1,75 +1,73 @@
-import $ from "jquery";
-import omit from "lodash/omit";
-import URI from "urijs";
-import humps from "humps";
-import { subscribeChannel } from "../socket";
-import { createStore, connectElements } from "../lib/redux_helpers.js";
+import $ from 'jquery'
+import omit from 'lodash/omit'
+import humps from 'humps'
+import { createStore, connectElements } from '../lib/redux_helpers.js'
 
 export const initialState = {
-    channelDisconnected: false,
-    transferCount: null,
-    tokenHolderCount: null
-};
+  channelDisconnected: false,
+  transferCount: null,
+  tokenHolderCount: null
+}
 
-export function reducer(state = initialState, action) {
+export function reducer (state = initialState, action) {
   switch (action.type) {
-    case "PAGE_LOAD":
-    case "ELEMENTS_LOAD": {
-      return Object.assign({}, state, omit(action, "type"));
+    case 'PAGE_LOAD':
+    case 'ELEMENTS_LOAD': {
+      return Object.assign({}, state, omit(action, 'type'))
     }
-    case "CHANNEL_DISCONNECTED": {
-      if (state.beyondPageOne) return state;
+    case 'CHANNEL_DISCONNECTED': {
+      if (state.beyondPageOne) return state
 
       return Object.assign({}, state, {
         channelDisconnected: true
-      });
+      })
     }
-  case "COUNTERS_FETCHED": {
+    case 'COUNTERS_FETCHED': {
       return Object.assign({}, state, {
-          transferCount: action.transferCount,
-          tokenHolderCount: action.tokenHolderCount
-      });
+        transferCount: action.transferCount,
+        tokenHolderCount: action.tokenHolderCount
+      })
     }
     default:
-      return state;
+      return state
   }
 }
 
 const elements = {
   '[data-page="counters"]': {
-    render($el, state) {
+    render ($el, state) {
       if (state.counters) {
-        return $el;
+        return $el
       }
-      return $el;
+      return $el
     }
   },
   '[token-transfer-count]': {
-      render ($el, state) {
-          if (state.transferCount) {
-              $el.text(state.transferCount + ' Transfers')
-              return $el.show()
-          } else {
-              return $el.hide()
-          }
+    render ($el, state) {
+      if (state.transferCount) {
+        $el.text(state.transferCount + ' Transfers')
+        return $el.show()
+      } else {
+        return $el.hide()
+      }
     }
   },
-    '[token-holder-count]': {
-      render ($el, state) {
-          if (state.tokenHolderCount) {
-              $el.text(state.tokenHolderCount + ' Addresses')
-              return $el.show()
-          } else {
-              return $el.hide()
-          }
+  '[token-holder-count]': {
+    render ($el, state) {
+      if (state.tokenHolderCount) {
+        $el.text(state.tokenHolderCount + ' Addresses')
+        return $el.show()
+      } else {
+        return $el.hide()
+      }
     }
-  },
-};
+  }
+}
 
-function loadCounters(store) {
-    const $element = $('[data-async-counters]')
-    const path = $element.data().asyncCounters
-  function fetchCounters() {
+function loadCounters (store) {
+  const $element = $('[data-async-counters]')
+  const path = $element.data().asyncCounters
+  function fetchCounters () {
     store.dispatch({type: 'START_REQUEST'})
     $.getJSON(path)
       .done(response => store.dispatch(Object.assign({type: 'COUNTERS_FETCHED'}, humps.camelizeKeys(response))))
@@ -80,10 +78,10 @@ function loadCounters(store) {
   fetchCounters()
 }
 
-const $tokenPage = $('[token-page]');
+const $tokenPage = $('[token-page]')
 
 if ($tokenPage.length) {
-  const store = createStore(reducer);
-  connectElements({ store, elements });
-  loadCounters(store);
+  const store = createStore(reducer)
+  connectElements({ store, elements })
+  loadCounters(store)
 }

--- a/apps/block_scout_web/assets/js/pages/token_counters.js
+++ b/apps/block_scout_web/assets/js/pages/token_counters.js
@@ -1,0 +1,83 @@
+import $ from "jquery";
+import omit from "lodash/omit";
+import URI from "urijs";
+import humps from "humps";
+import { subscribeChannel } from "../socket";
+import { createStore, connectElements } from "../lib/redux_helpers.js";
+
+export const initialState = {
+  channelDisconnected: false,
+  addressHash: null,
+  counters: null
+};
+
+export function reducer(state = initialState, action) {
+  switch (action.type) {
+    case "PAGE_LOAD":
+    case "ELEMENTS_LOAD": {
+      return Object.assign({}, state, omit(action, "type"));
+    }
+    case "CHANNEL_DISCONNECTED": {
+      if (state.beyondPageOne) return state;
+
+      return Object.assign({}, state, {
+        channelDisconnected: true
+      });
+    }
+    case "RECEIVED_COUNTERS_RESULT": {
+      return Object.assign({}, state, {
+        counters: action.msg.counters
+      });
+    }
+    default:
+      return state;
+  }
+}
+
+const elements = {
+  '[data-selector="channel-disconnected-message"]': {
+    render($el, state) {
+      if (state.channelDisconnected) $el.show();
+    }
+  },
+  '[data-page="counters"]': {
+    render($el, state) {
+      if (state.counters) {
+        return $el;
+      }
+      return $el;
+    }
+  }
+};
+
+const $tokenPage = $('[data-page="token-page"]');
+
+if ($tokenPage.length) {
+  const store = createStore(reducer);
+  const addressHash = $("#smart_contract_address_hash").val();
+  const { filter, blockNumber } = humps.camelizeKeys(
+    URI(window.location).query(true)
+  );
+
+  store.dispatch({
+    type: "PAGE_LOAD",
+    addressHash,
+    filter,
+    beyondPageOne: !!blockNumber
+  });
+  connectElements({ store, elements });
+
+  const addressChannel = subscribeChannel(`addresses:${addressHash}`);
+
+  addressChannel.onError(() =>
+    store.dispatch({
+      type: "CHANNEL_DISCONNECTED"
+    })
+  );
+  addressChannel.on("token_counters", msg =>
+    store.dispatch({
+      type: "RECEIVED_COUNTERS_RESULT",
+      msg: humps.camelizeKeys(msg)
+    })
+  );
+}

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
@@ -57,7 +57,8 @@ defmodule BlockScoutWeb.Tokens.HolderController do
         current_path: current_path(conn),
         token: Market.add_price(token),
         total_token_holders: total_token_holders,
-        total_token_transfers: total_token_transfers
+        total_token_transfers: total_token_transfers,
+        counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)})
       )
     else
       :error ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
@@ -12,8 +12,6 @@ defmodule BlockScoutWeb.Tokens.HolderController do
       next_page_params: 3
     ]
 
-  import BlockScoutWeb.Tokens.TokenController, only: [fetch_token_counters: 2]
-
   def index(conn, %{"token_id" => address_hash_string, "type" => "JSON"} = params) do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, token} <- Chain.token_from_address_hash(address_hash),
@@ -49,15 +47,11 @@ defmodule BlockScoutWeb.Tokens.HolderController do
 
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, token} <- Chain.token_from_address_hash(address_hash, options) do
-      {total_token_transfers, total_token_holders} = fetch_token_counters(token, address_hash)
-
       render(
         conn,
         "index.html",
         current_path: current_path(conn),
         token: Market.add_price(token),
-        total_token_holders: total_token_holders,
-        total_token_transfers: total_token_transfers,
         counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)})
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
@@ -7,7 +7,6 @@ defmodule BlockScoutWeb.Tokens.InventoryController do
   alias Phoenix.View
 
   import BlockScoutWeb.Chain, only: [split_list_by_page: 1, default_paging_options: 0]
-  import BlockScoutWeb.Tokens.TokenController, only: [fetch_token_counters: 2]
 
   def index(conn, %{"token_id" => address_hash_string, "type" => "JSON"} = params) do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
@@ -67,15 +66,11 @@ defmodule BlockScoutWeb.Tokens.InventoryController do
 
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, token} <- Chain.token_from_address_hash(address_hash, options) do
-      {total_token_transfers, total_token_holders} = fetch_token_counters(token, address_hash)
-
       render(
         conn,
         "index.html",
         current_path: current_path(conn),
         token: Market.add_price(token),
-        total_token_transfers: total_token_transfers,
-        total_token_holders: total_token_holders,
         counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)})
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
@@ -75,7 +75,8 @@ defmodule BlockScoutWeb.Tokens.InventoryController do
         current_path: current_path(conn),
         token: Market.add_price(token),
         total_token_transfers: total_token_transfers,
-        total_token_holders: total_token_holders
+        total_token_holders: total_token_holders,
+        counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)})
       )
     else
       :error ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/read_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/read_contract_controller.ex
@@ -3,21 +3,15 @@ defmodule BlockScoutWeb.Tokens.ReadContractController do
 
   alias Explorer.{Chain, Market}
 
-  import BlockScoutWeb.Tokens.TokenController, only: [fetch_token_counters: 2]
-
   def index(conn, %{"token_id" => address_hash_string}) do
     options = [necessity_by_association: %{[contract_address: :smart_contract] => :optional}]
 
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, token} <- Chain.token_from_address_hash(address_hash, options) do
-      {total_token_transfers, total_token_holders} = fetch_token_counters(token, address_hash)
-
       render(
         conn,
         "index.html",
         token: Market.add_price(token),
-        total_token_transfers: total_token_transfers,
-        total_token_holders: total_token_holders,
         counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)})
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/read_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/read_contract_controller.ex
@@ -17,7 +17,8 @@ defmodule BlockScoutWeb.Tokens.ReadContractController do
         "index.html",
         token: Market.add_price(token),
         total_token_transfers: total_token_transfers,
-        total_token_holders: total_token_holders
+        total_token_holders: total_token_holders,
+        counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)})
       )
     else
       :error ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/token_controller.ex
@@ -9,7 +9,19 @@ defmodule BlockScoutWeb.Tokens.TokenController do
     redirect(conn, to: token_transfer_path(conn, :index, address_hash_string))
   end
 
-  def fetch_token_counters(token, address_hash) do
+  def token_counters(conn, %{"id" => address_hash_string}) do
+    with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
+         {:ok, token} <- Chain.token_from_address_hash(address_hash) do
+      {transfer_count, token_holder_count} = fetch_token_counters(token, address_hash, 200)
+
+      json(conn, %{transfer_count: transfer_count, token_holder_counter: token_holder_count})
+    else
+      _ ->
+        not_found(conn)
+    end
+  end
+
+  def fetch_token_counters(token, address_hash, timeout \\ 40) do
     total_token_transfers_task =
       Task.async(fn ->
         Chain.count_token_transfers_from_token_hash(address_hash)
@@ -21,7 +33,7 @@ defmodule BlockScoutWeb.Tokens.TokenController do
       end)
 
     [total_token_transfers_task, total_token_holders_task]
-    |> Task.yield_many(:timer.seconds(40))
+    |> Task.yield_many(:timer.seconds(timeout))
     |> Enum.map(fn {_task, res} ->
       case res do
         {:ok, result} ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/token_controller.ex
@@ -14,14 +14,14 @@ defmodule BlockScoutWeb.Tokens.TokenController do
          {:ok, token} <- Chain.token_from_address_hash(address_hash) do
       {transfer_count, token_holder_count} = fetch_token_counters(token, address_hash, 200)
 
-      json(conn, %{transfer_count: transfer_count, token_holder_counter: token_holder_count})
+      json(conn, %{transfer_count: transfer_count, token_holder_count: token_holder_count})
     else
       _ ->
         not_found(conn)
     end
   end
 
-  def fetch_token_counters(token, address_hash, timeout \\ 40) do
+  defp fetch_token_counters(token, address_hash, timeout) do
     total_token_transfers_task =
       Task.async(fn ->
         Chain.count_token_transfers_from_token_hash(address_hash)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
@@ -6,7 +6,6 @@ defmodule BlockScoutWeb.Tokens.TransferController do
   alias Phoenix.View
 
   import BlockScoutWeb.Chain, only: [split_list_by_page: 1, paging_options: 1, next_page_params: 3]
-  import BlockScoutWeb.Tokens.TokenController, only: [fetch_token_counters: 2]
 
   def index(conn, %{"token_id" => address_hash_string, "type" => "JSON"} = params) do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
@@ -49,16 +48,12 @@ defmodule BlockScoutWeb.Tokens.TransferController do
 
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, token} <- Chain.token_from_address_hash(address_hash, options) do
-      {total_token_transfers, total_token_holders} = fetch_token_counters(token, address_hash)
-
       render(
         conn,
         "index.html",
         counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)}),
         current_path: current_path(conn),
-        token: Market.add_price(token),
-        total_token_transfers: total_token_transfers,
-        total_token_holders: total_token_holders
+        token: Market.add_price(token)
       )
     else
       :error ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
@@ -54,6 +54,7 @@ defmodule BlockScoutWeb.Tokens.TransferController do
       render(
         conn,
         "index.html",
+        counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)}),
         current_path: current_path(conn),
         token: Market.add_price(token),
         total_token_transfers: total_token_transfers,

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
@@ -5,6 +5,7 @@
     token: @token,
     total_token_transfers: @total_token_transfers,
     total_token_holders: @total_token_holders,
+    counters_path: @counters_path,
     conn: @conn
   ) %>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
@@ -3,8 +3,6 @@
     OverviewView,
     "_details.html",
     token: @token,
-    total_token_transfers: @total_token_transfers,
-    total_token_holders: @total_token_holders,
     counters_path: @counters_path,
     conn: @conn
   ) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
@@ -1,4 +1,4 @@
-<section data-page="token-page" class="address-overview">
+<section class="address-overview">
   <div class="row">
     <div class="card-section col-md-12 col-lg-7 pr-0-md">
       <div class="card">

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
@@ -1,4 +1,4 @@
-<section class="address-overview">
+<section data-page="token-page" class="address-overview">
   <div class="row">
     <div class="card-section col-md-12 col-lg-7 pr-0-md">
       <div class="card">

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/index.html.eex
@@ -5,6 +5,7 @@
     token: @token,
     total_token_transfers: @total_token_transfers,
     total_token_holders: @total_token_holders,
+    counters_path: @counters_path,
     conn: @conn
   ) %>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/index.html.eex
@@ -3,8 +3,6 @@
     OverviewView,
     "_details.html",
     token: @token,
-    total_token_transfers: @total_token_transfers,
-    total_token_holders: @total_token_holders,
     counters_path: @counters_path,
     conn: @conn
   ) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="card-section col-md-12 col-lg-8 pr-0-md">
       <div class="card">
-        <div class="card-body" data-async-counters="<%= @counters_path %>">
+        <div class="card-body" token-page data-async-counters="<%= @counters_path %>">
           <h1 class="card-title">
             <%= if token_name?(@token) do %>
               <%= @token.name %>
@@ -57,14 +57,10 @@
             </span>
             <div class="d-flex flex-row justify-content-start text-muted">
               <span class="mr-4"> <%= @token.type %> </span>
-              <%= if @total_token_holders > 0 do %>
-                <span class="mr-4"><%= @total_token_holders %>  <%= gettext "Addresses" %></span>
-              <% end %>
-              <%= if @total_token_transfers > 0 do %>
-                <span class="mr-4"><%= @total_token_transfers %> <%= gettext "Transfers" %></span>
-              <% end %>
+              <span token-holder-count class="mr-4"></span>
+              <span token-transfer-count class="mr-4"></span>
               <%= if decimals?(@token) do %>
-                <span class="mr-4"><%= @token.decimals %> <%= gettext "Decimals" %></span>
+                <span  class="mr-4"><%= @token.decimals %> <%= gettext "Decimals" %></span>
               <% end %>
             </div>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="card-section col-md-12 col-lg-8 pr-0-md">
       <div class="card">
-        <div class="card-body">
+        <div class="card-body" data-async-counters="<%= @counters_path %>">
           <h1 class="card-title">
             <%= if token_name?(@token) do %>
               <%= @token.name %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
@@ -5,6 +5,7 @@
     token: @token,
     total_token_transfers: @total_token_transfers,
     total_token_holders: @total_token_holders,
+    counters_path: @counters_path,
     conn: @conn
   ) %>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
@@ -3,8 +3,6 @@
     OverviewView,
     "_details.html",
     token: @token,
-    total_token_transfers: @total_token_transfers,
-    total_token_holders: @total_token_holders,
     counters_path: @counters_path,
     conn: @conn
   ) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/index.html.eex
@@ -5,6 +5,7 @@
     token: @token,
     total_token_transfers: @total_token_transfers,
     total_token_holders: @total_token_holders,
+    counters_path: @counters_path,
     conn: @conn
   ) %>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/index.html.eex
@@ -3,8 +3,6 @@
     OverviewView,
     "_details.html",
     token: @token,
-    total_token_transfers: @total_token_transfers,
-    total_token_holders: @total_token_holders,
     counters_path: @counters_path,
     conn: @conn
   ) %>

--- a/apps/block_scout_web/lib/block_scout_web/web_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/web_router.ex
@@ -220,6 +220,8 @@ defmodule BlockScoutWeb.WebRouter do
 
     get("/chain_blocks", ChainController, :chain_blocks, as: :chain_blocks)
 
+    get("/token_counters", Tokens.TokenController, :token_counters)
+
     get("/*path", PageNotFoundController, :index)
   end
 end

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -135,7 +135,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/index.html.eex:4
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:61
 msgid "Addresses"
 msgstr ""
 
@@ -824,7 +823,7 @@ msgid "Telegram"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:27
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:25
 msgid "There are no holders for this Token."
 msgstr ""
 
@@ -855,7 +854,7 @@ msgid "There are no tokens for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:27
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:25
 msgid "There are no tokens."
 msgstr ""
 
@@ -871,7 +870,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:26
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:26
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:24
 msgid "There are no transfers for this Token."
 msgstr ""
 
@@ -900,7 +899,7 @@ msgid "Token Details"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:17
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:15
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:9
 #: lib/block_scout_web/views/tokens/overview_view.ex:36
 msgid "Token Holders"
@@ -922,7 +921,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:3
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:16
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:71
@@ -999,7 +998,7 @@ msgid "Invalid Transaction Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:17
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:15
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:17
 #: lib/block_scout_web/views/tokens/overview_view.ex:38
 msgid "Inventory"
@@ -1055,7 +1054,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:14
-#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:22
+#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:20
 msgid "Loading..."
 msgstr ""
 
@@ -1239,7 +1238,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:51
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:93
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:36
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:109
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:105
 msgid "QR Code"
 msgstr ""
 
@@ -1382,10 +1381,10 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/chain/show.html.eex:91
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:19
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:22
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:20
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:21
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:22
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:21
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:20
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/index.html.eex:20
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:11
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:13
@@ -1518,7 +1517,7 @@ msgid "Topics"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:79
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:75
 msgid "Total Supply"
 msgstr ""
 
@@ -1804,8 +1803,8 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:153
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:94
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:102
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:110
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:118
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:106
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:114
 msgid "Close"
 msgstr ""
 
@@ -1822,7 +1821,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:69
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:67
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:63
 msgid "Decimals"
 msgstr ""
 
@@ -1871,6 +1870,5 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:67
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:64
 msgid "Transfers"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -824,7 +824,7 @@ msgid "Telegram"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:26
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:27
 msgid "There are no holders for this Token."
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid "There are no tokens for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:26
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:27
 msgid "There are no tokens."
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:26
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:25
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:26
 msgid "There are no transfers for this Token."
 msgstr ""
 
@@ -900,7 +900,7 @@ msgid "Token Details"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:16
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:17
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:9
 #: lib/block_scout_web/views/tokens/overview_view.ex:36
 msgid "Token Holders"
@@ -922,7 +922,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:3
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:15
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:16
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:71
@@ -999,7 +999,7 @@ msgid "Invalid Transaction Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:16
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:17
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:17
 #: lib/block_scout_web/views/tokens/overview_view.ex:38
 msgid "Inventory"
@@ -1055,7 +1055,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:14
-#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:21
+#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:22
 msgid "Loading..."
 msgstr ""
 
@@ -1382,10 +1382,10 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/chain/show.html.eex:91
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:19
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:21
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:22
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:21
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:21
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:20
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:22
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:21
 #: lib/block_scout_web/templates/transaction/index.html.eex:20
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:11
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:13

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -135,7 +135,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/index.html.eex:4
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:61
 msgid "Addresses"
 msgstr ""
 
@@ -824,7 +823,7 @@ msgid "Telegram"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:27
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:25
 msgid "There are no holders for this Token."
 msgstr ""
 
@@ -855,7 +854,7 @@ msgid "There are no tokens for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:27
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:25
 msgid "There are no tokens."
 msgstr ""
 
@@ -871,7 +870,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:26
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:26
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:24
 msgid "There are no transfers for this Token."
 msgstr ""
 
@@ -900,7 +899,7 @@ msgid "Token Details"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:17
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:15
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:9
 #: lib/block_scout_web/views/tokens/overview_view.ex:36
 msgid "Token Holders"
@@ -922,7 +921,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:3
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:16
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:71
@@ -999,7 +998,7 @@ msgid "Invalid Transaction Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:17
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:15
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:17
 #: lib/block_scout_web/views/tokens/overview_view.ex:38
 msgid "Inventory"
@@ -1055,7 +1054,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:14
-#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:22
+#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:20
 msgid "Loading..."
 msgstr ""
 
@@ -1239,7 +1238,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:51
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:93
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:36
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:109
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:105
 msgid "QR Code"
 msgstr ""
 
@@ -1382,10 +1381,10 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/chain/show.html.eex:91
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:19
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:22
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:20
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:21
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:22
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:21
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:20
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/index.html.eex:20
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:11
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:13
@@ -1518,7 +1517,7 @@ msgid "Topics"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:79
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:75
 msgid "Total Supply"
 msgstr ""
 
@@ -1804,8 +1803,8 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:153
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:94
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:102
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:110
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:118
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:106
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:114
 msgid "Close"
 msgstr ""
 
@@ -1822,7 +1821,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:69
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:67
+#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:63
 msgid "Decimals"
 msgstr ""
 
@@ -1871,6 +1870,5 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:67
-#: lib/block_scout_web/templates/tokens/overview/_details.html.eex:64
 msgid "Transfers"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -824,7 +824,7 @@ msgid "Telegram"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:26
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:27
 msgid "There are no holders for this Token."
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid "There are no tokens for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:26
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:27
 msgid "There are no tokens."
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:26
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:25
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:26
 msgid "There are no transfers for this Token."
 msgstr ""
 
@@ -900,7 +900,7 @@ msgid "Token Details"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:16
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:17
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:9
 #: lib/block_scout_web/views/tokens/overview_view.ex:36
 msgid "Token Holders"
@@ -922,7 +922,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:3
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:15
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:16
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:71
@@ -999,7 +999,7 @@ msgid "Invalid Transaction Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:16
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:17
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:17
 #: lib/block_scout_web/views/tokens/overview_view.ex:38
 msgid "Inventory"
@@ -1055,7 +1055,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:14
-#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:21
+#: lib/block_scout_web/templates/tokens/read_contract/index.html.eex:22
 msgid "Loading..."
 msgstr ""
 
@@ -1382,10 +1382,10 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/chain/show.html.eex:91
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:19
-#: lib/block_scout_web/templates/tokens/holder/index.html.eex:21
+#: lib/block_scout_web/templates/tokens/holder/index.html.eex:22
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:21
-#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:21
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:20
+#: lib/block_scout_web/templates/tokens/inventory/index.html.eex:22
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:21
 #: lib/block_scout_web/templates/transaction/index.html.eex:20
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:11
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:13

--- a/apps/block_scout_web/test/block_scout_web/controllers/tokens/read_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/tokens/read_contract_controller_test.exs
@@ -30,8 +30,6 @@ defmodule BlockScoutWeb.Tokens.ReadContractControllerTest do
 
       assert html_response(conn, 200)
       assert token.contract_address_hash == conn.assigns.token.contract_address_hash
-      assert conn.assigns.total_token_transfers
-      assert conn.assigns.total_token_holders
     end
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/tokens/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/tokens/token_controller_test.exs
@@ -30,7 +30,7 @@ defmodule BlockScoutWeb.Tokens.TokenControllerTest do
       assert conn.status == 200
       {:ok, response} = Jason.decode(conn.resp_body)
 
-      assert %{"token_holder_counter" => 0, "transfer_count" => 1} == response
+      assert %{"token_holder_count" => 0, "transfer_count" => 1} == response
     end
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/tokens/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/tokens/token_controller_test.exs
@@ -1,0 +1,36 @@
+defmodule BlockScoutWeb.Tokens.TokenControllerTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  describe "GET show/2" do
+    test "redirects to transfers page", %{conn: conn} do
+      contract_address = insert(:address)
+
+      conn = get(conn, token_path(conn, :show, contract_address.hash))
+
+      assert conn.status == 302
+    end
+  end
+
+  describe "GET token_counters/2" do
+    test "returns token counters", %{conn: conn} do
+      contract_address = insert(:address)
+
+      insert(:token, contract_address: contract_address)
+
+      token_id = 10
+
+      insert(:token_transfer,
+        from_address: contract_address,
+        token_contract_address: contract_address,
+        token_id: token_id
+      )
+
+      conn = get(conn, "/token_counters", %{"id" => to_string(contract_address.hash)})
+
+      assert conn.status == 200
+      {:ok, response} = Jason.decode(conn.resp_body)
+
+      assert %{"token_holder_counter" => 0, "transfer_count" => 1} == response
+    end
+  end
+end


### PR DESCRIPTION
resolves https://github.com/poanetwork/blockscout/issues/2771

## Motivation

Token counters fetching is the slowest part of the token page.

## Changelog

- fetch token counters async