### PR TITLE
Take into account FIRST_BLOCK for block rewards fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Features
 
 ### Fixes
-- [#3128](https://github.com/poanetwork/blockscout/pull/3128) - Token instance metadata retriever refinement: process metadata if only image URL is passed to token URI
+- [#3130](https://github.com/poanetwork/blockscout/pull/3130) - Take into account FIRST_BLOCK for block rewards fetching
+- [#3128](https://github.com/poanetwork/blockscout/pull/3128) - Token instance metadata retriever refinement: add processing of token metadata if only image URL is passed to token URI
 - [#3126](https://github.com/poanetwork/blockscout/pull/3126) - Fetch balance only for blocks which are greater or equal block with FIRST_BLOCK number
 - [#3122](https://github.com/poanetwork/blockscout/pull/3122) - Exclude balance percentage calculation for burn address on accounts page
 - [#3121](https://github.com/poanetwork/blockscout/pull/3121) - Geth: handle response from eth_getblockbyhash JSON RPC method without totalDifficulty (uncle blocks)


### PR DESCRIPTION
## Motivation

```
blockscout     | 2020-05-27T07:53:08.769 application=indexer fetcher=block_reward count=10 error_count=10 [error] failed to fetch: @�: (-32603) Internal error
blockscout     | @�: (-32603) Internal error
blockscout     | @�: (-32603) Internal error
blockscout     | @�: (-32603) Internal error
blockscout     | @�: (-32603) Internal error
blockscout     | @�: (-32603) Internal error
blockscout     | @�: (-32603) Internal error
blockscout     | @�: (-32603) Internal error
blockscout     | @�: (-32603) Internal error
blockscout     | @�: (-32603) Internal error
```

## Changelog

Validated blocks which send to `trace_block` JSON RPC method. The numbers should be greater than `FIRST_BLOCK` param.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
