### PR TITLE
Set outline none for nav dropdown item in mobile view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#2803](https://github.com/poanetwork/blockscout/pull/2803) - Fix block validator custom tooltip
 
 ### Chore
+- [#2845](https://github.com/poanetwork/blockscout/pull/2845) - Set outline none for nav dropdown item in mobile view (fix for Safari)
 - [#2844](https://github.com/poanetwork/blockscout/pull/2844) - Extend external reward types up to 20
 - [#2827](https://github.com/poanetwork/blockscout/pull/2827) - Node js 12.13.0 (latest LTS release) support
 - [#2818](https://github.com/poanetwork/blockscout/pull/2818) - allow hiding marketcap percentage

--- a/apps/block_scout_web/assets/css/components/_navbar.scss
+++ b/apps/block_scout_web/assets/css/components/_navbar.scss
@@ -25,6 +25,7 @@ $navbar-logo-width: auto !default;
   .navbar-nav {
     
     .nav-link {
+      outline: none;
       align-items: center;
       color: $header-links-color;
       display: flex;


### PR DESCRIPTION
## Motivation

Before (Safari):
![Screenshot 2019-11-07 at 15 00 09](https://user-images.githubusercontent.com/4341812/68387541-991c7c80-016f-11ea-87fc-ca9be37cc8b8.png)


After (Safari):
![Screenshot 2019-11-07 at 14 59 44](https://user-images.githubusercontent.com/4341812/68387523-928e0500-016f-11ea-89e4-3afbc095e464.png)


## Changelog

Set `outline: none` for `nav-link`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
