### PR TITLE
Remove networks images preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#2803](https://github.com/poanetwork/blockscout/pull/2803) - Fix block validator custom tooltip
 
 ### Chore
+- [#2846](https://github.com/poanetwork/blockscout/pull/2846) - Remove networks images preload
 - [#2845](https://github.com/poanetwork/blockscout/pull/2845) - Set outline none for nav dropdown item in mobile view (fix for Safari)
 - [#2844](https://github.com/poanetwork/blockscout/pull/2844) - Extend external reward types up to 20
 - [#2827](https://github.com/poanetwork/blockscout/pull/2827) - Node js 12.13.0 (latest LTS release) support

--- a/apps/block_scout_web/assets/css/app.scss
+++ b/apps/block_scout_web/assets/css/app.scss
@@ -60,7 +60,6 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 // Custom SCSS
 @import "layout";
 @import "typography";
-@import "images-preload";
 @import "code";
 @import "helpers";
 @import "elements";
@@ -110,7 +109,6 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "components/log-search";
 @import "components/radio";
 @import "components/modal_variables";
-@import "components/network-selector";
 @import "components/new_smart_contract";
 @import "components/radio_big";
 @import "components/btn_no_border";

--- a/apps/block_scout_web/assets/js/app.js
+++ b/apps/block_scout_web/assets/js/app.js
@@ -20,9 +20,6 @@ import 'bootstrap'
 
 import './locale'
 
-// support of preload in Firefox
-import '../node_modules/fg-loadcss/dist/cssrelpreload.min'
-
 import './pages/address'
 import './pages/address/coin_balances'
 import './pages/address/transactions'

--- a/apps/block_scout_web/assets/package-lock.json
+++ b/apps/block_scout_web/assets/package-lock.json
@@ -4126,11 +4126,6 @@
         "bser": "^2.0.0"
       }
     },
-    "fg-loadcss": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fg-loadcss/-/fg-loadcss-2.1.0.tgz",
-      "integrity": "sha512-HpvR2uRoKvrYAEwimw+k4Fr2NVHYPfld5Lc/f9uy3mKeUTXhS5urL24XA2rqyq5b2i410EXCLir4Uhsb8J1QaQ=="
-    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",

--- a/apps/block_scout_web/assets/package.json
+++ b/apps/block_scout_web/assets/package.json
@@ -25,7 +25,6 @@
     "bootstrap": "^4.1.3",
     "chart.js": "^2.7.2",
     "clipboard": "^2.0.1",
-    "fg-loadcss": "^2.1.0",
     "highlight.js": "^9.13.1",
     "highlightjs-solidity": "^1.0.6",
     "humps": "^2.0.1",

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -168,7 +168,6 @@
     </div>
   </div>
 </nav>
-<%= render BlockScoutWeb.LayoutView, "_network_selector.html" %>
 <script>
   if (localStorage.getItem("current-color-mode") === "dark") {
     var modeChanger = document.getElementById("dark-mode-changer");


### PR DESCRIPTION
## Motivation

After returning of old networks menu https://github.com/poanetwork/blockscout/pull/2797, networks images preload wasn't removed https://github.com/poanetwork/blockscout/pull/2570

## Changelog

Remove preload of network images for enhanced networks menu since that menu was disabled for a while and networks menu styles itself

## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
