### PR TITLE
Display implementation address at read/write proxy tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3173](https://github.com/poanetwork/blockscout/pull/3173) - Display implementation address at read/write proxy tabs
 - [#3171](https://github.com/poanetwork/blockscout/pull/3171) - Import accounts/contracts/balances from Geth genesis.json
 - [#3161](https://github.com/poanetwork/blockscout/pull/3161) - Write proxy contracts feature
 - [#3160](https://github.com/poanetwork/blockscout/pull/3160) - Write contracts feature

--- a/apps/block_scout_web/assets/css/components/_card.scss
+++ b/apps/block_scout_web/assets/css/components/_card.scss
@@ -257,3 +257,12 @@ $card-tab-icon-color-active: #fff !default;
     margin-left: 15px!important;
   } 
 }
+
+.implementation-title {
+  float: left;
+  margin-right: 5px;
+}
+
+.implementation-value {
+  line-height: 30px;
+}

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -40,6 +40,10 @@ defmodule BlockScoutWeb.SmartContractController do
           []
         end
 
+      implementation_address_hash_string =
+        Chain.get_implementation_address_hash(address.hash, address.smart_contract.abi) ||
+          "0x0000000000000000000000000000000000000000"
+
       conn
       |> put_status(200)
       |> put_layout(false)
@@ -48,6 +52,7 @@ defmodule BlockScoutWeb.SmartContractController do
         read_only_functions: functions,
         address: address,
         contract_abi: contract_abi,
+        implementation_address: implementation_address_hash_string,
         implementation_abi: implementation_abi,
         contract_type: contract_type
       )

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -1,3 +1,11 @@
+<%= if @contract_type == "proxy" do %>
+<div>
+    <h2 class="implementation-title">Implementation address: </h2><h3  class="implementation-value"><%= link(
+                  @implementation_address,
+                  to: address_path(@conn, :show, @implementation_address)
+                ) %></h3>
+</div>
+<% end %>
 <%= for {function, counter} <- Enum.with_index(@read_only_functions, 1) do %>
   <div class="d-flex py-2 border-bottom" data-function>
     <div class="py-2 pr-2 text-nowrap">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -568,8 +568,8 @@ msgid "ERC-721 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:32
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:67
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:40
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:75
 msgid "ETH"
 msgstr ""
 
@@ -1195,7 +1195,7 @@ msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:36
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:44
 msgid "Query"
 msgstr ""
 
@@ -1649,7 +1649,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:66
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:74
 msgid "WEI"
 msgstr ""
 
@@ -1937,7 +1937,7 @@ msgid "Waiting for transaction's confirmation..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:36
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:44
 msgid "Write"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -568,8 +568,8 @@ msgid "ERC-721 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:32
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:67
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:40
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:75
 msgid "ETH"
 msgstr ""
 
@@ -1195,7 +1195,7 @@ msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:36
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:44
 msgid "Query"
 msgstr ""
 
@@ -1649,7 +1649,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:66
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:74
 msgid "WEI"
 msgstr ""
 
@@ -1937,7 +1937,7 @@ msgid "Waiting for transaction's confirmation..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:36
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:44
 msgid "Write"
 msgstr ""
 


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/3162

## Motivation

Implementation address is not displayed at read/write proxy tabs

## Changelog

<img width="685" alt="Screenshot 2020-06-30 at 14 44 55" src="https://user-images.githubusercontent.com/4341812/86122537-ad3b3280-bae0-11ea-892b-5c4646cd2ca7.png">


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
