### PR TITLE
Fix coin supply api edpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#3224](https://github.com/poanetwork/blockscout/pull/3224) - Top tokens page
 
 ### Fixes
+- [#3235](https://github.com/poanetwork/blockscout/pull/3235) - Fix coin supply api edpoint
 - [#3233](https://github.com/poanetwork/blockscout/pull/3233) - Fix for the contract verifiaction for solc 0.5 family with experimental features enabled
 - [#3231](https://github.com/poanetwork/blockscout/pull/3231) - Improve search: unlimited number of searching results
 - [#3231](https://github.com/poanetwork/blockscout/pull/3231) - Improve search: allow search with space

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -54,8 +54,9 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
     cached_coin_total_supply =
       %Wei{value: Decimal.new(coin_total_supply_wei)}
       |> Wei.to(:ether)
+      |> Decimal.to_string(:normal)
 
-    render(conn, "coinsupply.json", cached_coin_total_supply)
+    render(conn, "coinsupply.json", total_supply: cached_coin_total_supply)
   end
 
   def ethprice(conn, _params) do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/rpc_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/rpc_view.ex
@@ -9,10 +9,9 @@ defmodule BlockScoutWeb.API.RPC.RPCView do
     }
   end
 
-  def render("show_value.json", data) do
+  def render("show_value.json", %{data: data}) do
     {value, _} =
       data
-      |> Decimal.to_string(:normal)
       |> Float.parse()
 
     value

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
@@ -15,8 +15,8 @@ defmodule BlockScoutWeb.API.RPC.StatsView do
     RPCView.render("show.json", data: total_supply)
   end
 
-  def render("coinsupply.json", total_supply) do
-    RPCView.render("show_value.json", total_supply)
+  def render("coinsupply.json", %{total_supply: total_supply}) do
+    RPCView.render("show_value.json", data: total_supply)
   end
 
   def render("ethprice.json", %{rates: rates}) do


### PR DESCRIPTION
Probably, caused by Phoenix minor upgrade from 1.4 to 1.5 in https://github.com/poanetwork/blockscout/pull/3143

## Motivation

https://blockscout.com/poa/core/api?module=stats&action=coinsupply returns
```
{
  "message": "Something went wrong.",
  "result": null,
  "status": "0"
}
```


## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
