### PR TITLE
Fix performance of coin supply API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3132](https://github.com/poanetwork/blockscout/pull/3132) - Fix performance of coin supply API endpoints
 - [#3130](https://github.com/poanetwork/blockscout/pull/3130) - Take into account FIRST_BLOCK for block rewards fetching
 - [#3128](https://github.com/poanetwork/blockscout/pull/3128) - Token instance metadata retriever refinement: add processing of token metadata if only image URL is passed to token URI
 - [#3126](https://github.com/poanetwork/blockscout/pull/3126) - Fetch balance only for blocks which are greater or equal block with FIRST_BLOCK number

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1518,7 +1518,7 @@ defmodule Explorer.Chain do
         a0 in Address,
         select: fragment("SUM(a0.fetched_coin_balance)"),
         where: a0.hash != ^burn_address_hash,
-        where: a0.fetched_coin_balance > 0
+        where: a0.fetched_coin_balance > ^0
       )
 
     Repo.one!(query) || 0
@@ -1530,7 +1530,7 @@ defmodule Explorer.Chain do
       from(
         a0 in Address,
         select: fragment("SUM(a0.fetched_coin_balance)"),
-        where: a0.fetched_coin_balance > 0
+        where: a0.fetched_coin_balance > ^0
       )
 
     Repo.one!(query) || 0

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1517,7 +1517,8 @@ defmodule Explorer.Chain do
       from(
         a0 in Address,
         select: fragment("SUM(a0.fetched_coin_balance)"),
-        where: a0.hash != ^burn_address_hash
+        where: a0.hash != ^burn_address_hash,
+        where: a0.fetched_coin_balance > 0
       )
 
     Repo.one!(query) || 0
@@ -1528,7 +1529,8 @@ defmodule Explorer.Chain do
     query =
       from(
         a0 in Address,
-        select: fragment("SUM(a0.fetched_coin_balance)")
+        select: fragment("SUM(a0.fetched_coin_balance)"),
+        where: a0.fetched_coin_balance > 0
       )
 
     Repo.one!(query) || 0


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/3131

## Motivation

Queries for coin supply endpoints are slow. For instance:
```
select SUM(a0.fetched_coin_balance) from addresses a0;
```

## Changelog

However, `addresses` table has index `"addresses_fetched_coin_balance_index" btree (fetched_coin_balance)` on `fetched_coin_balance` column which excludes empty or zero balances and it is not used by the query. We can modify query adding `where fetched_coin_balance > 0` clause to speed-up it without changing the result of the query.

```
core=> explain analyze select SUM(a0.fetched_coin_balance) from addresses a0 where fetched_coin_balance > 0;
                                                                                QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=3011.43..3011.44 rows=1 width=32) (actual time=48.242..48.243 rows=1 loops=1)
   ->  Index Only Scan using addresses_fetched_coin_balance_index on addresses a0  (cost=0.44..2807.17 rows=81704 width=3) (actual time=0.027..27.634 rows=73969 loops=1)
         Index Cond: (fetched_coin_balance > '0'::numeric)
         Heap Fetches: 2834
 Planning time: 0.244 ms
 Execution time: 48.284 ms
(6 rows)
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
