### PR TITLE
EIP-1967 support: transparent proxy pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3174](https://github.com/poanetwork/blockscout/pull/3174) - EIP-1967 support: transparent proxy pattern
 - [#3173](https://github.com/poanetwork/blockscout/pull/3173) - Display implementation address at read/write proxy tabs
 - [#3171](https://github.com/poanetwork/blockscout/pull/3171) - Import accounts/contracts/balances from Geth genesis.json
 - [#3161](https://github.com/poanetwork/blockscout/pull/3161) - Write proxy contracts feature

--- a/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
@@ -68,7 +68,56 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
     test "lists [] proxy read only functions if no verified implementation" do
       token_contract_address = insert(:contract_address)
 
-      insert(:smart_contract, address_hash: token_contract_address.hash)
+      insert(:smart_contract,
+        address_hash: token_contract_address.hash,
+        abi: [
+          %{
+            "type" => "function",
+            "stateMutability" => "view",
+            "payable" => false,
+            "outputs" => [%{"type" => "address", "name" => ""}],
+            "name" => "implementation",
+            "inputs" => [],
+            "constant" => true
+          }
+        ]
+      )
+
+      path =
+        smart_contract_path(BlockScoutWeb.Endpoint, :index,
+          hash: token_contract_address.hash,
+          type: :proxy,
+          action: :read
+        )
+
+      conn =
+        build_conn()
+        |> put_req_header("x-requested-with", "xmlhttprequest")
+        |> get(path)
+
+      assert conn.status == 200
+      assert conn.assigns.read_only_functions == []
+    end
+
+    test "lists [] proxy read only functions if no verified eip-1967 implementation" do
+      token_contract_address = insert(:contract_address)
+
+      insert(:smart_contract,
+        address_hash: token_contract_address.hash,
+        abi: [
+          %{
+            "type" => "function",
+            "stateMutability" => "nonpayable",
+            "payable" => false,
+            "outputs" => [%{"type" => "address", "name" => "", "internalType" => "address"}],
+            "name" => "implementation",
+            "inputs" => [],
+            "constant" => false
+          }
+        ]
+      )
+
+      blockchain_get_implementation_mock()
 
       path =
         smart_contract_path(BlockScoutWeb.Endpoint, :index,
@@ -179,6 +228,16 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
       :json_rpc,
       fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
         {:ok, [%{id: id, jsonrpc: "2.0", result: "0x0000000000000000000000000000000000000000000000000000000000000000"}]}
+      end
+    )
+  end
+
+  defp blockchain_get_implementation_mock do
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn %{id: _, method: _, params: [_, _, _]}, _options ->
+        {:ok, "0xcebb2CCCFe291F0c442841cBE9C1D06EED61Ca02"}
       end
     )
   end

--- a/apps/explorer/lib/explorer/smart_contract/writer.ex
+++ b/apps/explorer/lib/explorer/smart_contract/writer.ex
@@ -23,13 +23,8 @@ defmodule Explorer.SmartContract.Writer do
   end
 
   @spec write_functions_proxy(Hash.t()) :: [%{}]
-  def write_functions_proxy(contract_address_hash) do
-    abi =
-      contract_address_hash
-      |> Chain.address_hash_to_smart_contract()
-      |> Map.get(:abi)
-
-    implementation_abi = Chain.get_implementation_abi_from_proxy(contract_address_hash, abi)
+  def write_functions_proxy(implementation_address_hash_string) do
+    implementation_abi = Chain.get_implementation_abi(implementation_address_hash_string)
 
     case implementation_abi do
       nil ->

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -5410,5 +5410,33 @@ defmodule Explorer.ChainTest do
 
       assert implementation_abi == @implementation_abi
     end
+
+    test "get_implementation_abi/1 returns empty [] abi if implmentation address is null" do
+      assert Chain.get_implementation_abi(nil) == []
+    end
+
+    test "get_implementation_abi/1 returns [] if implementation is not verified" do
+      implementation_contract_address = insert(:contract_address)
+
+      implementation_contract_address_hash_string =
+        Base.encode16(implementation_contract_address.hash.bytes, case: :lower)
+
+      assert Chain.get_implementation_abi("0x" <> implementation_contract_address_hash_string) == []
+    end
+
+    test "get_implementation_abi/1 returns implementation abi if implementation is verified" do
+      proxy_contract_address = insert(:contract_address)
+      insert(:smart_contract, address_hash: proxy_contract_address.hash, abi: @proxy_abi)
+
+      implementation_contract_address = insert(:contract_address)
+      insert(:smart_contract, address_hash: implementation_contract_address.hash, abi: @implementation_abi)
+
+      implementation_contract_address_hash_string =
+        Base.encode16(implementation_contract_address.hash.bytes, case: :lower)
+
+      implementation_abi = Chain.get_implementation_abi("0x" <> implementation_contract_address_hash_string)
+
+      assert implementation_abi == @implementation_abi
+    end
   end
 end

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -220,24 +220,13 @@ defmodule Explorer.SmartContract.ReaderTest do
       implementation_contract_address_hash_string =
         Base.encode16(implementation_contract_address.hash.bytes, case: :lower)
 
-      expect(
-        EthereumJSONRPC.Mox,
-        :json_rpc,
-        fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
-          {:ok,
-           [
-             %{
-               id: id,
-               jsonrpc: "2.0",
-               result: "0x000000000000000000000000" <> implementation_contract_address_hash_string
-             }
-           ]}
-        end
-      )
-
       blockchain_get_function_mock()
 
-      response = Reader.read_only_functions_proxy(proxy_smart_contract.address_hash)
+      response =
+        Reader.read_only_functions_proxy(
+          proxy_smart_contract.address_hash,
+          "0x" <> implementation_contract_address_hash_string
+        )
 
       assert [
                %{

--- a/apps/explorer/test/explorer/smart_contract/writer_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/writer_test.exs
@@ -296,22 +296,7 @@ defmodule Explorer.SmartContract.WriterTest do
       implementation_contract_address_hash_string =
         Base.encode16(implementation_contract_address.hash.bytes, case: :lower)
 
-      expect(
-        EthereumJSONRPC.Mox,
-        :json_rpc,
-        fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
-          {:ok,
-           [
-             %{
-               id: id,
-               jsonrpc: "2.0",
-               result: "0x000000000000000000000000" <> implementation_contract_address_hash_string
-             }
-           ]}
-        end
-      )
-
-      response = Writer.write_functions_proxy(proxy_smart_contract.address_hash)
+      response = Writer.write_functions_proxy("0x" <> implementation_contract_address_hash_string)
 
       assert [
                %{


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/3163

## Motivation

Blockscout doesn't support retrieving of implementation from storage point defined by EIP-1967

## Changelog

- add `eth_getStorageAt` call support
- get implementation from `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc` storage pointer of proxy contract if `implementation` getter has `nonpayable` *stateMutability*.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
