### PR TITLE
Speed-up last coin balance timestamp query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#3125](https://github.com/poanetwork/blockscout/pull/3125)  - Availability to configure a number of days to consider at coin balance history chart via environment variable
 
 ### Fixes
+- [#3142](https://github.com/poanetwork/blockscout/pull/3142) - Speed-up last coin balance timestamp query (coin balance history page performance improvement)
 - [#3140](https://github.com/poanetwork/blockscout/pull/3140) - Fix performance of the balance changing history list loading
 - [#3133](https://github.com/poanetwork/blockscout/pull/3133) - Take into account FIRST_BLOCK in trace_ReplayBlockTransactions requests
 - [#3132](https://github.com/poanetwork/blockscout/pull/3132) - Fix performance of coin supply API endpoints


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/1946

## Motivation

Last coin balance query is slow

https://github.com/poanetwork/blockscout/blob/02ac0a3ecd2a20be4a00c8ef7381bc05f5d7d25b/apps/explorer/lib/explorer/chain/address/coin_balance.ex#L107-L113

in case of some addresses types. For instance, for emission funds account which balance changes every block https://blockscout.com/poa/sokol/address/0x523B6539Ff08d72A6C8Bb598Af95bF50c1EA839C/coin_balances

<img width="747" alt="Screenshot 2020-06-02 at 22 01 11" src="https://user-images.githubusercontent.com/4341812/83559043-98d53b80-a51c-11ea-917b-212b9f832f3a.png">


## Changelog

The solution is to extract subquery from *address_coin_balances* table to extract target block and then query for its timestamp. It significantly speeds-up the query:

Performance of the query before the changes:

```
sokol=> EXPLAIN ANALYZE SELECT b1."timestamp", a0."value" FROM "address_coin_balances" AS a0
sokol-> INNER JOIN "blocks" AS b1 ON a0."block_number" = b1."number"
sokol-> WHERE (a0."address_hash" = '\x523B6539Ff08d72A6C8Bb598Af95bF50c1EA839C')
sokol-> ORDER BY a0."block_number" DESC LIMIT 1;
^CCancel request sent
```

*Request cancelled after > 2 minutes of execution*

Performance of the query after the changes:

```
sokol=> EXPLAIN ANALYZE SELECT b.timestamp, a.value FROM blocks b inner join (
  SELECT a0."block_number", a0."value" FROM "address_coin_balances" AS a0
WHERE (a0."address_hash" = '\x523B6539Ff08d72A6C8Bb598Af95bF50c1EA839C')
ORDER BY a0."block_number" DESC LIMIT 1
) a on a."block_number" = b."number";
                                                                                                     QUERY PLAN

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
----------------
 Nested Loop  (cost=1.00..12.34 rows=1 width=17) (actual time=103.426..103.431 rows=1 loops=1)
   ->  Limit  (cost=0.56..3.86 rows=1 width=17) (actual time=62.781..62.783 rows=1 loops=1)
         ->  Index Scan Backward using address_coin_balances_address_hash_block_number_index on address_coin_balances a0  (cost=0.56..31800554.38 rows=9642152 width=17) (actual time=62.780..62.780
rows=1 loops=1)
               Index Cond: (address_hash = '\x523b6539ff08d72a6c8bb598af95bf50c1ea839c'::bytea)
   ->  Index Scan using blocks_number_index on blocks b  (cost=0.43..8.45 rows=1 width=16) (actual time=40.638..40.640 rows=1 loops=1)
         Index Cond: (number = a0.block_number)
 Planning time: 0.787 ms
 Execution time: 103.474 ms
(8 rows)
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
