### PR TITLE
Finally speedup pending tx list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3065](https://github.com/poanetwork/blockscout/pull/3065) - Transactions history chart
 
 ### Fixes
+- [#3077](https://github.com/poanetwork/blockscout/pull/3077) - Finally speedup pending tx list
 - [#3071](https://github.com/poanetwork/blockscout/pull/3071) - Speedup list of token transfers per token query
 - [#3070](https://github.com/poanetwork/blockscout/pull/3070) - Index creation to blazingly speedup token holders query
 - [#3064](https://github.com/poanetwork/blockscout/pull/3064) - Automatically define Block reward contract address in TokenBridge supply module

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2382,7 +2382,7 @@ defmodule Explorer.Chain do
     |> page_pending_transaction(paging_options)
     |> limit(^paging_options.page_size)
     |> pending_transactions_query()
-    |> order_by([transaction], desc: transaction.hash, desc: transaction.inserted_at)
+    |> order_by([transaction], desc: transaction.inserted_at, desc: transaction.hash)
     |> join_associations(necessity_by_association)
     |> preload([{:token_transfers, [:token, :from_address, :to_address]}])
     |> Repo.all()

--- a/apps/explorer/priv/repo/migrations/20200421102450_pending_txs.exs
+++ b/apps/explorer/priv/repo/migrations/20200421102450_pending_txs.exs
@@ -1,0 +1,16 @@
+defmodule Explorer.Repo.Migrations.PendingTxs do
+  use Ecto.Migration
+
+  def up do
+    execute(
+      "CREATE INDEX IF NOT EXISTS pending_txs_index ON transactions(inserted_at, hash) WHERE (block_hash IS NULL AND (error IS NULL OR (error != 'dropped/replaced')))"
+    )
+
+    drop_if_exists(index(:transactions, [:hash, :inserted_at], name: "transactions_hash_inserted_at_index"))
+  end
+
+  def down do
+    execute("DROP INDEX IF EXISTS pending_txs_index")
+    create_if_not_exists(index(:transactions, [:hash, :inserted_at]))
+  end
+end


### PR DESCRIPTION
Continuation of https://github.com/poanetwork/blockscout/pull/3042/files

## Motivation

Pending tx list is still not enough fast. This PR finally solves the problem by creating a partial index specific for pending txs list query.

## Changelog

1. Create a partial index: `CREATE INDEX IF NOT EXISTS pending_txs_index ON transactions(inserted_at, hash) WHERE (block_hash IS NULL AND (error IS NULL OR (error != 'dropped/replaced')))`
2. Remove not efficient index: `"transactions_hash_inserted_at_index" btree (hash, inserted_at)`
3. Change the ordering in pending txs list query back to : `[desc: transaction.inserted_at, desc: transaction.hash]`

And index size dramatically decreased:

Before:

 public.transactions_hash_inserted_at_index                             | **1715 MB**


After:

 public.pending_txs_index                                 | **824 kB**

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
