### PR TITLE
optimize txlist json rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixes
 - [#2755](https://github.com/poanetwork/blockscout/pull/2755) - various token instance fetcher fixes
+- [#2781](https://github.com/poanetwork/blockscout/pull/2781) - optimize txlist json rpc
 - [#2770](https://github.com/poanetwork/blockscout/pull/2770) - do not re-fetch token instances without uris
 - [#2761](https://github.com/poanetwork/blockscout/pull/2761) - add indexes for token instances fetching queries
 - [#2767](https://github.com/poanetwork/blockscout/pull/2767) - fix websocket subscriptions with token instances

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -1189,7 +1189,7 @@ defmodule BlockScoutWeb.Etherscan do
         key: "sort",
         type: "string",
         description:
-          "A string representing the order by block number direction. Defaults to ascending order. Available values: asc, desc"
+          "A string representing the order by block number direction. Defaults to descending order. Available values: asc, desc"
       },
       %{
         key: "startblock",

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -809,7 +809,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
           String.to_integer(transaction["blockNumber"])
         end)
 
-      assert block_numbers_order == Enum.sort(block_numbers_order, &(&1 <= &2))
+      assert block_numbers_order == Enum.sort(block_numbers_order, &(&1 >= &2))
       assert response["status"] == "1"
       assert response["message"] == "OK"
       assert :ok = ExJsonSchema.Validator.validate(txlist_schema(), response)
@@ -831,12 +831,12 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
         |> insert_list(:transaction, from_address: address)
         |> with_block(second_block)
 
-      _third_block_transactions =
+      first_block_transactions =
         2
         |> insert_list(:transaction, from_address: address)
         |> with_block(third_block)
 
-      first_block_transactions =
+      _third_block_transactions =
         2
         |> insert_list(:transaction, from_address: address)
         |> with_block(first_block)

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -11,7 +11,7 @@ defmodule Explorer.Etherscan do
   alias Explorer.Chain.{Block, Hash, InternalTransaction, Transaction}
 
   @default_options %{
-    order_by_direction: :asc,
+    order_by_direction: :desc,
     page_number: 1,
     page_size: 10_000,
     start_block: nil,

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -272,7 +272,7 @@ defmodule Explorer.Etherscan do
       from(
         t in Transaction,
         inner_join: b in assoc(t, :block),
-        order_by: [{^options.order_by_direction, t.block_number}],
+        order_by: [{^options.order_by_direction, b.number}],
         limit: ^options.page_size,
         offset: ^offset(options),
         select:

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -187,7 +187,7 @@ defmodule Explorer.EtherscanTest do
 
       block_numbers_order = Enum.map(found_transactions, & &1.block_number)
 
-      assert block_numbers_order == Enum.sort(block_numbers_order)
+      assert block_numbers_order == Enum.sort(block_numbers_order, &(&1 >= &2))
     end
 
     test "orders transactions by block, in descending order" do
@@ -227,12 +227,12 @@ defmodule Explorer.EtherscanTest do
         |> insert_list(:transaction, from_address: address)
         |> with_block(second_block)
 
-      third_block_transactions =
+      first_block_transactions =
         2
         |> insert_list(:transaction, from_address: address)
         |> with_block(third_block)
 
-      first_block_transactions =
+      third_block_transactions =
         2
         |> insert_list(:transaction, from_address: address)
         |> with_block(first_block)
@@ -960,7 +960,7 @@ defmodule Explorer.EtherscanTest do
 
       block_numbers_order = Enum.map(found_token_transfers, & &1.block_number)
 
-      assert block_numbers_order == Enum.sort(block_numbers_order)
+      assert block_numbers_order == Enum.sort(block_numbers_order, &(&1 >= &2))
     end
 
     test "orders token transfers by block, in descending order" do
@@ -1021,9 +1021,9 @@ defmodule Explorer.EtherscanTest do
 
       second_block_token_transfers = insert_list(2, :token_transfer, from_address: address, transaction: transaction2)
 
-      third_block_token_transfers = insert_list(2, :token_transfer, from_address: address, transaction: transaction3)
+      first_block_token_transfers = insert_list(2, :token_transfer, from_address: address, transaction: transaction3)
 
-      first_block_token_transfers = insert_list(2, :token_transfer, from_address: address, transaction: transaction1)
+      third_block_token_transfers = insert_list(2, :token_transfer, from_address: address, transaction: transaction1)
 
       options1 = %{page_number: 1, page_size: 2}
 


### PR DESCRIPTION
fixes https://github.com/poanetwork/blockscout/issues/1319

the query was sorted by transactions.block_number field
which doesn't have db
index (https://github.com/poanetwork/blockscout/pull/2698).

Now we will start sorting by blocks.number since transactions are
joined with blocks anyway.


## Changelog

- optimize txlist json rpc