### PR TITLE
Exclude balance percentage calculation for burn address on accounts page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Features
 
 ### Fixes
-- [#3073](https://github.com/poanetwork/blockscout/issues/3073) - Fix performance of Inventory tab loading for ERC-721 tokens
+- [#3122](https://github.com/poanetwork/blockscout/pull/3122) - Exclude balance percentage calculation for burn address on accounts page
+- [#3119](https://github.com/poanetwork/blockscout/pull/3119), [#3120](https://github.com/poanetwork/blockscout/pull/3120) - Fix performance of Inventory tab loading for ERC-721 tokens
 - [#3114](https://github.com/poanetwork/blockscout/pull/3114) - Fix performance of "Blocks validated" page
 - [#3112](https://github.com/poanetwork/blockscout/pull/3112) - Fix verification of contracts, compiled with nightly builds of solc compiler
 - [#3112](https://github.com/poanetwork/blockscout/pull/3112) - Check compiler version at contract verification

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -116,6 +116,17 @@ defmodule BlockScoutWeb.AddressView do
 
   def balance_percentage(_, nil), do: ""
 
+  def balance_percentage(
+        %Address{
+          hash: %Explorer.Chain.Hash{
+            byte_count: 20,
+            bytes: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
+          }
+        },
+        _
+      ),
+      do: ""
+
   def balance_percentage(%Address{fetched_coin_balance: balance}, total_supply) do
     if total_supply > 0 do
       balance

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -903,7 +903,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:314
+#: lib/block_scout_web/views/address_view.ex:325
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:90
 #: lib/block_scout_web/views/tokens/overview_view.ex:35
 #: lib/block_scout_web/views/transaction_view.ex:379
@@ -1041,7 +1041,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:52
 #: lib/block_scout_web/templates/layout/app.html.eex:30
-#: lib/block_scout_web/views/address_view.ex:127
+#: lib/block_scout_web/views/address_view.ex:138
 msgid "Market Cap"
 msgstr ""
 
@@ -1807,7 +1807,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:37
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
-#: lib/block_scout_web/views/address_view.ex:319
+#: lib/block_scout_web/views/address_view.ex:330
 msgid "Blocks Validated"
 msgstr ""
 
@@ -1817,18 +1817,18 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:315
+#: lib/block_scout_web/views/address_view.ex:326
 msgid "Code"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:26
-#: lib/block_scout_web/views/address_view.ex:318
+#: lib/block_scout_web/views/address_view.ex:329
 msgid "Coin Balance History"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_view.ex:316
+#: lib/block_scout_web/views/address_view.ex:327
 msgid "Decompiled Code"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:313
+#: lib/block_scout_web/views/address_view.ex:324
 #: lib/block_scout_web/views/transaction_view.ex:380
 msgid "Internal Transactions"
 msgstr ""
@@ -1847,7 +1847,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:320
+#: lib/block_scout_web/views/address_view.ex:331
 #: lib/block_scout_web/views/transaction_view.ex:381
 msgid "Logs"
 msgstr ""
@@ -1855,7 +1855,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:62
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
-#: lib/block_scout_web/views/address_view.ex:317
+#: lib/block_scout_web/views/address_view.ex:328
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -1864,7 +1864,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:14
 #: lib/block_scout_web/templates/address_token/index.html.eex:8
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:11
-#: lib/block_scout_web/views/address_view.ex:311
+#: lib/block_scout_web/views/address_view.ex:322
 msgid "Tokens"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:18
 #: lib/block_scout_web/templates/chain/show.html.eex:184
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:50
-#: lib/block_scout_web/views/address_view.ex:312
+#: lib/block_scout_web/views/address_view.ex:323
 msgid "Transactions"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -903,7 +903,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:314
+#: lib/block_scout_web/views/address_view.ex:325
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:90
 #: lib/block_scout_web/views/tokens/overview_view.ex:35
 #: lib/block_scout_web/views/transaction_view.ex:379
@@ -1041,7 +1041,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:52
 #: lib/block_scout_web/templates/layout/app.html.eex:30
-#: lib/block_scout_web/views/address_view.ex:127
+#: lib/block_scout_web/views/address_view.ex:138
 msgid "Market Cap"
 msgstr ""
 
@@ -1807,7 +1807,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:37
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
-#: lib/block_scout_web/views/address_view.ex:319
+#: lib/block_scout_web/views/address_view.ex:330
 msgid "Blocks Validated"
 msgstr ""
 
@@ -1817,18 +1817,18 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:315
+#: lib/block_scout_web/views/address_view.ex:326
 msgid "Code"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:26
-#: lib/block_scout_web/views/address_view.ex:318
+#: lib/block_scout_web/views/address_view.ex:329
 msgid "Coin Balance History"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_view.ex:316
+#: lib/block_scout_web/views/address_view.ex:327
 msgid "Decompiled Code"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:313
+#: lib/block_scout_web/views/address_view.ex:324
 #: lib/block_scout_web/views/transaction_view.ex:380
 msgid "Internal Transactions"
 msgstr ""
@@ -1847,7 +1847,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:320
+#: lib/block_scout_web/views/address_view.ex:331
 #: lib/block_scout_web/views/transaction_view.ex:381
 msgid "Logs"
 msgstr ""
@@ -1855,7 +1855,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:62
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
-#: lib/block_scout_web/views/address_view.ex:317
+#: lib/block_scout_web/views/address_view.ex:328
 #: lib/block_scout_web/views/tokens/overview_view.ex:37
 msgid "Read Contract"
 msgstr ""
@@ -1864,7 +1864,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:14
 #: lib/block_scout_web/templates/address_token/index.html.eex:8
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:11
-#: lib/block_scout_web/views/address_view.ex:311
+#: lib/block_scout_web/views/address_view.ex:322
 msgid "Tokens"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:18
 #: lib/block_scout_web/templates/chain/show.html.eex:184
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:50
-#: lib/block_scout_web/views/address_view.ex:312
+#: lib/block_scout_web/views/address_view.ex:323
 msgid "Transactions"
 msgstr ""
 


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/3103

## Motivation

https://github.com/poanetwork/blockscout/issues/3103#issuecomment-627220686

## Changelog

Doesn't show balance percentage to market cap for burn address.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
