### PR TITLE
Fix checksum address feature for tokens pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2834](https://github.com/poanetwork/blockscout/pull/2834) - always redirect to checksummed hash
 
 ### Fixes
+- [#3014](https://github.com/poanetwork/blockscout/pull/3014) - Fix checksum address feature for tokens pages
 - [#3012](https://github.com/poanetwork/blockscout/pull/3012) - Speedup token transfers list query
 - [#3011](https://github.com/poanetwork/blockscout/pull/3011) - Revert realtime fetcher small skips feature
 - [#3009](https://github.com/poanetwork/blockscout/pull/3009) - Fix broken export to CSV

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.Tokens.HolderController do
 
   alias BlockScoutWeb.Tokens.HolderView
   alias Explorer.{Chain, Market}
+  alias Explorer.Chain.Address
   alias Phoenix.View
 
   import BlockScoutWeb.Chain,
@@ -52,7 +53,7 @@ defmodule BlockScoutWeb.Tokens.HolderController do
         "index.html",
         current_path: current_path(conn),
         token: Market.add_price(token),
-        counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)})
+        counters_path: token_path(conn, :token_counters, %{"id" => Address.checksum(address_hash)})
       )
     else
       :error ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/instance/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/instance/transfer_controller.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.Tokens.Instance.TransferController do
 
   alias BlockScoutWeb.Tokens.TransferView
   alias Explorer.{Chain, Market}
+  alias Explorer.Chain.Address
   alias Phoenix.View
 
   import BlockScoutWeb.Chain, only: [split_list_by_page: 1, paging_options: 1, next_page_params: 3]
@@ -24,7 +25,7 @@ defmodule BlockScoutWeb.Tokens.Instance.TransferController do
               conn,
               :index,
               token_id,
-              token.contract_address_hash,
+              Address.checksum(token.contract_address_hash),
               Map.delete(next_page_params, "type")
             )
         end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.Tokens.InventoryController do
 
   alias BlockScoutWeb.Tokens.InventoryView
   alias Explorer.{Chain, Market}
-  alias Explorer.Chain.TokenTransfer
+  alias Explorer.Chain.{Address, TokenTransfer}
   alias Phoenix.View
 
   import BlockScoutWeb.Chain, only: [split_list_by_page: 1, default_paging_options: 0]
@@ -28,7 +28,7 @@ defmodule BlockScoutWeb.Tokens.InventoryController do
             token_inventory_path(
               conn,
               :index,
-              address_hash_string,
+              Address.checksum(address_hash_string),
               Map.delete(next_page_params, "type")
             )
         end
@@ -71,7 +71,7 @@ defmodule BlockScoutWeb.Tokens.InventoryController do
         "index.html",
         current_path: current_path(conn),
         token: Market.add_price(token),
-        counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)})
+        counters_path: token_path(conn, :token_counters, %{"id" => Address.checksum(address_hash)})
       )
     else
       :error ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/read_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/read_contract_controller.ex
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.Tokens.ReadContractController do
   use BlockScoutWeb, :controller
 
   alias Explorer.{Chain, Market}
+  alias Explorer.Chain.Address
 
   def index(conn, %{"token_id" => address_hash_string}) do
     options = [necessity_by_association: %{[contract_address: :smart_contract] => :optional}]
@@ -13,7 +14,7 @@ defmodule BlockScoutWeb.Tokens.ReadContractController do
         conn,
         "index.html",
         token: Market.add_price(token),
-        counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)})
+        counters_path: token_path(conn, :token_counters, %{"id" => Address.checksum(address_hash)})
       )
     else
       :not_found ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.Tokens.TransferController do
 
   alias BlockScoutWeb.Tokens.TransferView
   alias Explorer.{Chain, Market}
+  alias Explorer.Chain.Address
   alias Phoenix.View
 
   import BlockScoutWeb.Chain, only: [split_list_by_page: 1, paging_options: 1, next_page_params: 3]
@@ -19,7 +20,12 @@ defmodule BlockScoutWeb.Tokens.TransferController do
             nil
 
           next_page_params ->
-            token_transfer_path(conn, :index, token.contract_address_hash, Map.delete(next_page_params, "type"))
+            token_transfer_path(
+              conn,
+              :index,
+              Address.checksum(token.contract_address_hash),
+              Map.delete(next_page_params, "type")
+            )
         end
 
       transfers_json =
