### PR TITLE
Extend external reward types up to 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#2803](https://github.com/poanetwork/blockscout/pull/2803) - Fix block validator custom tooltip
 
 ### Chore
+- [#2844](https://github.com/poanetwork/blockscout/pull/2844) - Extend external reward types up to 20
 - [#2827](https://github.com/poanetwork/blockscout/pull/2827) - Node js 12.13.0 (latest LTS release) support
 - [#2818](https://github.com/poanetwork/blockscout/pull/2818) - allow hiding marketcap percentage
 - [#2817](https://github.com/poanetwork/blockscout/pull/2817) - move docker integration documentation to blockscout docs

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
@@ -180,6 +180,16 @@ defmodule EthereumJSONRPC.Parity.FetchedBeneficiaries do
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 8, do: :validator
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 9, do: :validator
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 10, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 11, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 12, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 13, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 14, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 15, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 16, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 17, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 18, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 19, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index == 20, do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "block", do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "uncle", do: :uncle
   defp get_address_type(reward_type, _index) when reward_type == "emptyStep", do: :validator


### PR DESCRIPTION
## Motivation

```
2019-11-06T22:28:05.871 application=indexer fetcher=block_catchup first_block_number=6404723 last_block_number=6404723 [error] ** (FunctionClauseError) no function clause matching in EthereumJSONRPC.Parity.FetchedBeneficiaries.get_address_type/2
    (ethereum_jsonrpc) lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex:172: EthereumJSONRPC.Parity.FetchedBeneficiaries.get_address_type("external", 11)
    (ethereum_jsonrpc) lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex:156: EthereumJSONRPC.Parity.FetchedBeneficiaries.trace_to_params_set/3
    (ethereum_jsonrpc) lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex:132: anonymous fn/3 in EthereumJSONRPC.Parity.FetchedBeneficiaries.traces_to_params_set/2
    (elixir) lib/enum.ex:3023: anonymous fn/3 in Enum.reduce/3
    (elixir) lib/stream.ex:1571: anonymous fn/3 in Enumerable.Stream.reduce/3
    (elixir) lib/stream.ex:1062: anonymous fn/3 in Stream.with_index/2
    (elixir) lib/enum.ex:3325: Enumerable.List.reduce/3
    (elixir) lib/stream.ex:1583: Enumerable.Stream.do_each/4
```

## Changelog

Extend `external` reward types up to 20

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
