### PR TITLE
Speedup address to logs query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,11 @@
 ### Features
 
 ### Fixes
+- [#2924](https://github.com/poanetwork/blockscout/pull/2924) - Speedup address to logs query
 - [#2906](https://github.com/poanetwork/blockscout/pull/2906) - fix address sum cache
-
 - [#2902](https://github.com/poanetwork/blockscout/pull/2902) - Offset in blocks retrieval for average block time
 
 ### Chore
-
 - [#2896](https://github.com/poanetwork/blockscout/pull/2896) - Disable Parity websockets tests
 
 

--- a/apps/explorer/priv/repo/migrations/20191218120138_logs_block_number_index_index.exs
+++ b/apps/explorer/priv/repo/migrations/20191218120138_logs_block_number_index_index.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.LogsBlockNumberIndexIndex do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(index(:logs, ["block_number DESC, index DESC"]))
+
+    drop_if_exists(index(:logs, [:block_number], name: "logs_block_number_index"))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20191218120138_logs_block_number_index_index.exs
+++ b/apps/explorer/priv/repo/migrations/20191218120138_logs_block_number_index_index.exs
@@ -3,7 +3,5 @@ defmodule Explorer.Repo.Migrations.LogsBlockNumberIndexIndex do
 
   def change do
     create_if_not_exists(index(:logs, ["block_number DESC, index DESC"]))
-
-    drop_if_exists(index(:logs, [:block_number], name: "logs_block_number_index"))
   end
 end


### PR DESCRIPTION
## Motivation

Logs tab on address page:

![Screenshot 2019-12-18 at 18 07 07](https://user-images.githubusercontent.com/4341812/71097579-3b913c00-21c1-11ea-908e-58c9987ab638.png)

For almost all addresses if there are tons of transactions in the chain like in ETH Mainnet.

## Changelog

1. Replace index on logs table on `block_number` field with a multicolumn index `block_number DESC, index DESC` to be able to sort in logs table

2. Change the query to use this index.


The query is transformed from 
```
SELECT l0.* FROM logs AS l0
INNER JOIN transactions AS t1
ON ((t1.block_hash = l0.block_hash)
AND (t1.block_number = l0.block_number))
AND (t1.hash = l0.transaction_hash)
WHERE (((t1.block_number < 9125388))
OR ((t1.block_number = 9125388)
AND (t1.index > 0))
OR (((t1.block_number = 9125388) AND (t1.index = 0))
AND (l0.index > 0)))
AND ((l0.address_hash = '\xdac17f958d2ee523a2206206994597c13d831ec7')
AND (l0.block_hash = t1.block_hash))
ORDER BY t1.block_number DESC, t1.index DESC LIMIT 51;
```

to

```
SELECT COUNT(a.*) FROM (
  SELECT l0.*
  FROM logs AS l0
  INNER JOIN transactions AS t1
  ON t1.hash = l0.transaction_hash
  WHERE (l0.address_hash = '\xdac17f958d2ee523a2206206994597c13d831ec7')
  AND (((t1.block_number < 9125388))
  OR ((t1.block_number = 9125388)
  AND (t1.index > 0))
  OR (((t1.block_number = 9125388) AND (t1.index = 0))
  AND (l0.index > 0)))
  ORDER BY l0.block_number DESC, l0.index DESC LIMIT 51
) a
INNER JOIN transactions AS t1 ON a.block_hash = t1.block_hash
AND a.block_number = t1.block_number
AND a.transaction_hash = t1.hash
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
