### PR TITLE
Fix filters functionality

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/checksum_address.ex
+++ b/apps/block_scout_web/lib/block_scout_web/checksum_address.ex
@@ -31,7 +31,14 @@ defmodule BlockScoutWeb.ChecksumAddress do
           if checksummed_hash != id do
             conn = %{conn | params: Map.merge(conn.params, %{param_name => checksummed_hash})}
 
-            new_path = String.replace(conn.request_path, id, checksummed_hash)
+            path_with_checksummed_address = String.replace(conn.request_path, id, checksummed_hash)
+
+            new_path =
+              if conn.query_string != "" do
+                path_with_checksummed_address <> "?" <> conn.query_string
+              else
+                path_with_checksummed_address
+              end
 
             conn
             |> Controller.redirect(to: new_path)


### PR DESCRIPTION
The issue caused by https://github.com/poanetwork/blockscout/pull/2834

## Motivation

Filters functionality doesn't work: all filters params are ignored because on redirect to checksummed address query string is lost.

## Changelog

Add query string to redirected address if it is not empty.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
