### PR TITLE
Fix performance of the balance changing history list loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#3106](https://github.com/poanetwork/blockscout/pull/3106), [#3115](https://github.com/poanetwork/blockscout/pull/3115) - Fix verification of contracts, created from factory (from internal transaction)
 
 ### Chore
+- [#3137](https://github.com/poanetwork/blockscout/pull/3137) - RSK Papyrus Release v2.0.1 hardfork: cumulativeDifficulty
 - [#3134](https://github.com/poanetwork/blockscout/pull/3134) - Get last value of fetched coinsupply API endpoint from DB if cache is empty
 - [#3124](https://github.com/poanetwork/blockscout/pull/3124) - Display upper border for tx speed if the value cannot be calculated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Current
 
 ### Features
+- [#3125](https://github.com/poanetwork/blockscout/pull/3125)  - Availability to configure a number of days to consider at coin balance history chart via environment variable
 
 ### Fixes
+- [#3140](https://github.com/poanetwork/blockscout/pull/3140) - Fix performance of the balance changing history list loading
 - [#3133](https://github.com/poanetwork/blockscout/pull/3133) - Take into account FIRST_BLOCK in trace_ReplayBlockTransactions requests
 - [#3132](https://github.com/poanetwork/blockscout/pull/3132) - Fix performance of coin supply API endpoints
 - [#3130](https://github.com/poanetwork/blockscout/pull/3130) - Take into account FIRST_BLOCK for block rewards fetching

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
@@ -23,6 +23,16 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
 
       {coin_balances, next_page} = split_list_by_page(coin_balances_plus_one)
 
+      deduplicated_coin_balances =
+        coin_balances
+        |> Enum.dedup_by(fn record ->
+          if record.delta == Decimal.new(0) do
+            :dup
+          else
+            System.unique_integer()
+          end
+        end)
+
       next_page_url =
         case next_page_params(next_page, coin_balances, params) do
           nil ->
@@ -38,7 +48,7 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
         end
 
       coin_balances_json =
-        Enum.map(coin_balances, fn coin_balance ->
+        Enum.map(deduplicated_coin_balances, fn coin_balance ->
           View.render_to_string(
             AddressCoinBalanceView,
             "_coin_balances.html",

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
@@ -480,7 +480,7 @@ defmodule EthereumJSONRPC.Block do
   end
 
   defp entry_to_elixir({key, quantity})
-       when key in ~w(difficulty gasLimit gasUsed minimumGasPrice number size totalDifficulty paidFees) and
+       when key in ~w(difficulty gasLimit gasUsed minimumGasPrice number size cumulativeDifficulty totalDifficulty paidFees) and
               not is_nil(quantity) do
     {key, quantity_to_integer(quantity)}
   end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3522,7 +3522,7 @@ defmodule Explorer.Chain do
     address_hash
     |> CoinBalanceDaily.balances_by_day()
     |> Repo.all()
-    |> Enum.sort(&(&1.date <= &2.date))
+    |> Enum.sort_by(fn %{date: d} -> {d.year, d.month, d.day} end)
     |> replace_last_value(latest_block_timestamp)
     |> normalize_balances_by_day()
   end
@@ -3537,7 +3537,6 @@ defmodule Explorer.Chain do
   defp normalize_balances_by_day(balances_by_day) do
     result =
       balances_by_day
-      |> Enum.map(fn day -> Map.take(day, [:date, :value]) end)
       |> Enum.filter(fn day -> day.value end)
       |> Enum.map(fn day -> Map.update!(day, :date, &to_string(&1)) end)
       |> Enum.map(fn day -> Map.update!(day, :value, &Wei.to(&1, :ether)) end)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3522,6 +3522,7 @@ defmodule Explorer.Chain do
     address_hash
     |> CoinBalanceDaily.balances_by_day()
     |> Repo.all()
+    |> Enum.sort(&(&1.date <= &2.date))
     |> replace_last_value(latest_block_timestamp)
     |> normalize_balances_by_day()
   end

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -76,12 +76,9 @@ defmodule Explorer.Chain.Address.CoinBalance do
       cb in CoinBalance,
       where: cb.address_hash == ^address_hash,
       where: not is_nil(cb.value),
-      inner_join: b in Block,
-      on: cb.block_number == b.number,
       order_by: [desc: :block_number],
       limit: ^page_size,
-      select_merge: %{delta: fragment("value - coalesce(lag(value, 1) over (order by block_number), 0)")},
-      select_merge: %{block_timestamp: b.timestamp}
+      select_merge: %{delta: fragment("value - coalesce(lag(value, 1) over (order by block_number), 0)")}
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -78,7 +78,7 @@ defmodule Explorer.Chain.Address.CoinBalance do
       where: not is_nil(cb.value),
       order_by: [desc: :block_number],
       limit: ^page_size,
-      select_merge: %{delta: fragment("value - coalesce(lag(value, 1) over (order by block_number), 0)")}
+      select_merge: %{delta: fragment("coalesce(lag(value, 1) over (order by block_number desc), 0) - value")}
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -78,7 +78,7 @@ defmodule Explorer.Chain.Address.CoinBalance do
       where: not is_nil(cb.value),
       order_by: [desc: :block_number],
       limit: ^page_size,
-      select_merge: %{delta: fragment("coalesce(lag(value, 1) over (order by block_number desc), 0) - value")}
+      select_merge: %{delta: fragment("value - coalesce(lead(value, 1) over (order by block_number desc), 0)")}
     )
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -5025,32 +5025,6 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "address_to_coin_balances/2" do
-    test "deduplicates records by zero delta" do
-      address = insert(:address)
-
-      1..5
-      |> Enum.each(fn block_number ->
-        insert(:block, number: block_number)
-        insert(:fetched_balance, value: 1, block_number: block_number, address_hash: address.hash)
-      end)
-
-      insert(:block, number: 6)
-      insert(:fetched_balance, value: 2, block_number: 6, address_hash: address.hash)
-
-      assert [first, second, third] = Chain.address_to_coin_balances(address.hash, [])
-
-      assert first.block_number == 6
-      assert first.delta == Decimal.new(1)
-
-      assert second.block_number == 5
-      assert second.delta == Decimal.new(0)
-
-      assert third.block_number == 1
-      assert third.delta == Decimal.new(1)
-    end
-  end
-
   describe "extract_db_name/1" do
     test "extracts correct db name" do
       db_url = "postgresql://viktor:@localhost:5432/blockscout-dev-1"


### PR DESCRIPTION
#1946

Should be merged after https://github.com/poanetwork/blockscout/pull/3125

## Motivation

Balance changing history list (which is under balance history chart) loading at *Coin Balance History* tab is very slow.

## Changelog

Eliminate joining to *Blocks* table in the query to find the list of balance changes by finding min/max blocks in the list and interpolate blocks timestamps using those min and max numbers.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
