### PR TITLE
Open possibility to set token metadata updater interval less than hour

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3538,9 +3538,9 @@ defmodule Explorer.Chain do
           reducer :: (entry :: Hash.Address.t(), accumulator -> accumulator)
         ) :: {:ok, accumulator}
         when accumulator: term()
-  def stream_cataloged_token_contract_address_hashes(initial, reducer, hours_ago_updated \\ 48)
+  def stream_cataloged_token_contract_address_hashes(initial, reducer, some_time_ago_updated \\ 2880)
       when is_function(reducer, 2) do
-    hours_ago_updated
+    some_time_ago_updated
     |> Token.cataloged_tokens()
     |> order_by(asc: :updated_at)
     |> Repo.stream_reduce(initial, reducer)

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -107,14 +107,14 @@ defmodule Explorer.Chain.Token do
 
   These are tokens with cataloged field set to true and updated_at is earlier or equal than an hour ago.
   """
-  def cataloged_tokens(hours \\ 48) do
+  def cataloged_tokens(minutes \\ 2880) do
     date_now = DateTime.utc_now()
-    hours_ago_date = DateTime.add(date_now, -:timer.hours(hours), :millisecond)
+    some_time_ago_date = DateTime.add(date_now, -:timer.minutes(minutes), :millisecond)
 
     from(
       token in __MODULE__,
       select: token.contract_address_hash,
-      where: token.cataloged == true and token.updated_at <= ^hours_ago_date
+      where: token.cataloged == true and token.updated_at <= ^some_time_ago_date
     )
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/token_updater.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_updater.ex
@@ -44,9 +44,9 @@ defmodule Indexer.Fetcher.TokenUpdater do
   @impl BufferedTask
   def init(initial, reducer, _) do
     metadata_updater_inverval = Application.get_env(:indexer, :metadata_updater_seconds_interval)
-    hour_interval = Kernel.round(metadata_updater_inverval / (60 * 60))
+    interval_in_minutes = Kernel.round(metadata_updater_inverval / 60)
 
-    {:ok, tokens} = Chain.stream_cataloged_token_contract_address_hashes(initial, reducer, hour_interval)
+    {:ok, tokens} = Chain.stream_cataloged_token_contract_address_hashes(initial, reducer, interval_in_minutes)
 
     tokens
   end


### PR DESCRIPTION
## Motivation

Need possibility for requesting new token metadata frequenter than once per hour

## Changelog

Change denomination of *stream_cataloged_token_contract_address_hashes* function's time input from hours to minnutes.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
