### PR TITLE
Transaction page: decoding logs from nested contracts calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#3184](https://github.com/poanetwork/blockscout/pull/3184) - Apps navbar menu item
 
 ### Fixes
+- [#3185](https://github.com/poanetwork/blockscout/pull/3185) - Transaction page: decoding logs from nested contracts calls
 - [#3178](https://github.com/poanetwork/blockscout/pull/3178) - Fix permanent fetching tokens...  when read/write proxy tab is active
 - [#3178](https://github.com/poanetwork/blockscout/pull/3178) - Fix unavailable navbar menu when read/write proxy tab is active
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_logs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_logs.html.eex
@@ -1,5 +1,5 @@
 <div data-test="transaction_log" class="tile tile-muted">
-  <% decoded_result = decode(@log, @transaction) %>
+  <% decoded_result = decode(@log, @transaction, @log.address) %>
   <%= case decoded_result do %>
     <%= {:error, :contract_not_verified, _cadidates} -> %>
       <div class="alert alert-info">

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_log_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_log_view.ex
@@ -4,7 +4,7 @@ defmodule BlockScoutWeb.TransactionLogView do
 
   alias Explorer.Chain.Log
 
-  def decode(log, transaction) do
-    Log.decode(log, transaction)
+  def decode(log, transaction, address) do
+    Log.decode(log, transaction, address)
   end
 end


### PR DESCRIPTION
## Motivation

If a contract is verified and a transaction to this contract made a call to another contract which is also verified and event emitted in the 2nd contract, Blockscout doesn't decode that event on transaction page of 1st contract.

For instance, https://blockscout.com/poa/xdai/tx/0x3869c26855af7799159e868ff0a80fc254b9fa63b9fd9a351aa5d90764a53533/logs

![Screenshot 2020-07-08 at 17 05 11](https://user-images.githubusercontent.com/4341812/86928438-35eb4b80-c13d-11ea-9392-4488e4e1e20d.png)


## Changelog

For any log at the transaction's page for decoding pass an address of a called contract, and not address of a contract to which origin transaction was made

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