@@ -51,7 +57,7 @@ defmodule BlockScoutWeb.Tokens.TransferController do
       render(
         conn,
         "index.html",
-        counters_path: token_path(conn, :token_counters, %{"id" => to_string(address_hash)}),
+        counters_path: token_path(conn, :token_counters, %{"id" => Address.checksum(address_hash)}),
         current_path: current_path(conn),
         token: Market.add_price(token)
       )

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
@@ -18,7 +18,7 @@
                   data-placement="top"
                   data-toggle="tooltip"
                   title='<%= gettext("View Contract") %>'
-                  onclick='<%= "location='#{address_path(@conn, :show, @token.contract_address_hash)}'" %>'
+                  onclick='<%= "location='#{address_path(@conn, :show, Address.checksum(@token.contract_address_hash))}'" %>'
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32.5 32.5" width="32" height="32"  transform="translate(8,8)">
                     <path fill-rule="evenodd" d="M15 16H1a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1zM14 2H2v12h12V2z"/>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex
@@ -8,7 +8,7 @@
    <%= if @token_instance.instance do %>
     <%= link(
         gettext("Metadata"),
-        to: token_instance_metadata_path(@conn, :index, @token.contract_address_hash, to_string(@token_instance.token_id)),
+        to: token_instance_metadata_path(@conn, :index, Address.checksum(@token.contract_address_hash), to_string(@token_instance.token_id)),
         class: "card-tab #{tab_status("metadata", @conn.request_path)}")
       %>
   <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
@@ -11,7 +11,7 @@
             <% end %>
             <!-- buttons -->
             <span class="overview-title-buttons float-right">
-              <span class="overview-title-item" data-clipboard-text="<%= @token.contract_address_hash %>">
+              <span class="overview-title-item" data-clipboard-text="<%= Address.checksum(@token.contract_address_hash) %>">
                 <span
                   aria-label='<%= gettext("Copy Address") %>'
                   class="btn-copy-icon"
@@ -44,12 +44,12 @@
             </span>
           </h1>
 
-          <h3><%= to_string(@token.contract_address_hash) %></h3>
+          <h3><%= Address.checksum(@token.contract_address_hash) %></h3>
 
           <div class="d-flex flex-column flex-md-row justify-content-start text-muted">
             <span class="mr-4 mb-3 mb-md-0">
               <%= link to:
-                  address_path(@conn, :show, @token.contract_address_hash),
+                  address_path(@conn, :show, Address.checksum(@token.contract_address_hash)),
                   "data-test": "token_contract_address"
               do %>
                 <%=  gettext "View Contract" %>
@@ -108,7 +108,7 @@
         </button>
       </div>
       <div class="modal-body">
-        <img src="data:image/png;base64, <%= BlockScoutWeb.AddressView.qr_code(@token.contract_address_hash) %> " class="qr-code" alt="qr_code" title="<%= @token.contract_address %>" />
+        <img src="data:image/png;base64, <%= BlockScoutWeb.AddressView.qr_code(Address.checksum(@token.contract_address_hash)) %> " class="qr-code" alt="qr_code" title="<%= @token.contract_address %>" />
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" data-dismiss="modal"><%= gettext "Close" %></button>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_metatags.html.eex
@@ -2,4 +2,4 @@
   <%= "#{token_name(@token)} (#{token_symbol(@token)}) - #{LayoutView.subnetwork_title()} - BlockScout" %>
 </title>
 <meta name="description" content="<%= token_name(@token) %>, balances, and analytics on the <%= LayoutView.network_title() %>">
-<meta name="keywords" content="<%= "#{token_name(@token)}, #{token_symbol(@token)}, #{to_string(@token.contract_address_hash)}, #{LayoutView.network_title()}, #{Explorer.coin()}" %>">
+<meta name="keywords" content="<%= "#{token_name(@token)}, #{token_symbol(@token)}, #{Address.checksum(@token.contract_address_hash)}, #{LayoutView.network_title()}, #{Explorer.coin()}" %>">

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_tabs.html.eex
@@ -9,21 +9,21 @@
         gettext("Token Holders"),
         class: "card-tab #{tab_status("token_holders", @conn.request_path)}",
         "data-test": "token_holders_tab",
