### PR TITLE
Remove logs from test folder too in the cleaning script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [2910](https://github.com/poanetwork/blockscout/pull/2910) - Reorganize queries and indexes for internal_transactions table
 
 ### Chore
+- [#2959](https://github.com/poanetwork/blockscout/pull/2959) - Remove logs from test folder too in the cleaning script
 - [#2947](https://github.com/poanetwork/blockscout/pull/2947) - Upgrade Circle CI postgres Docker image
 - [#2946](https://github.com/poanetwork/blockscout/pull/2946) - Fix vulnerable NPM deps
 - [#2942](https://github.com/poanetwork/blockscout/pull/2942) - Actualize Docker setup

--- a/rel/commands/clear_build.sh
+++ b/rel/commands/clear_build.sh
@@ -4,8 +4,12 @@ rm -rf ./_build
 rm -rf ./deps
 logs=$(find . -not -path '*/\.*' -name "logs" -type d)
 dev=$(find ${logs} -name "dev")
-files_and_dirs_in_logs=$(ls -d ${dev}/*)
-rm -rf $files_and_dirs_in_logs
+files_and_dirs_in_logs_dev=$(ls -d ${dev}/*)
+rm -rf $files_and_dirs_in_logs_dev
+
+test=$(find ${logs} -name "test")
+files_and_dirs_in_logs_test=$(ls -d ${test}/*)
+rm -rf $files_and_dirs_in_logs_test
 
 find . -name "node_modules" -type d -exec rm -rf '{}' +
 


### PR DESCRIPTION
## Motivation

Cleaning script removes logs only from `dev` folder

## Changelog

Adding of removal of logs from `test` folder

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
