### PR TITLE
Support unlimited number of external rewards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#3261](https://github.com/poanetwork/blockscout/pull/3261) - Bridged tokens table
 
 ### Fixes
+- [#3291](https://github.com/poanetwork/blockscout/pull/3291) - Support unlimited number of external rewards in block
 - [#3290](https://github.com/poanetwork/blockscout/pull/3290) - Eliminate protocol Jason.Encoder not implemented for... error
 - [#3284](https://github.com/poanetwork/blockscout/pull/3284) - Fix fetch_coin_balance query: coin balance delta
 - [#3276](https://github.com/poanetwork/blockscout/pull/3276) - Bridged tokens status/metadata fetcher refactoring

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/besu/fetched_beneficiaries.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/besu/fetched_beneficiaries.ex
@@ -171,7 +171,7 @@ defmodule EthereumJSONRPC.Besu.FetchedBeneficiaries do
   # The rewardType "uncle" will show reward for validating an uncle block
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 0, do: :validator
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 1, do: :emission_funds
-  defp get_address_type(reward_type, index) when reward_type == "external" and index > 2, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index >= 2, do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "block", do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "uncle", do: :uncle
   defp get_address_type(reward_type, _index) when reward_type == "emptyStep", do: :validator

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/besu/fetched_beneficiaries.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/besu/fetched_beneficiaries.ex
@@ -171,25 +171,7 @@ defmodule EthereumJSONRPC.Besu.FetchedBeneficiaries do
   # The rewardType "uncle" will show reward for validating an uncle block
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 0, do: :validator
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 1, do: :emission_funds
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 2, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 3, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 4, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 5, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 6, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 7, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 8, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 9, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 10, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 11, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 12, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 13, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 14, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 15, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 16, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 17, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 18, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 19, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 20, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index > 2, do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "block", do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "uncle", do: :uncle
   defp get_address_type(reward_type, _index) when reward_type == "emptyStep", do: :validator

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex
@@ -171,25 +171,7 @@ defmodule EthereumJSONRPC.Parity.FetchedBeneficiaries do
   # The rewardType "uncle" will show reward for validating an uncle block
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 0, do: :validator
   defp get_address_type(reward_type, index) when reward_type == "external" and index == 1, do: :emission_funds
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 2, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 3, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 4, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 5, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 6, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 7, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 8, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 9, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 10, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 11, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 12, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 13, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 14, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 15, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 16, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 17, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 18, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 19, do: :validator
-  defp get_address_type(reward_type, index) when reward_type == "external" and index == 20, do: :validator
+  defp get_address_type(reward_type, index) when reward_type == "external" and index >= 2, do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "block", do: :validator
   defp get_address_type(reward_type, _index) when reward_type == "uncle", do: :uncle
   defp get_address_type(reward_type, _index) when reward_type == "emptyStep", do: :validator


### PR DESCRIPTION
## Motivation

```
2020-09-11T10:37:28.429 application=indexer fetcher=block_catchup first_block_number=11937842 last_block_number=11937840 [error] ** (FunctionClauseError) no function clause matching in EthereumJSONRPC.Parity.FetchedBeneficiaries.get_address_type/2
    (ethereum_jsonrpc 0.1.0) lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex:172: EthereumJSONRPC.Parity.FetchedBeneficiaries.get_address_type("external", 21)
    (ethereum_jsonrpc 0.1.0) lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex:156: EthereumJSONRPC.Parity.FetchedBeneficiaries.trace_to_params_set/3
    (ethereum_jsonrpc 0.1.0) lib/ethereum_jsonrpc/parity/fetched_beneficiaries.ex:132: anonymous fn/3 in EthereumJSONRPC.Parity.FetchedBeneficiaries.traces_to_params_set/2
    (elixir 1.10.3) lib/enum.ex:3383: anonymous fn/3 in Enum.reduce/3
    (elixir 1.10.3) lib/stream.ex:1597: anonymous fn/3 in Enumerable.Stream.reduce/3
    (elixir 1.10.3) lib/stream.ex:1066: anonymous fn/3 in Stream.with_index/2
    (elixir 1.10.3) lib/enum.ex:3686: Enumerable.List.reduce/3
    (elixir 1.10.3) lib/stream.ex:1609: Enumerable.Stream.do_each/4
```

## Changelog

Remove limits for the number of rewards of *external* type


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
