### PR TITLE
Prevent division by zero on /accounts page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3044](https://github.com/poanetwork/blockscout/pull/3044) - Prevent division by zero on /accounts page
 - [#3043](https://github.com/poanetwork/blockscout/pull/3043) - Extract host name for split couple of indexer and web app
 - [#3042](https://github.com/poanetwork/blockscout/pull/3042) - Speedup pending txs list query
 - [#2944](https://github.com/poanetwork/blockscout/pull/2944) - Split js logic into multiple files

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
@@ -57,9 +57,12 @@ defmodule BlockScoutWeb.AddressController do
   end
 
   def index(conn, _params) do
+    total_supply = Chain.total_supply()
+
     render(conn, "index.html",
       current_path: current_path(conn),
-      address_count: Chain.address_estimated_count()
+      address_count: Chain.address_estimated_count(),
+      total_supply: total_supply
     )
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tile.html.eex
@@ -18,12 +18,10 @@
       <% end %>
     </span>
   </td>
-  <%= if balance_percentage_enabled?() do %>
+  <%= if balance_percentage_enabled?(@total_supply) do %>
     <td class="stakes-td color-lighten">
       <!-- percentage of coins from total supply -->
-      <%= if @total_supply do %>
-        <%= balance_percentage(@address, @total_supply) %>
-      <% end %>
+      <%= balance_percentage(@address, @total_supply) %>
     </td>
   <% end %>
   <td class="stakes-td">

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/index.html.eex
@@ -25,7 +25,7 @@
 		  Balance
 		</div>
 	      </th>
-              <%= if balance_percentage_enabled?() do %>
+              <%= if balance_percentage_enabled?(@total_supply) do %>
               <th class="stakes-table-th">
                 <div class="stakes-table-th-content">
                   Percentage
@@ -40,7 +40,7 @@
 	    </tr>
 	  </thead>
 	  <tbody data-items data-selector="top-addresses-list">
-	    <%= render BlockScoutWeb.CommonComponentsView, "_table-loader.html" %>
+	    <%= render BlockScoutWeb.CommonComponentsView, "_table-loader.html", total_supply: @total_supply %>
 	  </tbody>
 	</table>
       </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_table-loader.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_table-loader.html.eex
@@ -8,7 +8,7 @@
   <td class="stakes-td">
     <span class="table-content-loader"></span>
   </td>
-  <%= if balance_percentage_enabled?() do %>
+  <%= if balance_percentage_enabled?(@total_supply) do %>
   <td class="stakes-td">
     <span class="table-content-loader"></span>
   </td>
@@ -27,7 +27,7 @@
   <td class="stakes-td">
     <span class="table-content-loader"></span>
   </td>
-  <%= if balance_percentage_enabled?() do %>
+  <%= if balance_percentage_enabled?(@total_supply) do %>
   <td class="stakes-td">
     <span class="table-content-loader"></span>
   </td>
@@ -46,7 +46,7 @@
   <td class="stakes-td">
     <span class="table-content-loader"></span>
   </td>
-  <%= if balance_percentage_enabled?() do %>
+  <%= if balance_percentage_enabled?(@total_supply) do %>
   <td class="stakes-td">
     <span class="table-content-loader"></span>
   </td>
@@ -65,7 +65,7 @@
   <td class="stakes-td">
     <span class="table-content-loader"></span>
   </td>
-  <%= if balance_percentage_enabled?() do %>
+  <%= if balance_percentage_enabled?(@total_supply) do %>
   <td class="stakes-td">
     <span class="table-content-loader"></span>
   </td>
@@ -84,7 +84,7 @@
   <td class="stakes-td">
     <span class="table-content-loader"></span>
   </td>
-  <%= if balance_percentage_enabled?() do %>
+  <%= if balance_percentage_enabled?(@total_supply) do %>
   <td class="stakes-td">
     <span class="table-content-loader"></span>
   </td>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -110,20 +110,26 @@ defmodule BlockScoutWeb.AddressView do
     format_wei_value(balance, :ether)
   end
 
-  def balance_percentage_enabled? do
-    Application.get_env(:block_scout_web, :show_percentage)
+  def balance_percentage_enabled?(total_supply) do
+    Application.get_env(:block_scout_web, :show_percentage) && total_supply > 0
   end
 
   def balance_percentage(_, nil), do: ""
 
   def balance_percentage(%Address{fetched_coin_balance: balance}, total_supply) do
-    balance
-    |> Wei.to(:ether)
-    |> Decimal.div(Decimal.new(total_supply))
-    |> Decimal.mult(100)
-    |> Decimal.round(4)
-    |> Decimal.to_string(:normal)
-    |> Kernel.<>("% #{gettext("Market Cap")}")
+    if total_supply > 0 do
+      balance
+      |> Wei.to(:ether)
+      |> Decimal.div(Decimal.new(total_supply))
+      |> Decimal.mult(100)
+      |> Decimal.round(4)
+      |> Decimal.to_string(:normal)
+      |> Kernel.<>("% #{gettext("Market Cap")}")
+    else
+      balance
+      |> Wei.to(:ether)
+      |> Decimal.to_string(:normal)
+    end
   end
 
   def empty_exchange_rate?(exchange_rate) do

--- a/apps/block_scout_web/lib/block_scout_web/views/common_components_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/common_components_view.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.CommonComponentsView do
   use BlockScoutWeb, :view
 
-  def balance_percentage_enabled? do
-    Application.get_env(:block_scout_web, :show_percentage)
+  def balance_percentage_enabled?(total_supply) do
+    Application.get_env(:block_scout_web, :show_percentage) && total_supply > 0
   end
 end

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -897,7 +897,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:308
+#: lib/block_scout_web/views/address_view.ex:314
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:90
 #: lib/block_scout_web/views/tokens/overview_view.ex:35
 #: lib/block_scout_web/views/transaction_view.ex:314
@@ -1035,8 +1035,8 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:24
 #: lib/block_scout_web/templates/layout/app.html.eex:30
-#: lib/block_scout_web/views/address_view.ex:126
-#: lib/block_scout_web/views/address_view.ex:126
+#: lib/block_scout_web/views/address_view.ex:127
+#: lib/block_scout_web/views/address_view.ex:127
 msgid "Market Cap"
 msgstr ""
 
@@ -1488,7 +1488,7 @@ msgid "Transaction Speed"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tile.html.eex:33
+#: lib/block_scout_web/templates/address/_tile.html.eex:31
 msgid "Transactions sent"
 msgstr ""
 
@@ -1802,7 +1802,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:37
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
-#: lib/block_scout_web/views/address_view.ex:313
+#: lib/block_scout_web/views/address_view.ex:319
 msgid "Blocks Validated"
 msgstr ""
 
@@ -1812,18 +1812,18 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:309
+#: lib/block_scout_web/views/address_view.ex:315
 msgid "Code"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:26
-#: lib/block_scout_web/views/address_view.ex:312
+#: lib/block_scout_web/views/address_view.ex:318
 msgid "Coin Balance History"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_view.ex:310
+#: lib/block_scout_web/views/address_view.ex:316
 msgid "Decompiled Code"
 msgstr ""
 
@@ -1832,7 +1832,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:307
+#: lib/block_scout_web/views/address_view.ex:313
 #: lib/block_scout_web/views/transaction_view.ex:315
 msgid "Internal Transactions"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:314
+#: lib/block_scout_web/views/address_view.ex:320
 #: lib/block_scout_web/views/transaction_view.ex:316
 msgid "Logs"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:62
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
-#: lib/block_scout_web/views/address_view.ex:311
+#: lib/block_scout_web/views/address_view.ex:317
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -1859,7 +1859,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:14
 #: lib/block_scout_web/templates/address_token/index.html.eex:8
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:11
-#: lib/block_scout_web/views/address_view.ex:305
+#: lib/block_scout_web/views/address_view.ex:311
 msgid "Tokens"
 msgstr ""
 
@@ -1871,6 +1871,6 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:18
 #: lib/block_scout_web/templates/chain/show.html.eex:140
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:50
-#: lib/block_scout_web/views/address_view.ex:306
+#: lib/block_scout_web/views/address_view.ex:312
 msgid "Transactions"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -897,7 +897,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:308
+#: lib/block_scout_web/views/address_view.ex:314
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:90
 #: lib/block_scout_web/views/tokens/overview_view.ex:35
 #: lib/block_scout_web/views/transaction_view.ex:314
@@ -1035,8 +1035,8 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:24
 #: lib/block_scout_web/templates/layout/app.html.eex:30
-#: lib/block_scout_web/views/address_view.ex:126
-#: lib/block_scout_web/views/address_view.ex:126
+#: lib/block_scout_web/views/address_view.ex:127
+#: lib/block_scout_web/views/address_view.ex:127
 msgid "Market Cap"
 msgstr ""
 
@@ -1488,7 +1488,7 @@ msgid "Transaction Speed"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tile.html.eex:33
+#: lib/block_scout_web/templates/address/_tile.html.eex:31
 msgid "Transactions sent"
 msgstr ""
 
@@ -1802,7 +1802,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:37
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
-#: lib/block_scout_web/views/address_view.ex:313
+#: lib/block_scout_web/views/address_view.ex:319
 msgid "Blocks Validated"
 msgstr ""
 
@@ -1812,18 +1812,18 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:309
+#: lib/block_scout_web/views/address_view.ex:315
 msgid "Code"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:26
-#: lib/block_scout_web/views/address_view.ex:312
+#: lib/block_scout_web/views/address_view.ex:318
 msgid "Coin Balance History"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_view.ex:310
+#: lib/block_scout_web/views/address_view.ex:316
 msgid "Decompiled Code"
 msgstr ""
 
@@ -1832,7 +1832,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:307
+#: lib/block_scout_web/views/address_view.ex:313
 #: lib/block_scout_web/views/transaction_view.ex:315
 msgid "Internal Transactions"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:314
+#: lib/block_scout_web/views/address_view.ex:320
 #: lib/block_scout_web/views/transaction_view.ex:316
 msgid "Logs"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:62
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
-#: lib/block_scout_web/views/address_view.ex:311
+#: lib/block_scout_web/views/address_view.ex:317
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -1859,7 +1859,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:14
 #: lib/block_scout_web/templates/address_token/index.html.eex:8
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:11
-#: lib/block_scout_web/views/address_view.ex:305
+#: lib/block_scout_web/views/address_view.ex:311
 msgid "Tokens"
 msgstr ""
 
@@ -1871,6 +1871,6 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:18
 #: lib/block_scout_web/templates/chain/show.html.eex:140
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:50
-#: lib/block_scout_web/views/address_view.ex:306
+#: lib/block_scout_web/views/address_view.ex:312
 msgid "Transactions"
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
@@ -143,6 +143,26 @@ defmodule BlockScoutWeb.AddressViewTest do
     end
   end
 
+  describe "balance_percentage_enabled/1" do
+    test "with non_zero market cap" do
+      Application.put_env(:block_scout_web, :show_percentage, true)
+
+      assert AddressView.balance_percentage_enabled?(100_500) == true
+    end
+
+    test "with zero market cap" do
+      Application.put_env(:block_scout_web, :show_percentage, true)
+
+      assert AddressView.balance_percentage_enabled?(0) == false
+    end
+
+    test "with switched off show_percentage" do
+      Application.put_env(:block_scout_web, :show_percentage, false)
+
+      assert AddressView.balance_percentage_enabled?(100_501) == false
+    end
+  end
+
   test "balance_percentage/1" do
     Application.put_env(:explorer, :supply, Explorer.Chain.Supply.ProofOfAuthority)
     address = insert(:address, fetched_coin_balance: 2_524_608_000_000_000_000_000_000)


### PR DESCRIPTION
## Motivation

There is a division by zero in coin market cap percentage calculation on `/accounts` page for coins with zero market cap from CoinGecko.

## Changelog

Check total_supply before division

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
