### PR TITLE
Handle error at first trace request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Current
 
 ### Features
-- [#3013](https://github.com/poanetwork/blockscout/pull/3013) - Raw trace of transaction on-demand
+- [#3013](https://github.com/poanetwork/blockscout/pull/3013), [#3026](https://github.com/poanetwork/blockscout/pull/3026) - Raw trace of transaction on-demand
 - [#3000](https://github.com/poanetwork/blockscout/pull/3000) - Get rid of storing of internal transactions for simple coin transfers
 - [#2875](https://github.com/poanetwork/blockscout/pull/2875) - Save contract code from Parity genesis file
 - [#2834](https://github.com/poanetwork/blockscout/pull/2834) - always redirect to checksummed hash

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_raw_trace_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_raw_trace_controller.ex
@@ -35,7 +35,7 @@ defmodule BlockScoutWeb.TransactionRawTraceController do
         if first_trace_exists do
           internal_transactions
         else
-          {:ok, first_trace_params} =
+          response =
             Chain.fetch_first_trace(
               [
                 %{
@@ -48,13 +48,19 @@ defmodule BlockScoutWeb.TransactionRawTraceController do
               json_rpc_named_arguments
             )
 
-          InternalTransactions.run_insert_only(first_trace_params, %{
-            timeout: :infinity,
-            timestamps: Import.timestamps(),
-            internal_transactions: %{params: first_trace_params}
-          })
+          case response do
+            {:ok, first_trace_params} ->
+              InternalTransactions.run_insert_only(first_trace_params, %{
+                timeout: :infinity,
+                timestamps: Import.timestamps(),
+                internal_transactions: %{params: first_trace_params}
+              })
 
-          Chain.all_transaction_to_internal_transactions(hash)
+              Chain.all_transaction_to_internal_transactions(hash)
+
+            {:error, _} ->
+              internal_transactions
+          end
         end
 
       render(

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4070,10 +4070,13 @@ defmodule Explorer.Chain do
   Fetches the first trace from the Parity trace URL.
   """
   def fetch_first_trace(transactions_params, json_rpc_named_arguments) do
-    {:ok, [%{first_trace: first_trace, block_hash: block_hash, json_rpc_named_arguments: json_rpc_named_arguments}]} =
-      EthereumJSONRPC.fetch_first_trace(transactions_params, json_rpc_named_arguments)
+    case EthereumJSONRPC.fetch_first_trace(transactions_params, json_rpc_named_arguments) do
+      {:ok, [%{first_trace: first_trace, block_hash: block_hash, json_rpc_named_arguments: json_rpc_named_arguments}]} ->
+        format_tx_first_trace(first_trace, block_hash, json_rpc_named_arguments)
 
-    format_tx_first_trace(first_trace, block_hash, json_rpc_named_arguments)
+      {:error, error} ->
+        {:error, error}
+    end
   end
 
   defp format_tx_first_trace(first_trace, block_hash, json_rpc_named_arguments) do


### PR DESCRIPTION
Continuation of https://github.com/poanetwork/blockscout/pull/3013

## Motivation

Unhandled error response in `trace_replay_transaction_responses_to_first_trace_params` method request

## Changelog

Handle `:error` case of response from `trace_replay_transaction_responses_to_first_trace_params` method

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
 