### PR TITLE
Contract verification: check compiler version, verify compiled with nightly builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ### Features
 
 ### Fixes
-- [#3106](https://github.com/poanetwork/blockscout/pull/3106) - Verify contract using creation tx input
+- [#3112](https://github.com/poanetwork/blockscout/pull/3112) - Fix verification of contracts, compiled with nightly builds of solc compiler
+- [#3112](https://github.com/poanetwork/blockscout/pull/3112) - Check compiler version at contract verification
+- [#3106](https://github.com/poanetwork/blockscout/pull/3106) - Fix verification of contracts with `immutable` declaration
+- [#3106](https://github.com/poanetwork/blockscout/pull/3106) - Fix verification of contracts, created from factory (from internal transaction)
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -326,6 +326,7 @@ defmodule Explorer.Chain.SmartContract do
   defp upsert_contract_methods(changeset), do: changeset
 
   defp error_message(:compilation), do: "There was an error compiling your contract."
+  defp error_message(:compiler_version), do: "Compiler version does not match, please try again."
   defp error_message(:generated_bytecode), do: "Bytecode does not match, please try again."
   defp error_message(:constructor_arguments), do: "Constructor arguments do not match, please try again."
   defp error_message(:name), do: "Wrong contract name, please try again."

--- a/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file
 defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
   @moduledoc """
   Smart contract contrstructor arguments verification logic.
@@ -10,7 +11,7 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
   @metadata_hash_prefix_0_5_11 "a265627a7a72315820"
   @metadata_hash_prefix_0_6_0 "a264697066735822"
 
-  @metadata_hash_common_suffix "64736f6c6343"
+  @metadata_hash_common_suffix "64736f6c63"
 
   def verify(address_hash, contract_code, arguments_data, contract_source_code, contract_name) do
     arguments_data = arguments_data |> String.trim_trailing() |> String.trim_leading("0x")
@@ -53,7 +54,51 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
       # Solidity >= 0.5.10 https://solidity.readthedocs.io/en/v0.5.10/metadata.html
       @metadata_hash_prefix_0_5_10 <>
           <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
+          @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_10
+        )
+
+      @metadata_hash_prefix_0_5_10 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_10
+        )
+
+      @metadata_hash_prefix_0_5_10 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_10
+        )
+
+      @metadata_hash_prefix_0_5_10 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_10
+        )
+
+      @metadata_hash_prefix_0_5_10 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
         split_constructor_arguments_and_extract_check_func(
           constructor_arguments,
           check_func,
@@ -66,7 +111,51 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
       # Metadata: Update the swarm hash to the current specification, changes bzzr0 to bzzr1 and urls to use bzz-raw://
       @metadata_hash_prefix_0_5_11 <>
           <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
+          @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_11
+        )
+
+      @metadata_hash_prefix_0_5_11 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_11
+        )
+
+      @metadata_hash_prefix_0_5_11 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_11
+        )
+
+      @metadata_hash_prefix_0_5_11 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_11
+        )
+
+      @metadata_hash_prefix_0_5_11 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
         split_constructor_arguments_and_extract_check_func(
           constructor_arguments,
           check_func,
@@ -87,7 +176,51 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
       # Fixing PR has been created https://github.com/ethereum/solidity/pull/8174
       @metadata_hash_prefix_0_6_0 <>
           <<_::binary-size(68)>> <>
-          @metadata_hash_common_suffix <> <<_::binary-size(6)>> <> "0033" <> constructor_arguments ->
+          @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0033" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_6_0
+        )
+
+      @metadata_hash_prefix_0_6_0 <>
+          <<_::binary-size(68)>> <>
+          @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_6_0
+        )
+
+      @metadata_hash_prefix_0_6_0 <>
+          <<_::binary-size(68)>> <>
+          @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_6_0
+        )
+
+      @metadata_hash_prefix_0_6_0 <>
+          <<_::binary-size(68)>> <>
+          @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_6_0
+        )
+
+      @metadata_hash_prefix_0_6_0 <>
+          <<_::binary-size(68)>> <>
+          @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
         split_constructor_arguments_and_extract_check_func(
           constructor_arguments,
           check_func,


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/3110 https://github.com/poanetwork/blockscout/issues/3111

## Motivation

- BlockScout doesn't check compiler version on verification
- Contracts compiled with nightly builds cannot be verified


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
