### PR TITLE
Fix copy UTF8 tx input action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2834](https://github.com/poanetwork/blockscout/pull/2834) - always redirect to checksummed hash
 
 ### Fixes
+- [#3007](https://github.com/poanetwork/blockscout/pull/3007) - Fix copy UTF8 tx input action
 - [#2996](https://github.com/poanetwork/blockscout/pull/2996) - Fix awesomplete lib loading in Firefox
 - [#2993](https://github.com/poanetwork/blockscout/pull/2993), [#2999](https://github.com/poanetwork/blockscout/pull/2999) - Fix path definition for contract verification endpoint
 - [#2990](https://github.com/poanetwork/blockscout/pull/2990) - Fix import of Parity spec file

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -141,7 +141,7 @@
                   <span
                     aria-label="Copy Value"
                     class="btn-copy-icon tx-utf8-input transaction-input"
-                    data-clipboard-text="<%= @transaction.input %>"
+                    data-clipboard-text="<%= @transaction.input.bytes %>"
                     data-placement="top"
                     data-toggle="tooltip"
                     title='<%= gettext("Copy Txn Input") %>'


### PR DESCRIPTION
## Motivation

"Copy Txn UTF8 input button" copies not decoded input but hex instead.

## Changelog

Fix Copy Txn UTF8 input button action

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
