### PR TITLE
Improve search: allow search with space, order by token holders in descendant order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixes
 - [#3231](https://github.com/poanetwork/blockscout/pull/3231) - Improve search: unlimited number of searching results
 - [#3231](https://github.com/poanetwork/blockscout/pull/3231) - Improve search: allow search with space
-- [#3231](https://github.com/poanetwork/blockscout/pull/3231) - Improve search: order by token holders in descendant order
+- [#3231](https://github.com/poanetwork/blockscout/pull/3231) - Improve search: order by token holders in descending order and token/contract name is ascending order
 - [#3226](https://github.com/poanetwork/blockscout/pull/3226) - Fix notifier query for live update of token transfers
 - [#3220](https://github.com/poanetwork/blockscout/pull/3220) - Allow interaction with navbar menu at block-not-found page
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#3224](https://github.com/poanetwork/blockscout/pull/3224) - Top tokens page
 
 ### Fixes
+- [#3231](https://github.com/poanetwork/blockscout/pull/3231) - Improve search: unlimited number of searching results
 - [#3231](https://github.com/poanetwork/blockscout/pull/3231) - Improve search: allow search with space
 - [#3231](https://github.com/poanetwork/blockscout/pull/3231) - Improve search: order by token holders in descendant order
 - [#3226](https://github.com/poanetwork/blockscout/pull/3226) - Fix notifier query for live update of token transfers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [#3224](https://github.com/poanetwork/blockscout/pull/3224) - Top tokens page
 
 ### Fixes
+- [#3231](https://github.com/poanetwork/blockscout/pull/3231) - Improve search: allow search with space
+- [#3231](https://github.com/poanetwork/blockscout/pull/3231) - Improve search: order by token holders in descendant order
 - [#3226](https://github.com/poanetwork/blockscout/pull/3226) - Fix notifier query for live update of token transfers
 - [#3220](https://github.com/poanetwork/blockscout/pull/3220) - Allow interaction with navbar menu at block-not-found page
 

--- a/apps/block_scout_web/assets/css/components/_navbar.scss
+++ b/apps/block_scout_web/assets/css/components/_navbar.scss
@@ -186,6 +186,14 @@ $navbar-logo-width: auto !default;
   }
 }
 
+.input-group {
+
+  .awesomplete > ul {
+      overflow-y: auto !important;
+      max-height: 300px !important;
+  }
+}
+
 .navbar-collapse.collapsing,
 .navbar-collapse.collapse.show {
   display: flex;

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -174,6 +174,7 @@
                     ],
                     [ url: "#{chain_path(@conn, :token_autocomplete)}?q=",
                     limit: 0,
+                    maxItems: 1000,
                     minChars: 2,
                     value: "contract_address_hash",
                     label: "contract_address_hash",

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -167,7 +167,7 @@
                 <%= awesomplete(f, :q,
                     [
                     class: "form-control me auto",
-                    placeholder: gettext("Search by address, token symbol name, transaction hash, or block number"),
+                    placeholder: gettext("Search by address, token symbol, name, transaction hash, or block number"),
                     "aria-describedby": "search-icon",
                     "aria-label": gettext("Search"),
                     "data-test": "search_input"
@@ -178,7 +178,7 @@
                     value: "contract_address_hash",
                     label: "contract_address_hash",
                     descrSearch: true,
-                    descr: "symbol"
+                    descr: "name"
                     ]) %>
                 <div class="input-group-append">
                   <button class="input-group-text" id="search-icon">

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -179,7 +179,20 @@
                     value: "contract_address_hash",
                     label: "contract_address_hash",
                     descrSearch: true,
-                    descr: "name"
+                    descr: "name",
+                    sort: "function(x1, x2){
+                      const tokenName1 = x1.split('<b>').length > 1 ? x1.split('<b>')[1].split('</b>')[0].toLowerCase() : ''
+                      const tokenName2 = x2.split('<b>').length > 1 ? x2.split('<b>')[1].split('</b>')[0].toLowerCase() : ''
+                      const holdersCount1 = x1.split('<i>').length > 1 ? parseInt(x1.split('<i>')[1].split('</i>')[0].split('holder')[0], 10) : null
+                      const holdersCount2 = x2.split('<i>').length > 1 ? parseInt(x2.split('<i>')[1].split('</i>')[0].split('holder')[0], 10) : null
+                      if (holdersCount1 && holdersCount2 && holdersCount1 !== holdersCount2 || (holdersCount1 && !holdersCount2) || (!holdersCount1 && holdersCount2)) {
+                        holdersCount1 > holdersCount2
+                      } else {
+                        if (tokenName1 < tokenName2) { return -1 }
+                        if (tokenName1 > tokenName2) { return 1 }
+                        return 0
+                      }
+                    }"
                     ]) %>
                 <div class="input-group-append">
                   <button class="input-group-text" id="search-icon">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1250,7 +1250,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:166
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:170
 msgid "Search by address, token symbol name, transaction hash, or block number"
 msgstr ""
 
@@ -1939,4 +1938,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:15
 msgid "Copy Raw Trace"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:170
+msgid "Search by address, token symbol, name, transaction hash, or block number"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1244,7 +1244,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/index.html.eex:14
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:172
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:189
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:190
 msgid "Search"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1244,7 +1244,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/index.html.eex:14
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:172
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:190
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:203
 msgid "Search"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1250,7 +1250,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:166
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:170
 msgid "Search by address, token symbol name, transaction hash, or block number"
 msgstr ""
 
@@ -1939,4 +1938,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:15
 msgid "Copy Raw Trace"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:170
+msgid "Search by address, token symbol, name, transaction hash, or block number"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1244,7 +1244,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/index.html.eex:14
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:172
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:190
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:203
 msgid "Search"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1244,7 +1244,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/index.html.eex:14
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:172
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:189
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:190
 msgid "Search"
 msgstr ""
 
@@ -1940,7 +1940,7 @@ msgstr ""
 msgid "Copy Raw Trace"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:170
 msgid "Search by address, token symbol, name, transaction hash, or block number"
 msgstr ""

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1043,7 +1043,6 @@ defmodule Explorer.Chain do
     query =
       from(token in Token,
         where: fragment("to_tsvector('english', symbol || ' ' || name ) @@ to_tsquery(?)", ^term_final),
-        limit: 5,
         select: %{
           contract_address_hash: token.contract_address_hash,
           symbol: token.symbol,
@@ -1066,7 +1065,6 @@ defmodule Explorer.Chain do
     query =
       from(smart_contract in SmartContract,
         where: fragment("to_tsvector('english', name ) @@ to_tsquery(?)", ^term_final),
-        limit: 5,
         select: %{contract_address_hash: smart_contract.address_hash, name: smart_contract.name}
       )
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1046,7 +1046,13 @@ defmodule Explorer.Chain do
         select: %{
           contract_address_hash: token.contract_address_hash,
           symbol: token.symbol,
-          name: fragment("coalesce(?, '') || ' (' || coalesce(?, '') || ')'", token.name, token.symbol)
+          name:
+            fragment(
+              "'<b>' || coalesce(?, '') || '</b>' || ' (' || coalesce(?, '') || ') ' || '<i>' || coalesce(?::varchar(255), '') || ' holder(s)' || '</i>'",
+              token.name,
+              token.symbol,
+              token.holder_count
+            )
         },
         order_by: [desc: token.holder_count]
       )

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1034,13 +1034,22 @@ defmodule Explorer.Chain do
 
   @spec search_token(String.t()) :: [Token.t()]
   def search_token(word) do
-    term = String.replace(word, ~r/\W/u, "") <> ":*"
+    term =
+      word
+      |> String.replace(~r/ +/, " & ")
+
+    term_final = term <> ":*"
 
     query =
       from(token in Token,
-        where: fragment("to_tsvector('english', symbol || ' ' || name ) @@ to_tsquery(?)", ^term),
+        where: fragment("to_tsvector('english', symbol || ' ' || name ) @@ to_tsquery(?)", ^term_final),
         limit: 5,
-        select: %{contract_address_hash: token.contract_address_hash, symbol: token.symbol, name: token.name}
+        select: %{
+          contract_address_hash: token.contract_address_hash,
+          symbol: token.symbol,
+          name: fragment("coalesce(?, '') || ' (' || coalesce(?, '') || ')'", token.name, token.symbol)
+        },
+        order_by: [desc: token.holder_count]
       )
 
     Repo.all(query)
@@ -1048,13 +1057,17 @@ defmodule Explorer.Chain do
 
   @spec search_contract(String.t()) :: [SmartContract.t()]
   def search_contract(word) do
-    term = String.replace(word, ~r/\W/u, "") <> ":*"
+    term =
+      word
+      |> String.replace(~r/ +/, " & ")
+
+    term_final = term <> ":*"
 
     query =
       from(smart_contract in SmartContract,
-        where: fragment("to_tsvector('english', name ) @@ to_tsquery(?)", ^term),
+        where: fragment("to_tsvector('english', name ) @@ to_tsquery(?)", ^term_final),
         limit: 5,
-        select: %{contract_address_hash: smart_contract.address_hash, symbol: smart_contract.name}
+        select: %{contract_address_hash: smart_contract.address_hash, name: smart_contract.name}
       )
 
     Repo.all(query)


### PR DESCRIPTION
## Motivation

- Search by the name with whitespaces is not allowed
- results are not ordered

## Changelog

- Allow searching by several words (in case if name is composite)
- Order search results by holders count in descendant order
- Return `name (symbol)` instead of name in the dropdown
- unlimited searching results (previously, max 10 items)

## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
