### PR TITLE
Fix encoding of address output if function input exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#3261](https://github.com/poanetwork/blockscout/pull/3261) - Bridged tokens table
 
 ### Fixes
+- [#3264](https://github.com/poanetwork/blockscout/pull/3264) - Fix encoding of address output if function input exists
 - [#3259](https://github.com/poanetwork/blockscout/pull/3259) - Contract interaction: array input type parsing fix
 - [#3257](https://github.com/poanetwork/blockscout/pull/3257) - Contracts read/write: method_id instead function_name as a key
 - [#3256](https://github.com/poanetwork/blockscout/pull/3256) - Fix for invisible validator address at block page and wrong alert text color at xDai

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -418,7 +418,15 @@ defmodule Explorer.SmartContract.Reader do
     Map.put_new(output, "value", bytes_to_string(value))
   end
 
+  defp new_value(%{"type" => :address} = output, [value], _index) do
+    Map.put_new(output, "value", bytes_to_string(value))
+  end
+
   defp new_value(%{"type" => "address"} = output, values, index) do
+    Map.put_new(output, "value", bytes_to_string(Enum.at(values, index)))
+  end
+
+  defp new_value(%{"type" => :address} = output, values, index) do
     Map.put_new(output, "value", bytes_to_string(Enum.at(values, index)))
   end
 


### PR DESCRIPTION
## Motivation

*Adress* type output in the contract method call incorrectly decodes if the method contains inputs

<img width="604" alt="Screenshot 2020-08-28 at 20 56 26" src="https://user-images.githubusercontent.com/4341812/91602811-a0b64780-e974-11ea-9c2c-afe173b67277.png">


## Changelog

Add missing clauses in function for parsing of output - support *:address* atoms


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
