### PR TITLE
Return default hostname and database in dev mode

### DIFF
--- a/apps/explorer/config/dev.exs
+++ b/apps/explorer/config/dev.exs
@@ -1,7 +1,12 @@
 use Mix.Config
 
+database = if System.get_env("DATABASE_URL"), do: nil, else: "explorer_dev"
+hostname = if System.get_env("DATABASE_URL"), do: nil, else: "localhost"
+
 # Configure your database
 config :explorer, Explorer.Repo,
+  database: database,
+  hostname: hostname,
   url: System.get_env("DATABASE_URL"),
   pool_size: String.to_integer(System.get_env("POOL_SIZE", "50")),
   timeout: :timer.seconds(80)


### PR DESCRIPTION
## Motivation

Set default hostname and database in dev mode

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
