### PR TITLE
Speedup token transfers list query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2834](https://github.com/poanetwork/blockscout/pull/2834) - always redirect to checksummed hash
 
 ### Fixes
+- [#3012](https://github.com/poanetwork/blockscout/pull/3012) - Speedup token transfers list query
 - [#3009](https://github.com/poanetwork/blockscout/pull/3009) - Fix broken export to CSV
 - [#3007](https://github.com/poanetwork/blockscout/pull/3007) - Fix copy UTF8 tx input action
 - [#2996](https://github.com/poanetwork/blockscout/pull/2996) - Fix awesomplete lib loading in Firefox


### PR DESCRIPTION
## Motivation

`tokenTx` API endpoint returns 504 Gateway timout error even with using of pagination with 10 elements per page. For instance: https://blockscout.com/poa/core/api?module=account&action=tokentx&address=0xcb55fc893000a984a5ad73011f93d1540a5f0895&sort=desc&page=1&offset=10. The issue is because query to get list of token transfers is too long. This PT improves performance of this query.

## Changelog

Original query looks like:
```
SELECT t1.*, t0.*, b3."hash", b3."number", b3."timestamp", t2.*
FROM "transactions" AS t0
INNER JOIN "token_transfers" AS t1 ON ((t1."transaction_hash" = t0."hash")
AND (t1."block_number" = t0."block_number")) AND (t1."block_hash" = t0."block_hash")
INNER JOIN "addresses" AS a4 ON a4."hash" = t1."token_contract_address_hash"
INNER JOIN "tokens" AS t2 ON t2."contract_address_hash" = a4."hash"
INNER JOIN "blocks" AS b3 ON b3."hash" = t0."block_hash"
WHERE ((t1."from_address_hash" = '\xcb55fc893000a984a5ad73011f93d1540a5f0895')) OR (t1."to_address_hash" = '\xcb55fc893000a984a5ad73011f93d1540a5f0895')
ORDER BY t0."block_number" DESC
LIMIT 10 OFFSET 0;
```

It is suggested to extract subquery from `from token_transfers` and `tokens` ordering by token transfers fields: `block_number` and `log_index`, which have index in descent order. The modified query looks like:

```
core=> EXPLAIN ANALYZE (SELECT t0."nonce", t0."index", t0."gas", t0."gas_price", t0."gas_used", t0."cumulative_gas_used", t0."input", c.*, b3."hash", b3."number", b3."timestamp"
FROM "transactions" t0
INNER JOIN (SELECT t1."token_contract_address_hash", t1."transaction_hash", t1."from_address_hash", t1."to_address_hash", t1."amount", t1."token_id", t1."log_index", t1."block_number", t1."block_hash"
, t2."name", t2."symbol", t2."decimals", t2."type"
FROM "token_transfers" AS t1
INNER JOIN "tokens" AS t2 ON t2."contract_address_hash" = t1."token_contract_address_hash"
WHERE ((t1."from_address_hash" = '\xcb55fc893000a984a5ad73011f93d1540a5f0895')) OR (t1."to_address_hash" = '\xcb55fc893000a984a5ad73011f93d1540a5f0895')
ORDER BY t1."block_number" DESC, t1."log_index" DESC
LIMIT 10 OFFSET 0) c
INNER JOIN "blocks" AS b3 ON b3."hash" = c."block_hash"
ON (t0.hash = c.transaction_hash AND t0.block_hash = c.block_hash AND t0.block_number = c.block_number));
                                                                                                    QUERY PLAN

--------------------------------------------------------------------------------------------------------------------------
-----------------------------------------------------------------------------------------
 Nested Loop  (cost=1.69..217.61 rows=1 width=315) (actual time=24.814..29.119 rows=10 loops=1)
   Join Filter: (t1.block_hash = b3.hash)
   ->  Nested Loop  (cost=1.13..210.86 rows=1 width=299) (actual time=24.786..28.991 rows=10 loops=1)
         ->  Limit  (cost=0.57..124.83 rows=10 width=176) (actual time=24.746..28.844 rows=10 loops=1)
               ->  Nested Loop  (cost=0.57..354824.28 rows=28555 width=176) (actual time=24.744..28.835 rows=10 loops=1)
                     ->  Index Scan using "token_transfers_block_number_DESC_log_index_DESC_index" on token_transfers t1
(cost=0.43..349940.07 rows=28555 width=148) (actual time=24.702..28.749 rows=10 loops=1)
                           Filter: ((from_address_hash = '\xcb55fc893000a984a5ad73011f93d1540a5f0895'::bytea) OR (to_addre
ss_hash = '\xcb55fc893000a984a5ad73011f93d1540a5f0895'::bytea))
                           Rows Removed by Filter: 48317
                     ->  Index Scan using tokens_contract_address_hash_index on tokens t2  (cost=0.14..0.17 rows=1 width=4
9) (actual time=0.005..0.005 rows=1 loops=10)
                           Index Cond: (contract_address_hash = t1.token_contract_address_hash)
         ->  Index Scan using transactions_hash_inserted_at_index on transactions t0  (cost=0.56..8.58 rows=1 width=160) (
actual time=0.013..0.013 rows=1 loops=10)
               Index Cond: (hash = t1.transaction_hash)
               Filter: ((t1.block_hash = block_hash) AND (t1.block_number = block_number))
   ->  Index Scan using blocks_pkey on blocks b3  (cost=0.56..6.74 rows=1 width=49) (actual time=0.011..0.011 rows=1 loops
=10)
         Index Cond: (hash = t0.block_hash)
 Planning time: 1.928 ms
 Execution time: 29.220 ms
(17 rows)
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
