### PR TITLE
add token instance metadata check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#2822](https://github.com/poanetwork/blockscout/pull/2822) - Estimated address count on the main page, if cache is empty
 
 ### Fixes
+- [#2864](https://github.com/poanetwork/blockscout/pull/2864) - add token instance metadata type check
 - [#2855](https://github.com/poanetwork/blockscout/pull/2855) - Fix favicons load
 - [#2854](https://github.com/poanetwork/blockscout/pull/2854) - Fix all npm vulnerabilities
 - [#2851](https://github.com/poanetwork/blockscout/pull/2851) - Fix paths for front assets

--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -101,7 +101,11 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
       {:ok, %Response{body: body, status_code: 200}} ->
         {:ok, json} = decode_json(body)
 
-        {:ok, %{metadata: json}}
+        if is_map(json) do
+          {:ok, %{metadata: json}}
+        else
+          {:error, :wrong_metadata_type}
+        end
 
       {:ok, %Response{body: body}} ->
         {:error, body}


### PR DESCRIPTION
some token instances return integers as metadata


## Motivation

fixes
```
2019-11-19T09:35:55.538 [error] Task #PID<0.20704.5> started from Indexer.Fetcher.TokenInstance terminating
** (MatchError) no match of right hand side value: {:error, #Ecto.Changeset<action: :insert, changes: %{token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<104, 35, 202, 192, 134, 199, 8, 88, 185, 190, 194, 23, 112, 82, 10, 103, 36, 129, 169, 107>>}, token_id: #Decimal<3>}, errors: [metadata: {"is invalid", [type: :map, validation: :cast]}], data: #Explorer.Chain.Token.Instance<>, valid?: false>}
    (indexer) lib/indexer/fetcher/token_instance.ex:63: Indexer.Fetcher.TokenInstance.run/2
    (elixir) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (elixir) lib/task/supervised.ex:35: Task.Supervised.reply/5
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Function: &Indexer.BufferedTask.log_run/1
    Args: [%{batch: [%{contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<104, 35, 202, 192, 134, 199, 8, 88, 185, 190, 194, 23, 112, 82, 10, 103, 36, 129, 169, 107>>}, token_id: #Decimal<3>}], callback_module: Indexer.Fetcher.TokenInstance, callback_module_state: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.HTTPoison, url: "http://10.1.0.74:8545", method_to_url: [eth_getBalance: "http://10.1.0.74:8545", trace_block: "http://10.1.0.74:8545", trace_replayTransaction: "http://10.1.0.74:8545"], http_options: [recv_timeout: 600000, timeout: 600000, hackney: [pool: :ethereum_jsonrpc]]], variant: EthereumJSONRPC.Parity], metadata: []}]
```

## Changelog

- add token instance metadata check