### PR TITLE
Improve "get mined blocks" query performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3145](https://github.com/poanetwork/blockscout/pull/3145) - Pending txs per address API endpoint
 
 ### Fixes
+- [#3203](https://github.com/poanetwork/blockscout/pull/3203) - Improve "get mined blocks" query performance
 - [#3202](https://github.com/poanetwork/blockscout/pull/3202) - Fix contracts verification with experimental features enabled
 - [#3201](https://github.com/poanetwork/blockscout/pull/3201) - Connect to Metamask button
 - [#3192](https://github.com/poanetwork/blockscout/pull/3192) - Dropdown menu doesn't open at "not found" page

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -271,8 +271,6 @@ defmodule Explorer.Etherscan do
         b in Block,
         where: b.miner_hash == ^address_hash,
         order_by: [desc: b.number],
-        group_by: b.number,
-        group_by: b.timestamp,
         limit: ^merged_options.page_size,
         offset: ^offset(merged_options),
         select: %{

--- a/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
@@ -123,16 +123,16 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
         )
 
       @metadata_hash_prefix_0_5_11 <>
-        <<_::binary-size(64)>> <>
-        @experimental <>
-        @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
-      split_constructor_arguments_and_extract_check_func(
-        constructor_arguments,
-        check_func,
-        contract_source_code,
-        contract_name,
-        @experimental <> @metadata_hash_prefix_0_5_11
-      )
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @experimental <> @metadata_hash_prefix_0_5_11
+        )
 
       @metadata_hash_prefix_0_5_11 <>
           <<_::binary-size(64)>> <>
@@ -146,16 +146,16 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
         )
 
       @metadata_hash_prefix_0_5_11 <>
-        <<_::binary-size(64)>> <>
-        @experimental <>
-        @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
-      split_constructor_arguments_and_extract_check_func(
-        constructor_arguments,
-        check_func,
-        contract_source_code,
-        contract_name,
-        @experimental <> @metadata_hash_prefix_0_5_11
-      )
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @experimental <> @metadata_hash_prefix_0_5_11
+        )
 
       @metadata_hash_prefix_0_5_11 <>
           <<_::binary-size(64)>> <>
@@ -169,16 +169,16 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
         )
 
       @metadata_hash_prefix_0_5_11 <>
-        <<_::binary-size(64)>> <>
-        @experimental <>
-        @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
-      split_constructor_arguments_and_extract_check_func(
-        constructor_arguments,
-        check_func,
-        contract_source_code,
-        contract_name,
-        @experimental <> @metadata_hash_prefix_0_5_11
-      )
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @experimental <> @metadata_hash_prefix_0_5_11
+        )
 
       @metadata_hash_prefix_0_5_11 <>
           <<_::binary-size(64)>> <>
@@ -192,16 +192,16 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
         )
 
       @metadata_hash_prefix_0_5_11 <>
-        <<_::binary-size(64)>> <>
-        @experimental <>
-        @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
-      split_constructor_arguments_and_extract_check_func(
-        constructor_arguments,
-        check_func,
-        contract_source_code,
-        contract_name,
-        @experimental <> @metadata_hash_prefix_0_5_11
-      )
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @experimental <> @metadata_hash_prefix_0_5_11
+        )
 
       @metadata_hash_prefix_0_5_11 <>
           <<_::binary-size(64)>> <>
@@ -215,16 +215,16 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
         )
 
       @metadata_hash_prefix_0_5_11 <>
-        <<_::binary-size(64)>> <>
-        @experimental <>
-        @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
-      split_constructor_arguments_and_extract_check_func(
-        constructor_arguments,
-        check_func,
-        contract_source_code,
-        contract_name,
-        @experimental <> @metadata_hash_prefix_0_5_11
-      )
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @experimental <> @metadata_hash_prefix_0_5_11
+        )
 
       # ABIEncoder V2
       @metadata_hash_prefix_0_5_16 <>


### PR DESCRIPTION
## Motivation

https://forum.poa.network/t/querying-core-poa-network-blockchain-via-rpc-graphql/3591

> I’m trying to pull data from POA Core blockchain for analytics (e.g. blocks mined and list of transactions from specific POA address) via RPC and it’s timing out even for a single page with an offset of 1 (i.e. asking for just one item).

## Changelog

Remove grouping by number, timestamp

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
