### PR TITLE
Fix performance of Inventory tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3073](https://github.com/poanetwork/blockscout/issues/3073) - Fix performance of Inventory tab loading for ERC-721 tokens
 - [#3114](https://github.com/poanetwork/blockscout/pull/3114) - Fix performance of "Blocks validated" page
 - [#3112](https://github.com/poanetwork/blockscout/pull/3112) - Fix verification of contracts, compiled with nightly builds of solc compiler
 - [#3112](https://github.com/poanetwork/blockscout/pull/3112) - Check compiler version at contract verification

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -281,6 +281,7 @@ defmodule Explorer.Chain.TokenTransfer do
   end
 
   @doc """
+  Innventory tab query.
   A token ERC-721 is considered unique because it corresponds to the possession
   of a specific asset.
 
@@ -293,7 +294,7 @@ defmodule Explorer.Chain.TokenTransfer do
       tt in TokenTransfer,
       left_join: instance in Instance,
       on: tt.token_contract_address_hash == instance.token_contract_address_hash and tt.token_id == instance.token_id,
-      where: tt.token_contract_address_hash == ^contract_address_hash,
+      where: instance.token_contract_address_hash == ^contract_address_hash,
       order_by: [desc: tt.block_number],
       distinct: tt.token_id,
       preload: [:to_address],

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -296,7 +296,7 @@ defmodule Explorer.Chain.TokenTransfer do
       on: tt.token_contract_address_hash == instance.token_contract_address_hash and tt.token_id == instance.token_id,
       where: instance.token_contract_address_hash == ^contract_address_hash,
       order_by: [desc: tt.block_number],
-      distinct: tt.token_id,
+      distinct: [desc: tt.token_id],
       preload: [:to_address],
       select: %{tt | instance: instance}
     )

--- a/apps/explorer/priv/repo/migrations/20200521170002_create_token_transfers_token_contract_address_hash_token_id_block_number_index.exs
+++ b/apps/explorer/priv/repo/migrations/20200521170002_create_token_transfers_token_contract_address_hash_token_id_block_number_index.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.CreateTokenTransfersTokenContractAddressHashTokenIdBlockNumberIndex do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(index(:token_transfers, [:token_contract_address_hash, :token_id, :block_number]))
+  end
+end

--- a/apps/explorer/test/explorer/chain/token_transfer_test.exs
+++ b/apps/explorer/test/explorer/chain/token_transfer_test.exs
@@ -157,6 +157,12 @@ defmodule Explorer.Chain.TokenTransferTest do
         |> with_block(insert(:block, number: 1))
 
       insert(
+        :token_instance,
+        token_id: 42,
+        token_contract_address_hash: token_contract_address.hash
+      )
+
+      insert(
         :token_transfer,
         to_address: build(:address),
         transaction: transaction,
@@ -168,7 +174,7 @@ defmodule Explorer.Chain.TokenTransferTest do
       another_transaction =
         :transaction
         |> insert()
-        |> with_block(insert(:block, number: 2))
+        |> with_block(insert(:block, number: 3))
 
       last_owner =
         insert(


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/3073

## Motivation

Loading of ERC-721 token instances is slow

## Changelog



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
