### PR TITLE
Reduce execution time of stream_unfetched_token_instances query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,11 @@
 ### Features
 
 ### Fixes
+- [#2914](https://github.com/poanetwork/blockscout/pull/2914) - Reduce execution time of stream_unfetched_token_instances query
 - [#2906](https://github.com/poanetwork/blockscout/pull/2906) - fix address sum cache
-
 - [#2902](https://github.com/poanetwork/blockscout/pull/2902) - Offset in blocks retrieval for average block time
 
 ### Chore
-
 - [#2896](https://github.com/poanetwork/blockscout/pull/2896) - Disable Parity websockets tests
 
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2967,21 +2967,33 @@ defmodule Explorer.Chain do
         ) :: {:ok, accumulator}
         when accumulator: term()
   def stream_unfetched_token_instances(initial, reducer) when is_function(reducer, 2) do
+    nft_tokens =
+      from(
+        token in Token,
+        where: token.type == ^"ERC-721",
+        select: token.contract_address_hash
+      )
+
     query =
       from(
         token_transfer in TokenTransfer,
-        inner_join: token in Token,
+        inner_join: token in subquery(nft_tokens),
         on: token.contract_address_hash == token_transfer.token_contract_address_hash,
         left_join: instance in Instance,
         on:
           token_transfer.token_id == instance.token_id and
             token_transfer.token_contract_address_hash == instance.token_contract_address_hash,
-        where: token.type == ^"ERC-721" and is_nil(instance.token_id) and not is_nil(token_transfer.token_id),
-        distinct: [token_transfer.token_contract_address_hash, token_transfer.token_id],
+        where: is_nil(instance.token_id) and not is_nil(token_transfer.token_id),
         select: %{contract_address_hash: token_transfer.token_contract_address_hash, token_id: token_transfer.token_id}
       )
 
-    Repo.stream_reduce(query, initial, reducer)
+    distinct_query =
+      from(
+        q in subquery(query),
+        distinct: [q.token_contract_address_hash, q.token_id]
+      )
+
+    Repo.stream_reduce(distinct_query, initial, reducer)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2990,7 +2990,7 @@ defmodule Explorer.Chain do
     distinct_query =
       from(
         q in subquery(query),
-        distinct: [q.token_contract_address_hash, q.token_id]
+        distinct: [q.contract_address_hash, q.token_id]
       )
 
     Repo.stream_reduce(distinct_query, initial, reducer)


### PR DESCRIPTION
## Motivation

The query https://github.com/poanetwork/blockscout/blob/da54650a4a559393d29a499a486b51d1477789ef/apps/explorer/lib/explorer/chain.ex#L2969 executes more than 1 hour on ETH Mainnet instance

This PR aims to increase the performance of this query.

## Changelog

Decrease the subset before joining the tables

Before the changes query looked like this:

```
SELECT DISTINCT ON (t0."token_contract_address_hash", t0."token_id") t0."token_contract_address_hash", t0."token_id" FROM "token_transfers" AS t0
INNER JOIN "tokens" AS t1 ON t1."contract_address_hash" = t0."token_contract_address_hash"
LEFT OUTER JOIN "token_instances" AS t2 ON (t0."token_id" = t2."token_id")
AND (t0."token_contract_address_hash" = t2."token_contract_address_hash")
WHERE (((t1."type" = 'ERC-721')
AND t2."token_id" IS NULL) AND NOT (t0."token_id" IS NULL))
LIMIT 1;
```

EXPLAIN ANALYZE:

```
Planning Time: 0.520 ms
Execution Time: 0.851 ms
```

After the changes:

```
SELECT DISTINCT q."token_contract_address_hash", q."token_id" FROM (SELECT
  t0."token_contract_address_hash", t0."token_id" FROM "token_transfers" AS t0
INNER JOIN (SELECT * FROM "tokens" WHERE tokens."type" = 'ERC-721') AS t1 ON t1."contract_address_hash" = t0."token_contract_address_hash"
LEFT OUTER JOIN "token_instances" AS t2 ON (t0."token_id" = t2."token_id")
AND (t0."token_contract_address_hash" = t2."token_contract_address_hash")
AND t2."token_id" IS NULL AND NOT (t0."token_id" IS NULL)
) q;
```

EXPLAIN ANALYZE:

```
Planning Time: 0.423 ms
Execution Time: 0.592 ms
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
