### PR TITLE
create index for type of internal transactions

### DIFF
--- a/apps/explorer/priv/repo/migrations/20191128065115_create_index_for_itx_type.exs
+++ b/apps/explorer/priv/repo/migrations/20191128065115_create_index_for_itx_type.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.CreateIndexForItxType do
+  use Ecto.Migration
+
+  def change do
+    create(index(:internal_transactions, [:type]))
+  end
+end


### PR DESCRIPTION
when fetching internal transaction for an address
one of the query clauses that used filters `type` field
which do not have any indexes

https://github.com/poanetwork/blockscout/blob/master/apps/explorer/lib/explorer/chain/internal_transaction.ex#L498

Part of https://github.com/poanetwork/blockscout/issues/2879
