### PR TITLE
Speedup of blocks_without_reward_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,11 @@
 ### Features
 
 ### Fixes
+- [#2915](https://github.com/poanetwork/blockscout/pull/2915) - Speedup of blocks_without_reward_query
 - [#2906](https://github.com/poanetwork/blockscout/pull/2906) - fix address sum cache
-
 - [#2902](https://github.com/poanetwork/blockscout/pull/2902) - Offset in blocks retrieval for average block time
 
 ### Chore
-
 - [#2896](https://github.com/poanetwork/blockscout/pull/2896) - Disable Parity websockets tests
 
 

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -116,11 +116,23 @@ defmodule Explorer.Chain.Block do
   end
 
   def blocks_without_reward_query do
+    consensus_blocks_query =
+      from(
+        b in __MODULE__,
+        where: b.consensus == true
+      )
+
+    validator_rewards =
+      from(
+        r in Reward,
+        where: r.address_type == ^"validator"
+      )
+
     from(
-      b in __MODULE__,
-      left_join: r in Reward,
+      b in subquery(consensus_blocks_query),
+      left_join: r in subquery(validator_rewards),
       on: [block_hash: b.hash],
-      where: is_nil(r.block_hash) and b.consensus == true
+      where: is_nil(r.block_hash)
     )
   end
 

--- a/apps/explorer/priv/repo/migrations/20191208135613_block_rewards_block_hash_partial_index.exs
+++ b/apps/explorer/priv/repo/migrations/20191208135613_block_rewards_block_hash_partial_index.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.BlockRewardsBlockHashPartialIndex do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "CREATE INDEX IF NOT EXISTS block_rewards_block_hash_partial_index on block_rewards(block_hash) WHERE address_type='validator';"
+    )
+  end
+end


### PR DESCRIPTION
## Motivation

The query https://github.com/poanetwork/blockscout/blob/8c62be450d9a78b4a52ae6c3900f6b383d2b8382/apps/explorer/lib/explorer/chain/block.ex#L118 executes more than **5 hours** on ETH Mainnet instance.

This PR aims to decrease the execution time.

## Changelog

1. Add partial index on `block_rewards` table `block_hash` column where address type is `validator`
2. Decrease subsets of tables before joins, not after.

Before the changes:

```
8740 | 05:36:11.251542 |SELECT b0."hash", b0."consensus", b0."difficulty", b0."gas_limit", b0."gas_used", b0."nonce", b0."number", b0."size", b0."timestamp", b0."total_difficulty", b0."internal_transactions_indexed_at", b0."refetch_needed", b0."inserted_at", b0."updated_at", b0."miner_hash", b0."parent_hash" FROM "blocks" AS b0 LEFT OUTER JOIN "block_rewards" AS b1 ON b1."block_hash" = b0."hash" WHERE (b1."block_hash" IS NULL AND (b0."consensus" = TRUE))                                     | active
```

EXPLAIN ANALYZE on a small amount of the data:
```
Planning Time: 5.111 ms
Execution Time: 105251.312 ms
```

After the changes:

```
SELECT b0.* FROM
(SELECT * from "blocks" WHERE blocks."consensus" = TRUE) AS b0
LEFT OUTER JOIN
(SELECT * FROM "block_rewards"
WHERE block_rewards.address_type='validator') AS b1
ON b1."block_hash" = b0."hash"
WHERE b1."block_hash" IS NULL;
```

EXPLAIN ANALYZE on the same small set of the data, that it was before the changes:
```
Planning Time: 22.785 ms
Execution Time: 81535.140 ms
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
