### PR TITLE
Add tokenID for tokentx API action explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 ## Current
 
 ### Features
+- [#2918](https://github.com/poanetwork/blockscout/pull/2918) - Add tokenID for tokentx API action
 
 ### Fixes
 - [#2906](https://github.com/poanetwork/blockscout/pull/2906) - fix address sum cache
-
 - [#2902](https://github.com/poanetwork/blockscout/pull/2902) - Offset in blocks retrieval for average block time
 
 ### Chore
-
 - [#2896](https://github.com/poanetwork/blockscout/pull/2896) - Disable Parity websockets tests
 
 

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -589,6 +589,12 @@ defmodule BlockScoutWeb.Etherscan do
     example: ~s("Some Token Name")
   }
 
+  @token_id_type %{
+    type: "integer",
+    definition: "id of token",
+    example: ~s("0")
+  }
+
   @token_symbol_type %{
     type: "string",
     definition: "Trading symbol of the token.",
@@ -752,6 +758,7 @@ defmodule BlockScoutWeb.Etherscan do
         example: ~s("663046792267785498951364")
       },
       tokenName: @token_name_type,
+      tokenID: @token_id_type,
       tokenSymbol: @token_symbol_type,
       tokenDecimal: @token_decimal_type,
       transactionIndex: @transaction_index_type,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -121,7 +121,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
     }
   end
 
-  defp prepare_token_transfer(token_transfer) do
+  defp prepare_common_token_transfer(token_transfer) do
     %{
       "blockNumber" => to_string(token_transfer.block_number),
       "timeStamp" => to_string(DateTime.to_unix(token_transfer.block_timestamp)),
@@ -132,7 +132,6 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "contractAddress" => to_string(token_transfer.token_contract_address_hash),
       "to" => to_string(token_transfer.to_address_hash),
       "logIndex" => to_string(token_transfer.token_log_index),
-      "value" => get_token_value(token_transfer),
       "tokenName" => token_transfer.token_name,
       "tokenSymbol" => token_transfer.token_symbol,
       "tokenDecimal" => to_string(token_transfer.token_decimals),
@@ -146,12 +145,20 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
     }
   end
 
-  defp get_token_value(%{token_type: "ERC-721"} = token_transfer) do
-    to_string(token_transfer.token_id)
+  defp prepare_token_transfer(%{token_type: "ERC-721"} = token_transfer) do
+    token_transfer
+    |> prepare_common_token_transfer()
+    |> Map.put_new(:tokenID, token_transfer.token_id)
   end
 
-  defp get_token_value(token_transfer) do
-    to_string(token_transfer.amount)
+  defp prepare_token_transfer(%{token_type: "ERC-20"} = token_transfer) do
+    token_transfer
+    |> prepare_common_token_transfer()
+    |> Map.put_new(:value, to_string(token_transfer.amount))
+  end
+
+  defp prepare_token_transfer(token_transfer) do
+    prepare_common_token_transfer(token_transfer)
   end
 
   defp prepare_block(block) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -1807,7 +1807,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
                |> get("/api", params)
                |> json_response(200)
 
-      assert result["value"] == to_string(token_transfer.token_id)
+      assert result["tokenID"] == to_string(token_transfer.token_id)
       assert response["status"] == "1"
       assert response["message"] == "OK"
       assert :ok = ExJsonSchema.Validator.validate(tokentx_schema(), response)
@@ -2618,6 +2618,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
           "logIndex" => %{"type" => "string"},
           "value" => %{"type" => "string"},
           "tokenName" => %{"type" => "string"},
+          "tokenID" => %{"type" => "string"},
           "tokenSymbol" => %{"type" => "string"},
           "tokenDecimal" => %{"type" => "string"},
           "transactionIndex" => %{"type" => "string"},


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/2912

## Motivation

`tokenID` is missing in `tokentx` API endpoint

## Changelog

Add `tokenID` in output for `tokentx` endpoint explicitly in case of ERC-721 token instead to write the value to `value` key

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
