### PR TITLE
Fix coin balance history page: order of items, fix if no balance changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#3125](https://github.com/poanetwork/blockscout/pull/3125)  - Availability to configure a number of days to consider at coin balance history chart via environment variable
 
 ### Fixes
+- [#3146](https://github.com/poanetwork/blockscout/pull/3146) - Fix coin balance history page: order of items, fix if no balance changes
 - [#3142](https://github.com/poanetwork/blockscout/pull/3142) - Speed-up last coin balance timestamp query (coin balance history page performance improvement)
 - [#3140](https://github.com/poanetwork/blockscout/pull/3140) - Fix performance of the balance changing history list loading
 - [#3133](https://github.com/poanetwork/blockscout/pull/3133) - Take into account FIRST_BLOCK in trace_ReplayBlockTransactions requests

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
@@ -23,16 +23,6 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
 
       {coin_balances, next_page} = split_list_by_page(coin_balances_plus_one)
 
-      deduplicated_coin_balances =
-        coin_balances
-        |> Enum.dedup_by(fn record ->
-          if record.delta == Decimal.new(0) do
-            :dup
-          else
-            System.unique_integer()
-          end
-        end)
-
       next_page_url =
         case next_page_params(next_page, coin_balances, params) do
           nil ->
@@ -48,7 +38,7 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
         end
 
       coin_balances_json =
-        Enum.map(deduplicated_coin_balances, fn coin_balance ->
+        Enum.map(coin_balances, fn coin_balance ->
           View.render_to_string(
             AddressCoinBalanceView,
             "_coin_balances.html",

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -72,13 +72,18 @@ defmodule Explorer.Chain.Address.CoinBalance do
   The last coin balance from an Address is the last block indexed.
   """
   def fetch_coin_balances(address_hash, %PagingOptions{page_size: page_size}) do
-    from(
-      cb in CoinBalance,
-      where: cb.address_hash == ^address_hash,
-      where: not is_nil(cb.value),
-      order_by: [desc: :block_number],
-      limit: ^page_size,
-      select_merge: %{delta: fragment("value - coalesce(lead(value, 1) over (order by block_number desc), 0)")}
+    query =
+      from(
+        cb in CoinBalance,
+        where: cb.address_hash == ^address_hash,
+        where: not is_nil(cb.value),
+        order_by: [desc: :block_number],
+        select_merge: %{delta: fragment("value - coalesce(lead(value, 1) over (order by block_number desc), 0)")}
+      )
+
+    from(balance in subquery(query),
+      where: balance.delta != 0,
+      limit: ^page_size
     )
   end
 
@@ -87,21 +92,40 @@ defmodule Explorer.Chain.Address.CoinBalance do
   corresponds to the maximum balance in that day. Only the last 90 days of data are used.
   """
   def balances_by_day(address_hash, block_timestamp \\ nil) do
+    {days_to_consider, _} =
+      Application.get_env(:block_scout_web, BlockScoutWeb.Chain.Address.CoinBalance)[:coin_balance_history_days]
+      |> Integer.parse()
+
     CoinBalance
     |> join(:inner, [cb], b in Block, on: cb.block_number == b.number)
     |> where([cb], cb.address_hash == ^address_hash)
-    |> limit_time_interval(block_timestamp)
+    |> limit_time_interval(days_to_consider, block_timestamp)
     |> group_by([cb, b], fragment("date_trunc('day', ?)", b.timestamp))
     |> order_by([cb, b], fragment("date_trunc('day', ?)", b.timestamp))
     |> select([cb, b], %{date: type(fragment("date_trunc('day', ?)", b.timestamp), :date), value: max(cb.value)})
   end
 
-  def limit_time_interval(query, nil) do
-    query |> where([cb, b], b.timestamp >= fragment("date_trunc('day', now()) - interval '90 days'"))
+  def limit_time_interval(query, days_to_consider, nil) do
+    query
+    |> where(
+      [cb, b],
+      b.timestamp >=
+        fragment("date_trunc('day', now() - CAST(? AS INTERVAL))", ^%Postgrex.Interval{days: days_to_consider})
+    )
   end
 
-  def limit_time_interval(query, %{timestamp: timestamp}) do
-    query |> where([cb, b], b.timestamp >= fragment("(? AT TIME ZONE ?) - interval '90 days'", ^timestamp, ^"Etc/UTC"))
+  def limit_time_interval(query, days_to_consider, %{timestamp: timestamp}) do
+    query
+    |> where(
+      [cb, b],
+      b.timestamp >=
+        fragment(
+          "(? AT TIME ZONE ?) - CAST(? AS INTERVAL)",
+          ^timestamp,
+          ^"Etc/UTC",
+          ^%Postgrex.Interval{days: days_to_consider}
+        )
+    )
   end
 
   def last_coin_balance_timestamp(address_hash) do


### PR DESCRIPTION
## Motivation

1. Error is displayed if no balance changes https://blockscout.com/poa/xdai/address/0xf74769d9FFe1Cd17F20b283995CF9e7fA2A262ed/coin_balances

<img width="347" alt="Screenshot 2020-06-04 at 22 14 21" src="https://user-images.githubusercontent.com/4341812/83800826-c3f09400-a6b0-11ea-8b0f-b5b16ba91e06.png">

2. Wrong order of items 

<img width="1074" alt="Screenshot 2020-06-05 at 16 33 58" src="https://user-images.githubusercontent.com/4341812/83882159-5f821300-a74a-11ea-9429-cd8b261c7cd4.png">



## Changelog

- Check if there are balances changes
- Order items in DB query, remove post-ordering

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
