### PR TITLE
Speedup list of token transfers per token query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3065](https://github.com/poanetwork/blockscout/pull/3065) - Transactions history chart
 
 ### Fixes
+- [#3071](https://github.com/poanetwork/blockscout/pull/3071) - Speedup list of token transfers per token query
 - [#3070](https://github.com/poanetwork/blockscout/pull/3070) - Index creation to blazingly speedup token holders query
 - [#3064](https://github.com/poanetwork/blockscout/pull/3064) - Automatically define Block reward contract address in TokenBridge supply module
 - [#3061](https://github.com/poanetwork/blockscout/pull/3061) - Fix verification of contracts with error messages in require in parent contract

--- a/apps/block_scout_web/test/block_scout_web/controllers/tokens/inventory_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/tokens/inventory_controller_test.exs
@@ -49,16 +49,21 @@ defmodule BlockScoutWeb.Tokens.InventoryControllerTest do
         |> with_block()
 
       second_page_token_balances =
-        Enum.map(
-          1..50,
-          &insert(
+        Enum.map(1..50, fn i ->
+          insert(
             :token_transfer,
             transaction: transaction,
             token_contract_address: token.contract_address,
             token: token,
-            token_id: &1 + 1000
+            token_id: i + 1000
           )
-        )
+
+          insert(
+            :token_instance,
+            token_contract_address_hash: token.contract_address.hash,
+            token_id: i + 1000
+          )
+        end)
 
       conn =
         get(conn, token_inventory_path(conn, :index, token.contract_address_hash), %{
@@ -83,16 +88,21 @@ defmodule BlockScoutWeb.Tokens.InventoryControllerTest do
         |> insert()
         |> with_block()
 
-      Enum.each(
-        1..51,
-        &insert(
+      Enum.each(1..51, fn i ->
+        insert(
           :token_transfer,
           transaction: transaction,
           token_contract_address: token.contract_address,
           token: token,
-          token_id: &1 + 1000
+          token_id: i + 1000
         )
-      )
+
+        insert(
+          :token_instance,
+          token_contract_address_hash: token.contract_address.hash,
+          token_id: i + 1000
+        )
+      end)
 
       conn = get(conn, token_inventory_path(conn, :index, token.contract_address_hash), %{type: "JSON"})
 

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -147,8 +147,9 @@ defmodule Explorer.Chain.TokenTransfer do
       from(
         tt in TokenTransfer,
         where: tt.token_contract_address_hash == ^token_address_hash and not is_nil(tt.block_number),
+        where: not is_nil(tt.block_number),
         preload: [{:transaction, :block}, :token, :from_address, :to_address],
-        order_by: [desc: tt.block_number, desc: tt.log_index]
+        order_by: [desc: tt.block_number]
       )
 
     query
@@ -168,7 +169,7 @@ defmodule Explorer.Chain.TokenTransfer do
         where: tt.token_id == ^token_id,
         where: not is_nil(tt.block_number),
         preload: [{:transaction, :block}, :token, :from_address, :to_address],
-        order_by: [desc: tt.block_number, desc: tt.log_index]
+        order_by: [desc: tt.block_number]
       )
 
     query

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -85,7 +85,7 @@ defmodule Explorer.GraphQL do
   @doc """
   Returns a query to fetch token transfers for a token contract address hash.
 
-  Orders token transfers by descending block number, descending transaction index, and ascending log index.
+  Orders token transfers by descending block number.
   """
   @spec list_token_transfers_query(Hash.t()) :: Ecto.Query.t()
   def list_token_transfers_query(%Hash{byte_count: unquote(Hash.Address.byte_count())} = token_contract_address_hash) do
@@ -93,7 +93,7 @@ defmodule Explorer.GraphQL do
       tt in TokenTransfer,
       inner_join: t in assoc(tt, :transaction),
       where: tt.token_contract_address_hash == ^token_contract_address_hash,
-      order_by: [desc: tt.block_number, desc: t.index, asc: tt.log_index],
+      order_by: [desc: tt.block_number],
       select: tt
     )
   end

--- a/apps/explorer/priv/repo/migrations/20200410141202_create_index_token_transfers_token_contract_address_hash_block_number.exs
+++ b/apps/explorer/priv/repo/migrations/20200410141202_create_index_token_transfers_token_contract_address_hash_block_number.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.CreateIndexTokenTransfersTokenContractAddressHashBlockNumber do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(index(:token_transfers, [:token_contract_address_hash, :block_number]))
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4466,6 +4466,18 @@ defmodule Explorer.ChainTest do
       token_contract_address = insert(:contract_address)
       token = insert(:token, contract_address: token_contract_address, type: "ERC-721")
 
+      insert(
+        :token_instance,
+        token_contract_address_hash: token_contract_address.hash,
+        token_id: 11
+      )
+
+      insert(
+        :token_instance,
+        token_contract_address_hash: token_contract_address.hash,
+        token_id: 29
+      )
+
       transaction =
         :transaction
         |> insert()

--- a/apps/explorer/test/explorer/graphql_test.exs
+++ b/apps/explorer/test/explorer/graphql_test.exs
@@ -289,7 +289,7 @@ defmodule Explorer.GraphQLTest do
       end
     end
 
-    test "orders token transfers by descending block number, descending transaction index, and ascending log index" do
+    test "orders token transfers by descending block number" do
       first_block = insert(:block)
       second_block = insert(:block)
       third_block = insert(:block)
@@ -340,17 +340,8 @@ defmodule Explorer.GraphQLTest do
         |> Repo.preload(:transaction)
 
       block_number_order = Enum.map(found_token_transfers, & &1.block_number)
-      transaction_index_order = Enum.map(found_token_transfers, &{&1.block_number, &1.transaction.index})
 
       assert block_number_order == Enum.sort(block_number_order, &(&1 >= &2))
-      assert transaction_index_order == Enum.sort(transaction_index_order, &(&1 >= &2))
-
-      tt_by_block_transaction = Enum.group_by(found_token_transfers, &{&1.block_number, &1.transaction.index})
-
-      for {_, token_transfers} <- tt_by_block_transaction do
-        log_index_order = Enum.map(token_transfers, & &1.log_index)
-        assert log_index_order == Enum.sort(log_index_order)
-      end
     end
   end
 end


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/1408
Closes https://github.com/poanetwork/blockscout/issues/2644

## Motivation

Slow performance of token transfers and inventory queries at token page

## Changelog

Create an index on `token_transfers` table:

```
CREATE INDEX token_transfers_token_contract_address_hash_block_number_index ON token_transfers(token_contract_address_hash, block_number);
```

to increase the speed of retrieving of the list of token transfers

https://github.com/poanetwork/blockscout/blob/4ad6f91459100c5a5f391b8b542492959862c940/apps/explorer/lib/explorer/chain/token_transfer.ex#L146

https://github.com/poanetwork/blockscout/blob/4ad6f91459100c5a5f391b8b542492959862c940/apps/explorer/lib/explorer/chain/token_transfer.ex#L164

*Caveat*: token transfers will not be longer sorted by `log_index` after implementing of this PR


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
