### PR TITLE
Speedup tx list query on address page: check if an address has a reward, check if this is actual payout key of the validator - beneficiary, return only mined txs in tx list query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3065](https://github.com/poanetwork/blockscout/pull/3065) - Transactions history chart
 
 ### Fixes
+- [#3076](https://github.com/poanetwork/blockscout/pull/3076) - Speedup tx list query on address page: check if an address has a reward, check if this is actual payout key of the validator - beneficiary, return only mined txs in tx list query
 - [#3071](https://github.com/poanetwork/blockscout/pull/3071) - Speedup list of token transfers per token query
 - [#3070](https://github.com/poanetwork/blockscout/pull/3070) - Index creation to blazingly speedup token holders query
 - [#3064](https://github.com/poanetwork/blockscout/pull/3064) - Automatically define Block reward contract address in TokenBridge supply module

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -36,7 +36,7 @@ defmodule BlockScoutWeb.AddressTransactionController do
         |> Keyword.merge(paging_options(params))
         |> Keyword.merge(current_filter(params))
 
-      results_plus_one = Chain.address_to_transactions_with_rewards(address_hash, options)
+      results_plus_one = Chain.address_to_mined_transactions_with_rewards(address_hash, options)
       {results, next_page} = split_list_by_page(results_plus_one)
 
       next_page_url =
@@ -60,7 +60,6 @@ defmodule BlockScoutWeb.AddressTransactionController do
               View.render_to_string(
                 TransactionView,
                 "_emission_reward_tile.html",
-                conn: conn,
                 current_address: address,
                 emission_funds: emission_reward,
                 validator: validator_reward

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -190,11 +190,15 @@ defmodule BlockScoutWeb.Notifier do
 
   defp broadcast_rewards(rewards) do
     preloaded_rewards = Repo.preload(rewards, [:address, :block])
+    emission_reward = Enum.find(preloaded_rewards, fn reward -> reward.address_type == :emission_funds end)
 
-    Enum.each(preloaded_rewards, fn reward ->
+    preloaded_rewards_except_emission =
+      Enum.reject(preloaded_rewards, fn reward -> reward.address_type == :emission_funds end)
+
+    Enum.each(preloaded_rewards_except_emission, fn reward ->
       Endpoint.broadcast("rewards:#{to_string(reward.address_hash)}", "new_reward", %{
-        emission_funds: Enum.at(preloaded_rewards, 1),
-        validator: Enum.at(preloaded_rewards, 0)
+        emission_funds: emission_reward,
+        validator: reward
       })
     end)
   end

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
@@ -146,7 +146,7 @@
             <h2 class="card-title balance-card-title"><%= gettext "Block Rewards" %></h2>
             <div class="text-right" style="margin-left: 50%;" data-toggle="tooltip" data-placement="top" title="" data-original-title="Amount of distributed reward. Miners receive a static block reward + Tx fees + uncle fees.">
               <%= for block_reward <- @block.rewards do %>
-                <p class="address-current-balance"><%= block_reward_text(block_reward) %> <span class="text-muted"><%= format_wei_value(block_reward.reward, :ether) %></span></p>
+                <p class="address-current-balance"><%= block_reward_text(block_reward, @block.miner.hash) %> <span class="text-muted"><%= format_wei_value(block_reward.reward, :ether) %></span></p>
               <% end %>
             </div>
           <% else %>

--- a/apps/block_scout_web/lib/block_scout_web/views/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/block_view.ex
@@ -52,15 +52,25 @@ defmodule BlockScoutWeb.BlockView do
   def show_reward?([]), do: false
   def show_reward?(_), do: true
 
-  def block_reward_text(%Reward{address_type: :validator}) do
-    gettext("Miner Reward")
+  def block_reward_text(%Reward{address_hash: beneficiary_address, address_type: :validator}, block_miner_address) do
+    if Application.get_env(:explorer, Explorer.Chain.Block.Reward, %{})[:keys_manager_contract_address] do
+      %{payout_key: block_miner_payout_address} = Reward.get_validator_payout_key_by_mining(block_miner_address)
+
+      if beneficiary_address == block_miner_payout_address do
+        gettext("Miner Reward")
+      else
+        gettext("Chore Reward")
+      end
+    else
+      gettext("Miner Reward")
+    end
   end
 
-  def block_reward_text(%Reward{address_type: :emission_funds}) do
+  def block_reward_text(%Reward{address_type: :emission_funds}, _block_miner_address) do
     gettext("Emission Reward")
   end
 
-  def block_reward_text(%Reward{address_type: :uncle}) do
+  def block_reward_text(%Reward{address_type: :uncle}, _block_miner_address) do
     gettext("Uncle Reward")
   end
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -594,7 +594,7 @@ msgid "Emission Contract"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/block_view.ex:60
+#: lib/block_scout_web/views/block_view.ex:70
 msgid "Emission Reward"
 msgstr ""
 
@@ -1058,7 +1058,8 @@ msgid "Method Id"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/block_view.ex:56
+#: lib/block_scout_web/views/block_view.ex:60
+#: lib/block_scout_web/views/block_view.ex:65
 msgid "Miner Reward"
 msgstr ""
 
@@ -1524,7 +1525,7 @@ msgid "UTF-8"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/block_view.ex:64
+#: lib/block_scout_web/views/block_view.ex:74
 msgid "Uncle Reward"
 msgstr ""
 
@@ -1903,4 +1904,9 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction_token_transfer/_token_transfer.html.eex:8
 #: lib/block_scout_web/views/transaction_view.ex:316
 msgid "Token Minting"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_view.ex:62
+msgid "Chore Reward"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -594,7 +594,7 @@ msgid "Emission Contract"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/block_view.ex:60
+#: lib/block_scout_web/views/block_view.ex:70
 msgid "Emission Reward"
 msgstr ""
 
@@ -1058,7 +1058,8 @@ msgid "Method Id"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/block_view.ex:56
+#: lib/block_scout_web/views/block_view.ex:60
+#: lib/block_scout_web/views/block_view.ex:65
 msgid "Miner Reward"
 msgstr ""
 
@@ -1524,7 +1525,7 @@ msgid "UTF-8"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/block_view.ex:64
+#: lib/block_scout_web/views/block_view.ex:74
 msgid "Uncle Reward"
 msgstr ""
 
@@ -1903,4 +1904,9 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction_token_transfer/_token_transfer.html.eex:8
 #: lib/block_scout_web/views/transaction_view.ex:316
 msgid "Token Minting"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/block_view.ex:62
+msgid "Chore Reward"
 msgstr ""

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -137,6 +137,10 @@ else
   config :explorer, Explorer.Validator.MetadataProcessor, enabled: false
 end
 
+config :explorer, Explorer.Chain.Block.Reward,
+  validators_contract_address: System.get_env("VALIDATORS_CONTRACT"),
+  keys_manager_contract_address: System.get_env("KEYS_MANAGER_CONTRACT")
+
 config :explorer, Explorer.Staking.PoolsReader,
   validators_contract_address: System.get_env("POS_VALIDATORS_CONTRACT"),
   staking_contract_address: System.get_env("POS_STAKING_CONTRACT")

--- a/apps/explorer/lib/explorer/chain/address_token_transfer_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/address_token_transfer_csv_exporter.ex
@@ -36,7 +36,7 @@ defmodule Explorer.Chain.AddressTokenTransferCsvExporter do
 
     transactions =
       address_hash
-      |> Chain.address_to_transactions_with_rewards(options)
+      |> Chain.address_to_mined_transactions_with_rewards(options)
       |> Enum.filter(fn transaction -> Enum.count(transaction.token_transfers) > 0 end)
 
     new_acc = transactions ++ acc

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -501,6 +501,10 @@ defmodule Explorer.Chain.Transaction do
     ]
   end
 
+  def not_pending_transactions(query) do
+    where(query, [t], not is_nil(t.block_number))
+  end
+
   @collated_fields ~w(block_number cumulative_gas_used gas_used index)a
 
   @collated_message "can't be blank when the transaction is collated into a block"

--- a/apps/explorer/priv/repo/migrations/20200424070607_drop_block_rewards_address_hash_address_type_block_hash_index.exs
+++ b/apps/explorer/priv/repo/migrations/20200424070607_drop_block_rewards_address_hash_address_type_block_hash_index.exs
@@ -3,7 +3,9 @@ defmodule Explorer.Repo.Migrations.DropBlockRewardsAddressHashAddressTypeBlockHa
 
   def change do
     drop_if_exists(
-      index(:internal_transactions, [:address_hash, :block_hash, :address_type], name: "block_rewards_address_hash_address_type_block_hash_index")
+      index(:internal_transactions, [:address_hash, :block_hash, :address_type],
+        name: "block_rewards_address_hash_address_type_block_hash_index"
+      )
     )
   end
 end

--- a/apps/explorer/priv/repo/migrations/20200424070607_drop_block_rewards_address_hash_address_type_block_hash_index.exs
+++ b/apps/explorer/priv/repo/migrations/20200424070607_drop_block_rewards_address_hash_address_type_block_hash_index.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.DropBlockRewardsAddressHashAddressTypeBlockHashIndex do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(
+      index(:internal_transactions, [:address_hash, :block_hash, :address_type], name: "block_rewards_address_hash_address_type_block_hash_index")
+    )
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -383,13 +383,13 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "address_to_transactions_with_rewards/2" do
+  describe "address_to_mined_transactions_with_rewards/2" do
     test "without transactions" do
       %Address{hash: address_hash} = insert(:address)
 
       assert Repo.aggregate(Transaction, :count, :hash) == 0
 
-      assert [] == Chain.address_to_transactions_with_rewards(address_hash)
+      assert [] == Chain.address_to_mined_transactions_with_rewards(address_hash)
     end
 
     test "with from transactions" do
@@ -401,7 +401,7 @@ defmodule Explorer.ChainTest do
         |> with_block()
 
       assert [transaction] ==
-               Chain.address_to_transactions_with_rewards(address_hash, direction: :from)
+               Chain.address_to_mined_transactions_with_rewards(address_hash, direction: :from)
                |> Repo.preload([:block, :to_address, :from_address])
     end
 
@@ -414,7 +414,7 @@ defmodule Explorer.ChainTest do
         |> with_block()
 
       assert [transaction] ==
-               Chain.address_to_transactions_with_rewards(address_hash, direction: :to)
+               Chain.address_to_mined_transactions_with_rewards(address_hash, direction: :to)
                |> Repo.preload([:block, :to_address, :from_address])
     end
 
@@ -428,7 +428,7 @@ defmodule Explorer.ChainTest do
 
       # only contains "from" transaction
       assert [transaction] ==
-               Chain.address_to_transactions_with_rewards(address_hash, direction: :from)
+               Chain.address_to_mined_transactions_with_rewards(address_hash, direction: :from)
                |> Repo.preload([:block, :to_address, :from_address])
     end
 
@@ -441,7 +441,7 @@ defmodule Explorer.ChainTest do
         |> with_block()
 
       assert [transaction] ==
-               Chain.address_to_transactions_with_rewards(address_hash, direction: :to)
+               Chain.address_to_mined_transactions_with_rewards(address_hash, direction: :to)
                |> Repo.preload([:block, :to_address, :from_address])
     end
 
@@ -460,7 +460,7 @@ defmodule Explorer.ChainTest do
         |> with_block(block)
 
       assert [transaction2, transaction1] ==
-               Chain.address_to_transactions_with_rewards(address_hash)
+               Chain.address_to_mined_transactions_with_rewards(address_hash)
                |> Repo.preload([:block, :to_address, :from_address])
     end
 
@@ -481,7 +481,7 @@ defmodule Explorer.ChainTest do
           transaction_index: transaction.index
         )
 
-      assert [] == Chain.address_to_transactions_with_rewards(address.hash)
+      assert [] == Chain.address_to_mined_transactions_with_rewards(address.hash)
     end
 
     test "returns transactions that have token transfers for the given to_address" do
@@ -499,7 +499,7 @@ defmodule Explorer.ChainTest do
       )
 
       assert [transaction.hash] ==
-               Chain.address_to_transactions_with_rewards(address_hash)
+               Chain.address_to_mined_transactions_with_rewards(address_hash)
                |> Enum.map(& &1.hash)
     end
 
@@ -519,7 +519,7 @@ defmodule Explorer.ChainTest do
 
       assert second_page_hashes ==
                address_hash
-               |> Chain.address_to_transactions_with_rewards(
+               |> Chain.address_to_mined_transactions_with_rewards(
                  paging_options: %PagingOptions{
                    key: {block_number, index},
                    page_size: 2
@@ -568,7 +568,7 @@ defmodule Explorer.ChainTest do
 
       result =
         address_hash
-        |> Chain.address_to_transactions_with_rewards()
+        |> Chain.address_to_mined_transactions_with_rewards()
         |> Enum.map(& &1.hash)
 
       assert [fourth, third, second, first, sixth, fifth] == result
@@ -577,7 +577,14 @@ defmodule Explorer.ChainTest do
     test "with emission rewards" do
       Application.put_env(:block_scout_web, BlockScoutWeb.Chain, has_emission_funds: true)
 
+      Application.put_env(:explorer, Explorer.Chain.Block.Reward,
+        validators_contract_address: "0x0000000000000000000000000000000000000005",
+        keys_manager_contract_address: "0x0000000000000000000000000000000000000006"
+      )
+
       block = insert(:block)
+
+      block_miner_hash_string = Base.encode16(block.miner_hash.bytes, case: :lower)
 
       insert(
         :reward,
@@ -593,15 +600,50 @@ defmodule Explorer.ChainTest do
         address_type: :emission_funds
       )
 
-      assert [{_, _}] = Chain.address_to_transactions_with_rewards(block.miner.hash)
+      # isValidator => true
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
+          {:ok,
+           [%{id: id, jsonrpc: "2.0", result: "0x0000000000000000000000000000000000000000000000000000000000000001"}]}
+        end
+      )
 
-      Application.put_env(:block_scout_web, BlockScoutWeb.Chain, has_emission_funds: false)
+      # getPayoutByMining => 0x0000000000000000000000000000000000000001
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
+          {:ok, [%{id: id, result: "0x000000000000000000000000" <> block_miner_hash_string}]}
+        end
+      )
+
+      res = Chain.address_to_mined_transactions_with_rewards(block.miner.hash)
+
+      assert [{_, _}] = res
+
+      on_exit(fn ->
+        Application.put_env(:block_scout_web, BlockScoutWeb.Chain, has_emission_funds: false)
+
+        Application.put_env(:explorer, Explorer.Chain.Block.Reward,
+          validators_contract_address: nil,
+          keys_manager_contract_address: nil
+        )
+      end)
     end
 
     test "with emission rewards and transactions" do
       Application.put_env(:block_scout_web, BlockScoutWeb.Chain, has_emission_funds: true)
 
+      Application.put_env(:explorer, Explorer.Chain.Block.Reward,
+        validators_contract_address: "0x0000000000000000000000000000000000000005",
+        keys_manager_contract_address: "0x0000000000000000000000000000000000000006"
+      )
+
       block = insert(:block)
+
+      block_miner_hash_string = Base.encode16(block.miner_hash.bytes, case: :lower)
 
       insert(
         :reward,
@@ -618,13 +660,39 @@ defmodule Explorer.ChainTest do
       )
 
       :transaction
-      |> insert(from_address: block.miner)
+      |> insert(to_address: block.miner)
       |> with_block(block)
       |> Repo.preload(:token_transfers)
 
-      assert [_, {_, _}] = Chain.address_to_transactions_with_rewards(block.miner.hash, direction: :from)
+      # isValidator => true
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
+          {:ok,
+           [%{id: id, jsonrpc: "2.0", result: "0x0000000000000000000000000000000000000000000000000000000000000001"}]}
+        end
+      )
 
-      Application.put_env(:block_scout_web, BlockScoutWeb.Chain, has_emission_funds: false)
+      # getPayoutByMining => 0x0000000000000000000000000000000000000001
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
+          {:ok, [%{id: id, result: "0x000000000000000000000000" <> block_miner_hash_string}]}
+        end
+      )
+
+      assert [_, {_, _}] = Chain.address_to_mined_transactions_with_rewards(block.miner.hash, direction: :to)
+
+      on_exit(fn ->
+        Application.put_env(:block_scout_web, BlockScoutWeb.Chain, has_emission_funds: false)
+
+        Application.put_env(:explorer, Explorer.Chain.Block.Reward,
+          validators_contract_address: nil,
+          keys_manager_contract_address: nil
+        )
+      end)
     end
 
     test "with transactions if rewards are not in the range of blocks" do
@@ -651,7 +719,7 @@ defmodule Explorer.ChainTest do
       |> with_block()
       |> Repo.preload(:token_transfers)
 
-      assert [_] = Chain.address_to_transactions_with_rewards(block.miner.hash, direction: :from)
+      assert [_] = Chain.address_to_mined_transactions_with_rewards(block.miner.hash, direction: :from)
 
       Application.put_env(:block_scout_web, BlockScoutWeb.Chain, has_emission_funds: false)
     end
@@ -675,7 +743,104 @@ defmodule Explorer.ChainTest do
         address_type: :emission_funds
       )
 
-      assert [] == Chain.address_to_transactions_with_rewards(block.miner.hash)
+      assert [] == Chain.address_to_mined_transactions_with_rewards(block.miner.hash)
+    end
+  end
+
+  describe "address_to_transactions_tasks_range_of_blocks/2" do
+    test "returns empty extremums if no transactions" do
+      address = insert(:address)
+
+      extremums = Chain.address_to_transactions_tasks_range_of_blocks(address.hash, [])
+
+      assert extremums == %{
+               :min_block_number => nil,
+               :max_block_number => 0
+             }
+    end
+
+    test "returns correct extremums for from_address" do
+      address = insert(:address)
+
+      :transaction
+      |> insert(from_address: address)
+      |> with_block(insert(:block, number: 1000))
+
+      extremums = Chain.address_to_transactions_tasks_range_of_blocks(address.hash, [])
+
+      assert extremums == %{
+               :min_block_number => 1000,
+               :max_block_number => 1000
+             }
+    end
+
+    test "returns correct extremums for to_address" do
+      address = insert(:address)
+
+      :transaction
+      |> insert(to_address: address)
+      |> with_block(insert(:block, number: 1000))
+
+      extremums = Chain.address_to_transactions_tasks_range_of_blocks(address.hash, [])
+
+      assert extremums == %{
+               :min_block_number => 1000,
+               :max_block_number => 1000
+             }
+    end
+
+    test "returns correct extremums for created_contract_address" do
+      address = insert(:address)
+
+      :transaction
+      |> insert(created_contract_address: address)
+      |> with_block(insert(:block, number: 1000))
+
+      extremums = Chain.address_to_transactions_tasks_range_of_blocks(address.hash, [])
+
+      assert extremums == %{
+               :min_block_number => 1000,
+               :max_block_number => 1000
+             }
+    end
+
+    test "returns correct extremums for multiple number of transactions" do
+      address = insert(:address)
+
+      :transaction
+      |> insert(created_contract_address: address)
+      |> with_block(insert(:block, number: 1000))
+
+      :transaction
+      |> insert(created_contract_address: address)
+      |> with_block(insert(:block, number: 999))
+
+      :transaction
+      |> insert(created_contract_address: address)
+      |> with_block(insert(:block, number: 1003))
+
+      :transaction
+      |> insert(from_address: address)
+      |> with_block(insert(:block, number: 1001))
+
+      :transaction
+      |> insert(from_address: address)
+      |> with_block(insert(:block, number: 1004))
+
+      :transaction
+      |> insert(to_address: address)
+      |> with_block(insert(:block, number: 1002))
+
+      :transaction
+      |> insert(to_address: address)
+      |> with_block(insert(:block, number: 998))
+
+      extremums = Chain.address_to_transactions_tasks_range_of_blocks(address.hash, [])
+
+      assert extremums == %{
+               :min_block_number => 998,
+               :max_block_number => 1004
+             }
     end
   end
 


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/3075

## Motivation

List of transactions loads slowly for some addresses for BlockScout instances where emission distribution is enabled.

It is related to the fact that we should join results of query to `transactions` and `block_rewards` tables. However, we can first check if an address is present in `block_rewards` table (Postgres `if exists` query should be fast). And if it is not present, we can query only `transactions` table. Thus, I expect the increase of performance of tx list page for addresses which are not beneficiaries of rewards.

There are some fixes also introduced:
1. Emission funds distribution excluded if only outgoing transactions are filtered.
2. Block numbers extremums window search is fixed for the finding of rewards distribution
3. Emission contract tile is broken after distribution emission to an additional address (POAMania https://forum.poa.network/t/proposal-to-support-poa-mania-with-a-block-reward-adjustment/3297). Specifically, wrong `from` and `to` addresses are specified.

<img width="1112" alt="Screenshot 2020-04-17 at 15 19 41" src="https://user-images.githubusercontent.com/4341812/79723300-2dc60180-82ee-11ea-9ddc-205831158d99.png">

=>

<img width="1090" alt="Screenshot 2020-04-20 at 10 07 42" src="https://user-images.githubusercontent.com/4341812/79723665-ceb4bc80-82ee-11ea-87b2-b445dd2c04b0.png">


4. At the block page, POAMania reward is displayed as validator reward:

<img width="395" alt="Screenshot 2020-04-17 at 15 33 23" src="https://user-images.githubusercontent.com/4341812/79723367-4afad000-82ee-11ea-8c4d-e64ba6c1fcc9.png">

=>

<img width="394" alt="Screenshot 2020-04-20 at 09 50 51" src="https://user-images.githubusercontent.com/4341812/79723581-adec6700-82ee-11ea-918c-9ebae35cc38b.png">

`KEYS_MANAGER_CONTRACT` environment variable is introduced to get payout key by mining key. Related update in docs https://github.com/blockscout/docs/pull/17.



## Changelog

- Introducing of `address_has_rewards?(address_hash)` and add this check to `address_to_transactions_with_rewards` function
- `address_to_transactions_with_rewards` -> `address_to_mined_transactions_with_rewards`
- `get_validator_payout_key_by_mining` function added
- `block_reward_text` is extended with `block_miner_address_hash ` input param
- `call_contract` in `block_view` is added inn order to make a call to KeysManager contract to get payout key by mining
- `not_pending_transactions` query clause is added to get only mined transactions (with block_number tracked)

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
