### PR TITLE
Index creation to blazingly speedup token holders query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3065](https://github.com/poanetwork/blockscout/pull/3065) - Transactions history chart
 
 ### Fixes
+- [#3070](https://github.com/poanetwork/blockscout/pull/3070) - Index creation to blazingly speedup token holders query
 - [#3064](https://github.com/poanetwork/blockscout/pull/3064) - Automatically define Block reward contract address in TokenBridge supply module
 - [#3061](https://github.com/poanetwork/blockscout/pull/3061) - Fix verification of contracts with error messages in require in parent contract
 - [#2756](https://github.com/poanetwork/blockscout/pull/2756) - Improve subquery joins

--- a/apps/explorer/priv/repo/migrations/20200410115841_create_index_address_current_token_balances_token_contract_address_hash_value.exs
+++ b/apps/explorer/priv/repo/migrations/20200410115841_create_index_address_current_token_balances_token_contract_address_hash_value.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.CreateIndexAddressCurrentTokenBalancesTokenContractAddressHashValue do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(index(:address_current_token_balances, [:token_contract_address_hash, :value]))
+  end
+end


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/2644

## Motivation

The last step in the fixing of performance of token page is token holders query. Currently, it cannot be finished in 20 secs causing "Something went wrong, click to reload" error message.

## Changelog

In this PR, an index is creating:

```
CREATE INDEX address_current_token_balances_token_contract_address_hash_value_index ON address_current_token_balances(token_contract_address_hash, value);
```

which significantly improves the performance of token holders query https://github.com/poanetwork/blockscout/blob/abb1157ee5231f082c37ab2451de5063fd8d5479/apps/explorer/lib/explorer/chain/address/current_token_balance.ex#L114:

```
eth2s=> EXPLAIN ANALYZE SELECT a0."id", a0."value", a0."block_number", a0."value_fetched_at", a0."old_value", a0."address_hash", a0."token_contract_address_hash", a0."inserted_at", a0."updated_at"
FROM "address_current_token_balances" AS a0
WHERE (a0."token_contract_address_hash" = '\xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2')
AND (a0."address_hash" != '\x0000000000000000000000000000000000000000') AND (a0."value" > 0)
AND (NOT (a0."value" IS NULL))
ORDER BY a0."value" DESC LIMIT 51;
                                                                                                        QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.57..205.98 rows=51 width=94) (actual time=0.030..0.150 rows=51 loops=1)
   ->  Index Scan Backward using address_current_token_balances_token_contract_address_hash_valu on address_current_token_balances a0  (cost=0.57..38215.50 rows=9488 width=94) (actual time=0.028..0.129 rows=51 loops=1)
         Index Cond: ((token_contract_address_hash = '\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::bytea) AND (value > '0'::numeric) AND (value IS NOT NULL))
         Filter: (address_hash <> '\x0000000000000000000000000000000000000000'::bytea)
 Planning time: 0.261 ms
 Execution time: 0.186 ms
(6 rows)
```

Index creation costs 5.3 Gb additional space in case of ETH Mainnet instance:
```
public.address_current_token_balances_token_contract_address_hash_valu | 5359 MB
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
