### PR TITLE
Fix performance of coin balance history chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3118](https://github.com/poanetwork/blockscout/pull/3118) - Fix performance of coin balance history chart
 - [#3114](https://github.com/poanetwork/blockscout/pull/3114) - Fix performance of "Blocks validated" page
 - [#3112](https://github.com/poanetwork/blockscout/pull/3112) - Fix verification of contracts, compiled with nightly builds of solc compiler
 - [#3112](https://github.com/poanetwork/blockscout/pull/3112) - Check compiler version at contract verification

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -84,6 +84,10 @@ config :block_scout_web, BlockScoutWeb.Chain.TransactionHistoryChartController,
   # days
   history_size: 30
 
+config :block_scout_web, BlockScoutWeb.Chain.Address.CoinBalance,
+  # days
+  coin_balance_history_days: System.get_env("COIN_BALANCE_HISTORY_DAYS", "10")
+
 config :ex_cldr,
   default_locale: "en",
   default_backend: BlockScoutWeb.Cldr

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3494,7 +3494,7 @@ defmodule Explorer.Chain do
       |> Repo.one()
 
     address_hash
-    |> CoinBalance.balances_by_day(latest_block_timestamp)
+    |> CoinBalance.balances_by_day()
     |> replace_last_value(latest_block_timestamp)
     |> normalize_balances_by_day()
   end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3495,7 +3495,6 @@ defmodule Explorer.Chain do
 
     address_hash
     |> CoinBalance.balances_by_day(latest_block_timestamp)
-    |> Repo.all()
     |> replace_last_value(latest_block_timestamp)
     |> normalize_balances_by_day()
   end

--- a/apps/explorer/test/explorer/chain/address/coin_balance_test.exs
+++ b/apps/explorer/test/explorer/chain/address/coin_balance_test.exs
@@ -146,7 +146,6 @@ defmodule Explorer.Chain.Address.CoinBalanceTest do
       result =
         address.hash
         |> CoinBalance.balances_by_day()
-        |> Repo.all()
 
       assert(length(result) == 2)
 
@@ -171,7 +170,6 @@ defmodule Explorer.Chain.Address.CoinBalanceTest do
       result =
         address_a.hash
         |> CoinBalance.balances_by_day()
-        |> Repo.all()
 
       assert(length(result) == 2)
 
@@ -191,7 +189,6 @@ defmodule Explorer.Chain.Address.CoinBalanceTest do
       result =
         address.hash
         |> CoinBalance.balances_by_day()
-        |> Repo.all()
 
       assert(length(result) == 2)
 
@@ -221,7 +218,6 @@ defmodule Explorer.Chain.Address.CoinBalanceTest do
       result =
         address.hash
         |> CoinBalance.balances_by_day()
-        |> Repo.all()
 
       assert(length(result) == 1)
 
@@ -243,7 +239,6 @@ defmodule Explorer.Chain.Address.CoinBalanceTest do
       result =
         address.hash
         |> CoinBalance.balances_by_day()
-        |> Repo.all()
 
       assert(length(result) == 1)
 
@@ -265,7 +260,6 @@ defmodule Explorer.Chain.Address.CoinBalanceTest do
       result =
         address.hash
         |> CoinBalance.balances_by_day()
-        |> Repo.all()
 
       assert(length(result) == 1)
 
@@ -289,7 +283,6 @@ defmodule Explorer.Chain.Address.CoinBalanceTest do
       result =
         address.hash
         |> CoinBalance.balances_by_day(latest_block_timestamp)
-        |> Repo.all()
 
       assert(length(result) == 1)
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4733,7 +4733,7 @@ defmodule Explorer.ChainTest do
       today = NaiveDateTime.utc_now()
       noon = Timex.set(today, hour: 12)
       yesterday = Timex.shift(noon, days: -1)
-      block_one_day_ago = insert(:block, timestamp: yesterday)
+      block_one_day_ago = insert(:block, timestamp: yesterday, number: 1)
       insert(:fetched_balance, address_hash: address.hash, value: 1000, block_number: block_one_day_ago.number)
 
       balances = Chain.address_to_balances_by_day(address.hash)


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/1946

## Motivation

Coin balance history loading is slow

## Changelog


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
