### PR TITLE
Speedup pending block ops int txs to fetch query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,11 @@
 ### Features
 
 ### Fixes
+- [#2928](https://github.com/poanetwork/blockscout/pull/2928) - Speedup pending block ops int txs to fetch query
 - [#2906](https://github.com/poanetwork/blockscout/pull/2906) - fix address sum cache
-
 - [#2902](https://github.com/poanetwork/blockscout/pull/2902) - Offset in blocks retrieval for average block time
 
 ### Chore
-
 - [#2896](https://github.com/poanetwork/blockscout/pull/2896) - Disable Parity websockets tests
 
 

--- a/apps/explorer/priv/repo/migrations/20191220113006_pending_block_operations_block_hash_partial_index.exs
+++ b/apps/explorer/priv/repo/migrations/20191220113006_pending_block_operations_block_hash_partial_index.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.PendingBlockOperationsBlockHashPartialIndex do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "CREATE INDEX pending_block_operations_block_hash_index_partial ON pending_block_operations(block_hash) WHERE fetch_internal_transactions=true;"
+    )
+  end
+end


### PR DESCRIPTION
## Motivation

Improve the performance of int txs importer

## Changelog

One of the parts of indexing is to get block numbers which need dot be fetched. 2Mb partial index on `pending_block_operations` table on block's hash *where fetch_internal_transactions=true* increases the speed of that query up to 30 - 40%.

Query plan before:
```
                                                                     QUERY PLAN

----------------------------------------------------------------------------------------------------
-------------------------------------------------
 Gather  (cost=1000.56..170202.03 rows=31829 width=8) (actual time=0.233..113.157 rows=35029 loops=1
)
   Workers Planned: 1
   Workers Launched: 1
   ->  Nested Loop  (cost=0.56..166019.13 rows=18723 width=8) (actual time=0.027..100.006 rows=17514
 loops=2)
         ->  Parallel Seq Scan on pending_block_operations p  (cost=0.00..1563.86 rows=20686 width=3
3) (actual time=0.008..6.714 rows=17554 loops=2)
               Filter: fetch_internal_transactions
         ->  Index Scan using blocks_pkey on blocks b  (cost=0.56..7.95 rows=1 width=41) (actual tim
e=0.004..0.004 rows=1 loops=35107)
               Index Cond: (hash = p.block_hash)
               Filter: consensus
               Rows Removed by Filter: 0
 Planning time: 0.259 ms
 Execution time: 120.727 ms
```

And after index creation:

```
----------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------------------
------------
 Gather  (cost=1000.98..119764.17 rows=29886 width=8) (actual time=0.251..70.507 rows=32885 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Nested Loop  (cost=0.98..115775.57 rows=12452 width=8) (actual time=0.036..62.534 rows=10962
loops=3)
         ->  Parallel Index Only Scan using pending_block_operations_block_hash_index_partial on pen
ding_block_operations p  (cost=0.41..5922.80 rows=13758 width=33) (actual time=0.016..7.305 rows=109
97 loops=3)
               Heap Fetches: 8578
         ->  Index Scan using blocks_pkey on blocks b  (cost=0.56..7.98 rows=1 width=41) (actual tim
e=0.004..0.004 rows=1 loops=32991)
               Index Cond: (hash = p.block_hash)
               Filter: consensus
               Rows Removed by Filter: 0
 Planning time: 0.331 ms
 Execution time: 77.905 **ms**
```


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
