### PR TITLE
do not remove logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2449](https://github.com/poanetwork/blockscout/pull/2449) - add ability to send notification events through postgres notify
 
 ### Fixes
+- [#2871](https://github.com/poanetwork/blockscout/pull/2871) - do not remove logs
 - [#2800](https://github.com/poanetwork/blockscout/pull/2800) - return not found for not verified contract for token read_contract
 - [#2806](https://github.com/poanetwork/blockscout/pull/2806) - Fix blocks fetching on the main page
 - [#2803](https://github.com/poanetwork/blockscout/pull/2803) - Fix block validator custom tooltip

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
@@ -76,7 +76,7 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       block = insert(:block, number: 0)
 
       transaction = insert(:transaction, from_address: address) |> with_block(block)
-      insert(:log, address: address, transaction: transaction, data: "0x010101")
+      insert(:log, block: block, address: address, transaction: transaction, data: "0x010101")
 
       params = params(api_params, [%{"address" => to_string(address.hash)}])
 
@@ -94,7 +94,7 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       block = insert(:block, number: 0)
 
       transaction = insert(:transaction, from_address: address) |> with_block(block)
-      insert(:log, address: address, transaction: transaction, data: "0x010101", first_topic: "0x01")
+      insert(:log, block: block, address: address, transaction: transaction, data: "0x010101", first_topic: "0x01")
 
       params = params(api_params, [%{"address" => to_string(address.hash), "topics" => ["0x01"]}])
 
@@ -112,8 +112,8 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       block = insert(:block, number: 0)
 
       transaction = insert(:transaction, from_address: address) |> with_block(block)
-      insert(:log, address: address, transaction: transaction, data: "0x010101", first_topic: "0x01")
-      insert(:log, address: address, transaction: transaction, data: "0x020202", first_topic: "0x00")
+      insert(:log, address: address, block: block, transaction: transaction, data: "0x010101", first_topic: "0x01")
+      insert(:log, address: address, block: block, transaction: transaction, data: "0x020202", first_topic: "0x00")
 
       params = params(api_params, [%{"address" => to_string(address.hash), "topics" => [["0x01", "0x00"]]}])
 
@@ -127,14 +127,15 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
 
     test "paginates logs", %{conn: conn, api_params: api_params} do
       contract_address = insert(:contract_address)
+      block = insert(:block)
 
       transaction =
         :transaction
         |> insert(to_address: contract_address)
-        |> with_block()
+        |> with_block(block)
 
       inserted_records =
-        insert_list(2000, :log, address: contract_address, transaction: transaction, first_topic: "0x01")
+        insert_list(2000, :log, block: block, address: contract_address, transaction: transaction, first_topic: "0x01")
 
       params = params(api_params, [%{"address" => to_string(contract_address), "topics" => [["0x01"]]}])
 
@@ -191,10 +192,11 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
         transaction: transaction,
         data: "0x010101",
         first_topic: "0x01",
-        second_topic: "0x02"
+        second_topic: "0x02",
+        block: block
       )
 
-      insert(:log, address: address, transaction: transaction, data: "0x020202", first_topic: "0x01")
+      insert(:log, block: block, address: address, transaction: transaction, data: "0x020202", first_topic: "0x01")
 
       params = params(api_params, [%{"address" => to_string(address.hash), "topics" => ["0x01", "0x02"]}])
 
@@ -219,7 +221,8 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
         transaction: transaction,
         data: "0x010101",
         first_topic: "0x01",
-        second_topic: "0x02"
+        second_topic: "0x02",
+        block: block
       )
 
       insert(:log,
@@ -227,7 +230,8 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
         transaction: transaction,
         data: "0x020202",
         first_topic: "0x01",
-        second_topic: "0x03"
+        second_topic: "0x03",
+        block: block
       )
 
       params = params(api_params, [%{"address" => to_string(address.hash), "topics" => ["0x01", ["0x02", "0x03"]]}])
@@ -341,11 +345,11 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       transaction2 = insert(:transaction, from_address: address) |> with_block(block2)
       transaction3 = insert(:transaction, from_address: address) |> with_block(block3)
 
-      insert(:log, address: address, transaction: transaction1, data: "0x010101")
+      insert(:log, block: block1, address: address, transaction: transaction1, data: "0x010101")
 
-      insert(:log, address: address, transaction: transaction2, data: "0x020202")
+      insert(:log, block: block2, address: address, transaction: transaction2, data: "0x020202")
 
-      insert(:log, address: address, transaction: transaction3, data: "0x030303")
+      insert(:log, block: block3, address: address, transaction: transaction3, data: "0x030303")
 
       changeset = Ecto.Changeset.change(block3, %{consensus: false})
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
@@ -486,7 +486,8 @@ defmodule BlockScoutWeb.API.RPC.TransactionControllerTest do
           address: address,
           transaction: transaction,
           first_topic: "first topic",
-          second_topic: "second topic"
+          second_topic: "second topic",
+          block: block
         )
 
       params = %{

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
@@ -84,6 +84,7 @@ defmodule EthereumJSONRPC.Log do
         %{
           "address" => address_hash,
           "blockNumber" => block_number,
+          "blockHash" => block_hash,
           "data" => data,
           "logIndex" => index,
           "topics" => topics,
@@ -94,6 +95,7 @@ defmodule EthereumJSONRPC.Log do
       address_hash: address_hash,
       block_number: block_number,
       data: data,
+      block_hash: block_hash,
       index: index,
       transaction_hash: transaction_hash
     }

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
@@ -47,6 +47,7 @@ defmodule EthereumJSONRPC.Log do
         second_topic: nil,
         third_topic: nil,
         transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5",
+        block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
         type: "mined"
       }
 
@@ -70,6 +71,7 @@ defmodule EthereumJSONRPC.Log do
       %{
         address_hash: "0xda8b3276cde6d768a44b9dac659faa339a41ac55",
         block_number: 4448,
+        block_hash: "0x0b89f7f894f5d8ba941e16b61490e999a0fcaaf92dfcc70aee2ac5ddb5f243e1",
         data: "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
         first_topic: "0xadc1e8a294f8415511303acc4a8c0c5906c7eb0bf2a71043d7f4b03b46a39130",
         fourth_topic: nil,

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/receipts_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/receipts_test.exs
@@ -82,6 +82,7 @@ defmodule EthereumJSONRPC.ReceiptsTest do
                  "logs" => [
                    %{
                      "address" => address_hash,
+                     "blockHash" => "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
                      "blockNumber" => integer_to_quantity(block_number),
                      "data" => data,
                      "logIndex" => integer_to_quantity(index),

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -355,7 +355,7 @@ defmodule Explorer.Chain do
         or_where:
           transaction.block_number == ^block_number and transaction.index == ^transaction_index and
             log.index > ^log_index,
-        where: log.address_hash == ^address_hash,
+        where: log.address_hash == ^address_hash and log.block_hash == transaction.block_hash,
         limit: ^paging_options.page_size,
         select: log
       )

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -8,7 +8,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   import Ecto.Query, only: [from: 2, subquery: 1]
 
   alias Ecto.{Changeset, Multi, Repo}
-  alias Explorer.Chain.{Address, Block, Import, InternalTransaction, Log, TokenTransfer, Transaction}
+  alias Explorer.Chain.{Address, Block, Import, InternalTransaction, TokenTransfer, Transaction}
   alias Explorer.Chain.Block.Reward
   alias Explorer.Chain.Import.Runner
   alias Explorer.Chain.Import.Runner.Address.CurrentTokenBalances

--- a/apps/explorer/lib/explorer/chain/import/runner/logs.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/logs.ex
@@ -65,7 +65,7 @@ defmodule Explorer.Chain.Import.Runner.Logs do
       Import.insert_changes_list(
         repo,
         ordered_changes_list,
-        conflict_target: [:transaction_hash, :index],
+        conflict_target: [:transaction_hash, :index, :block_hash],
         on_conflict: on_conflict,
         for: Log,
         returning: true,

--- a/apps/explorer/lib/explorer/chain/import/runner/logs.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/logs.ex
@@ -59,7 +59,7 @@ defmodule Explorer.Chain.Import.Runner.Logs do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # Enforce Log ShareLocks order (see docs: sharelocks.md)
-    ordered_changes_list = Enum.sort_by(changes_list, &{&1.transaction_hash, &1.index})
+    ordered_changes_list = Enum.sort_by(changes_list, &{&1.transaction_hash, &1.block_hash, &1.index})
 
     {:ok, _} =
       Import.insert_changes_list(

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -62,7 +62,6 @@ defmodule Explorer.Chain.Log do
       type: Hash.Full
     )
 
-
     belongs_to(:block, Block,
       foreign_key: :block_hash,
       primary_key: true,

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -6,14 +6,15 @@ defmodule Explorer.Chain.Log do
   require Logger
 
   alias ABI.{Event, FunctionSelector}
-  alias Explorer.Chain.{Address, ContractMethod, Data, Hash, Transaction}
+  alias Explorer.Chain.{Address, Block, ContractMethod, Data, Hash, Transaction}
   alias Explorer.Repo
 
-  @required_attrs ~w(address_hash data index transaction_hash)a
+  @required_attrs ~w(address_hash data block_hash index transaction_hash)a
   @optional_attrs ~w(first_topic second_topic third_topic fourth_topic type)a
 
   @typedoc """
    * `address` - address of contract that generate the event
+   * `block_hash` - hash of the block
    * `address_hash` - foreign key for `address`
    * `data` - non-indexed log parameters.
    * `first_topic` - `topics[0]`
@@ -28,6 +29,7 @@ defmodule Explorer.Chain.Log do
   @type t :: %__MODULE__{
           address: %Ecto.Association.NotLoaded{} | Address.t(),
           address_hash: Hash.Address.t(),
+          block_hash: Hash.Full.t(),
           data: Data.t(),
           first_topic: String.t(),
           second_topic: String.t(),
@@ -55,6 +57,14 @@ defmodule Explorer.Chain.Log do
 
     belongs_to(:transaction, Transaction,
       foreign_key: :transaction_hash,
+      primary_key: true,
+      references: :hash,
+      type: Hash.Full
+    )
+
+
+    belongs_to(:block, Block,
+      foreign_key: :block_hash,
       primary_key: true,
       references: :hash,
       type: Hash.Full

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -78,6 +78,7 @@ defmodule Explorer.Chain.Log do
       ...>   %Explorer.Chain.Log{},
       ...>   %{
       ...>     address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+      ...>     block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
       ...>     data: "0x000000000000000000000000862d67cb0773ee3f8ce7ea89b328ffea861ab3ef",
       ...>     first_topic: "0x600bcf04a13e752d1e3670a5a9f1c21177ca2a93c6f5391d4f1298d098097c22",
       ...>     fourth_topic: nil,

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -10,11 +10,12 @@ defmodule Explorer.Chain.Log do
   alias Explorer.Repo
 
   @required_attrs ~w(address_hash data block_hash index transaction_hash)a
-  @optional_attrs ~w(first_topic second_topic third_topic fourth_topic type)a
+  @optional_attrs ~w(first_topic second_topic third_topic fourth_topic type block_number)a
 
   @typedoc """
    * `address` - address of contract that generate the event
    * `block_hash` - hash of the block
+   * `block_number` - The block number that the transfer took place.
    * `address_hash` - foreign key for `address`
    * `data` - non-indexed log parameters.
    * `first_topic` - `topics[0]`
@@ -30,6 +31,7 @@ defmodule Explorer.Chain.Log do
           address: %Ecto.Association.NotLoaded{} | Address.t(),
           address_hash: Hash.Address.t(),
           block_hash: Hash.Full.t(),
+          block_number: non_neg_integer() | nil,
           data: Data.t(),
           first_topic: String.t(),
           second_topic: String.t(),
@@ -50,6 +52,7 @@ defmodule Explorer.Chain.Log do
     field(:fourth_topic, :string)
     field(:index, :integer, primary_key: true)
     field(:type, :string)
+    field(:block_number, :integer)
 
     timestamps()
 

--- a/apps/explorer/priv/repo/migrations/20191121064805_add_block_hash_and_block_index_to_logs.exs
+++ b/apps/explorer/priv/repo/migrations/20191121064805_add_block_hash_and_block_index_to_logs.exs
@@ -1,0 +1,33 @@
+defmodule Explorer.Repo.Migrations.AddBlockHashAndBlockIndexToLogs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:logs) do
+      add(:block_hash, :bytea)
+    end
+
+    execute("""
+    UPDATE logs log
+    SET block_hash = with_block.block_hash
+    FROM (
+      SELECT l.transaction_hash,
+      t.block_hash
+      FROM logs l
+      JOIN transactions t
+      ON t.hash = l.transaction_hash
+    ) AS with_block
+    WHERE log.transaction_hash = with_block.transaction_hash
+    ;
+    """)
+
+    alter table(:logs) do
+      modify(:block_hash, references(:blocks, column: :hash, type: :bytea), null: false)
+    end
+
+    execute("""
+    ALTER table logs
+    DROP CONSTRAINT logs_pkey,
+    ADD PRIMARY KEY (transaction_hash, block_hash, index);
+    """)
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20191121064805_add_block_hash_and_block_index_to_logs.exs
+++ b/apps/explorer/priv/repo/migrations/20191121064805_add_block_hash_and_block_index_to_logs.exs
@@ -4,14 +4,17 @@ defmodule Explorer.Repo.Migrations.AddBlockHashAndBlockIndexToLogs do
   def change do
     alter table(:logs) do
       add(:block_hash, :bytea)
+      add(:block_number, :integer)
     end
 
     execute("""
     UPDATE logs log
-    SET block_hash = with_block.block_hash
+    SET block_hash = with_block.block_hash,
+    block_number = with_block.block_number
     FROM (
       SELECT l.transaction_hash,
-      t.block_hash
+      t.block_hash,
+      t.block_number
       FROM logs l
       JOIN transactions t
       ON t.hash = l.transaction_hash

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -153,22 +153,6 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
       assert count(TokenTransfer) == count
     end
 
-    test "remove_nonconsensus_logs deletes nonconsensus logs", %{
-      consensus_block: %{number: block_number} = block,
-      options: options
-    } do
-      old_block = insert(:block, number: block_number, consensus: true)
-      forked_transaction = :transaction |> insert() |> with_block(old_block)
-      %Log{transaction_hash: hash, index: index} = insert(:log, transaction: forked_transaction)
-
-      assert count(Log) == 1
-
-      assert {:ok, %{remove_nonconsensus_logs: [%{transaction_hash: ^hash, index: ^index}]}} =
-               run_block_consensus_change(block, true, options)
-
-      assert count(Log) == 0
-    end
-
     test "remove_nonconsensus_internal_transactions deletes nonconsensus internal transactions", %{
       consensus_block: %{number: block_number} = block,
       options: options

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -7,7 +7,7 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
   alias Ecto.Multi
   alias Explorer.Chain.Import.Runner.{Blocks, Transactions}
-  alias Explorer.Chain.{Address, Block, InternalTransaction, Log, Transaction, TokenTransfer}
+  alias Explorer.Chain.{Address, Block, InternalTransaction, Transaction, TokenTransfer}
   alias Explorer.{Chain, Repo}
 
   describe "run/1" do

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -86,6 +86,7 @@ defmodule Explorer.Chain.ImportTest do
       logs: %{
         params: [
           %{
+            block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
             address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
             data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
             first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
@@ -1564,7 +1565,13 @@ defmodule Explorer.Chain.ImportTest do
                    timeout: 1
                  },
                  logs: %{
-                   params: [params_for(:log, transaction_hash: transaction_hash, address_hash: miner_hash)],
+                   params: [
+                     params_for(:log,
+                       transaction_hash: transaction_hash,
+                       address_hash: miner_hash,
+                       block_hash: block_hash
+                     )
+                   ],
                    timeout: 1
                  },
                  token_transfers: %{

--- a/apps/explorer/test/explorer/chain/log_test.exs
+++ b/apps/explorer/test/explorer/chain/log_test.exs
@@ -9,7 +9,12 @@ defmodule Explorer.Chain.LogTest do
 
   describe "changeset/2" do
     test "accepts valid attributes" do
-      params = params_for(:log, address_hash: build(:address).hash, transaction_hash: build(:transaction).hash)
+      params =
+        params_for(:log,
+          address_hash: build(:address).hash,
+          transaction_hash: build(:transaction).hash,
+          block_hash: build(:block).hash
+        )
 
       assert %Changeset{valid?: true} = Log.changeset(%Log{}, params)
     end
@@ -26,7 +31,8 @@ defmodule Explorer.Chain.LogTest do
           :log,
           address_hash: build(:address).hash,
           first_topic: "ham",
-          transaction_hash: build(:transaction).hash
+          transaction_hash: build(:transaction).hash,
+          block_hash: build(:block).hash
         )
 
       assert %Changeset{changes: %{first_topic: "ham"}, valid?: true} = Log.changeset(%Log{}, params)

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -220,14 +220,14 @@ defmodule Explorer.ChainTest do
         |> insert(to_address: address)
         |> with_block()
 
-      insert(:log, transaction: transaction1, index: 1, address: address)
+      insert(:log, block: transaction1.block, transaction: transaction1, index: 1, address: address)
 
       transaction2 =
         :transaction
         |> insert(from_address: address)
         |> with_block()
 
-      insert(:log, transaction: transaction2, index: 2, address: address)
+      insert(:log, block: transaction2.block, transaction: transaction2, index: 2, address: address)
 
       assert Enum.count(Chain.address_to_logs(address_hash)) == 2
     end
@@ -243,7 +243,9 @@ defmodule Explorer.ChainTest do
       log1 = insert(:log, transaction: transaction, index: 1, address: address)
 
       2..51
-      |> Enum.map(fn index -> insert(:log, transaction: transaction, index: index, address: address) end)
+      |> Enum.map(fn index ->
+        insert(:log, block: transaction.block, transaction: transaction, index: index, address: address)
+      end)
       |> Enum.map(& &1.index)
 
       paging_options1 = %PagingOptions{page_size: 1}
@@ -263,14 +265,14 @@ defmodule Explorer.ChainTest do
         |> insert(to_address: address)
         |> with_block()
 
-      insert(:log, transaction: transaction1, index: 1, address: address)
+      insert(:log, block: transaction1.block, transaction: transaction1, index: 1, address: address)
 
       transaction2 =
         :transaction
         |> insert(from_address: address)
         |> with_block()
 
-      insert(:log, transaction: transaction2, index: 2, address: address, first_topic: "test")
+      insert(:log, block: transaction2.block, transaction: transaction2, index: 2, address: address, first_topic: "test")
 
       [found_log] = Chain.address_to_logs(address_hash, topic: "test")
 
@@ -285,14 +287,20 @@ defmodule Explorer.ChainTest do
         |> insert(to_address: address)
         |> with_block()
 
-      insert(:log, transaction: transaction1, index: 1, address: address, fourth_topic: "test")
+      insert(:log,
+        block: transaction1.block,
+        transaction: transaction1,
+        index: 1,
+        address: address,
+        fourth_topic: "test"
+      )
 
       transaction2 =
         :transaction
         |> insert(from_address: address)
         |> with_block()
 
-      insert(:log, transaction: transaction2, index: 2, address: address)
+      insert(:log, block: transaction2.block, transaction: transaction2, index: 2, address: address)
 
       [found_log] = Chain.address_to_logs(address_hash, topic: "test")
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1335,6 +1335,7 @@ defmodule Explorer.ChainTest do
       logs: %{
         params: [
           %{
+            block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
             address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
             data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
             first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -347,6 +347,7 @@ defmodule Explorer.Factory do
   def log_factory do
     %Log{
       address: build(:address),
+      block: build(:block),
       data: data(:log_data),
       first_topic: nil,
       fourth_topic: nil,


### PR DESCRIPTION
Part of #2865

This PR adds block_hash to logs table and adds it to a composite primary key. That's how we can get rid of heavy logs removal operation during blocks import.