### PR TITLE
Make a link to address page on decoded constructor argument of address type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- [#3069](https://github.com/poanetwork/blockscout/pull/3069) - Make a link to address page on decoded constructor argument of address type
 - [#3066](https://github.com/poanetwork/blockscout/pull/3066) - ERC-721 token instance page: link to token added
 
 ### Fixes

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
@@ -53,7 +53,7 @@
               <h3><%= gettext "Constructor Arguments" %></h3>
             </div>
             <div class="tile tile-muted mb-4">
-              <pre class="pre-wrap pre-scrollable"><code class="nohighlight"><%= raw(format_constructor_arguments(@address.smart_contract)) %></code>
+              <pre class="pre-wrap pre-scrollable"><code class="nohighlight"><%= raw(format_constructor_arguments(@address.smart_contract, @conn)) %></code>
               </pre>
             </div>
           </section>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_contract_view.ex
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.AddressContractView do
   use BlockScoutWeb, :view
 
   alias ABI.{FunctionSelector, TypeDecoder}
+  alias Explorer.Chain
   alias Explorer.Chain.{Address, Data, InternalTransaction, SmartContract}
 
   def render("scripts.html", %{conn: conn}) do
@@ -22,7 +23,7 @@ defmodule BlockScoutWeb.AddressContractView do
   def format_optimization_text(true), do: gettext("true")
   def format_optimization_text(false), do: gettext("false")
 
-  def format_constructor_arguments(contract) do
+  def format_constructor_arguments(contract, conn) do
     constructor_abi = Enum.find(contract.abi, fn el -> el["type"] == "constructor" && el["inputs"] != [] end)
 
     input_types = Enum.map(constructor_abi["inputs"], &FunctionSelector.parse_specification_type/1)
@@ -32,11 +33,24 @@ defmodule BlockScoutWeb.AddressContractView do
       |> decode_data(input_types)
       |> Enum.zip(constructor_abi["inputs"])
       |> Enum.reduce({0, "#{contract.constructor_arguments}\n\n"}, fn {val, %{"type" => type}}, {count, acc} ->
+        address_hash = "0x" <> Base.encode16(val, case: :lower)
+
+        address =
+          case Chain.string_to_address_hash(address_hash) do
+            {:ok, address} -> address
+            _ -> nil
+          end
+
         formatted_val =
-          if type =~ "address" || type =~ "bytes" do
-            Base.encode16(val, case: :lower)
-          else
-            val
+          cond do
+            type =~ "address" ->
+              get_formatted_address_data(address, address_hash, conn)
+
+            type =~ "bytes" ->
+              Base.encode16(val, case: :lower)
+
+            true ->
+              val
           end
 
         {count + 1, "#{acc}Arg [#{count}] (<b>#{type}</b>) : #{formatted_val}\n"}
@@ -45,6 +59,14 @@ defmodule BlockScoutWeb.AddressContractView do
     result
   rescue
     _ -> contract.constructor_arguments
+  end
+
+  defp get_formatted_address_data(address, address_hash, conn) do
+    if address != nil do
+      "<a href=" <> address_path(conn, :show, address) <> ">" <> address_hash <> "</a>"
+    else
+      address_hash
+    end
   end
 
   defp decode_data("0x" <> encoded_data, types) do

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1672,7 +1672,7 @@ msgid "custom RPC"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_contract_view.ex:23
+#: lib/block_scout_web/views/address_contract_view.ex:24
 msgid "false"
 msgstr ""
 
@@ -1714,7 +1714,7 @@ msgid "string"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_contract_view.ex:22
+#: lib/block_scout_web/views/address_contract_view.ex:23
 msgid "true"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1672,7 +1672,7 @@ msgid "custom RPC"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_contract_view.ex:23
+#: lib/block_scout_web/views/address_contract_view.ex:24
 msgid "false"
 msgstr ""
 
@@ -1714,7 +1714,7 @@ msgid "string"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_contract_view.ex:22
+#: lib/block_scout_web/views/address_contract_view.ex:23
 msgid "true"
 msgstr ""
 


### PR DESCRIPTION
Closes https://github.com/poanetwork/blockscout/issues/3068

## Motivation

Constructor argument of address type currently is not clickable in decoded view if the decoded argument is correct address.

## Changelog

Add a link to address page for constructor argument of address type

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
