### PR TITLE
RSK Papyrus Release v2.0.1 hardfork: cumulativeDifficulty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#3106](https://github.com/poanetwork/blockscout/pull/3106), [#3115](https://github.com/poanetwork/blockscout/pull/3115) - Fix verification of contracts, created from factory (from internal transaction)
 
 ### Chore
+- [#3137](https://github.com/poanetwork/blockscout/pull/3137) - RSK Papyrus Release v2.0.1 hardfork: cumulativeDifficulty
 - [#3134](https://github.com/poanetwork/blockscout/pull/3134) - Get last value of fetched coinsupply API endpoint from DB if cache is empty
 - [#3124](https://github.com/poanetwork/blockscout/pull/3124) - Display upper border for tx speed if the value cannot be calculated
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
@@ -480,7 +480,7 @@ defmodule EthereumJSONRPC.Block do
   end
 
   defp entry_to_elixir({key, quantity})
-       when key in ~w(difficulty gasLimit gasUsed minimumGasPrice number size totalDifficulty paidFees) and
+       when key in ~w(difficulty gasLimit gasUsed minimumGasPrice number size cumulativeDifficulty totalDifficulty paidFees) and
               not is_nil(quantity) do
     {key, quantity_to_integer(quantity)}
   end


### PR DESCRIPTION
## Motivation

https://github.com/rsksmart/rskj/releases/tag/PAPYRUS-2.0.1
happened at block 2,392,700 and causes an error in Blockscout:

```
2020-05-28T12:36:58.685 application=indexer fetcher=block_catchup first_block_number=2393023 last_block_number=2393014 [error] ** (FunctionClauseError) no function clause matching in EthereumJSONRPC.Block.entry_to_elixir/1
    (ethereum_jsonrpc 0.1.0) EthereumJSONRPC.Block.entry_to_elixir({"cumulativeDifficulty", "0x2c912722075cffd936"})
    (elixir 1.10.2) lib/enum.ex:1320: anonymous fn/4 in Enum.into/3
    (stdlib 3.9.2) maps.erl:232: :maps.fold_1/3
    (elixir 1.10.2) lib/enum.ex:2127: Enum.into/4
    (elixir 1.10.2) lib/enum.ex:1396: Enum."-map/2-lists^map/1-0-"/2
    (ethereum_jsonrpc 0.1.0) lib/ethereum_jsonrpc/blocks.ex:44: EthereumJSONRPC.Blocks.from_responses/2
    (ethereum_jsonrpc 0.1.0) lib/ethereum_jsonrpc.ex:464: EthereumJSONRPC.fetch_blocks_by_params/3
    (indexer 0.1.0) lib/indexer/block/fetcher.ex:130: Indexer.Block.Fetcher.fetch_and_import_range/2


Retrying.
```

## Changelog

Add `cumulativeDifficulty` to the list of expected parameters from block details JSON RPC response

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
