### PR TITLE
Revert realtime fetcher small skips feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2834](https://github.com/poanetwork/blockscout/pull/2834) - always redirect to checksummed hash
 
 ### Fixes
+- [#3011](https://github.com/poanetwork/blockscout/pull/3011) - Revert realtime fetcher small skips feature
 - [#3009](https://github.com/poanetwork/blockscout/pull/3009) - Fix broken export to CSV
 - [#3007](https://github.com/poanetwork/blockscout/pull/3007) - Fix copy UTF8 tx input action
 - [#2996](https://github.com/poanetwork/blockscout/pull/2996) - Fix awesomplete lib loading in Firefox

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -28,12 +28,6 @@ block_transformer =
       transformer
   end
 
-max_skipping_distance =
-  case Integer.parse(System.get_env("MAX_SKIPPING_DISTANCE", "")) do
-    {num, ""} -> num
-    _ -> 5
-  end
-
 config :indexer,
   block_transformer: block_transformer,
   ecto_repos: [Explorer.Repo],
@@ -42,8 +36,7 @@ config :indexer,
   # bytes
   memory_limit: 1 <<< 30,
   first_block: System.get_env("FIRST_BLOCK") || "0",
-  last_block: System.get_env("LAST_BLOCK") || "",
-  max_skipping_distance: max_skipping_distance
+  last_block: System.get_env("LAST_BLOCK") || ""
 
 # config :indexer, Indexer.Fetcher.ReplacedTransaction.Supervisor, disabled?: true
 # config :indexer, Indexer.Fetcher.BlockReward.Supervisor, disabled?: true

--- a/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
@@ -28,11 +28,6 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisorTest do
 
   setup :verify_on_exit!
 
-  # run the tests without the skipping window
-  setup do
-    Application.put_env(:indexer, :max_skipping_distance, 0)
-  end
-
   describe "start_link/1" do
     # See https://github.com/poanetwork/blockscout/issues/597
     @tag :no_geth

--- a/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
@@ -32,11 +32,6 @@ defmodule Indexer.Block.Catchup.FetcherTest do
     }
   end
 
-  setup do
-    # run the tests without the skipping window
-    Application.put_env(:indexer, :max_skipping_distance, 0)
-  end
-
   describe "import/1" do
     test "fetches uncles asynchronously", %{json_rpc_named_arguments: json_rpc_named_arguments} do
       CoinBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)

--- a/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
@@ -40,11 +40,6 @@ defmodule Indexer.Block.Realtime.FetcherTest do
     %{block_fetcher: block_fetcher, json_rpc_named_arguments: core_json_rpc_named_arguments}
   end
 
-  setup do
-    # run the tests with a realistic skipping window
-    Application.put_env(:indexer, :max_skipping_distance, 3)
-  end
-
   describe "Indexer.Block.Fetcher.fetch_and_import_range/1" do
     @tag :no_geth
     test "in range with internal transactions", %{
@@ -427,53 +422,6 @@ defmodule Indexer.Block.Realtime.FetcherTest do
                 },
                 errors: []
               }} = Indexer.Block.Fetcher.fetch_and_import_range(block_fetcher, 3_946_079..3_946_080)
-    end
-  end
-
-  describe "determine_fetching_action/4" do
-    test "when everything (except number) is nil results in fetching only the number" do
-      assert [14] == Realtime.Fetcher.determine_fetching_action(14, nil, nil)
-    end
-
-    test "when number is also max_number_seen results in fetching only the number" do
-      number = 23
-      assert [number] == Realtime.Fetcher.determine_fetching_action(number, nil, number)
-      assert [number] == Realtime.Fetcher.determine_fetching_action(number, 21, number)
-    end
-
-    test "when max_number_seen is nil, fetching will start from previous_number" do
-      # note: this is a way to force this behavior, used by `poll_latest_block_number`
-      number = 156
-      previous_number = 150
-      old_number = 94
-
-      assert (previous_number + 1)..number == Realtime.Fetcher.determine_fetching_action(number, previous_number, nil)
-      assert (number - 10)..number == Realtime.Fetcher.determine_fetching_action(number, old_number, nil)
-    end
-
-    test "when number immediately follows the previous_number it is fetched" do
-      max_number_seen = 26
-      number = 27
-
-      assert [number] == Realtime.Fetcher.determine_fetching_action(number, nil, max_number_seen)
-    end
-
-    test "when number is inside the allowed skipping window nothing is fetched" do
-      max_number_seen = 26
-
-      assert :skip == Realtime.Fetcher.determine_fetching_action(28, nil, max_number_seen)
-      assert :skip == Realtime.Fetcher.determine_fetching_action(29, nil, max_number_seen)
-    end
-
-    test "when number is over the allowed skipping window all the values since the previous_number will be fetched" do
-      max_number_seen = 390
-      previous_number = 381
-      max_skipping_distance = Application.get_env(:indexer, :max_skipping_distance)
-
-      number = max_number_seen + max_skipping_distance + 1
-
-      assert (number - 10)..number ==
-               Realtime.Fetcher.determine_fetching_action(number, previous_number, max_number_seen)
     end
   end
 end


### PR DESCRIPTION
Reverts #2470

## Motivation

This feature causes real time fetcher to skip blocks and catchup fetcher never processes them causing increasing the number of chain breaks. Noticed on Mainnet instance. In view of that fact and unclear profit from implementing of #2470 (it still tries to index indexed blocks), it is suggested to revert that PR.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
