### PR TITLE
Fix permanent fetching tokens and unavailable navbar menu when read/write proxy tab is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Features
 
 ### Fixes
+-[#3178](https://github.com/poanetwork/blockscout/pull/3178) - Fix permanent fetching tokens...  when read/write proxy tab is active
+-[#3178](https://github.com/poanetwork/blockscout/pull/3178) - Fix unavailable navbar menu when read/write proxy tab is active
 
 ### Chore
 

--- a/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
@@ -2,6 +2,7 @@ import $ from 'jquery'
 import ethNetProps from 'eth-net-props'
 import { walletEnabled, getCurrentAccount } from './write.js'
 import { openErrorModal, openWarningModal, openSuccessModal, openModalWithMessage } from '../modals.js'
+import '../../pages/address'
 
 const WEI_MULTIPLIER = 10 ** 18
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -86,6 +86,9 @@
       @view_module != Elixir.BlockScoutWeb.AddressContractView &&
       @view_module != Elixir.BlockScoutWeb.AddressContractVerificationView &&
       @view_module != Elixir.BlockScoutWeb.AddressReadContractView &&
+      @view_module != Elixir.BlockScoutWeb.AddressReadProxyView &&
+      @view_module != Elixir.BlockScoutWeb.AddressWriteContractView &&
+      @view_module != Elixir.BlockScoutWeb.AddressWriteProxyView &&
       @view_module != Elixir.BlockScoutWeb.Tokens.TransferView &&
       @view_module != Elixir.BlockScoutWeb.Tokens.ReadContractView &&
       @view_module != Elixir.BlockScoutWeb.Tokens.HolderView &&


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/3177
Resolves https://github.com/poanetwork/blockscout/issues/3176

## Motivation

- Navbar menu is not clickable when any of read/write tabs is active
- Fetching tokens... never disappears at read/write tabs


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
