### PR TITLE
Performance fix: index on blocks [miner_hash, number]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3114](https://github.com/poanetwork/blockscout/pull/3114) - Fix performance of "Blocks validated" page
 
 ### Chore
 

--- a/apps/explorer/priv/repo/migrations/20200518075748_create_index_blocks_miner_hash_number_index.exs
+++ b/apps/explorer/priv/repo/migrations/20200518075748_create_index_blocks_miner_hash_number_index.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.CreateIndexBlocksMinerHashNumberIndex do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(index(:blocks, [:miner_hash, :number]))
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/3063

## Motivation

"Blocks validated" page is slow

## Changelog

https://github.com/poanetwork/blockscout/issues/3063#issuecomment-629372669

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
