### PR TITLE
Remove indexing status alert for Ganache variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#2883](https://github.com/poanetwork/blockscout/pull/2883) - Fix long contracts names
 
 ### Chore
+- [#3032](https://github.com/poanetwork/blockscout/pull/3032) - Remove indexing status alert for Ganache variant
 - [#3030](https://github.com/poanetwork/blockscout/pull/3030) - Remove default websockets URL from config
 - [#2995](https://github.com/poanetwork/blockscout/pull/2995) - Support API_PATH env var in Docker file
 


### PR DESCRIPTION
## Motivation

Indexing status alert at the top of the main page appears for Ganache variant. Though, ganache doesn't' support tracing methods. Thus, the alert will never disappear.

![Screenshot 2020-02-27 at 16 17 31](https://user-images.githubusercontent.com/4341812/75448662-af4b8400-597c-11ea-802f-08aa5094ae84.png)

## Changelog

Hide this alert from Ganache variant

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
