### PR TITLE
Remove default websockets URL from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#2883](https://github.com/poanetwork/blockscout/pull/2883) - Fix long contracts names
 
 ### Chore
+- [#3030](https://github.com/poanetwork/blockscout/pull/3030) - Remove default websockets URL from config
 - [#2995](https://github.com/poanetwork/blockscout/pull/2995) - Support API_PATH env var in Docker file
 
 

--- a/apps/explorer/config/dev/ganache.exs
+++ b/apps/explorer/config/dev/ganache.exs
@@ -14,7 +14,7 @@ config :explorer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://localhost:7545"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ],
     variant: EthereumJSONRPC.Ganache
   ]

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -14,7 +14,7 @@ config :explorer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "wss://mainnet.infura.io/8lTvJTKmHPCHazkneJsY/ws"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ],
     variant: EthereumJSONRPC.Geth
   ]

--- a/apps/explorer/config/dev/parity.exs
+++ b/apps/explorer/config/dev/parity.exs
@@ -19,7 +19,7 @@ config :explorer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://localhost:8546"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ],
     variant: EthereumJSONRPC.Parity
   ]

--- a/apps/explorer/config/dev/rsk.exs
+++ b/apps/explorer/config/dev/rsk.exs
@@ -19,7 +19,7 @@ config :explorer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://localhost:8546"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ],
     variant: EthereumJSONRPC.RSK
   ]

--- a/apps/explorer/config/prod/ganache.exs
+++ b/apps/explorer/config/prod/ganache.exs
@@ -5,7 +5,7 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:7545",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
       http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Ganache
@@ -14,7 +14,7 @@ config :explorer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://localhost:7545"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ],
     variant: EthereumJSONRPC.Ganache
   ]

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -5,7 +5,7 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY",
+      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
       http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
     ],
     variant: EthereumJSONRPC.Geth
@@ -14,7 +14,7 @@ config :explorer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "wss://mainnet.infura.io/8lTvJTKmHPCHazkneJsY/ws"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ],
     variant: EthereumJSONRPC.Geth
   ]

--- a/apps/indexer/config/dev/ganache.exs
+++ b/apps/indexer/config/dev/ganache.exs
@@ -16,9 +16,9 @@ config :indexer,
     variant: EthereumJSONRPC.Ganache
   ],
   subscribe_named_arguments: [
-    transport: EthereumJSONRPC.WebSocket,
+    transport: System.get_env("ETHEREUM_JSONRPC_WS_URL") && EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://localhost:7545"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ]
   ]

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -19,6 +19,6 @@ config :indexer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "wss://mainnet.infura.io/ws/8lTvJTKmHPCHazkneJsY"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ]
   ]

--- a/apps/indexer/config/dev/parity.exs
+++ b/apps/indexer/config/dev/parity.exs
@@ -42,6 +42,6 @@ config :indexer,
     transport: System.get_env("ETHEREUM_JSONRPC_WS_URL") && EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://localhost:8546"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ]
   ]

--- a/apps/indexer/config/dev/rsk.exs
+++ b/apps/indexer/config/dev/rsk.exs
@@ -26,6 +26,6 @@ config :indexer,
     transport: System.get_env("ETHEREUM_JSONRPC_WS_URL") && EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://localhost:8546"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ]
   ]

--- a/apps/indexer/config/prod/ganache.exs
+++ b/apps/indexer/config/prod/ganache.exs
@@ -16,9 +16,9 @@ config :indexer,
     variant: EthereumJSONRPC.Ganache
   ],
   subscribe_named_arguments: [
-    transport: EthereumJSONRPC.WebSocket,
+    transport: System.get_env("ETHEREUM_JSONRPC_WS_URL") && EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "ws://localhost:7545"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ]
   ]

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -19,6 +19,6 @@ config :indexer,
     transport: EthereumJSONRPC.WebSocket,
     transport_options: [
       web_socket: EthereumJSONRPC.WebSocket.WebSocketClient,
-      url: System.get_env("ETHEREUM_JSONRPC_WS_URL") || "wss://mainnet.infura.io/ws/8lTvJTKmHPCHazkneJsY"
+      url: System.get_env("ETHEREUM_JSONRPC_WS_URL")
     ]
   ]


### PR DESCRIPTION
## Motivation

Archive node websockets are not required for Blockscout. Thus, we need to remove default valued from config

## Changelog

Remove default values in the config for websockets

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
