### PR TITLE
Fix fetch_coin_balance query: coin balance delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#3261](https://github.com/poanetwork/blockscout/pull/3261) - Bridged tokens table
 
 ### Fixes
+- [#3284](https://github.com/poanetwork/blockscout/pull/3284) - Fix fetch_coin_balance query: coin balance delta
 - [#3276](https://github.com/poanetwork/blockscout/pull/3276) - Bridged tokens status/metadata fetcher refactoring
 - [#3264](https://github.com/poanetwork/blockscout/pull/3264) - Fix encoding of address output if function input exists
 - [#3259](https://github.com/poanetwork/blockscout/pull/3259), [#3269](https://github.com/poanetwork/blockscout/pull/3269) - Contract interaction: array input type parsing fix


### PR DESCRIPTION
## Motivation

Current query in *fetch_coin_balance* function causes performance issues.


## Changelog

In order to address the performance of the query replace

```
SELECT a0."block_number", a0."value", a0."value_fetched_at", a0."inserted_at", a0."updated_at", a0."address_hash", value - coalesce(lag(value, 1) over (order by block_number), 0), b1."timestamp" FROM "address_coin_balances" AS a0 INNER JOIN "blocks" AS b1 ON a0."block_number" = b1."number" WHERE (a0."address_hash" = '\...') AND (a0."block_number" <= ...) ORDER BY a0."block_number" DESC LIMIT 1;
```

with

```
SELECT c."block_number", c."value", c."value_fetched_at", c."inserted_at", c."updated_at", c."address_hash", value - coalesce(lag(value, 1) over (order by block_number), 0) from (select a0."block_number", a0."value", a0."value_fetched_at", a0."inserted_at", a0."updated_at", a0."address_hash" FROM "address_coin_balances" AS a0  WHERE (a0."address_hash" = '\x...') AND (a0."block_number" <= ...) ORDER BY a0."block_number" DESC LIMIT 2) as c ORDER BY c."block_number" DESC LIMIT 1;
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
