### PR TITLE
Address contract twins feature performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#3261](https://github.com/poanetwork/blockscout/pull/3261) - Bridged tokens table
 
 ### Fixes
+- [#3303](https://github.com/poanetwork/blockscout/pull/3303) - Address contract twins feature performance
 - [#3295](https://github.com/poanetwork/blockscout/pull/3295) - Token instance: check if external_url is not null before trimming
 - [#3291](https://github.com/poanetwork/blockscout/pull/3291) - Support unlimited number of external rewards in block
 - [#3290](https://github.com/poanetwork/blockscout/pull/3290) - Eliminate protocol Jason.Encoder not implemented for... error

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3244,7 +3244,7 @@ defmodule Explorer.Chain do
               query =
                 from(
                   address in Address,
-                  left_join: smart_contract in SmartContract,
+                  inner_join: smart_contract in SmartContract,
                   on: address.hash == smart_contract.address_hash,
                   where: fragment("md5(contract_code::text)") == ^contract_code_md5,
                   where: address.hash != ^target_address_hash,


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/pull/3236

## Motivation

some pages of unverified contracts are not opened on tie due to long request for searching of verified contract twins

## Changelog

Replace left join with inner join in the target query

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
