### PR TITLE
Fix token instance QR code data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2834](https://github.com/poanetwork/blockscout/pull/2834) - always redirect to checksummed hash
 
 ### Fixes
+- [#3016](https://github.com/poanetwork/blockscout/pull/3016) - Fix token instance QR code data
 - [#3012](https://github.com/poanetwork/blockscout/pull/3012) - Speedup token transfers list query
 - [#3011](https://github.com/poanetwork/blockscout/pull/3011) - Revert realtime fetcher small skips feature
 - [#3009](https://github.com/poanetwork/blockscout/pull/3009) - Fix broken export to CSV

--- a/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
@@ -34,7 +34,7 @@ defmodule BlockScoutWeb.APIDocsView do
     end)
   end
 
-  def blockscout_url(is_api) do
+  def blockscout_url(is_api, set_path) do
     url_params = Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url]
     host = url_params[:host]
 
@@ -48,7 +48,7 @@ defmodule BlockScoutWeb.APIDocsView do
     scheme = Keyword.get(url_params, :scheme, "http")
 
     if host != "localhost" do
-      "#{scheme}://#{host}#{path}"
+      if set_path, do: "#{scheme}://#{host}#{path}", else: "#{scheme}://#{host}"
     else
       port = Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:http][:port]
       "#{scheme}://#{host}:#{to_string(port)}"
@@ -57,17 +57,19 @@ defmodule BlockScoutWeb.APIDocsView do
 
   def api_url do
     is_api = true
+    set_path = true
 
     is_api
-    |> blockscout_url()
+    |> blockscout_url(set_path)
     |> Path.join("api")
   end
 
   def eth_rpc_api_url do
     is_api = true
+    set_path = true
 
     is_api
-    |> blockscout_url()
+    |> blockscout_url(set_path)
     |> Path.join("api/eth_rpc")
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
@@ -4,7 +4,7 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewView do
   alias BlockScoutWeb.CurrencyHelpers
   alias Explorer.Chain.{Address, SmartContract, Token}
 
-  import BlockScoutWeb.APIDocsView, only: [blockscout_url: 1]
+  import BlockScoutWeb.APIDocsView, only: [blockscout_url: 2]
 
   @tabs ["token_transfers", "metadata"]
 
@@ -56,7 +56,8 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewView do
     token_instance_path = token_instance_path(conn, :show, to_string(hash), to_string(token_id))
 
     is_api = false
-    url = Path.join(blockscout_url(is_api), token_instance_path)
+    set_path = false
+    url = Path.join(blockscout_url(is_api, set_path), token_instance_path)
 
     url
     |> QRCode.to_png()

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -898,7 +898,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/address_view.ex:308
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:72
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:73
 #: lib/block_scout_web/views/tokens/overview_view.ex:35
 #: lib/block_scout_web/views/transaction_view.ex:314
 msgid "Token Transfers"
@@ -1774,7 +1774,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/metadata/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:10
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:73
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:74
 msgid "Metadata"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -898,7 +898,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/address_view.ex:308
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:72
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:73
 #: lib/block_scout_web/views/tokens/overview_view.ex:35
 #: lib/block_scout_web/views/transaction_view.ex:314
 msgid "Token Transfers"
@@ -1774,7 +1774,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/metadata/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:10
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:73
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:74
 msgid "Metadata"
 msgstr ""
 


### PR DESCRIPTION
## Motivation

URL behind QR-code on token instance page leads to 404 page

## Changelog

Add `set_path` parameter to `blockscout_url` method and pass `false` in case of constructing URL for  QR-code

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
