### PR TITLE
fix realtime fetcher small skips feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2822](https://github.com/poanetwork/blockscout/pull/2822) - Estimated address count on the main page, if cache is empty
 
 ### Fixes
+- [#2843](https://github.com/poanetwork/blockscout/pull/2843) - fix realtime fetcher small skips feature
 - [#2837](https://github.com/poanetwork/blockscout/pull/2837) - fix txlist ordering issue
 - [#2830](https://github.com/poanetwork/blockscout/pull/2830) - Fix wrong color of contract icon on xDai chain
 - [#2829](https://github.com/poanetwork/blockscout/pull/2829) - Fix for stuck gas limit label and value

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
@@ -308,7 +308,7 @@ defmodule EthereumJSONRPC.Transaction do
   end
 
   def to_elixir(transaction) when is_binary(transaction) do
-    Logger.warn(["Fetched transaction is not full: ", transaction])
+    #    Logger.warn(["Fetched transaction is not full: ", transaction])
 
     nil
   end

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -250,7 +250,11 @@ defmodule Indexer.Block.Realtime.Fetcher do
         [number]
 
       true ->
-        (previous_number + 1)..number
+        if number - previous_number - 1 > 10 do
+          (number - 10)..number
+        else
+          (previous_number + 1)..number
+        end
     end
   end
 

--- a/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
@@ -448,7 +448,7 @@ defmodule Indexer.Block.Realtime.FetcherTest do
       old_number = 94
 
       assert (previous_number + 1)..number == Realtime.Fetcher.determine_fetching_action(number, previous_number, nil)
-      assert (old_number + 1)..number == Realtime.Fetcher.determine_fetching_action(number, old_number, nil)
+      assert (number - 10)..number == Realtime.Fetcher.determine_fetching_action(number, old_number, nil)
     end
 
     test "when number immediately follows the previous_number it is fetched" do
@@ -472,7 +472,7 @@ defmodule Indexer.Block.Realtime.FetcherTest do
 
       number = max_number_seen + max_skipping_distance + 1
 
-      assert (previous_number + 1)..number ==
+      assert (number - 10)..number ==
                Realtime.Fetcher.determine_fetching_action(number, previous_number, max_number_seen)
     end
   end


### PR DESCRIPTION
If indexing is started from scratch, realtime fetcher
tries to index large ranges of blocks. For example, 5..1852044.
It produces errors like
`failed to fetch: :emfile.  Block will be retried by catchup indexer`

This PR limits the number of blocks to 10


## Changelog

- fix realtime fetcher small skips feature