### PR TITLE
change index order blocks' number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 
 ### Fixes
+- [#2874](https://github.com/poanetwork/blockscout/pull/2874) - change index order blocks' number
 - [#2864](https://github.com/poanetwork/blockscout/pull/2864) - add token instance metadata type check
 - [#2855](https://github.com/poanetwork/blockscout/pull/2855) - Fix favicons load
 - [#2854](https://github.com/poanetwork/blockscout/pull/2854) - Fix all npm vulnerabilities

--- a/apps/explorer/priv/repo/migrations/20191125060923_add_block_reward_sorting_index.exs
+++ b/apps/explorer/priv/repo/migrations/20191125060923_add_block_reward_sorting_index.exs
@@ -1,0 +1,15 @@
+defmodule Explorer.Repo.Migrations.AddBlockRewardSortingIndex do
+  use Ecto.Migration
+
+  def change do
+    drop(index(:blocks, [:number], name: "blocks_number_index"))
+
+    create(
+      index(
+        :blocks,
+        ["number DESC"],
+        name: "blocks_number_index"
+      )
+    )
+  end
+end


### PR DESCRIPTION
Block rewards are sorted by `number` field in the `blocks`
table in DESC order. By default, the index on that
field was created in ASC order.

This PR changes the order of the index.
Possible solution to https://github.com/poanetwork/blockscout/issues/2306

## Changelog

- change index order blocks' number