### PR TITLE
not trigger internal txs in fetchers

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -226,21 +226,18 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
   defp invalid_block_numbers(transactions, internal_transactions_params) do
     # Finds all mistmatches between transactions and internal transactions
     # for a block number:
-    # - there are no internal txs for some transactions
     # - there are no transactions for some internal transactions
     # - there are internal txs with a different block number than their transactions
     # Returns block numbers where any of these issues is found
 
-    required_tuples = MapSet.new(transactions, &{&1.hash, &1.block_number})
+    transaction_tuples = MapSet.new(transactions, &{&1.hash, &1.block_number})
 
     candidate_tuples = MapSet.new(internal_transactions_params, &{&1.transaction_hash, &1.block_number})
 
-    all_tuples = MapSet.union(required_tuples, candidate_tuples)
-
-    common_tuples = MapSet.intersection(required_tuples, candidate_tuples)
+    common_tuples = MapSet.intersection(candidate_tuples, transaction_tuples)
 
     invalid_numbers =
-      all_tuples
+      candidate_tuples
       |> MapSet.difference(common_tuples)
       |> MapSet.new(fn {_hash, block_number} -> block_number end)
       |> MapSet.to_list()

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -12,7 +12,6 @@ defmodule Indexer.Block.Catchup.Fetcher do
       async_import_block_rewards: 1,
       async_import_coin_balances: 2,
       async_import_created_contract_codes: 1,
-      async_import_internal_transactions: 1,
       async_import_replaced_transactions: 1,
       async_import_tokens: 1,
       async_import_token_balances: 1,
@@ -149,7 +148,6 @@ defmodule Indexer.Block.Catchup.Fetcher do
     async_import_block_rewards(block_reward_errors)
     async_import_coin_balances(imported, options)
     async_import_created_contract_codes(imported)
-    async_import_internal_transactions(imported)
     async_import_tokens(imported)
     async_import_token_balances(imported)
     async_import_uncles(imported)

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -15,7 +15,6 @@ defmodule Indexer.Block.Realtime.Fetcher do
     only: [
       async_import_block_rewards: 1,
       async_import_created_contract_codes: 1,
-      async_import_internal_transactions: 1,
       async_import_replaced_transactions: 1,
       async_import_tokens: 1,
       async_import_token_balances: 1,
@@ -384,7 +383,6 @@ defmodule Indexer.Block.Realtime.Fetcher do
        ) do
     async_import_block_rewards(block_reward_errors)
     async_import_created_contract_codes(imported)
-    async_import_internal_transactions(imported)
     async_import_tokens(imported)
     async_import_token_balances(imported)
     async_import_token_instances(imported)


### PR DESCRIPTION
internal transaction fetching is triggered in block
fetchers before block insertion. but pending ops are
inserted only during block insertion. So sometimes
internal transactions are being fetched without corresponding
records in pending ops table so these blocks are marked as
non-consensus. This PR removes internal transaction fetching
from block fetchers.

Another possible issue I found is that we mark blocks
invalid if there are no internal txs for some transactions in
these blocks. Some transactions may not have internal txs. This
is also fixed.


## Changelog
- not trigger internal txs in fetchers