### PR TITLE
Speedup pending txs list query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3042](https://github.com/poanetwork/blockscout/pull/3042) - Speedup pending txs list query
 - [#2944](https://github.com/poanetwork/blockscout/pull/2944) - Split js logic into multiple files
 
 ### Chore

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2367,7 +2367,7 @@ defmodule Explorer.Chain do
     |> page_pending_transaction(paging_options)
     |> limit(^paging_options.page_size)
     |> pending_transactions_query()
-    |> order_by([transaction], desc: transaction.inserted_at, desc: transaction.hash)
+    |> order_by([transaction], desc: transaction.hash, desc: transaction.inserted_at)
     |> join_associations(necessity_by_association)
     |> preload([{:token_transfers, [:token, :from_address, :to_address]}])
     |> Repo.all()


### PR DESCRIPTION
## Motivation

The currently implemented query is slow because it doesn't use current indexes effectively. Current query execution plan:

```
explain select * from transactions where block_hash is null and error is null order by inserted_at desc, hash desc limit 50;
                                                       QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=7535181.93..7535182.05 rows=50 width=398)
   ->  Sort  (cost=7535181.93..7541132.96 rows=2380414 width=398)
         Sort Key: inserted_at DESC, hash DESC
         ->  Bitmap Heap Scan on transactions  (cost=107203.94..7456106.29 rows=2380414 width=398)
               Recheck Cond: ((block_hash IS NULL) AND (error IS NULL))
               ->  Bitmap Index Scan on transactions_block_hash_error_index  (cost=0.00..106608.84 rows=2380414 width=0)
                     Index Cond: ((block_hash IS NULL) AND (error IS NULL))
(7 rows)
```

## Changelog

Change the order of columns in the sorting to utilize `"transactions_hash_inserted_at_index" btree (hash, inserted_at)` index

```
explain select * from transactions where block_hash is null and error is null order by hash desc, inserted_at desc limit 50;
                                                               QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.70..54264.67 rows=50 width=398)
   ->  Index Scan Backward using transactions_hash_inserted_at_index on transactions  (cost=0.70..2583414415.84 rows=2380414 width=398)
         Filter: ((block_hash IS NULL) AND (error IS NULL))
(3 rows)
```

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
