### PR TITLE
Token total supply on-demand fetcher

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -22,3 +22,4 @@ lib/block_scout_web/views/layout_view.ex:224: The call 'Elixir.Poison.Parser':'p
 lib/block_scout_web/controllers/api/rpc/transaction_controller.ex:21
 lib/block_scout_web/controllers/api/rpc/transaction_controller.ex:22
 lib/explorer/smart_contract/reader.ex:336
+lib/indexer/fetcher/token_total_supply_on_demand.ex:16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3268](https://github.com/poanetwork/blockscout/pull/3268) - Token total supply on-demand fetcher
 - [#3261](https://github.com/poanetwork/blockscout/pull/3261) - Bridged tokens table
 
 ### Fixes
@@ -19,7 +20,7 @@
 ### Features
 - [#3252](https://github.com/poanetwork/blockscout/pull/3252) - Gas price at the main page
 - [#3239](https://github.com/poanetwork/blockscout/pull/3239) - Hide address page tabs if no items
-- [#3236](https://github.com/poanetwork/blockscout/pull/3236) - Easy verification of contracts which hash verified twins (the same bytecode)
+- [#3236](https://github.com/poanetwork/blockscout/pull/3236) - Easy verification of contracts which has verified twins (the same bytecode)
 - [#3227](https://github.com/poanetwork/blockscout/pull/3227) - Distinguishing of bridged tokens
 - [#3224](https://github.com/poanetwork/blockscout/pull/3224) - Top tokens page
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
@@ -4,6 +4,7 @@ defmodule BlockScoutWeb.Tokens.TransferController do
   alias BlockScoutWeb.Tokens.TransferView
   alias Explorer.{Chain, Market}
   alias Explorer.Chain.Address
+  alias Indexer.Fetcher.TokenTotalSupplyOnDemand
   alias Phoenix.View
 
   import BlockScoutWeb.Chain, only: [split_list_by_page: 1, paging_options: 1, next_page_params: 3]
@@ -63,7 +64,8 @@ defmodule BlockScoutWeb.Tokens.TransferController do
         "index.html",
         counters_path: token_path(conn, :token_counters, %{"id" => Address.checksum(address_hash)}),
         current_path: current_path(conn),
-        token: Market.add_price(token)
+        token: Market.add_price(token),
+        token_total_supply_status: TokenTotalSupplyOnDemand.trigger_fetch(address_hash)
       )
     else
       :error ->

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3923,7 +3923,7 @@ defmodule Explorer.Chain do
         end
       )
       |> Multi.run(:token, fn repo, _ ->
-        with {:error, %Changeset{errors: [{^stale_error_field, {^stale_error_message, []}}]}} <-
+        with {:error, %Changeset{errors: [{^stale_error_field, {^stale_error_message, [_]}}]}} <-
                repo.insert(token_changeset, token_opts) do
           # the original token passed into `update_token/2` as stale error means it is unchanged
           {:ok, token}

--- a/apps/indexer/lib/indexer/fetcher/token_total_supply_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_total_supply_on_demand.ex
@@ -20,7 +20,7 @@ defmodule Indexer.Fetcher.TokenTotalSupplyOnDemand do
 
   ## Callbacks
 
-  def start_link(init_opts, server_opts) do
+  def start_link([init_opts, server_opts]) do
     GenServer.start_link(__MODULE__, init_opts, server_opts)
   end
 

--- a/apps/indexer/lib/indexer/fetcher/token_total_supply_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_total_supply_on_demand.ex
@@ -1,0 +1,48 @@
+defmodule Indexer.Fetcher.TokenTotalSupplyOnDemand do
+  @moduledoc """
+  Ensures that we have a reasonably up to date token supply.
+
+  """
+
+  use GenServer
+  use Indexer.Fetcher
+
+  alias Explorer.{Chain, Repo}
+  alias Explorer.Chain.{Address, Token}
+  alias Explorer.Token.MetadataRetriever
+
+  ## Interface
+
+  @spec trigger_fetch(Address.t()) :: :ok
+  def trigger_fetch(address) do
+    do_trigger_fetch(address)
+  end
+
+  ## Callbacks
+
+  def start_link(init_opts, server_opts) do
+    GenServer.start_link(__MODULE__, init_opts, server_opts)
+  end
+
+  def init(init_arg) do
+    {:ok, init_arg}
+  end
+
+  ## Implementation
+
+  defp do_trigger_fetch(address) when not is_nil(address) do
+    token_address_hash = "0x" <> Base.encode16(address.bytes)
+
+    token_params =
+      token_address_hash
+      |> MetadataRetriever.get_functions_of()
+
+    token =
+      Token
+      |> Repo.get_by(contract_address_hash: address)
+      |> Repo.preload([:contract_address])
+
+    {:ok, _} = Chain.update_token(%{token | updated_at: DateTime.utc_now()}, token_params)
+    :ok
+  end
+end

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -20,6 +20,7 @@ defmodule Indexer.Supervisor do
     Token,
     TokenBalance,
     TokenInstance,
+    TokenTotalSupplyOnDemand,
     TokenUpdater,
     UncleBlock
   }
@@ -117,6 +118,7 @@ defmodule Indexer.Supervisor do
 
       # Out-of-band fetchers
       {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
+      {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]},
 
       # Temporary workers
       {UncatalogedTokenTransfers.Supervisor, [[]]},


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/3267

## Motivation

Token total supply doesn't update with the new tokens mint/burn

## Changelog

On-demand token metadata update fetcher is added. It triggers when someone opens a token page

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
