### PR TITLE
Fix for verification of contracts from genesis block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#3157](https://github.com/poanetwork/blockscout/pull/3157) - Read methods of implementation on proxy contract
 
 ### Fixes
+- [#3169](https://github.com/poanetwork/blockscout/pull/3169) - Fix for verification of contracts from genesis block
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [#3157](https://github.com/poanetwork/blockscout/pull/3157) - Read methods of implementation on proxy contract
 
 ### Fixes
-- [#3169](https://github.com/poanetwork/blockscout/pull/3169) - Fix for verification of contracts from genesis block
+- [#3169](https://github.com/poanetwork/blockscout/pull/3169) - Fix for verification of contracts defined in genesis block
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/smart_contract/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier.ex
@@ -90,9 +90,15 @@ defmodule Explorer.SmartContract.Verifier do
       "compiler_version" => generated_compiler_version
     } = extract_bytecode_and_metadata_hash(bytecode)
 
-    "0x" <> blockchain_created_tx_input =
-      address_hash
-      |> Chain.smart_contract_creation_tx_bytecode()
+    blockchain_created_tx_input =
+      case Chain.smart_contract_creation_tx_bytecode(address_hash) do
+        nil ->
+          bytecode
+
+        blockchain_created_tx_input_with_0x ->
+          "0x" <> blockchain_created_tx_input = blockchain_created_tx_input_with_0x
+          blockchain_created_tx_input
+      end
 
     %{
       "metadata_hash" => _metadata_hash,


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/3165

## Motivation

Verification for contracts from genesis block doesn't work

## Changelog

Verification is broken because verification expects transaction/internal transaction to exist. Contracts from genesis block have no any of that. Thus, we should use contract bytecode as a fallback instead of tx input.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
