### PR TITLE
Fix read contract bytes array type output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3145](https://github.com/poanetwork/blockscout/pull/3145) - Pending txs per address API endpoint
 
 ### Fixes
+- [#3207](https://github.com/poanetwork/blockscout/pull/3207) - Fix read contract bytes array type output
 - [#3203](https://github.com/poanetwork/blockscout/pull/3203) - Improve "get mined blocks" query performance
 - [#3202](https://github.com/poanetwork/blockscout/pull/3202) - Fix contracts verification with experimental features enabled
 - [#3201](https://github.com/poanetwork/blockscout/pull/3201) - Connect to Metamask button

--- a/apps/block_scout_web/assets/css/_helpers.scss
+++ b/apps/block_scout_web/assets/css/_helpers.scss
@@ -33,3 +33,7 @@
 .hidden {
   display: none!important;
 }
+
+.word-break-all {
+  word-break: break-all;
+}

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -60,7 +60,7 @@
         <div data-function-response></div>
       </div>
     <% else %>
-      <span class="py-2">
+      <span class="py-2 word-break-all">
         <%= if outputs?(function["outputs"]) do %>
           <%= for output <- function["outputs"] do %>
             <%= if address?(output["type"]) do %>

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -321,8 +321,19 @@ defmodule Explorer.SmartContract.Reader do
     Map.put_new(output, "value", bytes_to_string(value))
   end
 
-  defp new_value(%{"type" => "bytes" <> _number} = output, values, index) do
-    Map.put_new(output, "value", bytes_to_string(Enum.at(values, index)))
+  defp new_value(%{"type" => "bytes" <> number_rest} = output, values, index) do
+    if String.contains?(number_rest, "[]") do
+      values_array = Enum.at(values, index)
+
+      values_array_formatted =
+        Enum.map(values_array, fn value ->
+          bytes_to_string(value)
+        end)
+
+      Map.put_new(output, "value", values_array_formatted)
+    else
+      Map.put_new(output, "value", bytes_to_string(Enum.at(values, index)))
+    end
   end
 
   defp new_value(%{"type" => "bytes"} = output, values, index) do

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -330,7 +330,9 @@ defmodule Explorer.SmartContract.Reader do
           bytes_to_string(value)
         end)
 
-      Map.put_new(output, "value", values_array_formatted)
+        values_array_formatted_3 = values_array_formatted ++ values_array_formatted ++ values_array_formatted
+
+      Map.put_new(output, "value", values_array_formatted_3)
     else
       Map.put_new(output, "value", bytes_to_string(Enum.at(values, index)))
     end


### PR DESCRIPTION
## Motivation

Error at "Read contract" page if a contract contains bytes array type.

```
blockscout     | Request: GET /smart_contracts?hash=0xe7d982c6554e490ee707144d2f38a1c1ca3ccaae&type=regular&action=read
blockscout     | ** (exit) an exception was raised:
blockscout     |     ** (ArgumentError) argument error
blockscout     |         :erlang.byte_size([<<238, 151, 199, 221, 46, 115, 76, 242, 52, 194, 186, 13, 131, 167, 70, 51, 225, 172, 127, 200, 169, 253, 119, 159, 132, 151, 160, 16, 156, 113, 185, 147>>, <<165, 241, 91, 31, 169, 32, 187, 219, 194, 143, 93, 120, 94, 82, 36, 227, 166, 110, 181, 247, 212, 9, 45, 201, 186, 130, 213, 229, 174, 58, 188, 135>>, <<94, 248, 58, 217, 85, 144, 51, 230, 233, 65, 219, 125, 124, 73, 90, 205, 206, 97, 99, 71, 210, 142, 144, 199, 206, 71, 203, 252, 252, 173, 59, 197>>, <<58, 71, 171, 91, 211, 165, 148, 195, 168, 153, 95, 143, 165, 141, 8, 118, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>, <<58, 71, 171, 91, 211, 165, 148, 195, 168, 153, 95, 143, 165, 141, 8, 118, 201, 104, 25, 202, 69, 22, 189, 118, 16, 12, 146, 70, 47, 47, 157, 192>>])
blockscout     |         (explorer 0.0.1) lib/explorer/smart_contract/reader.ex:343: Explorer.SmartContract.Reader.bytes_to_string/1
blockscout     |         (explorer 0.0.1) lib/explorer/smart_contract/reader.ex:325: Explorer.SmartContract.Reader.new_value/3
blockscout     |         (explorer 0.0.1) lib/explorer/smart_contract/reader.ex:316: anonymous fn/3 in Explorer.SmartContract.Reader.link_outputs_and_values/3
blockscout     |         (elixir 1.10.2) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
blockscout     |         (explorer 0.0.1) lib/explorer/smart_contract/reader.ex:315: Explorer.SmartContract.Reader.link_outputs_and_values/3
blockscout     |         (explorer 0.0.1) lib/explorer/smart_contract/reader.ex:233: Explorer.SmartContract.Reader.fetch_current_value_from_blockchain/3
blockscout     |         (elixir 1.10.2) lib/enum.ex:1396: Enum."-map/2-lists^map/1-0-"/2
```

## Changelog

Properly format output value in case of bytes array type

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
