### PR TITLE
Extract host name for split couple of indexer and web app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3043](https://github.com/poanetwork/blockscout/pull/3043) - Extract host name for split couple of indexer and web app
 - [#3042](https://github.com/poanetwork/blockscout/pull/3042) - Speedup pending txs list query
 - [#2944](https://github.com/poanetwork/blockscout/pull/2944) - Split js logic into multiple files
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4073,6 +4073,19 @@ defmodule Explorer.Chain do
     end
   end
 
+  def extract_db_host(db_url) do
+    if db_url == nil do
+      ""
+    else
+      db_url
+      |> String.split("@")
+      |> Enum.take(-1)
+      |> Enum.at(0)
+      |> String.split(":")
+      |> Enum.at(0)
+    end
+  end
+
   @doc """
   Fetches the first trace from the Parity trace URL.
   """

--- a/apps/explorer/lib/explorer/chain/events/listener.ex
+++ b/apps/explorer/lib/explorer/chain/events/listener.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Chain.Events.Listener do
   use GenServer
 
   alias Postgrex.Notifications
-  import Explorer.Chain, only: [extract_db_name: 1]
+  import Explorer.Chain, only: [extract_db_name: 1, extract_db_host: 1]
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, "chain_event", name: __MODULE__)
@@ -22,6 +22,7 @@ defmodule Explorer.Chain.Events.Listener do
     {:ok, pid} =
       explorer_repo
       |> Keyword.put(:database, extract_db_name(db_url))
+      |> Keyword.put(:hostname, extract_db_host(db_url))
       |> Notifications.start_link()
 
     ref = Notifications.listen!(pid, channel)

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4887,6 +4887,23 @@ defmodule Explorer.ChainTest do
     end
   end
 
+  describe "extract_db_host/1" do
+    test "extracts correct db host" do
+      db_url = "postgresql://viktor:@localhost:5432/blockscout-dev-1"
+      assert Chain.extract_db_host(db_url) == "localhost"
+    end
+
+    test "returns empty db name" do
+      db_url = ""
+      assert Chain.extract_db_host(db_url) == ""
+    end
+
+    test "returns nil db name" do
+      db_url = nil
+      assert Chain.extract_db_host(db_url) == ""
+    end
+  end
+
   describe "fetch_first_trace/2" do
     test "fetched first trace", %{
       json_rpc_named_arguments: json_rpc_named_arguments


### PR DESCRIPTION
Addition to https://github.com/poanetwork/blockscout/pull/3025

## Motivation

We should also extract hostname from DB URL provided in order to make a splitting couple: indexer - web app work.

## Changelog

`extract_db_host(db_url)` function is introduced

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
