### PR TITLE
Address logs decoding fix

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_logs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/_logs.html.eex
@@ -1,5 +1,5 @@
 <div data-test="transaction_log" class="tile tile-muted">
-  <% decoded_result = decode(@log, @transaction, @log.address) %>
+  <% decoded_result = decode(@log, @transaction) %>
   <%= case decoded_result do %>
     <%= {:error, :contract_not_verified, _cadidates} -> %>
       <div class="alert alert-info">

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_log_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_log_view.ex
@@ -4,7 +4,7 @@ defmodule BlockScoutWeb.TransactionLogView do
 
   alias Explorer.Chain.Log
 
-  def decode(log, transaction, address) do
-    Log.decode(log, transaction, address)
+  def decode(log, transaction) do
+    Log.decode(log, transaction)
   end
 end

--- a/apps/explorer/test/explorer/chain/log_test.exs
+++ b/apps/explorer/test/explorer/chain/log_test.exs
@@ -58,28 +58,28 @@ defmodule Explorer.Chain.LogTest do
     end
 
     test "that a contract call transaction that has a verified contract returns the decoded input data" do
-      smart_contract =
-        insert(:smart_contract,
-          abi: [
-            %{
-              "anonymous" => false,
-              "inputs" => [
-                %{"indexed" => true, "name" => "_from_human", "type" => "string"},
-                %{"indexed" => false, "name" => "_number", "type" => "uint256"},
-                %{"indexed" => true, "name" => "_belly", "type" => "bool"}
-              ],
-              "name" => "WantsPets",
-              "type" => "event"
-            }
-          ]
-        )
+      to_address = insert(:address, contract_code: "0x")
+
+      insert(:smart_contract,
+        abi: [
+          %{
+            "anonymous" => false,
+            "inputs" => [
+              %{"indexed" => true, "name" => "_from_human", "type" => "string"},
+              %{"indexed" => false, "name" => "_number", "type" => "uint256"},
+              %{"indexed" => true, "name" => "_belly", "type" => "bool"}
+            ],
+            "name" => "WantsPets",
+            "type" => "event"
+          }
+        ],
+        address_hash: to_address.hash
+      )
 
       topic1 = "0x" <> Base.encode16(:keccakf1600.hash(:sha3_256, "WantsPets(string,uint256,bool)"), case: :lower)
       topic2 = "0x" <> Base.encode16(:keccakf1600.hash(:sha3_256, "bob"), case: :lower)
       topic3 = "0x0000000000000000000000000000000000000000000000000000000000000001"
       data = "0x0000000000000000000000000000000000000000000000000000000000000000"
-
-      to_address = insert(:address, smart_contract: smart_contract)
 
       transaction =
         :transaction_to_verified_contract
@@ -88,6 +88,7 @@ defmodule Explorer.Chain.LogTest do
 
       log =
         insert(:log,
+          address: to_address,
           transaction: transaction,
           first_topic: topic1,
           second_topic: topic2,


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/3186

## Motivation

Logs are not decoded at address page even if the contract, which produces the logs, is verified

## Changelog

At decoding, pass ABI of a contract which produces the log, and not a contract to which transaction is generated from which that log came from.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
