### PR TITLE
Fix missing conn in eex template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [#3044](https://github.com/poanetwork/blockscout/pull/3044) - Prevent division by zero on /accounts page
 - [#3043](https://github.com/poanetwork/blockscout/pull/3043) - Extract host name for split couple of indexer and web app
 - [#3042](https://github.com/poanetwork/blockscout/pull/3042) - Speedup pending txs list query
-- [#2944](https://github.com/poanetwork/blockscout/pull/2944) - Split js logic into multiple files
+- [#2944](https://github.com/poanetwork/blockscout/pull/2944), [#3046](https://github.com/poanetwork/blockscout/pull/3046) - Split js logic into multiple files
 
 ### Chore
 

--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -127,6 +127,7 @@ defmodule BlockScoutWeb.AddressChannel do
       View.render_to_string(
         TransactionView,
         "_tile.html",
+        conn: socket,
         current_address: address,
         transaction: transaction
       )

--- a/apps/block_scout_web/lib/block_scout_web/channels/transaction_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/transaction_channel.ex
@@ -29,7 +29,8 @@ defmodule BlockScoutWeb.TransactionChannel do
       View.render_to_string(
         TransactionView,
         "_tile.html",
-        transaction: transaction
+        transaction: transaction,
+        conn: socket
       )
 
     push(socket, "pending_transaction", %{
@@ -47,7 +48,8 @@ defmodule BlockScoutWeb.TransactionChannel do
       View.render_to_string(
         TransactionView,
         "_tile.html",
-        transaction: transaction
+        transaction: transaction,
+        conn: socket
       )
 
     push(socket, "transaction", %{

--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -213,7 +213,7 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
           Logger.info(
             "Index had to catch up.",
             first_block_number: first_block_number,
-            last_block_number: 0,
+            last_block_number: last_block_number,
             missing_block_count: missing_block_count,
             shrunk: shrunk
           )
@@ -236,7 +236,12 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
 
   def handle_info(
         {ref,
-         %{first_block_number: first_block_number, missing_block_count: missing_block_count, shrunk: true = shrunk}},
+         %{
+           first_block_number: first_block_number,
+           missing_block_count: missing_block_count,
+           last_block_number: last_block_number,
+           shrunk: true = shrunk
+         }},
         %__MODULE__{
           task: %Task{ref: ref}
         } = state
@@ -247,7 +252,7 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
     Logger.info(
       "Index had to catch up, but the sequence was shrunk to save memory, so retrying immediately.",
       first_block_number: first_block_number,
-      last_block_number: 0,
+      last_block_number: last_block_number,
       missing_block_count: missing_block_count,
       shrunk: shrunk
     )


### PR DESCRIPTION
Caused by https://github.com/poanetwork/blockscout/pull/2944

## Motivation

Fix missing conn in eex template

```
2020-03-11T13:07:34.253 [error] GenServer #PID<0.1858.0> terminating
** (ArgumentError) assign @conn not available in eex template.

Please make sure all proper assigns have been set. If this
is a child template, ensure assigns are given explicitly by
the parent template as they are not automatically forwarded.

Available assigns: [:transaction, :view_module, :view_template]

    (phoenix_html) lib/phoenix_html/engine.ex:133: Phoenix.HTML.Engine.fetch_assign!/2
    (block_scout_web) lib/block_scout_web/templates/transaction/_tile.html.eex:79: BlockScoutWeb.TransactionView."_tile.html"/1
    (phoenix) lib/phoenix/view.ex:399: Phoenix.View.render_to_iodata/3
    (phoenix) lib/phoenix/view.ex:406: Phoenix.View.render_to_string/3
    (block_scout_web) lib/block_scout_web/channels/transaction_channel.ex:47: BlockScoutWeb.TransactionChannel.handle_out/3
    (phoenix) lib/phoenix/channel/server.ex:301: Phoenix.Channel.Server.handle_info/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: %Phoenix.Socket.Broadcast{event: "transaction", payload: %{transaction: %Explorer.Chain.Transaction{token_transfers: [], block_number: 13717882, gas_used: #Decimal<167623>, status: :ok, __meta__: #Ecto.Schema.Metadata<:loaded, "transactions">, to_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<143, 43, 120, 22, 155, 9, 112, 241, 26, 118, 46, 86, 101, 157, 181, 43, 89, 203, 207, 27>>}, block_hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<65, 143, 6, 193, 20, 234, 107, 181, 255, 235, 42, 82, 193, 102, 10, 203, 139, 63, 197, 81, 7, 33, 146, 221, 86, 118, 102, 130, 67, 50, 23, 108>>}, to_address: %Explorer.Chain.Address{__meta__: #Ecto.Schema.Metadata<:loaded, "addresses">, contract_code: nil, contracts_creation_internal_transaction: #Ecto.Association.NotLoaded<association :contracts_creation_internal_transaction is not loaded>, contracts_creation_transaction: #Ecto.Association.NotLoaded<association :contracts_creation_transaction is not loaded>, decompiled: false, decompiled_smart_contracts: #Ecto.Association.NotLoaded<association :decompiled_smart_contracts is not loaded>, fetched_coin_balance: #Explorer.Chain.Wei<0>, fetched_coin_balance_block_number: 13717882, has_decompiled_code?: nil, hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<143, 43, 120, 22, 155, 9, 112, 241, 26, 118, 46, 86, 101, 157, 181, 43, 89, 203, 207, 27>>}, inserted_at: ~U[2020-03-11 09:55:11.572245Z], names: [], nonce: nil, smart_contract: #Ecto.Association.NotLoaded<association :smart_contract is not loaded>, stale?: nil, token: #Ecto.Association.NotLoaded<association :token is not loaded>, updated_at: ~U[2020-03-11 09:55:11.572245Z], verified: false}, uncles: #Ecto.Association.NotLoaded<association :uncles is not loaded>, created_contract_address_hash: nil, v: #Decimal<190>, earliest_processing_start: nil, old_block_hash: nil, gas: #Decimal<2000000>, created_contract_code_indexed_at: nil, index: 0, internal_transactions: #Ecto.Association.NotLoaded<association :internal_transactions is not loaded>, r: #Decimal<79705879289432373293941911602428710404554274375268917778821522166849195901621>, error: nil, created_contract_address: nil, inserted_at: ~U[2020-03-11 10:07:34.187693Z], cumulative_gas_used: #Decimal<167623>, from_address: %Explorer.Chain.Address{__meta__: #Ecto.Schema.Metadata<:loaded, "addresses">, contract_code: nil, contracts_creation_internal_transaction: #Ecto.Association.NotLoaded<association :contracts_creation_internal_transaction is not loaded>, contracts_creation_transaction: #Ecto.Association.NotLoaded<association :contracts_creation_transaction is not loaded>, decompiled: false, decompiled_smart_contracts: #Ecto.Association.NotLoaded<association :decompiled_smart_contracts is not loaded>, fetched_coin_balance: #Explorer.Chain.Wei<35101058841931379331>, fetched_coin_balance_block_number: 13717882, has_decompiled_code?: nil, hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<116, 17, 59, 3, 93, 222, 243, 183, 227, 4, 158, 26, ...>>}, inserted_at: ~U[2020-03-11 09:55:11.572245Z], names: [%Explorer.Chain.Address.Name{__meta__: #Ecto.Schema.Metadata<:loaded, "address_names">, address: #Ecto.Association.NotLoaded<association :address is not loaded>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<116, 17, 59, 3, 93, 222, ...>>}, inserted_at: ~U[2020-03-11 09:55:15.957588Z], metadata: %{"address" => "1960 Courtland Dr Kent", "created_date" => 1538068930, "expiration_date" => 1693022400, "license_id" => "2018-RE-740814", "state" => "OH", "zipcode" => "44240"}, name: "Irvin Cardenas", primary: true, updated_at: ~U[2020-03-11 09:55:15.957588Z]}], nonce: 16038, smart_contract: #Ecto.Association.NotLoaded<association :smart_contract is not loaded>, stale?: nil, token: #Ecto.Association.NotLoaded<association :token is not loaded>, updated_at: ~U[2020-03-11 09:55:11.572245Z], verified: false}, nonce: 16038, updated_at: ~U[2020-03-11 10:07:34.187693Z], from_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<116, 17, 59, 3, 93, 222, 243, 183, 227, 4, 158, 26, 115, 27, 223, 149, 229, 75, 51, ...>>}, forks: #Ecto.Association.NotLoaded<association :forks is not loaded>, hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<247, 41, 246, 34, 125, 58, 242, 208, 58, 106, 209, 241, 132, 34, 136, 83, 210, ...>>}, logs: #Ecto.Association.NotLoaded<association :logs is not loaded>, input: %Explorer.Chain.Data{bytes: <<11, 97, 186, 133, 178, 136, 83, 207, 58, 23, 140, 241, 156, 32, 124, 180, ...>>}, block: %Explorer.Chain.Block{__meta__: #Ecto.Schema.Metadata<:loaded, "blocks">, consensus: true, difficulty: #Decimal<340282366920938463463374607431768211453>, gas_limit: #Decimal<10000000>, gas_used: #Decimal<167623>, hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<65, 143, 6, 193, 20, 234, 107, 181, ...>>}, inserted_at: ~U[2020-03-11 10:07:34.187693Z], miner: #Ecto.Association.NotLoaded<association :miner is not loaded>, miner_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<116, 17, 59, 3, 93, ...>>}, nephew_relations: #Ecto.Association.NotLoaded<association :nephew_relations is not loaded>, nephews: #Ecto.Association.NotLoaded<association :nephews is not loaded>, nonce: %Explorer.Chain.Hash{byte_count: 8, bytes: <<0, 0, ...>>}, number: 13717882, parent: #Ecto.Association.NotLoaded<association :parent is not loaded>, parent_hash: %Explorer.Chain.Hash{byte_count: 32, ...}, pending_operations: #Ecto.Association.NotLoaded<association :pending_operations is not loaded>, ...}, value: #Explorer.Chain.Wei<0>, s: #Decimal<35541084409516924932082028496459121638170949830387298427040864522090605951961>, gas_price: #Explorer.Chain.Wei<0>}}, topic: "transactions:new_transaction"}
State: %Phoenix.Socket{assigns: %{locale: "en"}, channel: BlockScoutWeb.TransactionChannel, channel_pid: #PID<0.1858.0>, endpoint: BlockScoutWeb.Endpoint, handler: BlockScoutWeb.UserSocket, id: nil, join_ref: "5", joined: true, private: %{log_handle_in: :debug, log_join: :info}, pubsub_server: BlockScoutWeb.PubSub, ref: nil, serializer: Phoenix.Socket.V2.JSONSerializer, topic: "transactions:new_transaction", transport: :websocket, transport_pid: #PID<0.1848.0>}
```

## Changelog

Pass `conn` to render TransactionView in  "_tile.html"

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
