### PR TITLE
Offset in blocks retrieval for average block time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- [#2902](https://github.com/poanetwork/blockscout/pull/2902) - Offset in blocks retrieval for average block time
+
 ### Chore
 
 - [#2896](https://github.com/poanetwork/blockscout/pull/2896) - Disable Parity websockets tests

--- a/apps/explorer/lib/explorer/counters/average_block_time.ex
+++ b/apps/explorer/lib/explorer/counters/average_block_time.ex
@@ -63,24 +63,25 @@ defmodule Explorer.Counters.AverageBlockTime do
 
   defp refresh_timestamps do
     timestamps_query =
-      from(block in Block,
-        limit: 100,
-        offset: 0,
-        order_by: [desc: block.number],
-        select: {block.number, block.timestamp}
-      )
-
-    query =
       if Application.get_env(:explorer, :include_uncles_in_average_block_time) do
-        timestamps_query
+        from(block in Block,
+          limit: 100,
+          offset: 100,
+          order_by: [desc: block.number],
+          select: {block.number, block.timestamp}
+        )
       else
-        from(block in timestamps_query,
-          where: block.consensus == true
+        from(block in Block,
+          limit: 100,
+          offset: 100,
+          order_by: [desc: block.number],
+          where: block.consensus == true,
+          select: {block.number, block.timestamp}
         )
       end
 
     timestamps =
-      query
+      timestamps_query
       |> Repo.all()
       |> Enum.sort_by(fn {_, timestamp} -> timestamp end, &>=/2)
       |> Enum.map(fn {number, timestamp} ->

--- a/apps/explorer/test/explorer/counters/average_block_time_test.exs
+++ b/apps/explorer/test/explorer/counters/average_block_time_test.exs
@@ -34,11 +34,19 @@ defmodule Explorer.Counters.AverageBlockTimeTest do
 
       first_timestamp = Timex.now()
 
-      insert(:block, number: block_number, consensus: true, timestamp: Timex.shift(first_timestamp, seconds: 3))
-      insert(:block, number: block_number, consensus: false, timestamp: Timex.shift(first_timestamp, seconds: 9))
-      insert(:block, number: block_number, consensus: false, timestamp: Timex.shift(first_timestamp, seconds: 6))
+      insert(:block, number: block_number, consensus: true, timestamp: Timex.shift(first_timestamp, seconds: -100 - 3))
+      insert(:block, number: block_number, consensus: false, timestamp: Timex.shift(first_timestamp, seconds: -100 - 9))
+      insert(:block, number: block_number, consensus: false, timestamp: Timex.shift(first_timestamp, seconds: -100 - 6))
 
-      assert Repo.aggregate(Block, :count, :hash) == 3
+      Enum.each(1..100, fn i ->
+        insert(:block,
+          number: block_number + i,
+          consensus: true,
+          timestamp: Timex.shift(first_timestamp, seconds: -(101 - i) - 9)
+        )
+      end)
+
+      assert Repo.aggregate(Block, :count, :hash) == 103
 
       AverageBlockTime.refresh()
 
@@ -55,6 +63,14 @@ defmodule Explorer.Counters.AverageBlockTimeTest do
       insert(:block, number: block_number, consensus: false, timestamp: Timex.shift(first_timestamp, seconds: 4))
       insert(:block, number: block_number + 1, consensus: true, timestamp: Timex.shift(first_timestamp, seconds: 5))
 
+      Enum.each(1..100, fn i ->
+        insert(:block,
+          number: block_number + i + 1,
+          consensus: true,
+          timestamp: Timex.shift(first_timestamp, seconds: -(101 - i) - 5)
+        )
+      end)
+
       AverageBlockTime.refresh()
 
       assert AverageBlockTime.average_block_time() == Timex.Duration.parse!("PT2S")
@@ -68,6 +84,14 @@ defmodule Explorer.Counters.AverageBlockTimeTest do
       insert(:block, number: block_number, consensus: true, timestamp: Timex.shift(first_timestamp, seconds: 3))
       insert(:block, number: block_number, consensus: false, timestamp: Timex.shift(first_timestamp, seconds: 4))
       insert(:block, number: block_number + 1, consensus: true, timestamp: Timex.shift(first_timestamp, seconds: 5))
+
+      Enum.each(1..100, fn i ->
+        insert(:block,
+          number: block_number + i + 1,
+          consensus: true,
+          timestamp: Timex.shift(first_timestamp, seconds: -(101 - i) - 5)
+        )
+      end)
 
       AverageBlockTime.refresh()
 
@@ -83,7 +107,15 @@ defmodule Explorer.Counters.AverageBlockTimeTest do
       insert(:block, number: block_number + 2, consensus: true, timestamp: Timex.shift(first_timestamp, seconds: 9))
       insert(:block, number: block_number + 1, consensus: true, timestamp: Timex.shift(first_timestamp, seconds: 6))
 
-      assert Repo.aggregate(Block, :count, :hash) == 3
+      Enum.each(1..100, fn i ->
+        insert(:block,
+          number: block_number + i + 2,
+          consensus: true,
+          timestamp: Timex.shift(first_timestamp, seconds: -(101 - i) - 9)
+        )
+      end)
+
+      assert Repo.aggregate(Block, :count, :hash) == 103
 
       AverageBlockTime.refresh()
 


### PR DESCRIPTION
## Motivation

1. If non-consensus blocks are excluded in the calculation, the total amount of accounted blocks is <= 100. But it should be 100 for both cases: excluding/including of non-consensus blocks.
2. function `refresh_timestamps` gets the latest blocks but there could be reorgs and thus missing blocks in the DB that contaminates the average value.
For instance, on Kovan it should be 4 sec:

![Screenshot 2019-12-02 at 14 53 59](https://user-images.githubusercontent.com/4341812/69957366-98c79500-1513-11ea-82cf-981a0eba8035.png)
 

## Changelog

- add an offset of 100 blocks in `refresh_timestamps` function
- fixate limit of 100 target blocks for the case, when we exclude non-consensus blocks from calculation

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
