### PR TITLE
Disable token supply on-demand fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 - [#3279](https://github.com/poanetwork/blockscout/pull/3279) - NFT instance: link to the app
 - [#3278](https://github.com/poanetwork/blockscout/pull/3278) - Support of fetching of NFT metadata from IPFS
 - [#3273](https://github.com/poanetwork/blockscout/pull/3273) - Update token metadata at burn/mint events
-- [#3268](https://github.com/poanetwork/blockscout/pull/3268) - Token total supply on-demand fetcher
 - [#3261](https://github.com/poanetwork/blockscout/pull/3261) - Bridged tokens table
 
 ### Fixes

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
@@ -4,7 +4,6 @@ defmodule BlockScoutWeb.Tokens.TransferController do
   alias BlockScoutWeb.Tokens.TransferView
   alias Explorer.{Chain, Market}
   alias Explorer.Chain.Address
-  alias Indexer.Fetcher.TokenTotalSupplyOnDemand
   alias Phoenix.View
 
   import BlockScoutWeb.Chain, only: [split_list_by_page: 1, paging_options: 1, next_page_params: 3]
@@ -64,8 +63,7 @@ defmodule BlockScoutWeb.Tokens.TransferController do
         "index.html",
         counters_path: token_path(conn, :token_counters, %{"id" => Address.checksum(address_hash)}),
         current_path: current_path(conn),
-        token: Market.add_price(token),
-        token_total_supply_status: TokenTotalSupplyOnDemand.trigger_fetch(address_hash)
+        token: Market.add_price(token)
       )
     else
       :error ->

--- a/apps/indexer/lib/indexer/fetcher/token_total_supply_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_total_supply_on_demand.ex
@@ -1,6 +1,7 @@
 defmodule Indexer.Fetcher.TokenTotalSupplyOnDemand do
   @moduledoc """
   Ensures that we have a reasonably up to date token supply.
+  Currently disabled because caaused a deadlock when opening not-verified contract address.
 
   """
 

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -20,7 +20,6 @@ defmodule Indexer.Supervisor do
     Token,
     TokenBalance,
     TokenInstance,
-    TokenTotalSupplyOnDemand,
     TokenUpdater,
     UncleBlock
   }
@@ -118,7 +117,6 @@ defmodule Indexer.Supervisor do
 
       # Out-of-band fetchers
       {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
-      {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]},
 
       # Temporary workers
       {UncatalogedTokenTransfers.Supervisor, [[]]},


### PR DESCRIPTION
Revert https://github.com/poanetwork/blockscout/pull/3268

## Motivation

Token supply on-demand fetcher causes deadlocks in the DB when opening page for the unverified contract. Moreover, it is not needed, because we update token metadata (together with supply) on burn/mint events https://github.com/poanetwork/blockscout/pull/3273.


## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
