### PR TITLE
Improve DB migration to "pending_block_operations" indexing approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Current
 
 ### Features
-- [#2835](https://github.com/poanetwork/blockscout/pull/2835), [#2871](https://github.com/poanetwork/blockscout/pull/2871), [#2872](https://github.com/poanetwork/blockscout/pull/2872), [#2886](https://github.com/poanetwork/blockscout/pull/2886), [#2925](https://github.com/poanetwork/blockscout/pull/2925) - Add "block_hash" to logs, token_transfers and internal transactions and "pending blocks operations" approach
+- [#2835](https://github.com/poanetwork/blockscout/pull/2835), [#2871](https://github.com/poanetwork/blockscout/pull/2871), [#2872](https://github.com/poanetwork/blockscout/pull/2872), [#2886](https://github.com/poanetwork/blockscout/pull/2886), [#2925](https://github.com/poanetwork/blockscout/pull/2925), [#2936](https://github.com/poanetwork/blockscout/pull/2936) - Add "block_hash" to logs, token_transfers and internal transactions and "pending blocks operations" approach
 - [#2926](https://github.com/poanetwork/blockscout/pull/2926) - API endpoint: sum balances except burnt address
 - [#2918](https://github.com/poanetwork/blockscout/pull/2918) - Add tokenID for tokentx API action explicitly
 

--- a/apps/explorer/priv/repo/migrations/20191018140054_add_pending_internal_txs_operation.exs
+++ b/apps/explorer/priv/repo/migrations/20191018140054_add_pending_internal_txs_operation.exs
@@ -60,11 +60,37 @@ defmodule Explorer.Repo.Migrations.AddPendingInternalTxsOperation do
     DECLARE
         duplicates_count INTEGER := 0;
         blocks_scanned INTEGER := 0;
+        int_txs_count INTEGER := 0;
         temprow RECORD;
     BEGIN
-        FOR temprow IN
-            SELECT number, hash FROM blocks
-        LOOP
+        SELECT COUNT(*) INTO int_txs_count FROM internal_transactions;
+        IF int_txs_count < 10000000 THEN
+
+          FOR temprow IN
+              SELECT block_hash FROM internal_transactions
+              GROUP BY block_hash, block_index HAVING COUNT(*) > 1
+          LOOP
+              duplicates_count := duplicates_count + 1;
+              RAISE NOTICE '% duplicates, blocks scanned %, block #%, block hash is %', duplicates_count, blocks_scanned, temprow.number , temprow.hash;
+
+              IF NOT EXISTS (
+                  SELECT 1 FROM pending_block_operations
+                  WHERE block_hash = temprow.block_hash
+              ) THEN
+                  INSERT INTO pending_block_operations
+                  (block_hash, inserted_at, updated_at, fetch_internal_transactions)
+                  SELECT b.hash, now(), now(), TRUE FROM blocks b
+                  WHERE b.hash = temprow.block_hash;
+              END IF;
+
+              DELETE FROM internal_transactions
+              WHERE block_hash = temprow.block_hash;
+
+              RAISE NOTICE 'DELETED';
+          END LOOP;
+
+        ELSE
+          FOR temprow IN SELECT number, hash FROM blocks LOOP
             blocks_scanned := blocks_scanned + 1;
             IF EXISTS (
                 SELECT 1 FROM transactions WHERE block_hash = temprow.hash
@@ -93,7 +119,8 @@ defmodule Explorer.Repo.Migrations.AddPendingInternalTxsOperation do
                     RAISE NOTICE 'DELETED';
                 END IF;
             END IF;
-        END LOOP;
+          END LOOP;
+        END IF;
         RAISE NOTICE 'SCRIPT FINISHED';
     END $$;
     """)


### PR DESCRIPTION
## Motivation

If `internal_transactions` is small (< 10,000,000 rows) a better approach is to clear {`block_hash`, `block_index`} duplicates at once rather than to iterate through all blocks.

## Changelog

Change migration script

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
