### PR TITLE
Fix for accounts page with token-bridge supply

### DIFF
--- a/apps/explorer/lib/explorer/chain/supply/token_bridge.ex
+++ b/apps/explorer/lib/explorer/chain/supply/token_bridge.ex
@@ -85,18 +85,25 @@ defmodule Explorer.Chain.Supply.TokenBridge do
       |> Enum.map(fn {key, _value} -> key end)
       |> List.first()
 
-    value =
-      case Reader.query_contract(address, abi, params) do
-        %{^method_name => {:ok, [result]}} -> result
-        _ -> 0
-      end
-
     type =
       abi
       |> Enum.at(0)
       |> Map.get("outputs", [])
       |> Enum.at(0)
       |> Map.get("type", "")
+
+    value =
+      case Reader.query_contract(address, abi, params) do
+        %{^method_name => {:ok, [result]}} ->
+          result
+
+        _ ->
+          case type do
+            "address" -> "0x0000000000000000000000000000000000000000"
+            "uint256" -> 0
+            _ -> 0
+          end
+      end
 
     case type do
       "address" ->


### PR DESCRIPTION
## Motivation

*Accounts* page returns internal server error:
```
blockscout-quorum    | Request: GET /accounts
blockscout-quorum    | ** (exit) an exception was raised:
blockscout-quorum    |     ** (FunctionClauseError) no function clause matching in Base.encode16/2
blockscout-quorum    |         (elixir 1.10.2) lib/base.ex:271: Base.encode16(0, [])
blockscout-quorum    |         (explorer 0.0.1) lib/explorer/chain/supply/token_bridge.ex:103: Explorer.Chain.Supply.TokenBridge.call_contract/3
blockscout-quorum    |         (explorer 0.0.1) lib/explorer/chain/supply/token_bridge.ex:75: Explorer.Chain.Supply.TokenBridge.minted_coins/0
blockscout-quorum    |         (explorer 0.0.1) lib/explorer/chain/supply/token_bridge.ex:140: Explorer.Chain.Supply.TokenBridge.update_cache/0
blockscout-quorum    |         (explorer 0.0.1) lib/explorer/chain/supply/token_bridge.ex:116: Explorer.Chain.Supply.TokenBridge.cached_total_coins/1
blockscout-quorum    |         (explorer 0.0.1) lib/explorer/chain.ex:3209: Explorer.Chain.total_supply/0
blockscout-quorum    |         (block_scout_web 0.0.1) lib/block_scout_web/controllers/address_controller.ex:60: BlockScoutWeb.AddressController.index/2
blockscout-quorum    |         (block_scout_web 0.0.1) lib/block_scout_web/controllers/address_controller.ex:1: BlockScoutWeb.AddressController.action/2
```
when token supply is provided through the bridge and bridge contracts are not provided in env vars.


## Changelog

Refine a fallback function for querying of a bridge contract by returning different fallback values depending on the function return value type.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
