### PR TITLE
Hide address page tabs if no items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3239](https://github.com/poanetwork/blockscout/pull/3239) - Hide address page tabs if no items
 - [#3236](https://github.com/poanetwork/blockscout/pull/3236) - Easy verification of contracts which hash verified twins (the same bytecode)
 - [#3227](https://github.com/poanetwork/blockscout/pull/3227) - Distinguishing of bridged tokens
 - [#3224](https://github.com/poanetwork/blockscout/pull/3224) - Top tokens page

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
@@ -4,41 +4,51 @@
         class: "card-tab #{tab_status("transactions", @conn.request_path)}",
         to: address_transaction_path(@conn, :index, @address.hash)
       ) %>
-  <%= link(
-      gettext("Token Transfers"),
-      class: "card-tab #{tab_status("token_transfers", @conn.request_path)}",
-      "data-test": "token_transfers_tab_link",
-      to: address_token_transfers_path(@conn, :index, @address.hash)
-      ) %>
+  <%= if Chain.check_if_token_transfers_at_address(@address.hash) do %>
+    <%= link(
+        gettext("Token Transfers"),
+        class: "card-tab #{tab_status("token_transfers", @conn.request_path)}",
+        "data-test": "token_transfers_tab_link",
+        to: address_token_transfers_path(@conn, :index, @address.hash)
+        ) %>
+  <% end %>
+  <%= if Chain.check_if_tokens_at_address(@address.hash) do %>
   <%= link(
         gettext("Tokens"),
         class: "card-tab #{tab_status("tokens", @conn.request_path)}",
         to: address_token_path(@conn, :index, @address.hash),
         "data-test": "tokens_tab_link"
       ) %>
-  <%= link(
-        gettext("Internal Transactions"),
-        class: "card-tab #{tab_status("internal_transactions", @conn.request_path)}",
-        "data-test": "internal_transactions_tab_link",
-        to: address_internal_transaction_path(@conn, :index, @address.hash)
-      ) %>
+  <% end %>
+  <%= if Chain.check_if_internal_transactions_at_address(@address.hash) do %>
+    <%= link(
+          gettext("Internal Transactions"),
+          class: "card-tab #{tab_status("internal_transactions", @conn.request_path)}",
+          "data-test": "internal_transactions_tab_link",
+          to: address_internal_transaction_path(@conn, :index, @address.hash)
+        ) %>
+  <% end %>
   <%= link(
         gettext("Coin Balance History"),
         class: "card-tab #{tab_status("coin_balances", @conn.request_path)}",
         "data-test": "coin_balance_tab_link",
         to: address_coin_balance_path(@conn, :index, @address.hash)
       ) %>
-  <%= link(
-      gettext("Logs"),
-      class: "card-tab #{tab_status("logs", @conn.request_path)}",
-      to: address_logs_path(@conn, :index, @address.hash)
-      ) %>
-  <%= link(
-    gettext("Blocks Validated"),
-    class: "card-tab #{tab_status("validations", @conn.request_path)}",
-    "data-test": "validations_tab_link",
-    to: address_validation_path(@conn, :index, @address.hash)
-  ) %>
+  <%= if Chain.check_if_logs_at_address(@address.hash) do %>
+    <%= link(
+        gettext("Logs"),
+        class: "card-tab #{tab_status("logs", @conn.request_path)}",
+        to: address_logs_path(@conn, :index, @address.hash)
+        ) %>
+  <% end %>
+  <%= if Chain.check_if_validated_blocks_at_address(@address.hash) do %>
+    <%= link(
+      gettext("Blocks Validated"),
+      class: "card-tab #{tab_status("validations", @conn.request_path)}",
+      "data-test": "validations_tab_link",
+      to: address_validation_path(@conn, :index, @address.hash)
+    ) %>
+  <% end %>
   <%= if contract?(@address) do %>
     <%= link(
         to: address_contract_path(@conn, :index, @address.hash),

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
@@ -20,14 +20,12 @@
         "data-test": "tokens_tab_link"
       ) %>
   <% end %>
-  <%= if Chain.check_if_internal_transactions_at_address(@address.hash) do %>
-    <%= link(
-          gettext("Internal Transactions"),
-          class: "card-tab #{tab_status("internal_transactions", @conn.request_path)}",
-          "data-test": "internal_transactions_tab_link",
-          to: address_internal_transaction_path(@conn, :index, @address.hash)
-        ) %>
-  <% end %>
+  <%= link(
+        gettext("Internal Transactions"),
+        class: "card-tab #{tab_status("internal_transactions", @conn.request_path)}",
+        "data-test": "internal_transactions_tab_link",
+        to: address_internal_transaction_path(@conn, :index, @address.hash)
+      ) %>
   <%= link(
         gettext("Coin Balance History"),
         class: "card-tab #{tab_status("coin_balances", @conn.request_path)}",

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -493,7 +493,7 @@ msgid "Decoded"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:56
+#: lib/block_scout_web/templates/address/_tabs.html.eex:66
 msgid "Decompiled code"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgid "Token Transfer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:8
+#: lib/block_scout_web/templates/address/_tabs.html.eex:9
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:3
@@ -1792,14 +1792,14 @@ msgid "Copy Txn Input"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:37
+#: lib/block_scout_web/templates/address/_tabs.html.eex:46
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
 #: lib/block_scout_web/views/address_view.ex:354
 msgid "Blocks Validated"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:46
+#: lib/block_scout_web/templates/address/_tabs.html.eex:56
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:165
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
@@ -1809,7 +1809,7 @@ msgid "Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:26
+#: lib/block_scout_web/templates/address/_tabs.html.eex:32
 #: lib/block_scout_web/views/address_view.ex:353
 msgid "Coin Balance History"
 msgstr ""
@@ -1820,7 +1820,7 @@ msgid "Decompiled Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:20
+#: lib/block_scout_web/templates/address/_tabs.html.eex:25
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
@@ -1830,7 +1830,7 @@ msgid "Internal Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:32
+#: lib/block_scout_web/templates/address/_tabs.html.eex:39
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
@@ -1840,7 +1840,7 @@ msgid "Logs"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:62
+#: lib/block_scout_web/templates/address/_tabs.html.eex:72
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
 #: lib/block_scout_web/views/address_view.ex:349
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
@@ -1848,7 +1848,7 @@ msgid "Read Contract"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:14
+#: lib/block_scout_web/templates/address/_tabs.html.eex:17
 #: lib/block_scout_web/templates/address_token/index.html.eex:8
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:11
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:83
@@ -1904,13 +1904,13 @@ msgid "Revert reason"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:69
+#: lib/block_scout_web/templates/address/_tabs.html.eex:79
 #: lib/block_scout_web/views/address_view.ex:350
 msgid "Read Proxy"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:76
+#: lib/block_scout_web/templates/address/_tabs.html.eex:86
 #: lib/block_scout_web/views/address_view.ex:351
 msgid "Write Contract"
 msgstr ""
@@ -1927,7 +1927,7 @@ msgid "Write"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:83
+#: lib/block_scout_web/templates/address/_tabs.html.eex:93
 #: lib/block_scout_web/views/address_view.ex:352
 msgid "Write Proxy"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -493,7 +493,7 @@ msgid "Decoded"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:66
+#: lib/block_scout_web/templates/address/_tabs.html.eex:64
 msgid "Decompiled code"
 msgstr ""
 
@@ -1792,14 +1792,14 @@ msgid "Copy Txn Input"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:46
+#: lib/block_scout_web/templates/address/_tabs.html.eex:44
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
 #: lib/block_scout_web/views/address_view.ex:354
 msgid "Blocks Validated"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:56
+#: lib/block_scout_web/templates/address/_tabs.html.eex:54
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:165
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
@@ -1809,7 +1809,7 @@ msgid "Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:32
+#: lib/block_scout_web/templates/address/_tabs.html.eex:30
 #: lib/block_scout_web/views/address_view.ex:353
 msgid "Coin Balance History"
 msgstr ""
@@ -1820,7 +1820,7 @@ msgid "Decompiled Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:25
+#: lib/block_scout_web/templates/address/_tabs.html.eex:24
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
@@ -1830,7 +1830,7 @@ msgid "Internal Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:39
+#: lib/block_scout_web/templates/address/_tabs.html.eex:37
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
@@ -1840,7 +1840,7 @@ msgid "Logs"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:72
+#: lib/block_scout_web/templates/address/_tabs.html.eex:70
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
 #: lib/block_scout_web/views/address_view.ex:349
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
@@ -1904,13 +1904,13 @@ msgid "Revert reason"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:79
+#: lib/block_scout_web/templates/address/_tabs.html.eex:77
 #: lib/block_scout_web/views/address_view.ex:350
 msgid "Read Proxy"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:86
+#: lib/block_scout_web/templates/address/_tabs.html.eex:84
 #: lib/block_scout_web/views/address_view.ex:351
 msgid "Write Contract"
 msgstr ""
@@ -1927,7 +1927,7 @@ msgid "Write"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:93
+#: lib/block_scout_web/templates/address/_tabs.html.eex:91
 #: lib/block_scout_web/views/address_view.ex:352
 msgid "Write Proxy"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -493,7 +493,7 @@ msgid "Decoded"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:56
+#: lib/block_scout_web/templates/address/_tabs.html.eex:66
 msgid "Decompiled code"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgid "Token Transfer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:8
+#: lib/block_scout_web/templates/address/_tabs.html.eex:9
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:3
@@ -1792,14 +1792,14 @@ msgid "Copy Txn Input"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:37
+#: lib/block_scout_web/templates/address/_tabs.html.eex:46
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
 #: lib/block_scout_web/views/address_view.ex:354
 msgid "Blocks Validated"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:46
+#: lib/block_scout_web/templates/address/_tabs.html.eex:56
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:165
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
@@ -1809,7 +1809,7 @@ msgid "Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:26
+#: lib/block_scout_web/templates/address/_tabs.html.eex:32
 #: lib/block_scout_web/views/address_view.ex:353
 msgid "Coin Balance History"
 msgstr ""
@@ -1820,7 +1820,7 @@ msgid "Decompiled Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:20
+#: lib/block_scout_web/templates/address/_tabs.html.eex:25
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
@@ -1830,7 +1830,7 @@ msgid "Internal Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:32
+#: lib/block_scout_web/templates/address/_tabs.html.eex:39
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
@@ -1840,7 +1840,7 @@ msgid "Logs"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:62
+#: lib/block_scout_web/templates/address/_tabs.html.eex:72
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
 #: lib/block_scout_web/views/address_view.ex:349
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
@@ -1848,7 +1848,7 @@ msgid "Read Contract"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:14
+#: lib/block_scout_web/templates/address/_tabs.html.eex:17
 #: lib/block_scout_web/templates/address_token/index.html.eex:8
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:11
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:83
@@ -1904,13 +1904,13 @@ msgid "Revert reason"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:69
+#: lib/block_scout_web/templates/address/_tabs.html.eex:79
 #: lib/block_scout_web/views/address_view.ex:350
 msgid "Read Proxy"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:76
+#: lib/block_scout_web/templates/address/_tabs.html.eex:86
 #: lib/block_scout_web/views/address_view.ex:351
 msgid "Write Contract"
 msgstr ""
@@ -1927,7 +1927,7 @@ msgid "Write"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:83
+#: lib/block_scout_web/templates/address/_tabs.html.eex:93
 #: lib/block_scout_web/views/address_view.ex:352
 msgid "Write Proxy"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -493,7 +493,7 @@ msgid "Decoded"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:66
+#: lib/block_scout_web/templates/address/_tabs.html.eex:64
 msgid "Decompiled code"
 msgstr ""
 
@@ -1792,14 +1792,14 @@ msgid "Copy Txn Input"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:46
+#: lib/block_scout_web/templates/address/_tabs.html.eex:44
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
 #: lib/block_scout_web/views/address_view.ex:354
 msgid "Blocks Validated"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:56
+#: lib/block_scout_web/templates/address/_tabs.html.eex:54
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:165
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
@@ -1809,7 +1809,7 @@ msgid "Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:32
+#: lib/block_scout_web/templates/address/_tabs.html.eex:30
 #: lib/block_scout_web/views/address_view.ex:353
 msgid "Coin Balance History"
 msgstr ""
@@ -1820,7 +1820,7 @@ msgid "Decompiled Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:25
+#: lib/block_scout_web/templates/address/_tabs.html.eex:24
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
@@ -1830,7 +1830,7 @@ msgid "Internal Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:39
+#: lib/block_scout_web/templates/address/_tabs.html.eex:37
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
@@ -1840,7 +1840,7 @@ msgid "Logs"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:72
+#: lib/block_scout_web/templates/address/_tabs.html.eex:70
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
 #: lib/block_scout_web/views/address_view.ex:349
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
@@ -1904,13 +1904,13 @@ msgid "Revert reason"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:79
+#: lib/block_scout_web/templates/address/_tabs.html.eex:77
 #: lib/block_scout_web/views/address_view.ex:350
 msgid "Read Proxy"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:86
+#: lib/block_scout_web/templates/address/_tabs.html.eex:84
 #: lib/block_scout_web/views/address_view.ex:351
 msgid "Write Contract"
 msgstr ""
@@ -1927,7 +1927,7 @@ msgid "Write"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:93
+#: lib/block_scout_web/templates/address/_tabs.html.eex:91
 #: lib/block_scout_web/views/address_view.ex:352
 msgid "Write Proxy"
 msgstr ""

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1859,6 +1859,43 @@ defmodule Explorer.Chain do
     |> Repo.all()
   end
 
+  def check_if_validated_blocks_at_address(address_hash) do
+    Repo.exists?(from(b in Block, where: b.miner_hash == ^address_hash))
+  end
+
+  def check_if_logs_at_address(address_hash) do
+    Repo.exists?(from(l in Log, where: l.address_hash == ^address_hash))
+  end
+
+  def check_if_internal_transactions_at_address(address_hash) do
+    internal_transactions_exists_by_created_contract_address_hash =
+      Repo.exists?(from(it in InternalTransaction, where: it.created_contract_address_hash == ^address_hash))
+
+    internal_transactions_exists_by_from_address_hash =
+      Repo.exists?(from(it in InternalTransaction, where: it.from_address_hash == ^address_hash))
+
+    internal_transactions_exists_by_to_address_hash =
+      Repo.exists?(from(it in InternalTransaction, where: it.to_address_hash == ^address_hash))
+
+    internal_transactions_exists_by_created_contract_address_hash || internal_transactions_exists_by_from_address_hash ||
+      internal_transactions_exists_by_to_address_hash
+  end
+
+  def check_if_token_transfers_at_address(address_hash) do
+    token_transfers_exists_by_from_address_hash =
+      Repo.exists?(from(tt in TokenTransfer, where: tt.from_address_hash == ^address_hash))
+
+    token_transfers_exists_by_to_address_hash =
+      Repo.exists?(from(tt in TokenTransfer, where: tt.to_address_hash == ^address_hash))
+
+    token_transfers_exists_by_from_address_hash ||
+      token_transfers_exists_by_to_address_hash
+  end
+
+  def check_if_tokens_at_address(address_hash) do
+    Repo.exists?(from(tb in CurrentTokenBalance, where: tb.address_hash == ^address_hash))
+  end
+
   @doc """
   Counts all of the block validations and groups by the `miner_hash`.
   """


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/735

## Motivation

BlockScout displays all tabs at address page even if there are no items under the tab.

## Changelog

Hide next tabs if no items:
- Token Transfers
- Tokens
- Logs
- Blocks Validated

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
