### PR TITLE
fix txlist ordering issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2822](https://github.com/poanetwork/blockscout/pull/2822) - Estimated address count on the main page, if cache is empty
 
 ### Fixes
+- [#2837](https://github.com/poanetwork/blockscout/pull/2837) - fix txlist ordering issue
 - [#2830](https://github.com/poanetwork/blockscout/pull/2830) - Fix wrong color of contract icon on xDai chain
 - [#2829](https://github.com/poanetwork/blockscout/pull/2829) - Fix for stuck gas limit label and value
 - [#2828](https://github.com/poanetwork/blockscout/pull/2828) - Fix for script that clears compilation/launching assets

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -272,7 +272,7 @@ defmodule Explorer.Etherscan do
       from(
         t in Transaction,
         inner_join: b in assoc(t, :block),
-        order_by: [{^options.order_by_direction, b.number}],
+        order_by: [{^options.order_by_direction, t.block_number}],
         limit: ^options.page_size,
         offset: ^offset(options),
         select:


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/2582

## Motivation

When using `block_number` field from the transaction table, the query is not timing out.

## Changelog

- fix `txlist` ordering issue