### PR TITLE
Write contract: display currently connected address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3281](https://github.com/poanetwork/blockscout/pull/3281) - Write contract: display currently connected address
 - [#3279](https://github.com/poanetwork/blockscout/pull/3279) - NFT instance: link to the app
 - [#3278](https://github.com/poanetwork/blockscout/pull/3278) - Support of fetching of NFT tokens metadata from IPFS
 - [#3273](https://github.com/poanetwork/blockscout/pull/3273) - Update token metadata at burn/mint events

--- a/apps/block_scout_web/assets/css/components/_card.scss
+++ b/apps/block_scout_web/assets/css/components/_card.scss
@@ -270,3 +270,9 @@ $card-tab-icon-color-active: #fff !default;
 .implementation-value {
   line-height: 30px;
 }
+
+.connect-container {
+  display: flex;
+  height: 36px;
+  line-height: 36px;
+}

--- a/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
@@ -19,15 +19,47 @@ const loadFunctions = (element) => {
     response => $element.html(response)
   )
     .done(function () {
+      const $connectTo = $('[connect-to]')
       const $connect = $('[connect-metamask]')
+      const $connectedTo = $('[connected-to]')
+      const $reconnect = $('[re-connect-metamask]')
+      const $connectedToAddress = $('[connected-to-address]')
 
-      if (hideConnectButton()) {
-        $connect.addClass('hidden')
-      } else {
-        $connect.removeClass('hidden')
-      }
+      window.ethereum && window.ethereum.on('accountsChanged', function (accounts) {
+        if (accounts.length === 0) {
+          $connectTo.removeClass('hidden')
+          $connect.removeClass('hidden')
+          $connectedTo.addClass('hidden')
+        } else {
+          $connectTo.addClass('hidden')
+          $connect.removeClass('hidden')
+          $connectedTo.removeClass('hidden')
+          $connectedToAddress.html(`<a href='/address/${accounts[0]}'>${accounts[0]}</a>`)
+        }
+      })
+
+      hideConnectButton().then(({ shouldHide, account }) => {
+        if (shouldHide && account) {
+          $connectTo.addClass('hidden')
+          $connect.removeClass('hidden')
+          $connectedTo.removeClass('hidden')
+          $connectedToAddress.html(`<a href='/address/${account}'>${account}</a>`)
+        } else if (shouldHide) {
+          $connectTo.removeClass('hidden')
+          $connect.addClass('hidden')
+          $connectedTo.addClass('hidden')
+        } else {
+          $connectTo.removeClass('hidden')
+          $connect.removeClass('hidden')
+          $connectedTo.addClass('hidden')
+        }
+      })
 
       $connect.on('click', () => {
+        connectToWallet()
+      })
+
+      $reconnect.on('click', () => {
         connectToWallet()
       })
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/icons/_inactive_icon.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/icons/_inactive_icon.html.eex
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="6" height="6">
+    <circle cx="3" cy="3" r="3" fill="#7f295e" />
+</svg>

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -12,7 +12,19 @@ to: address_contract_path(@conn, :index, metadata_for_verification.address_hash)
   <% end %>
 <% end %>
 <%= if @action== "write" do %>
-  <button connect-metamask class="button btn-line">Connect to Metamask</button>
+  <div connect-to class="connect-container">
+    <span style="margin-top: -2px;" class="mr-2">
+      <%= render BlockScoutWeb.IconsView, "_inactive_icon.html" %>
+    </span>
+     <h2 style="margin-top: -2px;">Disconnected</h2>
+    <button connect-metamask class="button btn-line ml-4">Connect to Metamask</button>
+  </div>
+  <div connected-to class="connect-container hidden">
+    <span style="margin-top: -2px;" class="mr-2">
+      <%= render BlockScoutWeb.IconsView, "_active_icon.html" %>
+    </span>
+    <h2 style="margin-top: -2px;">Connected to</h2><h3 connected-to-address class="ml-2"></h3>
+  </div>
 <% end %>
 <%= if @contract_type == "proxy" do %>
 <div class="implementation-container">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -563,8 +563,8 @@ msgid "ERC-721 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:57
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:92
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:69
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:104
 msgid "ETH"
 msgstr ""
 
@@ -1182,7 +1182,7 @@ msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:61
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:73
 msgid "Query"
 msgstr ""
 
@@ -1634,7 +1634,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:91
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:103
 msgid "WEI"
 msgstr ""
 
@@ -1925,7 +1925,7 @@ msgid "Waiting for transaction's confirmation..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:61
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:73
 msgid "Write"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -563,8 +563,8 @@ msgid "ERC-721 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:57
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:92
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:69
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:104
 msgid "ETH"
 msgstr ""
 
@@ -1182,7 +1182,7 @@ msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:61
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:73
 msgid "Query"
 msgstr ""
 
@@ -1634,7 +1634,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:91
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:103
 msgid "WEI"
 msgstr ""
 
@@ -1925,7 +1925,7 @@ msgid "Waiting for transaction's confirmation..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:61
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:73
 msgid "Write"
 msgstr ""
 


### PR DESCRIPTION
## Motivation

Improve UX of contract's write functionality

## Changelog

Display address to which contract's write page currently connected. Also, take into account *accountsChanged* events.

<img width="336" alt="Screenshot 2020-09-03 at 18 48 13" src="https://user-images.githubusercontent.com/4341812/92139588-9c78a700-ee18-11ea-98df-c4196ab530f3.png">

![Screenshot 2020-09-03 at 18 49 06](https://user-images.githubusercontent.com/4341812/92139789-eeb9c800-ee18-11ea-83d4-36b5600e1b20.png)



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