-        to: token_holder_path(@conn, :index, @token.contract_address_hash)
+        to: token_holder_path(@conn, :index, Address.checksum(@token.contract_address_hash))
       )
     %>
   <%= if display_inventory?(@token) do %>
     <%= link(
           gettext("Inventory"),
           class: "card-tab #{tab_status("inventory", @conn.request_path)}",
-          to: token_inventory_path(@conn, :index, @token.contract_address_hash)
+          to: token_inventory_path(@conn, :index, Address.checksum(@token.contract_address_hash))
         )
     %>
   <% end %>
   <%= if smart_contract_with_read_only_functions?(@token) do %>
     <%= link(
         gettext("Read Contract"),
-        to: token_read_contract_path(@conn, :index, @token.contract_address_hash),
+        to: token_read_contract_path(@conn, :index, Address.checksum(@token.contract_address_hash)),
         class: "card-tab #{tab_status("read_contract", @conn.request_path)}")
       %>
   <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/read_contract/index.html.eex
@@ -11,7 +11,7 @@
     <div class="card">
       <%= render OverviewView, "_tabs.html", assigns %>
       <!-- loaded via AJAX -->
-      <div class="card-body" data-smart-contract-functions data-hash="<%= to_string(@token.contract_address.hash) %>" data-url="<%= smart_contract_path(@conn, :index) %>">
+      <div class="card-body" data-smart-contract-functions data-hash="<%= Address.checksum(@token.contract_address.hash) %>" data-url="<%= smart_contract_path(@conn, :index) %>">
         <div class="tile tile-muted text-center">
           <span class="loading-spinner-small mr-2">
             <span class="loading-spinner-block-1"></span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex
@@ -8,7 +8,7 @@
     <div class="col-md-7 col-lg-8 d-flex flex-column pr-2 pr-sm-2 pr-md-0">
       <%= render BlockScoutWeb.TransactionView, "_link.html", transaction_hash: @token_transfer.transaction_hash %>
       <span class="text-nowrap">
-        <%= link to: address_token_transfers_path(@conn, :index, to_string(@token_transfer.from_address), to_string(@token.contract_address_hash)), "data-test": "address_hash_link" do %>
+        <%= link to: address_token_transfers_path(@conn, :index, Address.checksum(@token_transfer.from_address), Address.checksum(@token.contract_address_hash)), "data-test": "address_hash_link" do %>
             <%= render(
                   BlockScoutWeb.AddressView,
                   "_responsive_hash.html",
@@ -18,7 +18,7 @@
                 ) %>
         <% end %>
         &rarr;
-        <%= link to: address_token_transfers_path(@conn, :index, to_string(@token_transfer.to_address), to_string(@token.contract_address_hash)), "data-test": "address_hash_link" do %>
+        <%= link to: address_token_transfers_path(@conn, :index, Address.checksum(@token_transfer.to_address), Address.checksum(@token.contract_address_hash)), "data-test": "address_hash_link" do %>
             <%= render(
                   BlockScoutWeb.AddressView,
                   "_responsive_hash.html",
@@ -32,7 +32,7 @@
         <span class="tile-title">
           <%= case token_transfer_amount(@token_transfer) do %>
             <% {:ok, :erc721_instance} -> %>
-              <%= "TokenID ["%><%= link(@token_transfer.token_id, to: token_instance_path(@conn, :show, @token_transfer.token.contract_address_hash, to_string(@token_transfer.token_id))) %><%= "]" %>
+              <%= "TokenID ["%><%= link(@token_transfer.token_id, to: token_instance_path(@conn, :show, Address.checksum(@token_transfer.token.contract_address_hash), to_string(@token_transfer.token_id))) %><%= "]" %>
             <% {:ok, value} -> %>
               <%= value %>
           <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/read_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/read_contract_view.ex
@@ -2,4 +2,5 @@ defmodule BlockScoutWeb.Tokens.ReadContractView do
   use BlockScoutWeb, :view
 
   alias BlockScoutWeb.Tokens.OverviewView
+  alias Explorer.Chain.Address
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/transfer_view.ex
@@ -2,4 +2,5 @@ defmodule BlockScoutWeb.Tokens.TransferView do
   use BlockScoutWeb, :view
 
   alias BlockScoutWeb.Tokens.OverviewView
+  alias Explorer.Chain.Address
 end


### PR DESCRIPTION
Issue caused by #2834

## Motivation

- Some links on token/instances pages are broken
- Checksummed address feature doesn't spread to token/instances pages

## Changelog


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
