### PR TITLE
Get last value of fetched coinsupply API endpoint from DB if cache is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#3106](https://github.com/poanetwork/blockscout/pull/3106), [#3115](https://github.com/poanetwork/blockscout/pull/3115) - Fix verification of contracts, created from factory (from internal transaction)
 
 ### Chore
+- [#3134](https://github.com/poanetwork/blockscout/pull/3134) - Get last value of fetched coinsupply API endpoint from DB if cache is empty
 - [#3124](https://github.com/poanetwork/blockscout/pull/3124) - Display upper border for tx speed if the value cannot be calculated
 
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -44,8 +44,15 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
   def coinsupply(conn, _params) do
     cached_coin_total_supply_wei = AddressSumMinusBurnt.get_sum_minus_burnt()
 
+    coin_total_supply_wei =
+      if Decimal.cmp(cached_coin_total_supply_wei, 0) == :gt do
+        cached_coin_total_supply_wei
+      else
+        Chain.get_last_fetched_counter("sum_coin_total_supply_minus_burnt")
+      end
+
     cached_coin_total_supply =
-      %Wei{value: Decimal.new(cached_coin_total_supply_wei)}
+      %Wei{value: Decimal.new(coin_total_supply_wei)}
       |> Wei.to(:ether)
 
     render(conn, "coinsupply.json", cached_coin_total_supply)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -28,6 +28,8 @@ defmodule Explorer.Chain do
   alias Ecto.Adapters.SQL
   alias Ecto.{Changeset, Multi}
 
+  alias Explorer.Counters.LastFetchedCounter
+
   alias Explorer.Chain
 
   alias Explorer.Chain.{
@@ -2160,6 +2162,27 @@ defmodule Explorer.Chain do
       _ ->
         block_status(nil)
     end
+  end
+
+  @spec upsert_last_fetched_counter(map()) :: {:ok, LastFetchedCounter.t()} | {:error, Ecto.Changeset.t()}
+  def upsert_last_fetched_counter(params) do
+    changeset = LastFetchedCounter.changeset(%LastFetchedCounter{}, params)
+
+    Repo.insert(changeset,
+      on_conflict: :replace_all,
+      conflict_target: [:counter_type]
+    )
+  end
+
+  def get_last_fetched_counter(type) do
+    query =
+      from(
+        last_fetched_counter in LastFetchedCounter,
+        where: last_fetched_counter.counter_type == ^type,
+        select: last_fetched_counter.value
+      )
+
+    Repo.one!(query)
   end
 
   defp block_status({number, timestamp}) do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2182,7 +2182,7 @@ defmodule Explorer.Chain do
         select: last_fetched_counter.value
       )
 
-    Repo.one!(query)
+    Repo.one!(query) || 0
   end
 
   defp block_status({number, timestamp}) do

--- a/apps/explorer/lib/explorer/chain/cache/address_sum_minus_burnt.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum_minus_burnt.ex
@@ -31,6 +31,13 @@ defmodule Explorer.Chain.Cache.AddressSumMinusBurnt do
         try do
           result = Chain.fetch_sum_coin_total_supply_minus_burnt()
 
+          params = %{
+            counter_type: "sum_coin_total_supply_minus_burnt",
+            value: result
+          }
+
+          Chain.upsert_last_fetched_counter(params)
+
           set_sum_minus_burnt(result)
         rescue
           e ->

--- a/apps/explorer/lib/explorer/counters/last_fetched_counter.ex
+++ b/apps/explorer/lib/explorer/counters/last_fetched_counter.ex
@@ -1,0 +1,30 @@
+defmodule Explorer.Counters.LastFetchedCounter do
+  @moduledoc """
+  Stores last fetched counters.
+  """
+
+  alias Explorer.Counters.LastFetchedCounter
+  use Explorer.Schema
+
+  import Ecto.Changeset
+
+  @type t :: %LastFetchedCounter{
+          counter_type: String.t(),
+          value: Decimal.t()
+        }
+
+  @primary_key false
+  schema "last_fetched_counters" do
+    field(:counter_type, :string)
+    field(:value, :decimal)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:counter_type, :value])
+    |> validate_required([:counter_type])
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20200527144742_add_counters_table.exs
+++ b/apps/explorer/priv/repo/migrations/20200527144742_add_counters_table.exs
@@ -1,0 +1,12 @@
+defmodule Explorer.Repo.Migrations.AddCountersTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:last_fetched_counters, primary_key: false) do
+      add(:counter_type, :string, primary_key: true, null: false)
+      add(:value, :numeric, precision: 100, null: true)
+
+      timestamps(null: false, type: :utc_datetime_usec)
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

`coinsupply` API endpoint returns 0 supply for sometime after restart of the application because it retrieved from ETS (in-memory cache), which is cleared on application restart.

## Changelog

In order to provide uninterrupted service for `coinsupply` API endpoint, it is suggested to store last fetched value on cache update for this counter in the DB. And if cache is empty (for instance, on application restart), get that value from DB.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
