### PR TITLE
Fix verification of contracts created from factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [#3112](https://github.com/poanetwork/blockscout/pull/3112) - Fix verification of contracts, compiled with nightly builds of solc compiler
 - [#3112](https://github.com/poanetwork/blockscout/pull/3112) - Check compiler version at contract verification
 - [#3106](https://github.com/poanetwork/blockscout/pull/3106) - Fix verification of contracts with `immutable` declaration
-- [#3106](https://github.com/poanetwork/blockscout/pull/3106) - Fix verification of contracts, created from factory (from internal transaction)
+- [#3106](https://github.com/poanetwork/blockscout/pull/3106), [#3115](https://github.com/poanetwork/blockscout/pull/3115) - Fix verification of contracts, created from factory (from internal transaction)
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2734,7 +2734,9 @@ defmodule Explorer.Chain do
       creation_int_tx_query =
         from(
           itx in InternalTransaction,
+          join: t in assoc(itx, :transaction),
           where: itx.created_contract_address_hash == ^address_hash,
+          where: t.status == ^1,
           select: itx.init
         )
 


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/3108

## Motivation

```
2020-05-18T12:30:39.169 [error] Task #PID<0.9944.1> started from #PID<0.11593.4> terminating
** (Ecto.MultipleResultsError) expected at most one result but got 2 in query:

from i0 in Explorer.Chain.InternalTransaction,
  where: i0.created_contract_address_hash == ^"0x5933331BB25aAc7fF7BBb22e4E35F65D5882e621",
  select: i0.init

    (ecto 3.3.1) lib/ecto/repo/queryable.ex:104: Ecto.Repo.Queryable.one/3
    (explorer 0.0.1) lib/explorer/chain.ex:2743: Explorer.Chain.smart_contract_creation_tx_bytecode/1
    (explorer 0.0.1) lib/explorer/smart_contract/verifier.ex:95: Explorer.SmartContract.Verifier.compare_bytecodes/6
    (elixir 1.10.2) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
    (explorer 0.0.1) lib/explorer/smart_contract/publisher.ex:29: Explorer.SmartContract.Publisher.publish/3
    (explorer 0.0.1) lib/explorer/smart_contract/publisher_worker.ex:13: Explorer.SmartContract.PublisherWorker.perform/1
    (elixir 1.10.2) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (stdlib 3.9) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Function: #Function<3.104694414/0 in Que.Job.perform/1>
```

## Changelog

Find contract creation internal transactions only from success transaction

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
