### PR TITLE
Fix notifier query for live update of token transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#3224](https://github.com/poanetwork/blockscout/pull/3224) - Top tokens page
 
 ### Fixes
+- [#3226](https://github.com/poanetwork/blockscout/pull/3226) - Fix notifier query for live update of token transfers
 - [#3220](https://github.com/poanetwork/blockscout/pull/3220) - Allow interaction with navbar menu at block-not-found page
 
 ### Chore

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -119,7 +119,8 @@ defmodule BlockScoutWeb.Notifier do
           &(TokenTransfer
             |> Repo.get_by(
               transaction_hash: &1.transaction_hash,
-              token_contract_address_hash: &1.token_contract_address_hash
+              token_contract_address_hash: &1.token_contract_address_hash,
+              log_index: &1.log_index
             )
             |> Repo.preload([:from_address, :to_address, :token, transaction: :block]))
         )


### PR DESCRIPTION
## Motivation

An error in live update of token transfers notifier
```
2020-08-06T08:22:52.780 [error] GenServer BlockScoutWeb.RealtimeEventHandler terminating
** (Ecto.MultipleResultsError) expected at most one result but got 3 in query:

from t0 in Explorer.Chain.TokenTransfer,
  where: t0.transaction_hash == ^%Explorer.Chain.Hash{byte_count: 32, bytes: <<67, 97, 100, 11, 67, 162, 176, 10, 231, 126, 89, 195, 220, 251, 96, 53, 204, 213, 38, 200, 242, 204, 234, 212, 187, 138, 16, 229, 188, 33, 236, 227>>} and t0.token_contract_address_hash == ^%Explorer.Chain.Hash{byte_count: 20, bytes: <<184, 26, 254, 39, 193, 3, 188, 212, 47, 64, 38, 207, 113, 154, 246, 216, 2, 146, 135, 101>>}

    (ecto 3.3.4) lib/ecto/repo/queryable.ex:115: Ecto.Repo.Queryable.one/3
    (block_scout_web 0.0.1) lib/block_scout_web/notifier.ex:120: anonymous fn/1 in BlockScoutWeb.Notifier.handle_event/1
    (elixir 1.10.3) lib/stream.ex:572: anonymous fn/4 in Stream.map/2
    (elixir 1.10.3) lib/enum.ex:3686: Enumerable.List.reduce/3
    (elixir 1.10.3) lib/stream.ex:1609: Enumerable.Stream.do_each/4
    (elixir 1.10.3) lib/enum.ex:3383: Enum.each/2
    (block_scout_web 0.0.1) lib/block_scout_web/notifier.ex:128: anonymous fn/2 in BlockScoutWeb.Notifier.handle_event/1
    (stdlib 3.9) maps.erl:232: :maps.fold_1/3
Last message: {:chain_event, :token_transfers, :realtime, [%Explorer.Chain.TokenTransfer{__meta__: #Ecto.Schema.Metadata<:loaded, "token_transfers">, amount: nil, block: #Ecto.Association.NotLoaded<association :block is not loaded>, block_hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<229, 35, 163, 91, 148, 131, 246, 63, 74, 118, 111, 193, 225, 79, 153, 221, 194, 106, 236, 110, 17, 51, 41, 180, 52, 2, 171, 86, 161, 229, 155, 67>>}, block_number: 16114673, from_address: #Ecto.Association.NotLoaded<association :from_address is not loaded>, from_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>}, inserted_at: ~U[2020-08-06 08:22:51.988463Z], instance: #Ecto.Association.NotLoaded<association :instance is not loaded>, log_index: 1, to_address: #Ecto.Association.NotLoaded<association :to_address is not loaded>, to_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<95, 137, 210, 12, 74, 136, 252, 36, 121, 176, 133, 34, 213, 173, 208, 182, 5, 0, 30, 62>>}, token: #Ecto.Association.NotLoaded<association :token is not loaded>, token_contract_address: #Ecto.Association.NotLoaded<association :token_contract_address is not loaded>, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<81, 44, 31, 207, 64, 17, 51, 104, 15, 55, 58, 56, 111, 63, 117, 43, 152, 7, 11, 197>>}, token_id: #Decimal<8723718>, transaction: #Ecto.Association.NotLoaded<association :transaction is not loaded>, transaction_hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<67, 97, 100, 11, 67, 162, 176, 10, 231, 126, 89, 195, 220, 251, 96, 53, 204, 213, 38, 200, 242, 204, 234, 212, 187, ...>>}, updated_at: ~U[2020-08-06 08:22:51.988463Z]}, %Explorer.Chain.TokenTransfer{__meta__: #Ecto.Schema.Metadata<:loaded, "token_transfers">, amount: #Decimal<10000000>, block: #Ecto.Association.NotLoaded<association :block is not loaded>, block_hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<229, 35, 163, 91, 148, 131, 246, 63, 74, 118, 111, 193, 225, 79, 153, 221, 194, 106, 236, 110, 17, 51, 41, 180, 52, 2, 171, 86, 161, 229, 155, 67>>}, block_number: 16114673, from_address: #Ecto.Association.NotLoaded<association :from_address is not loaded>, from_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<20, 230, 231, 152, 63, 223, 21, 11, 60, 8, 6, 5, 32, 233, 132, 142, 239, 230, 238, 97>>}, inserted_at: ~U[2020-08-06 08:22:51.988463Z], instance: #Ecto.Association.NotLoaded<association :instance is not loaded>, log_index: 4, to_address: #Ecto.Association.NotLoaded<association :to_address is not loaded>, to_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<208, 62, 168, 98, 76, 140, 89, 135, 35, 80, 72, 144, 31, 182, 20, 253, 202, 137, 177, 23>>}, token: #Ecto.Association.NotLoaded<association :token is not loaded>, token_contract_address: #Ecto.Association.NotLoaded<association :token_contract_address is not loaded>, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<184, 26, 254, 39, 193, 3, 188, 212, 47, 64, 38, 207, 113, 154, 246, 216, 2, 146, 135, 101>>}, token_id: nil, transaction: #Ecto.Association.NotLoaded<association :transaction is not loaded>, transaction_hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<67, 97, 100, 11, 67, 162, 176, 10, 231, 126, 89, 195, 220, 251, 96, 53, 204, 213, 38, 200, 242, 204, 234, 212, ...>>}, updated_at: ~U[2020-08-06 08:22:51.988463Z]}, %Explorer.Chain.TokenTransfer{__meta__: #Ecto.Schema.Metadata<:loaded, "token_transfers">, amount: #Decimal<40000000>, block: #Ecto.Association.NotLoaded<association :block is not loaded>, block_hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<229, 35, 163, 91, 148, 131, 246, 63, 74, 118, 111, 193, 225, 79, 153, 221, 194, 106, 236, 110, 17, 51, 41, 180, 52, 2, 171, 86, 161, 229, 155, 67>>}, block_number: 16114673, from_address: #Ecto.Association.NotLoaded<association :from_address is not loaded>, from_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<20, 230, 231, 152, 63, 223, 21, 11, 60, 8, 6, 5, 32, 233, 132, 142, 239, 230, 238, 97>>}, inserted_at: ~U[2020-08-06 08:22:51.988463Z], instance: #Ecto.Association.NotLoaded<association :instance is not loaded>, log_index: 5, to_address: #Ecto.Association.NotLoaded<association :to_address is not loaded>, to_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<208, 62, 168, 98, 76, 140, 89, 135, 35, 80, 72, 144, 31, 182, 20, 253, 202, 137, 177, 23>>}, token: #Ecto.Association.NotLoaded<association :token is not loaded>, token_contract_address: #Ecto.Association.NotLoaded<association :token_contract_address is not loaded>, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<184, 26, 254, 39, 193, 3, 188, 212, 47, 64, 38, 207, 113, 154, 246, 216, 2, 146, 135, 101>>}, token_id: nil, transaction: #Ecto.Association.NotLoaded<association :transaction is not loaded>, transaction_hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<67, 97, 100, 11, 67, 162, 176, 10, 231, 126, 89, 195, 220, 251, 96, 53, 204, 213, 38, 200, 242, 204, 234, ...>>}, updated_at: ~U[2020-08-06 08:22:51.988463Z]}, %Explorer.Chain.TokenTransfer{__meta__: #Ecto.Schema.Metadata<:loaded, "token_transfers">, amount: #Decimal<20000000>, block: #Ecto.Association.NotLoaded<association :block is not loaded>, block_hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<229, 35, 163, 91, 148, 131, 246, 63, 74, 118, 111, 193, 225, 79, 153, 221, 194, 106, 236, 110, 17, 51, 41, 180, 52, 2, 171, 86, 161, 229, 155, 67>>}, block_number: 16114673, from_address: #Ecto.Association.NotLoaded<association :from_address is not loaded>, from_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<20, 230, 231, 152, 63, 223, 21, 11, 60, 8, 6, 5, 32, 233, 132, 142, 239, 230, 238, 97>>}, inserted_at: ~U[2020-08-06 08:22:51.988463Z], instance: #Ecto.Association.NotLoaded<association :instance is not loaded>, log_index: 6, to_address: #Ecto.Association.NotLoaded<association :to_address is not loaded>, to_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<167, 155, 41, 173, 126, 1, 150, 201, 91, 135, 244, 102, 61, 237, 130, 251, 242, 227, 173, 216>>}, token: #Ecto.Association.NotLoaded<association :token is not loaded>, token_contract_address: #Ecto.Association.NotLoaded<association :token_contract_address is not loaded>, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<184, 26, 254, 39, 193, 3, 188, 212, 47, 64, 38, 207, 113, 154, 246, 216, 2, 146, 135, 101>>}, token_id: nil, transaction: #Ecto.Association.NotLoaded<association :transaction is not loaded>, transaction_hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<67, 97, 100, 11, 67, 162, 176, 10, 231, 126, 89, 195, 220, 251, 96, 53, 204, 213, 38, 200, 242, 204, ...>>}, updated_at: ~U[2020-08-06 08:22:51.988463Z]}, %Explorer.Chain.TokenTransfer{__meta__: #Ecto.Schema.Metadata<:loaded, " (truncated)
```

## Changelog

Fix query for notifier which should return only one row: add clause with *log_index*.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
