### PR TITLE
fix address sum cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#2901](https://github.com/poanetwork/blockscout/pull/2901) - fix address sum cache
 
 ### Chore
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -106,6 +106,8 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
 
   describe "ethsupply" do
     test "returns total supply from DB", %{conn: conn} do
+      insert(:address, fetched_coin_balance: 6)
+
       params = %{
         "module" => "stats",
         "action" => "ethsupply"

--- a/apps/explorer/lib/explorer/chain/cache/address_sum.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum.ex
@@ -18,7 +18,11 @@ defmodule Explorer.Chain.Cache.AddressSum do
   defp handle_fallback(:sum) do
     result = fetch_from_db()
 
-    {:update, result}
+    if Application.get_env(:explorer, __MODULE__)[:enabled] do
+      {:update, result}
+    else
+      {:return, result}
+    end
   end
 
   defp fetch_from_db do

--- a/apps/explorer/lib/explorer/chain/cache/address_sum.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum.ex
@@ -16,33 +16,13 @@ defmodule Explorer.Chain.Cache.AddressSum do
   alias Explorer.Chain
 
   defp handle_fallback(:sum) do
-    # This will get the task PID if one exists and launch a new task if not
-    # See next `handle_fallback` definition
-    get_async_task()
+    result = fetch_from_db()
 
-    {:return, nil}
+    {:update, result}
   end
 
-  defp handle_fallback(:async_task) do
-    # If this gets called it means an async task was requested, but none exists
-    # so a new one needs to be launched
-    {:ok, task} =
-      Task.start(fn ->
-        try do
-          result = Chain.fetch_sum_coin_total_supply()
-
-          set_sum(result)
-        rescue
-          e ->
-            Logger.debug([
-              "Coudn't update address sum test #{inspect(e)}"
-            ])
-        end
-
-        set_async_task(nil)
-      end)
-
-    {:update, task}
+  defp fetch_from_db do
+    Chain.fetch_sum_coin_total_supply()
   end
 
   # By setting this as a `callback` an async task will be started each time the

--- a/apps/explorer/test/explorer/chain/cache/address_sum_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/address_sum_test.exs
@@ -12,7 +12,7 @@ defmodule Explorer.Chain.Cache.AddressSumTest do
   test "returns default address sum" do
     result = AddressSum.get_sum()
 
-    assert is_nil(result)
+    assert result == 0
   end
 
   test "updates cache if initial value is zero" do

--- a/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
@@ -93,7 +93,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalancesTest do
         value_fetched_at: DateTime.utc_now()
       }
 
-      run_changes(new_changes, options) |> IO.inspect()
+      run_changes(new_changes, options)
     end
   end
 


### PR DESCRIPTION
on the first call address sum cache starts a task to
fetch a value from the DB and return nil

Related commit https://github.com/poanetwork/blockscout/commit/b87fc2d7ab2ef9d97c62292e2029f9c06c5b87a9


## Changelog

- fix address sum cache