### PR TITLE
Fix for invisible validator address at block page and wrong alert text color at xDai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3256](https://github.com/poanetwork/blockscout/pull/3256) - Fix for invisible validator address at block page and wrong alert text color at xDai
 
 ### Chore
 

--- a/apps/block_scout_web/assets/css/theme/_dai_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_dai_variables.scss
@@ -47,7 +47,7 @@ $tile-type-block-color: $secondary;
 $tile-type-progress-bar-color: $secondary;
 a.tile-title { color: $secondary !important; }
 .card-body {  
-	a:not(.dropdown-item):not(.button) {
+	a:not(.dropdown-item):not(.button):not([data-test=address_hash_link]):not(.alert-link) {
 		color: $secondary;
 
 		&:hover {


### PR DESCRIPTION
2nd fix of #3240 implementation

<img width="431" alt="Screenshot 2020-08-25 at 16 42 02" src="https://user-images.githubusercontent.com/4341812/91181697-eb745d00-e6f1-11ea-8839-d7f8cc889447.png">
<img width="374" alt="Screenshot 2020-08-25 at 16 41 38" src="https://user-images.githubusercontent.com/4341812/91181701-ed3e2080-e6f1-11ea-98d8-649b1832987b.png">
