### PR TITLE
CoinGecko API coin id environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3089](https://github.com/poanetwork/blockscout/pull/3089) - CoinGecko API coin id environment variable
 - [#3069](https://github.com/poanetwork/blockscout/pull/3069) - Make a link to address page on decoded constructor argument of address type
 - [#3067](https://github.com/poanetwork/blockscout/pull/3067) - Show proper title of the tile or container for token burnings/mintings instead of "Token Transfer"
 - [#3066](https://github.com/poanetwork/blockscout/pull/3066) - ERC-721 token instance page: link to token added

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -9,6 +9,7 @@ use Mix.Config
 config :explorer,
   ecto_repos: [Explorer.Repo],
   coin: System.get_env("COIN") || "POA",
+  coingecko_coin_id: System.get_env("COINGECKO_COIN_ID"),
   token_functions_reader_max_retries: 3,
   allowed_evm_versions:
     System.get_env("ALLOWED_EVM_VERSIONS") ||

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
@@ -44,7 +44,14 @@ defmodule Explorer.ExchangeRates.Source.CoinGecko do
 
   @impl Source
   def source_url do
-    {:ok, id} = coin_id()
+    explicit_coin_id = Application.get_env(:explorer, :coingecko_coin_id)
+
+    {:ok, id} =
+      if explicit_coin_id do
+        {:ok, explicit_coin_id}
+      else
+        coin_id()
+      end
 
     "#{base_url()}/coins/#{id}"
   end


### PR DESCRIPTION
Solves https://github.com/poanetwork/blockscout/issues/3087

## Motivation

A search of coin price in Coingecko is by coin symbol. However, symbol is not unique. Thus, result of the search can be unexpected if multiple coins with the same symbol are tracked in Coingecko.

## Changelog

Add `COINGECKO_COIN_ID` environment variable in order to open an ability to explicitly set Coinngecko ID of the coin.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
