### PR TITLE
restart cache for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#2906](https://github.com/poanetwork/blockscout/pull/2906) - fix address sum cache
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 ### Fixes
-- [#2901](https://github.com/poanetwork/blockscout/pull/2901) - fix address sum cache
+- [#2906](https://github.com/poanetwork/blockscout/pull/2906) - fix address sum cache
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Features
 
 ### Fixes
-- [#2906](https://github.com/poanetwork/blockscout/pull/2906) - fix address sum cache
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#2901](https://github.com/poanetwork/blockscout/pull/2901) - fix address sum cache
 
 ### Chore
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
-  use BlockScoutWeb.ConnCase
+  use BlockScoutWeb.ConnCase, async: false
 
   import Mox
 
@@ -10,6 +10,19 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
   setup do
     Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.AddressSum.child_id())
     Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.AddressSum.child_id())
+
+    # Use TestSource mock for this test set
+    configuration = Application.get_env(:explorer, Explorer.ExchangeRates)
+    Application.put_env(:explorer, Explorer.ExchangeRates, source: TestSource)
+    Application.put_env(:explorer, Explorer.ExchangeRates, table_name: :rates)
+    Application.put_env(:explorer, Explorer.ExchangeRates, enabled: true)
+
+    ExchangeRates.init([])
+
+    on_exit(fn ->
+      Application.put_env(:explorer, Explorer.ExchangeRates, configuration)
+    end)
+
     :ok
   end
 
@@ -133,22 +146,6 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
 
   describe "ethprice" do
     setup :set_mox_global
-
-    setup do
-      # Use TestSource mock for this test set
-      configuration = Application.get_env(:explorer, Explorer.ExchangeRates)
-      Application.put_env(:explorer, Explorer.ExchangeRates, source: TestSource)
-      Application.put_env(:explorer, Explorer.ExchangeRates, table_name: :rates)
-      Application.put_env(:explorer, Explorer.ExchangeRates, enabled: true)
-
-      ExchangeRates.init([])
-
-      :ok
-
-      on_exit(fn ->
-        Application.put_env(:explorer, Explorer.ExchangeRates, configuration)
-      end)
-    end
 
     test "returns the configured coin's price information", %{conn: conn} do
       symbol = Application.get_env(:explorer, :coin)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -7,6 +7,12 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
   alias Explorer.ExchangeRates.Token
   alias Explorer.ExchangeRates.Source.TestSource
 
+  setup do
+    Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.AddressSum.child_id())
+    Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.AddressSum.child_id())
+    :ok
+  end
+
   describe "tokensupply" do
     test "with missing contract address", %{conn: conn} do
       params = %{
@@ -106,6 +112,8 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
 
   describe "ethsupply" do
     test "returns total supply from DB", %{conn: conn} do
+      insert(:address, fetched_coin_balance: 6)
+
       params = %{
         "module" => "stats",
         "action" => "ethsupply"

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2922,7 +2922,7 @@ defmodule Explorer.Chain do
   """
   @spec total_supply :: non_neg_integer() | nil
   def total_supply do
-    supply_module().total()
+    supply_module().total() || 0
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/cache/address_sum.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum.ex
@@ -10,21 +10,44 @@ defmodule Explorer.Chain.Cache.AddressSum do
     key: :sum,
     key: :async_task,
     ttl_check_interval: Application.get_env(:explorer, __MODULE__)[:ttl_check_interval],
-    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl]
+    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
+    callback: &async_task_on_deletion(&1)
 
   alias Explorer.Chain
 
   defp handle_fallback(:sum) do
-    result = fetch_from_db()
+    # This will get the task PID if one exists and launch a new task if not
+    # See next `handle_fallback` definition
+    get_async_task()
 
-    if Application.get_env(:explorer, __MODULE__)[:enabled] do
-      {:update, result}
-    else
-      {:return, result}
-    end
+    {:return, Decimal.new(0)}
   end
 
-  defp fetch_from_db do
-    Chain.fetch_sum_coin_total_supply()
+  defp handle_fallback(:async_task) do
+    # If this gets called it means an async task was requested, but none exists
+    # so a new one needs to be launched
+    {:ok, task} =
+      Task.start(fn ->
+        try do
+          result = Chain.fetch_sum_coin_total_supply()
+
+          set_sum(result)
+        rescue
+          e ->
+            Logger.debug([
+              "Coudn't update address sum test #{inspect(e)}"
+            ])
+        end
+
+        set_async_task(nil)
+      end)
+
+    {:update, task}
   end
+
+  # By setting this as a `callback` an async task will be started each time the
+  # `sum` expires (unless there is one already running)
+  defp async_task_on_deletion({:delete, _, :sum}), do: get_async_task()
+
+  defp async_task_on_deletion(_data), do: nil
 end

--- a/apps/explorer/lib/explorer/chain/cache/address_sum.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum.ex
@@ -10,8 +10,7 @@ defmodule Explorer.Chain.Cache.AddressSum do
     key: :sum,
     key: :async_task,
     ttl_check_interval: Application.get_env(:explorer, __MODULE__)[:ttl_check_interval],
-    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
-    callback: &async_task_on_deletion(&1)
+    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl]
 
   alias Explorer.Chain
 
@@ -25,35 +24,7 @@ defmodule Explorer.Chain.Cache.AddressSum do
     end
   end
 
-  defp handle_fallback(:async_task) do
-    # If this gets called it means an async task was requested, but none exists
-    # so a new one needs to be launched
-    {:ok, task} =
-      Task.start(fn ->
-        try do
-          result = fetch_from_db()
-
-          set_sum(result)
-        rescue
-          e ->
-            Logger.debug([
-              "Coudn't update address sum test #{inspect(e)}"
-            ])
-        end
-
-        set_async_task(nil)
-      end)
-
-    {:update, task}
-  end
-
   defp fetch_from_db do
     Chain.fetch_sum_coin_total_supply()
   end
-
-  # By setting this as a `callback` an async task will be started each time the
-  # `sum` expires (unless there is one already running)
-  defp async_task_on_deletion({:delete, _, :sum}), do: get_async_task()
-
-  defp async_task_on_deletion(_data), do: nil
 end

--- a/apps/explorer/test/explorer/chain/cache/address_sum_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/address_sum_test.exs
@@ -12,7 +12,7 @@ defmodule Explorer.Chain.Cache.AddressSumTest do
   test "returns default address sum" do
     result = AddressSum.get_sum()
 
-    assert result == 0
+    assert result == Decimal.new(0)
   end
 
   test "updates cache if initial value is zero" do

--- a/apps/explorer/test/explorer/chain/cache/address_sum_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/address_sum_test.exs
@@ -12,7 +12,7 @@ defmodule Explorer.Chain.Cache.AddressSumTest do
   test "returns default address sum" do
     result = AddressSum.get_sum()
 
-    assert is_nil(result)
+    assert result == 0
   end
 
   test "updates cache if initial value is zero" do

--- a/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
@@ -93,7 +93,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalancesTest do
         value_fetched_at: DateTime.utc_now()
       }
 
-      run_changes(new_changes, options) |> IO.inspect()
+      run_changes(new_changes, options)
     end
   end
 

--- a/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
@@ -93,7 +93,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalancesTest do
         value_fetched_at: DateTime.utc_now()
       }
 
-      run_changes(new_changes, options)
+      run_changes(new_changes, options) |> IO.inspect()
     end
   end
 


### PR DESCRIPTION
on the first call address sum cache starts a task to
fetch a value from the DB and return nil

Related commit https://github.com/poanetwork/blockscout/commit/b87fc2d7ab2ef9d97c62292e2029f9c06c5b87a9


## Changelog

- fix address sum cache