### PR TITLE
Fix pool size default value in config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
   eslint:
     docker:
       # Ensure .tool-versions matches
-      - image: circleci/node:12.15.0-browsers-legacy
+      - image: circleci/node:12.16.1-browsers-legacy
 
     working_directory: ~/app
 
@@ -275,7 +275,7 @@ jobs:
   jest:
     docker:
       # Ensure .tool-versions matches
-      - image: circleci/node:12.15.0-browsers-legacy
+      - image: circleci/node:12.16.1-browsers-legacy
 
     working_directory: ~/app
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2834](https://github.com/poanetwork/blockscout/pull/2834) - always redirect to checksummed hash
 
 ### Fixes
+- [#3024](https://github.com/poanetwork/blockscout/pull/3024) - Fix pool size default value in config
 - [#3021](https://github.com/poanetwork/blockscout/pull/3021), [#3022](https://github.com/poanetwork/blockscout/pull/3022) - Refine dev/test config
 - [#3016](https://github.com/poanetwork/blockscout/pull/3016), [#3017](https://github.com/poanetwork/blockscout/pull/3017) - Fix token instance QR code data
 - [#3014](https://github.com/poanetwork/blockscout/pull/3014) - Fix checksum address feature for tokens pages

--- a/apps/explorer/config/dev.exs
+++ b/apps/explorer/config/dev.exs
@@ -3,7 +3,7 @@ use Mix.Config
 # Configure your database
 config :explorer, Explorer.Repo,
   url: System.get_env("DATABASE_URL"),
-  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "50"),
+  pool_size: String.to_integer(System.get_env("POOL_SIZE", "50")),
   timeout: :timer.seconds(80)
 
 config :explorer, Explorer.Tracer, env: "dev", disabled?: true

--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -3,7 +3,7 @@ use Mix.Config
 # Configures the database
 config :explorer, Explorer.Repo,
   url: System.get_env("DATABASE_URL"),
-  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+  pool_size: String.to_integer(System.get_env("POOL_SIZE", "50")),
   ssl: String.equivalent?(System.get_env("ECTO_USE_SSL") || "true", "true"),
   prepare: :unnamed,
   timeout: :timer.seconds(60)


### PR DESCRIPTION
## Motivation

The default value of `POOL_SIZE` env var doesn't read in the production environment.

## Changelog

Fix default value reading in prod env
- increase the value up to 50 (what is closer to real production instances)

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
