### PR TITLE
Contracts read/write: method_id instead function_name as a key

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -21,4 +21,4 @@ lib/block_scout_web/views/layout_view.ex:138: The call 'Elixir.Poison.Parser':'p
 lib/block_scout_web/views/layout_view.ex:224: The call 'Elixir.Poison.Parser':'parse!'
 lib/block_scout_web/controllers/api/rpc/transaction_controller.ex:21
 lib/block_scout_web/controllers/api/rpc/transaction_controller.ex:22
-lib/explorer/smart_contract/reader.ex:335
+lib/explorer/smart_contract/reader.ex:336

--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -21,3 +21,4 @@ lib/block_scout_web/views/layout_view.ex:138: The call 'Elixir.Poison.Parser':'p
 lib/block_scout_web/views/layout_view.ex:224: The call 'Elixir.Poison.Parser':'parse!'
 lib/block_scout_web/controllers/api/rpc/transaction_controller.ex:21
 lib/block_scout_web/controllers/api/rpc/transaction_controller.ex:22
+lib/explorer/smart_contract/reader.ex:335

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3257](https://github.com/poanetwork/blockscout/pull/3257) - Contracts read/write: method_id instead function_name as a key
 
 ### Chore
 

--- a/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
@@ -53,6 +53,7 @@ const readWriteFunction = (element) => {
     if (action === 'read') {
       const url = $form.data('url')
       const $functionName = $form.find('input[name=function_name]')
+      const $methodId = $form.find('input[name=method_id]')
       const $functionInputs = $form.find('input[name=function_input]')
 
       const args = $.map($functionInputs, element => {
@@ -61,6 +62,7 @@ const readWriteFunction = (element) => {
 
       const data = {
         function_name: $functionName.val(),
+        method_id: $methodId.val(),
         args
       }
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -94,7 +94,7 @@ defmodule BlockScoutWeb.SmartContractController do
       outputs =
         Reader.query_function(
           address_hash,
-          %{name: params["function_name"], args: params["args"]},
+          %{method_id: params["method_id"], args: params["args"]},
           contract_type
         )
 
@@ -104,6 +104,7 @@ defmodule BlockScoutWeb.SmartContractController do
       |> render(
         "_function_response.html",
         function_name: params["function_name"],
+        method_id: params["method_id"],
         outputs: outputs
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -42,6 +42,7 @@ to: address_contract_path(@conn, :index, metadata_for_verification.address_hash)
         <%= render BlockScoutWeb.SmartContractView, "_pending_contract_write.html" %>
         <form class="form-inline" data-function-form data-action="<%= if writeable?(function), do: :write, else: :read %>" data-type="<%= @contract_type %>" data-url="<%= smart_contract_path(@conn, :show, @address.hash) %>" data-contract-address="<%= @address.hash %>" data-contract-abi="<%= @contract_abi %>" data-implementation-abi="<%= @implementation_abi  %>" data-chain-id="<%= Explorer.Chain.Cache.NetVersion.get_version() %>">
           <input type="hidden" name="function_name" value='<%= function["name"] %>' />
+          <input type="hidden" name="method_id" value='<%= function["method_id"] %>' />
 
           <%= if queryable?(function["inputs"]) do %>
             <%= for input <- function["inputs"] do %>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -562,8 +562,8 @@ msgid "ERC-721 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:56
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:91
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:57
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:92
 msgid "ETH"
 msgstr ""
 
@@ -1181,7 +1181,7 @@ msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:60
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:61
 msgid "Query"
 msgstr ""
 
@@ -1633,7 +1633,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:90
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:91
 msgid "WEI"
 msgstr ""
 
@@ -1923,7 +1923,7 @@ msgid "Waiting for transaction's confirmation..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:60
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:61
 msgid "Write"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -562,8 +562,8 @@ msgid "ERC-721 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:56
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:91
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:57
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:92
 msgid "ETH"
 msgstr ""
 
@@ -1181,7 +1181,7 @@ msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:60
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:61
 msgid "Query"
 msgstr ""
 
@@ -1633,7 +1633,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:90
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:91
 msgid "WEI"
 msgstr ""
 
@@ -1923,7 +1923,7 @@ msgid "Waiting for transaction's confirmation..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:60
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:61
 msgid "Write"
 msgstr ""
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
@@ -240,6 +240,7 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
           :show,
           Address.checksum(smart_contract.address_hash),
           function_name: "get",
+          method_id: "6d4ce63c",
           args: []
         )
 
@@ -253,7 +254,7 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
       assert %{
                function_name: "get",
                layout: false,
-               outputs: [%{"name" => "", "type" => "uint256", "value" => 0}]
+               outputs: [%{"type" => "uint256", "value" => 0}]
              } = conn.assigns
     end
   end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/contract_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/contract_test.exs
@@ -14,6 +14,7 @@ defmodule EthereumJSONRPC.ContractTest do
           "constant" => false,
           "inputs" => [],
           "name" => "get1",
+          "method_id" => "054c1a75",
           "outputs" => [%{"name" => "", "type" => "uint256"}],
           "payable" => false,
           "stateMutability" => "nonpayable",
@@ -23,6 +24,7 @@ defmodule EthereumJSONRPC.ContractTest do
           "constant" => true,
           "inputs" => [],
           "name" => "get2",
+          "method_id" => "d2178b08",
           "outputs" => [%{"name" => "", "type" => "uint256"}],
           "payable" => false,
           "stateMutability" => "view",
@@ -32,6 +34,7 @@ defmodule EthereumJSONRPC.ContractTest do
           "constant" => true,
           "inputs" => [],
           "name" => "get3",
+          "method_id" => "8321045c",
           "outputs" => [%{"name" => "", "type" => "uint256"}],
           "payable" => false,
           "stateMutability" => "view",
@@ -42,9 +45,9 @@ defmodule EthereumJSONRPC.ContractTest do
       contract_address = "0x0000000000000000000000000000000000000000"
 
       functions = [
-        %{contract_address: contract_address, function_name: "get1", args: []},
-        %{contract_address: contract_address, function_name: "get2", args: [], block_number: 1000},
-        %{contract_address: contract_address, function_name: "get3", args: []}
+        %{contract_address: contract_address, method_id: "054c1a75", args: []},
+        %{contract_address: contract_address, method_id: "d2178b08", args: [], block_number: 1000},
+        %{contract_address: contract_address, method_id: "8321045c", args: []}
       ]
 
       expect(
@@ -97,6 +100,7 @@ defmodule EthereumJSONRPC.ContractTest do
           "constant" => false,
           "inputs" => [],
           "name" => "get",
+          "method_id" => "6d4ce63c",
           "outputs" => [%{"name" => "", "type" => "uint256"}],
           "payable" => false,
           "stateMutability" => "nonpayable",
@@ -107,8 +111,8 @@ defmodule EthereumJSONRPC.ContractTest do
       contract_address = "0x0000000000000000000000000000000000000000"
 
       functions = [
-        %{contract_address: contract_address, function_name: "get", args: []},
-        %{contract_address: contract_address, function_name: "get", args: [], block_number: 1000}
+        %{contract_address: contract_address, method_id: "6d4ce63c", args: []},
+        %{contract_address: contract_address, method_id: "6d4ce63c", args: [], block_number: 1000}
       ]
 
       expect(

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4782,11 +4782,12 @@ defmodule Explorer.Chain do
         implementation_address
       end
     else
+      # 5c60da1b = keccak256(implementation())
       implementation_address =
         case Reader.query_contract(proxy_address_hash, abi, %{
-               "implementation" => []
+               "5c60da1b" => []
              }) do
-          %{"implementation" => {:ok, [result]}} -> result
+          %{"5c60da1b" => {:ok, [result]}} -> result
           _ -> nil
         end
 

--- a/apps/explorer/lib/explorer/chain/block/reward.ex
+++ b/apps/explorer/lib/explorer/chain/block/reward.ex
@@ -143,7 +143,8 @@ defmodule Explorer.Chain.Block.Reward do
       Application.get_env(:explorer, Explorer.Chain.Block.Reward, %{})[:validators_contract_address]
 
     if validators_contract_address do
-      is_validator_params = %{"isValidator" => [mining_key.bytes]}
+      # facd743b=keccak256(isValidator(address))
+      is_validator_params = %{"facd743b" => [mining_key.bytes]}
 
       call_contract(validators_contract_address, @is_validator_abi, is_validator_params)
     else
@@ -161,7 +162,8 @@ defmodule Explorer.Chain.Block.Reward do
       if keys_manager_contract_address do
         payout_key =
           if keys_manager_contract_address do
-            get_payout_by_mining_params = %{"getPayoutByMining" => [mining_key.bytes]}
+            # 7cded930=keccak256(getPayoutByMining(address))
+            get_payout_by_mining_params = %{"7cded930" => [mining_key.bytes]}
 
             payout_key_hash =
               call_contract(keys_manager_contract_address, @get_payout_by_mining_abi, get_payout_by_mining_params)
@@ -188,14 +190,14 @@ defmodule Explorer.Chain.Block.Reward do
   defp call_contract(address, abi, params) do
     abi = [abi]
 
-    method_name =
+    method_id =
       params
       |> Enum.map(fn {key, _value} -> key end)
       |> List.first()
 
     value =
       case Reader.query_contract(address, abi, params) do
-        %{^method_name => {:ok, [result]}} -> result
+        %{^method_id => {:ok, [result]}} -> result
         _ -> @empty_address
       end
 

--- a/apps/explorer/lib/explorer/chain/supply/token_bridge.ex
+++ b/apps/explorer/lib/explorer/chain/supply/token_bridge.ex
@@ -18,7 +18,8 @@ defmodule Explorer.Chain.Supply.TokenBridge do
     "inputs" => [],
     "constant" => true
   }
-  @total_burned_coins_params %{"totalBurntCoins" => []}
+  # 0e8162ba=keccak256(totalBurntCoins())
+  @total_burned_coins_params %{"0e8162ba" => []}
 
   @block_reward_contract_abi %{
     "type" => "function",
@@ -30,7 +31,8 @@ defmodule Explorer.Chain.Supply.TokenBridge do
     "constant" => true
   }
 
-  @block_reward_contract_params %{"blockRewardContract" => []}
+  # 56b54bae=keccak256(blockRewardContract())
+  @block_reward_contract_params %{"56b54bae" => []}
 
   @total_minted_coins_abi %{
     "type" => "function",
@@ -42,7 +44,8 @@ defmodule Explorer.Chain.Supply.TokenBridge do
     "constant" => true
   }
 
-  @total_minted_coins_params %{"mintedTotally" => []}
+  # 553a5c85=keccak256(mintedTotallymintedTotally())
+  @total_minted_coins_params %{"553a5c85" => []}
 
   @ets_table :token_bridge_contract_coin_cache
   # 30 minutes
@@ -80,7 +83,7 @@ defmodule Explorer.Chain.Supply.TokenBridge do
   defp call_contract(address, abi, params) do
     abi = [abi]
 
-    method_name =
+    method_id =
       params
       |> Enum.map(fn {key, _value} -> key end)
       |> List.first()
@@ -94,7 +97,7 @@ defmodule Explorer.Chain.Supply.TokenBridge do
 
     value =
       case Reader.query_contract(address, abi, params) do
-        %{^method_name => {:ok, [result]}} ->
+        %{^method_id => {:ok, [result]}} ->
           result
 
         _ ->

--- a/apps/explorer/lib/explorer/chain_spec/poa/importer.ex
+++ b/apps/explorer/lib/explorer/chain_spec/poa/importer.ex
@@ -22,7 +22,8 @@ defmodule Explorer.ChainSpec.POA.Importer do
     "inputs" => [],
     "constant" => true
   }
-  @block_reward_amount_params %{"blockRewardAmount" => []}
+  # 26cc2256=keccak256(blockRewardAmount())
+  @block_reward_amount_params %{"26cc2256" => []}
   @emission_funds_amount_abi %{
     "type" => "function",
     "stateMutability" => "view",
@@ -32,7 +33,8 @@ defmodule Explorer.ChainSpec.POA.Importer do
     "inputs" => [],
     "constant" => true
   }
-  @emission_funds_amount_params %{"emissionFundsAmount" => []}
+  # ee8d75ff=keccak256(emissionFundsAmount())
+  @emission_funds_amount_params %{"ee8d75ff" => []}
   @emission_funds_block_start 5_098_087
 
   def import_emission_rewards do
@@ -91,7 +93,7 @@ defmodule Explorer.ChainSpec.POA.Importer do
   defp call_contract(address, abi, params) do
     abi = [abi]
 
-    method_name =
+    method_id =
       params
       |> Enum.map(fn {key, _value} -> key end)
       |> List.first()
@@ -100,7 +102,7 @@ defmodule Explorer.ChainSpec.POA.Importer do
 
     value =
       case Reader.query_contract(address, abi, params) do
-        %{^method_name => {:ok, [result]}} -> result
+        %{^method_id => {:ok, [result]}} -> result
         _ -> 0
       end
 

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -96,10 +96,10 @@ defmodule Explorer.SmartContract.Reader do
   def query_contract(contract_address, abi, functions) do
     requests =
       functions
-      |> Enum.map(fn {function_name, args} ->
+      |> Enum.map(fn {method_id, args} ->
         %{
           contract_address: contract_address,
-          function_name: function_name,
+          method_id: method_id,
           args: args
         }
       end)
@@ -108,7 +108,7 @@ defmodule Explorer.SmartContract.Reader do
     |> query_contracts(abi)
     |> Enum.zip(requests)
     |> Enum.into(%{}, fn {response, request} ->
-      {request.function_name, response}
+      {request.method_id, response}
     end)
   end
 
@@ -121,11 +121,11 @@ defmodule Explorer.SmartContract.Reader do
   def query_contract(contract_address, from, abi, functions) do
     requests =
       functions
-      |> Enum.map(fn {function_name, args} ->
+      |> Enum.map(fn {method_id, args} ->
         %{
           contract_address: contract_address,
           from: from,
-          function_name: function_name,
+          method_id: method_id,
           args: args
         }
       end)
@@ -134,7 +134,7 @@ defmodule Explorer.SmartContract.Reader do
     |> query_contracts(abi)
     |> Enum.zip(requests)
     |> Enum.into(%{}, fn {response, request} ->
-      {request.function_name, response}
+      {request.method_id, response}
     end)
   end
 
@@ -200,9 +200,11 @@ defmodule Explorer.SmartContract.Reader do
         []
 
       _ ->
-        abi
+        abi_with_method_id = get_abi_with_method_id(abi)
+
+        abi_with_method_id
         |> Enum.filter(&(&1["constant"] || &1["stateMutability"] == "view"))
-        |> Enum.map(&fetch_current_value_from_blockchain(&1, abi, contract_address_hash))
+        |> Enum.map(&fetch_current_value_from_blockchain(&1, abi_with_method_id, contract_address_hash))
     end
   end
 
@@ -214,9 +216,72 @@ defmodule Explorer.SmartContract.Reader do
         []
 
       _ ->
-        implementation_abi
+        implementation_abi_with_method_id = get_abi_with_method_id(implementation_abi)
+
+        implementation_abi_with_method_id
         |> Enum.filter(&(&1["constant"] || &1["stateMutability"] == "view"))
-        |> Enum.map(&fetch_current_value_from_blockchain(&1, implementation_abi, contract_address_hash))
+        |> Enum.map(&fetch_current_value_from_blockchain(&1, implementation_abi_with_method_id, contract_address_hash))
+    end
+  end
+
+  defp get_abi_with_method_id(abi) do
+    parsed_abi =
+      abi
+      |> ABI.parse_specification()
+
+    abi_with_method_id =
+      abi
+      |> Enum.map(fn target_method ->
+        methods =
+          parsed_abi
+          |> Enum.filter(fn method ->
+            Atom.to_string(method.type) == Map.get(target_method, "type") &&
+              method.function == Map.get(target_method, "name") &&
+              Enum.count(method.input_names) == Enum.count(Map.get(target_method, "inputs")) &&
+              input_types_matched?(method.types, target_method)
+          end)
+
+        if Enum.count(methods) > 0 do
+          method = Enum.at(methods, 0)
+          method_id = Map.get(method, :method_id)
+          method_with_id = Map.put(target_method, "method_id", Base.encode16(method_id, case: :lower))
+          method_with_id
+        else
+          target_method
+        end
+      end)
+
+    abi_with_method_id
+  end
+
+  defp input_types_matched?(types, target_method) do
+    Enum.all?(types, fn target_type ->
+      index = Enum.find_index(types, fn type -> type == target_type end)
+      type_to_compare = Map.get(Enum.at(Map.get(target_method, "inputs"), index), "type")
+      target_type_formatted = format_input_type(target_type)
+      target_type_formatted == type_to_compare
+    end)
+  end
+
+  defp format_input_type(input_type) do
+    case input_type do
+      {:array, {type, size}, array_size} ->
+        Atom.to_string(type) <> Integer.to_string(size) <> "[" <> Integer.to_string(array_size) <> "]"
+
+      {:array, type, array_size} ->
+        Atom.to_string(type) <> "[" <> Integer.to_string(array_size) <> "]"
+
+      {:array, {type, size}} ->
+        Atom.to_string(type) <> Integer.to_string(size) <> "[]"
+
+      {:array, type} ->
+        Atom.to_string(type) <> "[]"
+
+      {type, size} ->
+        Atom.to_string(type) <> Integer.to_string(size)
+
+      type ->
+        Atom.to_string(type)
     end
   end
 
@@ -224,16 +289,16 @@ defmodule Explorer.SmartContract.Reader do
     values =
       case function do
         %{"inputs" => []} ->
-          name = function["name"]
+          method_id = function["method_id"]
           args = function["inputs"]
           outputs = function["outputs"]
 
           contract_address_hash
-          |> query_verified_contract(%{name => normalize_args(args)}, abi)
-          |> link_outputs_and_values(outputs, name)
+          |> query_verified_contract(%{method_id => normalize_args(args)}, abi)
+          |> link_outputs_and_values(outputs, method_id)
 
         _ ->
-          link_outputs_and_values(%{}, Map.get(function, "outputs", []), function["name"])
+          link_outputs_and_values(%{}, Map.get(function, "outputs", []), function["method_id"])
       end
 
     Map.replace!(function, "outputs", values)
@@ -242,13 +307,13 @@ defmodule Explorer.SmartContract.Reader do
   @doc """
   Fetches the blockchain value of a function that requires arguments.
   """
-  @spec query_function(String.t(), %{name: String.t(), args: nil}, atom()) :: [%{}]
-  def query_function(contract_address_hash, %{name: name, args: nil}, type) do
-    query_function(contract_address_hash, %{name: name, args: []}, type)
+  @spec query_function(String.t(), %{method_id: String.t(), args: nil}, atom()) :: [%{}]
+  def query_function(contract_address_hash, %{method_id: method_id, args: nil}, type) do
+    query_function(contract_address_hash, %{method_id: method_id, args: []}, type)
   end
 
-  @spec query_function(Hash.t(), %{name: String.t(), args: [term()]}, atom()) :: [%{}]
-  def query_function(contract_address_hash, %{name: name, args: args}, type) do
+  @spec query_function(Hash.t(), %{method_id: String.t(), args: [term()]}, atom()) :: [%{}]
+  def query_function(contract_address_hash, %{method_id: method_id, args: args}, type) do
     abi =
       contract_address_hash
       |> Chain.address_hash_to_smart_contract()
@@ -261,23 +326,47 @@ defmodule Explorer.SmartContract.Reader do
         abi
       end
 
-    outputs =
-      case final_abi do
+    parsed_final_abi =
+      final_abi
+      |> ABI.parse_specification()
+
+    %{outputs: outputs, method_id: method_id} =
+      case parsed_final_abi do
         nil ->
           nil
 
         _ ->
-          function =
-            final_abi
-            |> Enum.filter(fn function -> function["name"] == name end)
+          function_object =
+            parsed_final_abi
+            |> Enum.filter(fn %ABI.FunctionSelector{method_id: find_method_id} ->
+              Base.encode16(find_method_id, case: :lower) == method_id
+            end)
             |> List.first()
 
-          function["outputs"]
+          %ABI.FunctionSelector{returns: returns, method_id: method_id} = function_object
+
+          outputs = extract_outputs(returns)
+
+          %{outputs: outputs, method_id: method_id}
       end
 
     contract_address_hash
-    |> query_verified_contract(%{name => normalize_args(args)}, final_abi)
-    |> link_outputs_and_values(outputs, name)
+    |> query_verified_contract(%{method_id => normalize_args(args)}, final_abi)
+    |> link_outputs_and_values(outputs, method_id)
+  end
+
+  defp extract_outputs(returns) do
+    returns
+    |> Enum.map(fn output ->
+      case output do
+        {type, size} ->
+          full_type = Atom.to_string(type) <> Integer.to_string(size)
+          %{"type" => full_type}
+
+        type ->
+          %{"type" => type}
+      end
+    end)
   end
 
   @doc """
@@ -308,9 +397,9 @@ defmodule Explorer.SmartContract.Reader do
     end
   end
 
-  def link_outputs_and_values(blockchain_values, outputs, function_name) do
+  def link_outputs_and_values(blockchain_values, outputs, method_id) do
     default_value = Enum.map(outputs, fn _ -> "" end)
-    {_, value} = Map.get(blockchain_values, function_name, {:ok, default_value})
+    {_, value} = Map.get(blockchain_values, method_id, {:ok, default_value})
 
     for {output, index} <- Enum.with_index(outputs) do
       new_value(output, List.wrap(value), index)

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -339,7 +339,11 @@ defmodule Explorer.SmartContract.Reader do
           function_object =
             parsed_final_abi
             |> Enum.filter(fn %ABI.FunctionSelector{method_id: find_method_id} ->
-              Base.encode16(find_method_id, case: :lower) == method_id
+              if find_method_id do
+                Base.encode16(find_method_id, case: :lower) == method_id
+              else
+                find_method_id == method_id
+              end
             end)
             |> List.first()
 

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -255,8 +255,9 @@ defmodule Explorer.SmartContract.Reader do
   end
 
   defp input_types_matched?(types, target_method) do
-    Enum.all?(types, fn target_type ->
-      index = Enum.find_index(types, fn type -> type == target_type end)
+    types
+    |> Enum.with_index()
+    |> Enum.all?(fn {target_type, index} ->
       type_to_compare = Map.get(Enum.at(Map.get(target_method, "inputs"), index), "type")
       target_type_formatted = format_input_type(target_type)
       target_type_formatted == type_to_compare
@@ -336,16 +337,7 @@ defmodule Explorer.SmartContract.Reader do
           nil
 
         _ ->
-          function_object =
-            parsed_final_abi
-            |> Enum.filter(fn %ABI.FunctionSelector{method_id: find_method_id} ->
-              if find_method_id do
-                Base.encode16(find_method_id, case: :lower) == method_id
-              else
-                find_method_id == method_id
-              end
-            end)
-            |> List.first()
+          function_object = find_function_by_method(parsed_final_abi, method_id)
 
           %ABI.FunctionSelector{returns: returns, method_id: method_id} = function_object
 
@@ -357,6 +349,18 @@ defmodule Explorer.SmartContract.Reader do
     contract_address_hash
     |> query_verified_contract(%{method_id => normalize_args(args)}, final_abi)
     |> link_outputs_and_values(outputs, method_id)
+  end
+
+  defp find_function_by_method(parsed_abi, method_id) do
+    parsed_abi
+    |> Enum.filter(fn %ABI.FunctionSelector{method_id: find_method_id} ->
+      if find_method_id do
+        Base.encode16(find_method_id, case: :lower) == method_id || find_method_id == method_id
+      else
+        find_method_id == method_id
+      end
+    end)
+    |> List.first()
   end
 
   defp extract_outputs(returns) do

--- a/apps/explorer/lib/explorer/staking/pools_reader.ex
+++ b/apps/explorer/lib/explorer/staking/pools_reader.ex
@@ -11,31 +11,34 @@ defmodule Explorer.Staking.PoolsReader do
 
   @spec get_active_pools() :: [String.t()]
   def get_active_pools do
-    {:ok, [active_pools]} = call_staking_method("getPools", [])
+    # 673a2a1f = keccak256(getPools())
+    {:ok, [active_pools]} = call_staking_method("673a2a1f", [])
     active_pools
   end
 
   @spec get_inactive_pools() :: [String.t()]
   def get_inactive_pools do
-    {:ok, [inactive_pools]} = call_staking_method("getPoolsInactive", [])
+    # df6f55f5 = keccak256(getPoolsInactive())
+    {:ok, [inactive_pools]} = call_staking_method("df6f55f5", [])
     inactive_pools
   end
 
   @spec pool_data(String.t()) :: {:ok, map()} | :error
   def pool_data(staking_address) do
-    with {:ok, [mining_address]} <- call_validators_method("miningByStakingAddress", [staking_address]),
+    # 00535175 = keccak256(miningByStakingAddress(address))
+    with {:ok, [mining_address]} <- call_validators_method("00535175", [staking_address]),
          data = fetch_pool_data(staking_address, mining_address),
-         {:ok, [is_active]} <- data["isPoolActive"],
-         {:ok, [delegator_addresses]} <- data["poolDelegators"],
+         {:ok, [is_active]} <- data["a711e6a1"],
+         {:ok, [delegator_addresses]} <- data["9ea8082b"],
          delegators_count = Enum.count(delegator_addresses),
          delegators = delegators_data(delegator_addresses, staking_address),
-         {:ok, [staked_amount]} <- data["stakeAmountTotalMinusOrderedWithdraw"],
-         {:ok, [self_staked_amount]} <- data["stakeAmountMinusOrderedWithdraw"],
-         {:ok, [is_validator]} <- data["isValidator"],
-         {:ok, [was_validator_count]} <- data["validatorCounter"],
-         {:ok, [is_banned]} <- data["isValidatorBanned"],
-         {:ok, [banned_until]} <- data["bannedUntil"],
-         {:ok, [was_banned_count]} <- data["banCounter"] do
+         {:ok, [staked_amount]} <- data["234fbf2b"],
+         {:ok, [self_staked_amount]} <- data["58daab6a"],
+         {:ok, [is_validator]} <- data["facd743b"],
+         {:ok, [was_validator_count]} <- data["b41832e4"],
+         {:ok, [is_banned]} <- data["a92252ae"],
+         {:ok, [banned_until]} <- data["5836d08a"],
+         {:ok, [was_banned_count]} <- data["1d0cd4c6"] do
       {
         :ok,
         %{
@@ -61,20 +64,25 @@ defmodule Explorer.Staking.PoolsReader do
 
   defp delegators_data(delegators, pool_address) do
     Enum.map(delegators, fn address ->
+      # a697ecff = keccak256(stakeAmount(address,address))
+      # e9ab0300 = keccak256(orderedWithdrawAmount(address,address))
+      # 6bda1577 = keccak256(maxWithdrawAllowed(address,address))
+      # 950a6513 = keccak256(maxWithdrawOrderAllowed(address,address))
+      # a4205967 = keccak256(orderWithdrawEpoch(address,address))
       data =
         call_methods([
-          {:staking, "stakeAmount", [pool_address, address]},
-          {:staking, "orderedWithdrawAmount", [pool_address, address]},
-          {:staking, "maxWithdrawAllowed", [pool_address, address]},
-          {:staking, "maxWithdrawOrderAllowed", [pool_address, address]},
-          {:staking, "orderWithdrawEpoch", [pool_address, address]}
+          {:staking, "a697ecff", [pool_address, address]},
+          {:staking, "e9ab0300", [pool_address, address]},
+          {:staking, "6bda1577", [pool_address, address]},
+          {:staking, "950a6513", [pool_address, address]},
+          {:staking, "a4205967", [pool_address, address]}
         ])
 
-      {:ok, [stake_amount]} = data["stakeAmount"]
-      {:ok, [ordered_withdraw]} = data["orderedWithdrawAmount"]
-      {:ok, [max_withdraw_allowed]} = data["maxWithdrawAllowed"]
-      {:ok, [max_ordered_withdraw_allowed]} = data["maxWithdrawOrderAllowed"]
-      {:ok, [ordered_withdraw_epoch]} = data["orderWithdrawEpoch"]
+      {:ok, [stake_amount]} = data["a697ecff"]
+      {:ok, [ordered_withdraw]} = data["e9ab0300"]
+      {:ok, [max_withdraw_allowed]} = data["6bda1577"]
+      {:ok, [max_ordered_withdraw_allowed]} = data["950a6513"]
+      {:ok, [ordered_withdraw_epoch]} = data["a4205967"]
 
       %{
         delegator_address_hash: address,
@@ -107,16 +115,25 @@ defmodule Explorer.Staking.PoolsReader do
   end
 
   defp fetch_pool_data(staking_address, mining_address) do
+    # a711e6a1 = keccak256(isPoolActive(address))
+    # 9ea8082b = keccak256(poolDelegators(address))
+    # 234fbf2b = keccak256(stakeAmountTotalMinusOrderedWithdraw(address))
+    # 58daab6a = keccak256(stakeAmountMinusOrderedWithdraw(address,address))
+    # facd743b = keccak256(isValidator(address))
+    # b41832e4 = keccak256(validatorCounter(address))
+    # a92252ae = keccak256(isValidatorBanned(address))
+    # 5836d08a = keccak256(bannedUntil(address))
+    # 1d0cd4c6 = keccak256(banCounter(address))
     call_methods([
-      {:staking, "isPoolActive", [staking_address]},
-      {:staking, "poolDelegators", [staking_address]},
-      {:staking, "stakeAmountTotalMinusOrderedWithdraw", [staking_address]},
-      {:staking, "stakeAmountMinusOrderedWithdraw", [staking_address, staking_address]},
-      {:validators, "isValidator", [mining_address]},
-      {:validators, "validatorCounter", [mining_address]},
-      {:validators, "isValidatorBanned", [mining_address]},
-      {:validators, "bannedUntil", [mining_address]},
-      {:validators, "banCounter", [mining_address]}
+      {:staking, "a711e6a1", [staking_address]},
+      {:staking, "9ea8082b", [staking_address]},
+      {:staking, "234fbf2b", [staking_address]},
+      {:staking, "58daab6a", [staking_address, staking_address]},
+      {:validators, "facd743b", [mining_address]},
+      {:validators, "b41832e4", [mining_address]},
+      {:validators, "a92252ae", [mining_address]},
+      {:validators, "5836d08a", [mining_address]},
+      {:validators, "1d0cd4c6", [mining_address]}
     ])
   end
 
@@ -127,15 +144,15 @@ defmodule Explorer.Staking.PoolsReader do
     |> Enum.map(&format_request/1)
     |> Reader.query_contracts(contract_abi)
     |> Enum.zip(methods)
-    |> Enum.into(%{}, fn {response, {_, function_name, _}} ->
-      {function_name, response}
+    |> Enum.into(%{}, fn {response, {_, method_id, _}} ->
+      {method_id, response}
     end)
   end
 
-  defp format_request({contract_name, function_name, params}) do
+  defp format_request({contract_name, method_id, params}) do
     %{
       contract_address: contract(contract_name),
-      function_name: function_name,
+      method_id: method_id,
       args: params
     }
   end

--- a/apps/explorer/lib/explorer/token/balance_reader.ex
+++ b/apps/explorer/lib/explorer/token/balance_reader.ex
@@ -44,7 +44,7 @@ defmodule Explorer.Token.BalanceReader do
        }) do
     %{
       contract_address: token_contract_address_hash,
-      function_name: "balanceOf",
+      method_id: "70a08231",
       args: [address_hash],
       block_number: block_number
     }

--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -37,7 +37,8 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
   end
 
   def fetch_metadata(contract_address_hash, token_id) do
-    contract_functions = %{"tokenURI" => [token_id]}
+    # c87b56dd =  keccak256(tokenURI(uint256))
+    contract_functions = %{"c87b56dd" => [token_id]}
 
     contract_address_hash
     |> query_contract(contract_functions)
@@ -48,26 +49,26 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     Reader.query_contract(contract_address_hash, @abi, contract_functions)
   end
 
-  def fetch_json(%{"tokenURI" => {:ok, [""]}}) do
+  def fetch_json(%{"c87b56dd" => {:ok, [""]}}) do
     {:ok, %{error: @no_uri_error}}
   end
 
-  def fetch_json(%{"tokenURI" => {:error, "(-32015) VM execution error."}}) do
+  def fetch_json(%{"c87b56dd" => {:error, "(-32015) VM execution error."}}) do
     {:ok, %{error: @no_uri_error}}
   end
 
-  def fetch_json(%{"tokenURI" => {:ok, ["http://" <> _ = token_uri]}}) do
+  def fetch_json(%{"c87b56dd" => {:ok, ["http://" <> _ = token_uri]}}) do
     fetch_metadata(token_uri)
   end
 
-  def fetch_json(%{"tokenURI" => {:ok, ["https://" <> _ = token_uri]}}) do
+  def fetch_json(%{"c87b56dd" => {:ok, ["https://" <> _ = token_uri]}}) do
     fetch_metadata(token_uri)
   end
 
-  def fetch_json(%{"tokenURI" => {:ok, ["data:application/json," <> json]}}) do
+  def fetch_json(%{"c87b56dd" => {:ok, ["data:application/json," <> json]}}) do
     decoded_json = URI.decode(json)
 
-    fetch_json(%{"tokenURI" => {:ok, [decoded_json]}})
+    fetch_json(%{"c87b56dd" => {:ok, [decoded_json]}})
   rescue
     e ->
       Logger.debug(["Unknown metadata format #{inspect(json)}. error #{inspect(e)}"],
@@ -77,7 +78,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
       {:error, json}
   end
 
-  def fetch_json(%{"tokenURI" => {:ok, [json]}}) do
+  def fetch_json(%{"c87b56dd" => {:ok, [json]}}) do
     {:ok, json} = decode_json(json)
 
     check_type(json)

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -86,11 +86,15 @@ defmodule Explorer.Token.MetadataRetriever do
     }
   ]
 
+  # 18160ddd = keccak256(totalSupply())
+  # 313ce567 = keccak256(decimals())
+  # 06fdde03 = keccak256(name())
+  # 95d89b41 = keccak256(symbol())
   @contract_functions %{
-    "totalSupply" => [],
-    "decimals" => [],
-    "name" => [],
-    "symbol" => []
+    "18160ddd" => [],
+    "313ce567" => [],
+    "06fdde03" => [],
+    "95d89b41" => []
   }
 
   @doc """
@@ -126,8 +130,8 @@ defmodule Explorer.Token.MetadataRetriever do
       hashes
       |> Enum.flat_map(fn hash ->
         @contract_functions
-        |> Enum.map(fn {function, args} ->
-          %{contract_address: hash, function_name: function, args: args}
+        |> Enum.map(fn {method_id, args} ->
+          %{contract_address: hash, method_id: method_id, args: args}
         end)
       end)
 
@@ -140,7 +144,7 @@ defmodule Explorer.Token.MetadataRetriever do
       |> Enum.zip(hashes)
       |> Enum.map(fn {result, hash} ->
         formatted_result =
-          ["decimals", "name", "symbol", "totalSupply"]
+          ["name", "totalSupply", "decimals", "symbol"]
           |> Enum.zip(result)
           |> format_contract_functions_result(hash)
 
@@ -227,8 +231,8 @@ defmodule Explorer.Token.MetadataRetriever do
 
   defp format_contract_functions_result(contract_functions, contract_address_hash) do
     contract_functions =
-      for {function_name, {:ok, [function_data]}} <- contract_functions, into: %{} do
-        {atomized_key(function_name), function_data}
+      for {method_id, {:ok, [function_data]}} <- contract_functions, into: %{} do
+        {atomized_key(method_id), function_data}
       end
 
     contract_functions
@@ -240,6 +244,10 @@ defmodule Explorer.Token.MetadataRetriever do
   defp atomized_key("name"), do: :name
   defp atomized_key("symbol"), do: :symbol
   defp atomized_key("totalSupply"), do: :total_supply
+  defp atomized_key("313ce567"), do: :decimals
+  defp atomized_key("06fdde03"), do: :name
+  defp atomized_key("95d89b41"), do: :symbol
+  defp atomized_key("18160ddd"), do: :total_supply
 
   # It's a temp fix to store tokens that have names and/or symbols with characters that the database
   # doesn't accept. See https://github.com/poanetwork/blockscout/issues/669 for more info.

--- a/apps/explorer/lib/explorer/validator/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/validator/metadata_retriever.ex
@@ -16,18 +16,20 @@ defmodule Explorer.Validator.MetadataRetriever do
   end
 
   defp fetch_validators_list do
-    %{"getValidators" => {:ok, [validators]}} =
+    # b7ab4db5 = keccak256(getValidators())
+    %{"b7ab4db5" => {:ok, [validators]}} =
       Reader.query_contract(config(:validators_contract_address), contract_abi("validators.json"), %{
-        "getValidators" => []
+        "b7ab4db5" => []
       })
 
     validators
   end
 
   defp fetch_validator_metadata(validator_address) do
-    %{"validators" => {:ok, fields}} =
+    # fa52c7d8 = keccak256(validators(address))
+    %{"fa52c7d8" => {:ok, fields}} =
       Reader.query_contract(config(:metadata_contract_address), contract_abi("metadata.json"), %{
-        "validators" => [validator_address]
+        "fa52c7d8" => [validator_address]
       })
 
     fields

--- a/apps/explorer/package-lock.json
+++ b/apps/explorer/package-lock.json
@@ -125,7 +125,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "path-is-absolute": {

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -9,6 +9,8 @@ defmodule Explorer.SmartContract.ReaderTest do
 
   doctest Explorer.SmartContract.Reader
 
+  # 6d4ce63c = keccak from get()
+
   setup :verify_on_exit!
 
   describe "query_contract/4" do
@@ -19,9 +21,9 @@ defmodule Explorer.SmartContract.ReaderTest do
 
       blockchain_get_function_mock()
 
-      response = Reader.query_contract(contract_address_hash, abi, %{"get" => []})
+      response = Reader.query_contract(contract_address_hash, abi, %{"6d4ce63c" => []})
 
-      assert %{"get" => {:ok, [0]}} == response
+      assert %{"6d4ce63c" => {:ok, [0]}} == response
     end
 
     test "handles errors when there are malformed function arguments" do
@@ -40,11 +42,11 @@ defmodule Explorer.SmartContract.ReaderTest do
         "type" => "function"
       }
 
-      string_argument = %{"sum" => ["abc"]}
+      string_argument = %{"a50e1860" => ["abc"]}
 
       response = Reader.query_contract(contract_address_hash, [int_function_abi], string_argument)
 
-      assert %{"sum" => {:error, "Data overflow encoding int, data `abc` cannot fit in 256 bits"}} = response
+      assert %{"a50e1860" => {:error, "Data overflow encoding int, data `abc` cannot fit in 256 bits"}} = response
     end
 
     test "handles standardize errors returned from RPC requests" do
@@ -60,9 +62,9 @@ defmodule Explorer.SmartContract.ReaderTest do
         end
       )
 
-      response = Reader.query_contract(contract_address_hash, abi, %{"get" => []})
+      response = Reader.query_contract(contract_address_hash, abi, %{"6d4ce63c" => []})
 
-      assert %{"get" => {:error, "(12345) Error message"}} = response
+      assert %{"6d4ce63c" => {:error, "(12345) Error message"}} = response
     end
 
     test "handles bad_gateway errors returned from RPC requests" do
@@ -78,9 +80,9 @@ defmodule Explorer.SmartContract.ReaderTest do
         end
       )
 
-      response = Reader.query_contract(contract_address_hash, abi, %{"get" => []})
+      response = Reader.query_contract(contract_address_hash, abi, %{"6d4ce63c" => []})
 
-      assert %{"get" => {:error, "Bad gateway"}} = response
+      assert %{"6d4ce63c" => {:error, "Bad gateway"}} = response
     end
 
     test "handles other types of errors" do
@@ -96,9 +98,9 @@ defmodule Explorer.SmartContract.ReaderTest do
         end
       )
 
-      response = Reader.query_contract(contract_address_hash, abi, %{"get" => []})
+      response = Reader.query_contract(contract_address_hash, abi, %{"6d4ce63c" => []})
 
-      assert %{"get" => {:error, "no function clause matches"}} = response
+      assert %{"6d4ce63c" => {:error, "no function clause matches"}} = response
     end
   end
 
@@ -111,7 +113,7 @@ defmodule Explorer.SmartContract.ReaderTest do
 
       blockchain_get_function_mock()
 
-      assert Reader.query_verified_contract(hash, %{"get" => []}) == %{"get" => {:ok, [0]}}
+      assert Reader.query_verified_contract(hash, %{"6d4ce63c" => []}) == %{"6d4ce63c" => {:ok, [0]}}
     end
   end
 
@@ -259,11 +261,10 @@ defmodule Explorer.SmartContract.ReaderTest do
 
       assert [
                %{
-                 "name" => "",
                  "type" => "uint256",
                  "value" => 0
                }
-             ] = Reader.query_function(smart_contract.address_hash, %{name: "get", args: []}, :regular)
+             ] = Reader.query_function(smart_contract.address_hash, %{method_id: "6d4ce63c", args: []}, :regular)
     end
 
     test "nil arguments is treated as []" do
@@ -273,11 +274,10 @@ defmodule Explorer.SmartContract.ReaderTest do
 
       assert [
                %{
-                 "name" => "",
                  "type" => "uint256",
                  "value" => 0
                }
-             ] = Reader.query_function(smart_contract.address_hash, %{name: "get", args: nil}, :regular)
+             ] = Reader.query_function(smart_contract.address_hash, %{method_id: "6d4ce63c", args: nil}, :regular)
     end
   end
 

--- a/apps/explorer/test/explorer/token/instance_metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/instance_metadata_retriever_test.exs
@@ -44,10 +44,10 @@ defmodule Explorer.Token.InstanceMetadataRetrieverTest do
       end
 
       assert %{
-               "tokenURI" => {:ok, ["https://vault.warriders.com/18290729947667102496.json"]}
+               "c87b56dd" => {:ok, ["https://vault.warriders.com/18290729947667102496.json"]}
              } ==
                InstanceMetadataRetriever.query_contract("0x5caebd3b32e210e85ce3e9d51638b9c445481567", %{
-                 "tokenURI" => [18_290_729_947_667_102_496]
+                 "c87b56dd" => [18_290_729_947_667_102_496]
                })
     end
   end
@@ -72,13 +72,13 @@ defmodule Explorer.Token.InstanceMetadataRetrieverTest do
 
       assert {:ok, %{metadata: %{"name" => "Sérgio Mendonça"}}} ==
                InstanceMetadataRetriever.fetch_json(%{
-                 "tokenURI" => {:ok, ["http://localhost:#{bypass.port}/api/card/55265"]}
+                 "c87b56dd" => {:ok, ["http://localhost:#{bypass.port}/api/card/55265"]}
                })
     end
 
     test "decodes json file in tokenURI" do
       data = %{
-        "tokenURI" =>
+        "c87b56dd" =>
           {:ok,
            [
              "data:application/json,{\"name\":\"Home%20Address%20-%200x0000000000C1A6066c6c8B9d63e9B6E8865dC117\",\"description\":\"This%20NFT%20can%20be%20redeemed%20on%20HomeWork%20to%20grant%20a%20controller%20the%20exclusive%20right%20to%20deploy%20contracts%20with%20arbitrary%20bytecode%20to%20the%20designated%20home%20address.\",\"image\":\"data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNDQgNzIiPjxzdHlsZT48IVtDREFUQVsuQntzdHJva2UtbGluZWpvaW46cm91bmR9LkN7c3Ryb2tlLW1pdGVybGltaXQ6MTB9LkR7c3Ryb2tlLXdpZHRoOjJ9LkV7ZmlsbDojOWI5YjlhfS5Ge3N0cm9rZS1saW5lY2FwOnJvdW5kfV1dPjwvc3R5bGU+PGcgdHJhbnNmb3JtPSJtYXRyaXgoMS4wMiAwIDAgMS4wMiA4LjEgMCkiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0xOSAzMmgzNHYyNEgxOXoiLz48ZyBzdHJva2U9IiMwMDAiIGNsYXNzPSJCIEMgRCI+PHBhdGggZmlsbD0iI2E1NzkzOSIgZD0iTTI1IDQwaDl2MTZoLTl6Ii8+PHBhdGggZmlsbD0iIzkyZDNmNSIgZD0iTTQwIDQwaDh2N2gtOHoiLz48cGF0aCBmaWxsPSIjZWE1YTQ3IiBkPSJNNTMgMzJIMTl2LTFsMTYtMTYgMTggMTZ6Ii8+PHBhdGggZmlsbD0ibm9uZSIgZD0iTTE5IDMyaDM0djI0SDE5eiIvPjxwYXRoIGZpbGw9IiNlYTVhNDciIGQ9Ik0yOSAyMWwtNSA1di05aDV6Ii8+PC9nPjwvZz48ZyB0cmFuc2Zvcm09Im1hdHJpeCguODQgMCAwIC44NCA2NSA1KSI+PHBhdGggZD0iTTkuNSAyMi45bDQuOCA2LjRhMy4xMiAzLjEyIDAgMCAxLTMgMi4ybC00LjgtNi40Yy4zLTEuNCAxLjYtMi40IDMtMi4yeiIgZmlsbD0iI2QwY2ZjZSIvPjxwYXRoIGZpbGw9IiMwMTAxMDEiIGQ9Ik00MS43IDM4LjVsNS4xLTYuNSIvPjxwYXRoIGQ9Ik00Mi45IDI3LjhMMTguNCA1OC4xIDI0IDYybDIxLjgtMjcuMyAyLjMtMi44eiIgY2xhc3M9IkUiLz48cGF0aCBmaWxsPSIjMDEwMTAxIiBkPSJNNDMuNCAyOS4zbC00LjcgNS44Ii8+PHBhdGggZD0iTTQ2LjggMzJjMy4yIDIuNiA4LjcgMS4yIDEyLjEtMy4yczMuNi05LjkuMy0xMi41bC01LjEgNi41LTIuOC0uMS0uNy0yLjcgNS4xLTYuNWMtMy4yLTIuNi04LjctMS4yLTEyLjEgMy4ycy0zLjYgOS45LS4zIDEyLjUiIGNsYXNzPSJFIi8+PHBhdGggZmlsbD0iI2E1NzkzOSIgZD0iTTI3LjMgMjZsMTEuOCAxNS43IDMuNCAyLjQgOS4xIDE0LjQtMy4yIDIuMy0xIC43LTEwLjItMTMuNi0xLjMtMy45LTExLjgtMTUuN3oiLz48cGF0aCBkPSJNMTIgMTkuOWw1LjkgNy45IDEwLjItNy42LTMuNC00LjVzNi44LTUuMSAxMC43LTQuNWMwIDAtNi42LTMtMTMuMyAxLjFTMTIgMTkuOSAxMiAxOS45eiIgY2xhc3M9IkUiLz48ZyBmaWxsPSJub25lIiBzdHJva2U9IiMwMDAiIGNsYXNzPSJCIEMgRCI+PHBhdGggZD0iTTUyIDU4LjlMNDAuOSA0My4ybC0zLjEtMi4zLTEwLjYtMTQuNy0yLjkgMi4yIDEwLjYgMTQuNyAxLjEgMy42IDExLjUgMTUuNXpNMTIuNSAxOS44bDUuOCA4IDEwLjMtNy40LTMuMy00LjZzNi45LTUgMTAuOC00LjNjMCAwLTYuNi0zLjEtMTMuMy45cy0xMC4zIDcuNC0xMC4zIDcuNHptLTIuNiAyLjlsNC43IDYuNWMtLjUgMS4zLTEuNyAyLjEtMyAyLjJsLTQuNy02LjVjLjMtMS40IDEuNi0yLjQgMy0yLjJ6Ii8+PHBhdGggZD0iTTQxLjMgMzguNWw1LjEtNi41bS0zLjUtMi43bC00LjYgNS44bTguMS0zLjFjMy4yIDIuNiA4LjcgMS4yIDEyLjEtMy4yczMuNi05LjkuMy0xMi41bC01LjEgNi41LTIuOC0uMS0uOC0yLjcgNS4xLTYuNWMtMy4yLTIuNi04LjctMS4yLTEyLjEgMy4yLTMuNCA0LjMtMy42IDkuOS0uMyAxMi41IiBjbGFzcz0iRiIvPjxwYXRoIGQ9Ik0zMC44IDQ0LjRMMTkgNTguOWw0IDMgMTAtMTIuNyIgY2xhc3M9IkYiLz48L2c+PC9nPjwvc3ZnPg==\"}"


### PR DESCRIPTION
## Motivation

https://blockscout.com/poa/sokol/address/0xD99dFe5F3253CDACd1C4eCe0Da524187fD9EacF4/contracts

<img width="637" alt="Screenshot 2020-08-26 at 12 31 30" src="https://user-images.githubusercontent.com/4341812/91287211-16b18780-e798-11ea-996e-d3badfe57abf.png">
<img width="659" alt="Screenshot 2020-08-26 at 12 31 16" src="https://user-images.githubusercontent.com/4341812/91287215-17e2b480-e798-11ea-878d-ba131b90eebe.png">


## Changelog

Add method id as key in the list of contract methods instead of function name

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
