### PR TITLE
Fix for the contract verifiaction for solc 0.5 family with experimental features enabled

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -7,7 +7,7 @@ apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex:400: Function timestamp_to_datetim
 lib/explorer/repo/prometheus_logger.ex:8
 lib/block_scout_web/views/layout_view.ex:175
 lib/explorer/smart_contract/publisher_worker.ex:6
-lib/explorer/smart_contract/verifier.ex:84
+lib/explorer/smart_contract/verifier.ex:83
 apps/explorer/lib/explorer/repo/prometheus_logger.ex:8: Function microseconds_time/1 has no local return
 apps/explorer/lib/explorer/repo/prometheus_logger.ex:8: The call 'Elixir.System':convert_time_unit(__@1::any(),'native','microseconds') breaks the contract (integer(),time_unit() | 'native',time_unit() | 'native') -> integer()
 lib/block_scout_web/views/layout_view.ex:172: The call 'Elixir.Poison.Parser':'parse!'(any(),#{'keys':='atoms!'}) will never return since the success typing is (binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | []),[{atom(),_}]) -> 'false' | 'nil' | 'true' | binary() | ['false' | 'nil' | 'true' | binary() | [any()] | number() | map()] | number() | map() and the contract is (iodata(),'Elixir.Keyword':t()) -> t()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#3224](https://github.com/poanetwork/blockscout/pull/3224) - Top tokens page
 
 ### Fixes
+- [#3233](https://github.com/poanetwork/blockscout/pull/3233) - Fix for the contract verifiaction for solc 0.5 family with experimental features enabled
 - [#3226](https://github.com/poanetwork/blockscout/pull/3226) - Fix notifier query for live update of token transfers
 - [#3220](https://github.com/poanetwork/blockscout/pull/3220) - Allow interaction with navbar menu at block-not-found page
 

--- a/apps/explorer/lib/explorer/smart_contract/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier.ex
@@ -13,9 +13,8 @@ defmodule Explorer.SmartContract.Verifier do
   alias Explorer.SmartContract.Verifier.ConstructorArguments
 
   @metadata_hash_prefix_0_4_23 "a165627a7a72305820"
-  @metadata_hash_prefix_0_5_10 "a265627a7a72305820"
-  @metadata_hash_prefix_0_5_11 "a265627a7a72315820"
-  @metadata_hash_prefix_0_5_16 "a365627a7a72315820"
+  @metadata_hash_prefix_0_5_family_1 "65627a7a723"
+  @metadata_hash_prefix_0_5_family_2 "5820"
   @metadata_hash_prefix_0_6_0 "a264697066735822"
 
   @experimental "6c6578706572696d656e74616cf5"
@@ -191,165 +190,68 @@ defmodule Explorer.SmartContract.Verifier do
       @metadata_hash_prefix_0_4_23 <> <<metadata_hash::binary-size(64)>> <> "0029" <> _constructor_arguments ->
         do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
 
+      # Solidity >= 0.5 family && experimantal
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <>
+          "43" <> <<compiler_version::binary-size(6)>> <> <<_::binary-size(4)>> <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
+          <<metadata_hash::binary-size(64)>> <>
+          @experimental <>
+          <<_::binary-size(4)>> <> _constructor_arguments ->
+        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
+
       # Solidity >= 0.5.9; https://github.com/ethereum/solidity/blob/aa4ee3a1559ebc0354926af962efb3fcc7dc15bd/docs/metadata.rst
-      @metadata_hash_prefix_0_5_10 <>
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
           <<metadata_hash::binary-size(64)>> <>
           @metadata_hash_common_suffix <>
           "43" <> <<compiler_version::binary-size(6)>> <> "0032" <> _constructor_arguments ->
         do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
 
-      @metadata_hash_prefix_0_5_10 <>
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
           <<metadata_hash::binary-size(64)>> <>
           @metadata_hash_common_suffix <>
           "7826" <> <<compiler_version::binary-size(76)>> <> "0057" <> _constructor_arguments ->
         do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
 
-      @metadata_hash_prefix_0_5_10 <>
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
           <<metadata_hash::binary-size(64)>> <>
           @metadata_hash_common_suffix <>
           "7827" <> <<compiler_version::binary-size(78)>> <> "0057" <> _constructor_arguments ->
         do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
 
-      @metadata_hash_prefix_0_5_10 <>
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
           <<metadata_hash::binary-size(64)>> <>
           @metadata_hash_common_suffix <>
           "7828" <> <<compiler_version::binary-size(80)>> <> "0058" <> _constructor_arguments ->
         do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
 
-      @metadata_hash_prefix_0_5_10 <>
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
           <<metadata_hash::binary-size(64)>> <>
-          @metadata_hash_common_suffix <>
-          "7829" <> <<compiler_version::binary-size(82)>> <> "0059" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      # Solidity >= 0.5.11 https://github.com/ethereum/solidity/blob/develop/Changelog.md#0511-2019-08-12
-      # Metadata: Update the swarm hash to the current specification, changes bzzr0 to bzzr1 and urls to use bzz-raw://
-      @metadata_hash_prefix_0_5_11 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @metadata_hash_common_suffix <>
-          "43" <> <<compiler_version::binary-size(6)>> <> "0032" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <>
-          "43" <> <<compiler_version::binary-size(6)>> <> "0032" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @metadata_hash_common_suffix <>
-          "7826" <> <<compiler_version::binary-size(76)>> <> "0057" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <>
-          "7826" <> <<compiler_version::binary-size(76)>> <> "0057" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @metadata_hash_common_suffix <>
-          "7827" <> <<compiler_version::binary-size(78)>> <> "0057" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <>
-          "7827" <> <<compiler_version::binary-size(78)>> <> "0057" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @metadata_hash_common_suffix <>
-          "7828" <> <<compiler_version::binary-size(80)>> <> "0058" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <>
-          "7828" <> <<compiler_version::binary-size(80)>> <> "0058" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @metadata_hash_common_suffix <>
-          "7829" <> <<compiler_version::binary-size(82)>> <> "0059" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <>
-          "7829" <> <<compiler_version::binary-size(82)>> <> "0059" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @metadata_hash_common_suffix <>
-          "43" <> <<compiler_version::binary-size(6)>> <> "0032" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <>
-          "43" <> <<compiler_version::binary-size(6)>> <> "0040" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @metadata_hash_common_suffix <>
-          "7826" <> <<compiler_version::binary-size(76)>> <> "0057" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <>
-          "7826" <> <<compiler_version::binary-size(76)>> <> "0057" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @metadata_hash_common_suffix <>
-          "7827" <> <<compiler_version::binary-size(78)>> <> "0057" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <>
-          "7827" <> <<compiler_version::binary-size(78)>> <> "0057" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @metadata_hash_common_suffix <>
-          "7828" <> <<compiler_version::binary-size(80)>> <> "0058" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <>
-          "7828" <> <<compiler_version::binary-size(80)>> <> "0058" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @metadata_hash_common_suffix <>
-          "7829" <> <<compiler_version::binary-size(82)>> <> "0059" <> _constructor_arguments ->
-        do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<metadata_hash::binary-size(64)>> <>
-          @experimental <>
           @metadata_hash_common_suffix <>
           "7829" <> <<compiler_version::binary-size(82)>> <> "0059" <> _constructor_arguments ->
         do_extract_bytecode_and_metadata_hash_output(metadata_hash, extracted, compiler_version)

--- a/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
@@ -7,9 +7,8 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
   alias Explorer.Chain
 
   @metadata_hash_prefix_0_4_23 "a165627a7a72305820"
-  @metadata_hash_prefix_0_5_10 "a265627a7a72305820"
-  @metadata_hash_prefix_0_5_11 "a265627a7a72315820"
-  @metadata_hash_prefix_0_5_16 "a365627a7a72315820"
+  @metadata_hash_prefix_0_5_family_1 "65627a7a723"
+  @metadata_hash_prefix_0_5_family_2 "5820"
   @metadata_hash_prefix_0_6_0 "a264697066735822"
 
   @experimental "6c6578706572696d656e74616cf5"
@@ -53,8 +52,42 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
           @metadata_hash_prefix_0_4_23
         )
 
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          @metadata_hash_common_suffix <>
+          "43" <> <<_::binary-size(6)>> <> <<_::binary-size(4)>> <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_family_1
+        )
+
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
+          <<_::binary-size(64)>> <>
+          @experimental <>
+          <<_::binary-size(4)>> <> constructor_arguments ->
+        split_constructor_arguments_and_extract_check_func(
+          constructor_arguments,
+          check_func,
+          contract_source_code,
+          contract_name,
+          @metadata_hash_prefix_0_5_family_1
+        )
+
       # Solidity >= 0.5.10 https://solidity.readthedocs.io/en/v0.5.10/metadata.html
-      @metadata_hash_prefix_0_5_10 <>
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
           <<_::binary-size(64)>> <>
           @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
         split_constructor_arguments_and_extract_check_func(
@@ -62,10 +95,13 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
           check_func,
           contract_source_code,
           contract_name,
-          @metadata_hash_prefix_0_5_10
+          @metadata_hash_prefix_0_5_family_1
         )
 
-      @metadata_hash_prefix_0_5_10 <>
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
           <<_::binary-size(64)>> <>
           @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
         split_constructor_arguments_and_extract_check_func(
@@ -73,10 +109,13 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
           check_func,
           contract_source_code,
           contract_name,
-          @metadata_hash_prefix_0_5_10
+          @metadata_hash_prefix_0_5_family_1
         )
 
-      @metadata_hash_prefix_0_5_10 <>
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
           <<_::binary-size(64)>> <>
           @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
         split_constructor_arguments_and_extract_check_func(
@@ -84,10 +123,13 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
           check_func,
           contract_source_code,
           contract_name,
-          @metadata_hash_prefix_0_5_10
+          @metadata_hash_prefix_0_5_family_1
         )
 
-      @metadata_hash_prefix_0_5_10 <>
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
           <<_::binary-size(64)>> <>
           @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
         split_constructor_arguments_and_extract_check_func(
@@ -95,10 +137,13 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
           check_func,
           contract_source_code,
           contract_name,
-          @metadata_hash_prefix_0_5_10
+          @metadata_hash_prefix_0_5_family_1
         )
 
-      @metadata_hash_prefix_0_5_10 <>
+      <<_::binary-size(2)>> <>
+          @metadata_hash_prefix_0_5_family_1 <>
+          <<_::binary-size(1)>> <>
+          @metadata_hash_prefix_0_5_family_2 <>
           <<_::binary-size(64)>> <>
           @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
         split_constructor_arguments_and_extract_check_func(
@@ -106,240 +151,7 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
           check_func,
           contract_source_code,
           contract_name,
-          @metadata_hash_prefix_0_5_10
-        )
-
-      # Solidity >= 0.5.11 https://github.com/ethereum/solidity/blob/develop/Changelog.md#0511-2019-08-12
-      # Metadata: Update the swarm hash to the current specification, changes bzzr0 to bzzr1 and urls to use bzz-raw://
-      @metadata_hash_prefix_0_5_11 <>
-          <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @metadata_hash_prefix_0_5_11
-        )
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<_::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @experimental <> @metadata_hash_prefix_0_5_11
-        )
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @metadata_hash_prefix_0_5_11
-        )
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<_::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @experimental <> @metadata_hash_prefix_0_5_11
-        )
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @metadata_hash_prefix_0_5_11
-        )
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<_::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @experimental <> @metadata_hash_prefix_0_5_11
-        )
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @metadata_hash_prefix_0_5_11
-        )
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<_::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @experimental <> @metadata_hash_prefix_0_5_11
-        )
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @metadata_hash_prefix_0_5_11
-        )
-
-      @metadata_hash_prefix_0_5_11 <>
-          <<_::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @experimental <> @metadata_hash_prefix_0_5_11
-        )
-
-      # ABIEncoder V2
-      @metadata_hash_prefix_0_5_16 <>
-          <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @metadata_hash_prefix_0_5_16
-        )
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<_::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <> "43" <> <<_::binary-size(6)>> <> "0032" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @experimental <> @metadata_hash_prefix_0_5_16
-        )
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @metadata_hash_prefix_0_5_16
-        )
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<_::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <> "7826" <> <<_::binary-size(76)>> <> "0057" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @experimental <> @metadata_hash_prefix_0_5_16
-        )
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @metadata_hash_prefix_0_5_16
-        )
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<_::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <> "7827" <> <<_::binary-size(78)>> <> "0057" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @experimental <> @metadata_hash_prefix_0_5_16
-        )
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @metadata_hash_prefix_0_5_16
-        )
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<_::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <> "7828" <> <<_::binary-size(80)>> <> "0058" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @experimental <> @metadata_hash_prefix_0_5_16
-        )
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<_::binary-size(64)>> <>
-          @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @metadata_hash_prefix_0_5_16
-        )
-
-      @metadata_hash_prefix_0_5_16 <>
-          <<_::binary-size(64)>> <>
-          @experimental <>
-          @metadata_hash_common_suffix <> "7829" <> <<_::binary-size(82)>> <> "0059" <> constructor_arguments ->
-        split_constructor_arguments_and_extract_check_func(
-          constructor_arguments,
-          check_func,
-          contract_source_code,
-          contract_name,
-          @experimental <> @metadata_hash_prefix_0_5_16
+          @metadata_hash_prefix_0_5_family_1
         )
 
       # Solidity >= 0.6.0 https://github.com/ethereum/solidity/blob/develop/Changelog.md#060-2019-12-17


### PR DESCRIPTION

## Motivation

The compilation is failed for contracts which have constructor arguments, compiled with 0.5.x compilers and experimental features are enabled.

## Changelog

- Refactoring of update introduced in https://github.com/poanetwork/blockscout/pull/3202 for more stable verification

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
