### PR TITLE
Hide "We are indexing this chain right now. Some of the counts may be inaccurate" banner if no txs in blockchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#2470](https://github.com/poanetwork/blockscout/pull/2470) - Allow Realtime Fetcher to wait for small skips
 
 ### Fixes
+- [#2793](https://github.com/poanetwork/blockscout/pull/2793) - Hide "We are indexing this chain right now. Some of the counts may be inaccurate" banner if no txs in blockchain
 - [#2779](https://github.com/poanetwork/blockscout/pull/2779) - fix fetching `latin1` encoded data
 - [#2783](https://github.com/poanetwork/blockscout/pull/2783) - Fix stuck value and ticker on the token page
 - [#2781](https://github.com/poanetwork/blockscout/pull/2781) - optimize txlist json rpc

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_app_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_app_test.exs
@@ -6,6 +6,8 @@ defmodule BlockScoutWeb.ViewingAppTest do
   alias BlockScoutWeb.AppPage
   alias BlockScoutWeb.Counters.BlocksIndexedCounter
   alias Explorer.Counters.AddressesCounter
+  alias Explorer.{Repo}
+  alias Explorer.Chain.{Transaction}
 
   setup do
     start_supervised!(AddressesCounter)
@@ -16,9 +18,14 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   describe "loading bar when indexing" do
     test "shows blocks indexed percentage", %{session: session} do
-      for index <- 5..9 do
-        insert(:block, number: index)
-      end
+      [block | _] =
+        for index <- 5..9 do
+          insert(:block, number: index)
+        end
+
+      :transaction
+      |> insert()
+      |> with_block(block)
 
       assert Decimal.cmp(Explorer.Chain.indexed_ratio(), Decimal.from_float(0.5)) == :eq
 
@@ -28,9 +35,14 @@ defmodule BlockScoutWeb.ViewingAppTest do
     end
 
     test "shows tokens loading", %{session: session} do
-      for index <- 0..9 do
-        insert(:block, number: index)
-      end
+      [block | _] =
+        for index <- 0..9 do
+          insert(:block, number: index)
+        end
+
+      :transaction
+      |> insert()
+      |> with_block(block)
 
       assert Decimal.cmp(Explorer.Chain.indexed_ratio(), 1) == :eq
 
@@ -40,9 +52,14 @@ defmodule BlockScoutWeb.ViewingAppTest do
     end
 
     test "updates blocks indexed percentage", %{session: session} do
-      for index <- 5..9 do
-        insert(:block, number: index)
-      end
+      [block | _] =
+        for index <- 5..9 do
+          insert(:block, number: index)
+        end
+
+      :transaction
+      |> insert()
+      |> with_block(block)
 
       BlocksIndexedCounter.calculate_blocks_indexed()
 
@@ -60,9 +77,14 @@ defmodule BlockScoutWeb.ViewingAppTest do
     end
 
     test "updates when blocks are fully indexed", %{session: session} do
-      for index <- 1..9 do
-        insert(:block, number: index)
-      end
+      [block | _] =
+        for index <- 1..9 do
+          insert(:block, number: index)
+        end
+
+      :transaction
+      |> insert()
+      |> with_block(block)
 
       BlocksIndexedCounter.calculate_blocks_indexed()
 
@@ -85,6 +107,10 @@ defmodule BlockScoutWeb.ViewingAppTest do
           insert(:block, number: index)
         end
 
+      :transaction
+      |> insert()
+      |> with_block(block)
+
       BlocksIndexedCounter.calculate_blocks_indexed()
 
       assert Decimal.cmp(Explorer.Chain.indexed_ratio(), 1) == :eq
@@ -93,9 +119,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
       |> AppPage.visit_page()
       |> assert_has(AppPage.indexed_status("Indexing Tokens"))
 
-      :transaction
-      |> insert()
-      |> with_block(block, internal_transactions_indexed_at: DateTime.utc_now())
+      Repo.update_all(Transaction, set: [internal_transactions_indexed_at: DateTime.utc_now()])
 
       BlocksIndexedCounter.calculate_blocks_indexed()
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -715,19 +715,28 @@ defmodule Explorer.Chain do
   """
   @spec finished_indexing?() :: boolean()
   def finished_indexing? do
-    min_block_number_transaction = Repo.aggregate(Transaction, :min, :block_number)
-
-    if min_block_number_transaction do
+    transaction_exists =
       Transaction
-      |> where([t], t.block_number == ^min_block_number_transaction and is_nil(t.internal_transactions_indexed_at))
       |> limit(1)
       |> Repo.one()
-      |> case do
-        nil -> true
-        _ -> false
+
+    min_block_number_transaction = Repo.aggregate(Transaction, :min, :block_number)
+
+    if transaction_exists do
+      if min_block_number_transaction do
+        Transaction
+        |> where([t], t.block_number == ^min_block_number_transaction and is_nil(t.internal_transactions_indexed_at))
+        |> limit(1)
+        |> Repo.one()
+        |> case do
+          nil -> true
+          _ -> false
+        end
+      else
+        false
       end
     else
-      false
+      true
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -972,6 +972,10 @@ defmodule Explorer.ChainTest do
       assert Chain.finished_indexing?()
     end
 
+    test "finished indexing (no txs)" do
+      assert Chain.finished_indexing?()
+    end
+
     test "not finished indexing" do
       block = insert(:block, number: 1)
 


### PR DESCRIPTION
## Motivation

Blokcscout shows " n% Blocks Indexed - We're indexing this chain right now. Some of the counts may be inaccurate." banner at the top even if blockchain doesn't have transactions

## Changelog

### Enhancements

If there are no transactions in the blockchain, the banner is hidden

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
