### PR TITLE
Take into account FIRST_BLOCK in trace_ReplayBlockTransactions requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3133](https://github.com/poanetwork/blockscout/pull/3133) - Take into account FIRST_BLOCK in trace_ReplayBlockTransactions requests
 - [#3130](https://github.com/poanetwork/blockscout/pull/3130) - Take into account FIRST_BLOCK for block rewards fetching
 - [#3128](https://github.com/poanetwork/blockscout/pull/3128) - Token instance metadata retriever refinement: add processing of token metadata if only image URL is passed to token URI
 - [#3126](https://github.com/poanetwork/blockscout/pull/3126) - Fetch balance only for blocks which are greater or equal block with FIRST_BLOCK number

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -305,9 +305,17 @@ defmodule EthereumJSONRPC do
   @doc """
   Fetches internal transactions for entire blocks from variant API.
   """
-  def fetch_block_internal_transactions(params_list, json_rpc_named_arguments) when is_list(params_list) do
+  def fetch_block_internal_transactions(block_numbers, json_rpc_named_arguments) when is_list(block_numbers) do
+    min_block = first_block_to_fetch()
+
+    filtered_block_numbers =
+      block_numbers
+      |> Enum.filter(fn block_number ->
+        block_number >= min_block
+      end)
+
     Keyword.fetch!(json_rpc_named_arguments, :variant).fetch_block_internal_transactions(
-      params_list,
+      filtered_block_numbers,
       json_rpc_named_arguments
     )
   end


### PR DESCRIPTION
## Motivation

```
2020-05-27T13:14:54.939 application=indexer fetcher=internal_transaction count=10 error_count=10 [error] failed to fetch internal transactions for blocks: [%{code: -32603, data: %{"blockNumber" => 13515086}, message: "Internal error"}, %{code: -32603, data: %{"blockNumber" => 13513794}, message: "Internal error"}, %{code: -32603, data: %{"blockNumber" => 13513789}, message: "Internal error"}, %{code: -32603, data: %{"blockNumber" => 13514436}, message: "Internal error"}, %{code: -32603, data: %{"blockNumber" => 13514459}, message: "Internal error"}, %{code: -32603, data: %{"blockNumber" => 13514984}, message: "Internal error"}, %{code: -32603, data: %{"blockNumber" => 13514814}, message: "Internal error"}, %{code: -32603, data: %{"blockNumber" => 13514759}, message: "Internal error"}, %{code: -32603, data: %{"blockNumber" => 13514761}, message: "Internal error"}, %{code: -32603, data: %{"blockNumber" => 13514945}, message: "Internal error"}]
```

## Changelog

Validate blocks which send to `trace_ReplayBlockTransactions` JSON RPC method. The numbers should be greater than `FIRST_BLOCK` param.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
