### PR TITLE
Introduce API_PATH env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ### Features
 
 ### Fixes
-
-- [#2897]( https://github.com/poanetwork/blockscout/pull/2897) - remove duplicate indexes
+- [#2989](https://github.com/poanetwork/blockscout/pull/2989) - Introduce API_PATH env var
+- [#2897](https://github.com/poanetwork/blockscout/pull/2897) - remove duplicate indexes
 
 ### Chore
 

--- a/apps/block_scout_web/assets/js/lib/try_eth_api.js
+++ b/apps/block_scout_web/assets/js/lib/try_eth_api.js
@@ -44,8 +44,9 @@ function parseInput (input) {
   }
 }
 
-function dropDomain (url) {
-  return new URL(url).pathname
+function composeRequestUrl () {
+  const url = $('[data-endpoint-url]').attr('data-endpoint-url')
+  return url
 }
 
 $('button[data-try-eth-api-ui-button-type="execute"]').click(event => {
@@ -64,10 +65,8 @@ $('button[data-try-eth-api-ui-button-type="execute"]').click(event => {
     clickedButton.html(loadingText)
   }
 
-  const url = $('[data-endpoint-url]').attr('data-endpoint-url')
-
   $.ajax({
-    url: dropDomain(url),
+    url: composeRequestUrl(),
     type: 'POST',
     data: JSON.stringify(formData),
     dataType: 'json',

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -41,7 +41,8 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
   url: [
     scheme: System.get_env("BLOCKSCOUT_PROTOCOL") || "http",
     host: System.get_env("BLOCKSCOUT_HOST") || "localhost",
-    path: System.get_env("NETWORK_PATH") || "/"
+    path: System.get_env("NETWORK_PATH") || "/",
+    api_path: System.get_env("API_PATH") || "/"
   ],
   render_errors: [view: BlockScoutWeb.ErrorView, accepts: ~w(html json)],
   pubsub: [name: BlockScoutWeb.PubSub]

--- a/apps/block_scout_web/config/dev.exs
+++ b/apps/block_scout_web/config/dev.exs
@@ -21,7 +21,8 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
   url: [
     scheme: "http",
     host: System.get_env("BLOCKSCOUT_HOST") || "localhost",
-    path: System.get_env("NETWORK_PATH") || "/"
+    path: System.get_env("NETWORK_PATH") || "/",
+    api_path: System.get_env("API_PATH") || "/"
   ],
   https: [
     port: (port && port + 1) || 4001,

--- a/apps/block_scout_web/config/prod.exs
+++ b/apps/block_scout_web/config/prod.exs
@@ -23,7 +23,8 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
     scheme: System.get_env("BLOCKSCOUT_PROTOCOL") || "https",
     port: System.get_env("PORT"),
     host: System.get_env("BLOCKSCOUT_HOST") || "localhost",
-    path: System.get_env("NETWORK_PATH") || "/"
+    path: System.get_env("NETWORK_PATH") || "/",
+    api_path: System.get_env("API_PATH") || "/"
   ]
 
 config :block_scout_web, BlockScoutWeb.Tracer, env: "production", disabled?: true

--- a/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
@@ -34,10 +34,17 @@ defmodule BlockScoutWeb.APIDocsView do
     end)
   end
 
-  def blockscout_url do
+  def blockscout_url(is_api) do
     url_params = Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url]
     host = url_params[:host]
-    path = url_params[:path]
+
+    path =
+      if is_api do
+        url_params[:api_path]
+      else
+        url_params[:path]
+      end
+
     scheme = Keyword.get(url_params, :scheme, "http")
 
     if host != "localhost" do
@@ -49,12 +56,18 @@ defmodule BlockScoutWeb.APIDocsView do
   end
 
   def api_url do
-    blockscout_url()
+    is_api = true
+
+    is_api
+    |> blockscout_url()
     |> Path.join("api")
   end
 
   def eth_rpc_api_url do
-    blockscout_url()
+    is_api = true
+
+    is_api
+    |> blockscout_url()
     |> Path.join("api/eth_rpc")
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
@@ -4,7 +4,7 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewView do
   alias BlockScoutWeb.CurrencyHelpers
   alias Explorer.Chain.{Address, SmartContract, Token}
 
-  import BlockScoutWeb.APIDocsView, only: [blockscout_url: 0]
+  import BlockScoutWeb.APIDocsView, only: [blockscout_url: 1]
 
   @tabs ["token_transfers", "metadata"]
 
@@ -55,7 +55,8 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewView do
   def qr_code(conn, token_id, hash) do
     token_instance_path = token_instance_path(conn, :show, to_string(hash), to_string(token_id))
 
-    url = Path.join(blockscout_url(), token_instance_path)
+    is_api = false
+    url = Path.join(blockscout_url(is_api), token_instance_path)
 
     url
     |> QRCode.to_png()

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -898,7 +898,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/address_view.ex:308
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:71
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:72
 #: lib/block_scout_web/views/tokens/overview_view.ex:35
 #: lib/block_scout_web/views/transaction_view.ex:314
 msgid "Token Transfers"
@@ -1774,7 +1774,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/metadata/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:10
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:72
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:73
 msgid "Metadata"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -898,7 +898,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/address_view.ex:308
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:71
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:72
 #: lib/block_scout_web/views/tokens/overview_view.ex:35
 #: lib/block_scout_web/views/transaction_view.ex:314
 msgid "Token Transfers"
@@ -1774,7 +1774,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/metadata/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:10
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:72
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:73
 msgid "Metadata"
 msgstr ""
 

--- a/apps/block_scout_web/test/block_scout_web/views/api_docs_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api_docs_view_test.exs
@@ -14,7 +14,7 @@ defmodule BlockScoutWeb.ApiDocsViewTest do
 
     test "adds slash before path" do
       Application.put_env(:block_scout_web, BlockScoutWeb.Endpoint,
-        url: [scheme: "https", host: "blockscout.com", port: 9999, path: "/chain/dog"]
+        url: [scheme: "https", host: "blockscout.com", port: 9999, api_path: "/chain/dog"]
       )
 
       assert APIDocsView.api_url() == "https://blockscout.com/chain/dog/api"
@@ -22,7 +22,7 @@ defmodule BlockScoutWeb.ApiDocsViewTest do
 
     test "does not add slash to empty path" do
       Application.put_env(:block_scout_web, BlockScoutWeb.Endpoint,
-        url: [scheme: "https", host: "blockscout.com", port: 9999, path: ""]
+        url: [scheme: "https", host: "blockscout.com", port: 9999, api_path: ""]
       )
 
       assert APIDocsView.api_url() == "https://blockscout.com/api"
@@ -49,7 +49,7 @@ defmodule BlockScoutWeb.ApiDocsViewTest do
 
     test "adds slash before path" do
       Application.put_env(:block_scout_web, BlockScoutWeb.Endpoint,
-        url: [scheme: "https", host: "blockscout.com", port: 9999, path: "/chain/dog"]
+        url: [scheme: "https", host: "blockscout.com", port: 9999, api_path: "/chain/dog"]
       )
 
       assert APIDocsView.eth_rpc_api_url() == "https://blockscout.com/chain/dog/api/eth_rpc"


### PR DESCRIPTION
## Motivation

If Blockscot instance is proxied to blockscout.com there are 2 problems exist:
- URL on API docs page doesn't include path on blockscout.com for the instance that confusing developers
- Try it out section doesn't work for ETH RPC API endpoints

## Changelog

`API_PATH` ENV var introduced which indicates the path for API URL. If it is not set, it is `/`.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
