### PR TITLE
Token instance: check if external_url is not null before trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#3261](https://github.com/poanetwork/blockscout/pull/3261) - Bridged tokens table
 
 ### Fixes
+- [#3295](https://github.com/poanetwork/blockscout/pull/3295) - Token instance: check if external_url is not null before trimming
 - [#3291](https://github.com/poanetwork/blockscout/pull/3291) - Support unlimited number of external rewards in block
 - [#3290](https://github.com/poanetwork/blockscout/pull/3290) - Eliminate protocol Jason.Encoder not implemented for... error
 - [#3284](https://github.com/poanetwork/blockscout/pull/3284) - Fix fetch_coin_balance query: coin balance delta

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
@@ -48,7 +48,7 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewView do
         external_url(nil)
       end
 
-    if String.trim(result) == "", do: external_url(nil), else: result
+    if !result || (result && String.trim(result)) == "", do: external_url(nil), else: result
   end
 
   def total_supply_usd(token) do


### PR DESCRIPTION
## Motivation

Eliminate error like this
```
Request: GET /tokens/0x7D37700d88D5258e6Ca100D2694dD87A49101412/instance/3/token-transfers
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in String.Break.trim_leading/1
        (elixir 1.10.3) lib/elixir/unicode/properties.ex:298: String.Break.trim_leading(nil)
        (elixir 1.10.3) lib/string.ex:1177: String.trim/1
        (block_scout_web 0.0.1) lib/block_scout_web/views/tokens/instance/overview_view.ex:51: BlockScoutWeb.Tokens.Instance.OverviewView.external_url/1
        (block_scout_web 0.0.1) lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:66: BlockScoutWeb.Tokens.Instance.OverviewView."_details.html"/1
        (block_scout_web 0.0.1) lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:2: BlockScoutWeb.Tokens.Instance.TransferView."index.html"/1
        (phoenix 1.5.4) lib/phoenix/view.ex:310: Phoenix.View.render_within/3
        (phoenix 1.5.4) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.4) lib/phoenix/controller.ex:776: Phoenix.Controller.render_and_send/4
```

## Changelog

Check if *external_url* is nil in metadata before trimming

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
