### PR TITLE
Fix contracts verification with experimental features enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3145](https://github.com/poanetwork/blockscout/pull/3145) - Pending txs per address API endpoint
 
 ### Fixes
+- [#3202](https://github.com/poanetwork/blockscout/pull/3202) - Fix contracts verification with experimental features enabled
 - [#3192](https://github.com/poanetwork/blockscout/pull/3192) - Dropdown menu doesn't open at "not found" page
 - [#3190](https://github.com/poanetwork/blockscout/pull/3190) - Contract log/method decoded view improvements: eliminate horizontal scroll, remove excess borders, whitespaces
 - [#3185](https://github.com/poanetwork/blockscout/pull/3185) - Transaction page: decoding logs from nested contracts calls

--- a/apps/explorer/lib/explorer/smart_contract/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier.ex
@@ -15,8 +15,10 @@ defmodule Explorer.SmartContract.Verifier do
   @metadata_hash_prefix_0_4_23 "a165627a7a72305820"
   @metadata_hash_prefix_0_5_10 "a265627a7a72305820"
   @metadata_hash_prefix_0_5_11 "a265627a7a72315820"
+  @metadata_hash_prefix_0_5_16 "a365627a7a72315820"
   @metadata_hash_prefix_0_6_0 "a264697066735822"
 
+  @experimental "6c6578706572696d656e74616cf5"
   @metadata_hash_common_suffix "64736f6c63"
 
   def evaluate_authenticity(_, %{"name" => ""}), do: {:error, :name}
@@ -230,6 +232,20 @@ defmodule Explorer.SmartContract.Verifier do
 
       @metadata_hash_prefix_0_5_11 <>
           <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <>
+          "43" <> <<compiler_version::binary-size(6)>> <> "0032" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_11 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @metadata_hash_common_suffix <>
+          "7826" <> <<compiler_version::binary-size(76)>> <> "0057" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_11 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
           @metadata_hash_common_suffix <>
           "7826" <> <<compiler_version::binary-size(76)>> <> "0057" <> _constructor_arguments ->
         do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
@@ -242,12 +258,98 @@ defmodule Explorer.SmartContract.Verifier do
 
       @metadata_hash_prefix_0_5_11 <>
           <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <>
+          "7827" <> <<compiler_version::binary-size(78)>> <> "0057" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_11 <>
+          <<metadata_hash::binary-size(64)>> <>
           @metadata_hash_common_suffix <>
           "7828" <> <<compiler_version::binary-size(80)>> <> "0058" <> _constructor_arguments ->
         do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
 
       @metadata_hash_prefix_0_5_11 <>
           <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <>
+          "7828" <> <<compiler_version::binary-size(80)>> <> "0058" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_11 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @metadata_hash_common_suffix <>
+          "7829" <> <<compiler_version::binary-size(82)>> <> "0059" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_11 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <>
+          "7829" <> <<compiler_version::binary-size(82)>> <> "0059" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @metadata_hash_common_suffix <>
+          "43" <> <<compiler_version::binary-size(6)>> <> "0032" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <>
+          "43" <> <<compiler_version::binary-size(6)>> <> "0040" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @metadata_hash_common_suffix <>
+          "7826" <> <<compiler_version::binary-size(76)>> <> "0057" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <>
+          "7826" <> <<compiler_version::binary-size(76)>> <> "0057" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @metadata_hash_common_suffix <>
+          "7827" <> <<compiler_version::binary-size(78)>> <> "0057" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <>
+          "7827" <> <<compiler_version::binary-size(78)>> <> "0057" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @metadata_hash_common_suffix <>
+          "7828" <> <<compiler_version::binary-size(80)>> <> "0058" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <>
+          "7828" <> <<compiler_version::binary-size(80)>> <> "0058" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @metadata_hash_common_suffix <>
+          "7829" <> <<compiler_version::binary-size(82)>> <> "0059" <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
           @metadata_hash_common_suffix <>
           "7829" <> <<compiler_version::binary-size(82)>> <> "0059" <> _constructor_arguments ->
         do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)

--- a/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
@@ -9,8 +9,10 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
   @metadata_hash_prefix_0_4_23 "a165627a7a72305820"
   @metadata_hash_prefix_0_5_10 "a265627a7a72305820"
   @metadata_hash_prefix_0_5_11 "a265627a7a72315820"
+  @metadata_hash_prefix_0_5_16 "a365627a7a72315820"
   @metadata_hash_prefix_0_6_0 "a264697066735822"
 
+  @experimental "6c6578706572696d656e74616cf5"
   @metadata_hash_common_suffix "64736f6c63"
 
   def verify(address_hash, contract_code, arguments_data, contract_source_code, contract_name) do
@@ -121,6 +123,18 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
         )
 
       @metadata_hash_prefix_0_5_11 <>
+        <<_::binary-size(64)>> <>
+        @experimental <>
+        @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
+      split_constructor_arguments_and_extract_check_func(
+        constructor_arguments,
+        check_func,
+        contract_source_code,
+        contract_name,
+        @experimental <> @metadata_hash_prefix_0_5_11
+      )
+
+      @metadata_hash_prefix_0_5_11 <>
           <<_::binary-size(64)>> <>
           @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
         split_constructor_arguments_and_extract_check_func(
@@ -130,6 +144,18 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
           contract_name,
           @metadata_hash_prefix_0_5_11
         )
+
+      @metadata_hash_prefix_0_5_11 <>
+        <<_::binary-size(64)>> <>
+        @experimental <>
+        @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
+      split_constructor_arguments_and_extract_check_func(
+        constructor_arguments,
+        check_func,
+        contract_source_code,
+        contract_name,
+        @experimental <> @metadata_hash_prefix_0_5_11
+      )
 
       @metadata_hash_prefix_0_5_11 <>
           <<_::binary-size(64)>> <>
@@ -143,6 +169,18 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
         )
 
       @metadata_hash_prefix_0_5_11 <>
+        <<_::binary-size(64)>> <>
+        @experimental <>
+        @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
+      split_constructor_arguments_and_extract_check_func(
+        constructor_arguments,
+        check_func,
+        contract_source_code,
+        contract_name,
+        @experimental <> @metadata_hash_prefix_0_5_11
+      )
+
+      @metadata_hash_prefix_0_5_11 <>
           <<_::binary-size(64)>> <>
           @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
         split_constructor_arguments_and_extract_check_func(
@@ -154,6 +192,18 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
         )
 
       @metadata_hash_prefix_0_5_11 <>
+        <<_::binary-size(64)>> <>
+        @experimental <>
+        @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
+      split_constructor_arguments_and_extract_check_func(
+        constructor_arguments,
+        check_func,
+        contract_source_code,
+        contract_name,
+        @experimental <> @metadata_hash_prefix_0_5_11
+      )
+
+      @metadata_hash_prefix_0_5_11 <>
           <<_::binary-size(64)>> <>
           @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
         split_constructor_arguments_and_extract_check_func(
@@ -162,6 +212,134 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
           contract_source_code,
           contract_name,
           @metadata_hash_prefix_0_5_11
+        )
+
+      @metadata_hash_prefix_0_5_11 <>
+        <<_::binary-size(64)>> <>
+        @experimental <>
+        @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
+      split_constructor_arguments_and_extract_check_func(
+        constructor_arguments,
+        check_func,
+        contract_source_code,
+        contract_name,
+        @experimental <> @metadata_hash_prefix_0_5_11
+      )
+
+      # ABIEncoder V2
+      @metadata_hash_prefix_0_5_16 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_16
+        )
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @experimental <> @metadata_hash_prefix_0_5_16
+        )
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_16
+        )
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @experimental <> @metadata_hash_prefix_0_5_16
+        )
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_16
+        )
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @experimental <> @metadata_hash_prefix_0_5_16
+        )
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_16
+        )
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @experimental <> @metadata_hash_prefix_0_5_16
+        )
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<_::binary-size(64)>> <>
+          @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_16
+        )
+
+      @metadata_hash_prefix_0_5_16 <>
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @experimental <> @metadata_hash_prefix_0_5_16
         )
 
       # Solidity >= 0.6.0 https://github.com/ethereum/solidity/blob/develop/Changelog.md#060-2019-12-17


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/3191

## Motivation

Verification of contracts with enabled experimental features doesn't work.

## Changelog

Process a specific additional hex  `6c6578706572696d656e74616cf5 ` added to the bytecode of contract stored in the blockchain if experimental features are enabled.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
