### PR TITLE
Update token metadata at burn/mint events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3273](https://github.com/poanetwork/blockscout/pull/3273) - Update token metadata at burn/mint events
 - [#3268](https://github.com/poanetwork/blockscout/pull/3268) - Token total supply on-demand fetcher
 - [#3261](https://github.com/poanetwork/blockscout/pull/3261) - Bridged tokens table
 

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -71,6 +71,17 @@ defmodule Explorer.Chain.Address do
              :names
            ]}
 
+  @derive {Jason.Encoder,
+           except: [
+             :__meta__,
+             :smart_contract,
+             :decompiled_smart_contracts,
+             :token,
+             :contracts_creation_internal_transaction,
+             :contracts_creation_transaction,
+             :names
+           ]}
+
   @primary_key {:hash, Hash.Address, autogenerate: false}
   schema "addresses" do
     field(:fetched_coin_balance, Wei)

--- a/apps/explorer/lib/explorer/chain/bridged_token.ex
+++ b/apps/explorer/lib/explorer/chain/bridged_token.ex
@@ -31,6 +31,14 @@ defmodule Explorer.Chain.BridgedToken do
              :updated_at
            ]}
 
+  @derive {Jason.Encoder,
+           except: [
+             :__meta__,
+             :home_token_contract_address,
+             :inserted_at,
+             :updated_at
+           ]}
+
   @primary_key false
   schema "bridged_tokens" do
     field(:foreign_chain_id, :decimal)

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -57,6 +57,14 @@ defmodule Explorer.Chain.Token do
              :updated_at
            ]}
 
+  @derive {Jason.Encoder,
+           except: [
+             :__meta__,
+             :contract_address,
+             :inserted_at,
+             :updated_at
+           ]}
+
   @primary_key false
   schema "tokens" do
     field(:name, :string)

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -185,6 +185,25 @@ defmodule Explorer.Chain.Transaction do
              :value
            ]}
 
+  @derive {Jason.Encoder,
+           only: [
+             :block_number,
+             :cumulative_gas_used,
+             :error,
+             :gas,
+             :gas_price,
+             :gas_used,
+             :index,
+             :created_contract_code_indexed_at,
+             :input,
+             :nonce,
+             :r,
+             :s,
+             :v,
+             :status,
+             :value
+           ]}
+
   @primary_key {:hash, Hash.Full, autogenerate: false}
   schema "transactions" do
     field(:block_number, :integer)


### PR DESCRIPTION
## Motivation

Total supply doesn't updates through indexing fetchers. Currently, it updates only by on-demand fetcher https://github.com/poanetwork/blockscout/pull/3268.

## Changelog

Add token metadata updater to token transfer parsing method if *to* or *from* of token transfer is *burn_address*. Thus, token supply will be updated with every burn or mint of tokens.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
