### PR TITLE
Handle nil values from response of CoinGecko price API

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -24,6 +24,6 @@ lib/block_scout_web/controllers/api/rpc/transaction_controller.ex:22
 lib/explorer/smart_contract/reader.ex:336
 lib/indexer/fetcher/token_total_supply_on_demand.ex:16
 lib/explorer/exchange_rates/source.ex:41
-lib/explorer/exchange_rates/source/coin_gecko.ex:115
-lib/explorer/exchange_rates/source/coin_gecko.ex:136
+lib/explorer/exchange_rates/source/coin_gecko.ex:148
+lib/explorer/exchange_rates/source/coin_gecko.ex:169
 lib/explorer/smart_contract/verifier.ex:89

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#3261](https://github.com/poanetwork/blockscout/pull/3261) - Bridged tokens table
 
 ### Fixes
+- [#3314](https://github.com/poanetwork/blockscout/pull/3314) - Handle nil values from response of CoinGecko price API
 - [#3312](https://github.com/poanetwork/blockscout/pull/3312) - Replace symbol for some tokens to be able to find price in CoinGecko for OmniBridge balance
 - [#3307](https://github.com/poanetwork/blockscout/pull/3307) - Replace "latest" compiler version with the actual one
 - [#3303](https://github.com/poanetwork/blockscout/pull/3303) - Address contract twins feature performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 - [#3314](https://github.com/poanetwork/blockscout/pull/3314) - Handle nil values from response of CoinGecko price API
+- [#3313](https://github.com/poanetwork/blockscout/pull/3313) - Fix xDai styles: invisible tokens on address
 - [#3312](https://github.com/poanetwork/blockscout/pull/3312) - Replace symbol for some tokens to be able to find price in CoinGecko for OmniBridge balance
 - [#3307](https://github.com/poanetwork/blockscout/pull/3307) - Replace "latest" compiler version with the actual one
 - [#3303](https://github.com/poanetwork/blockscout/pull/3303) - Address contract twins feature performance

--- a/apps/block_scout_web/assets/css/theme/_dai_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_dai_variables.scss
@@ -47,7 +47,7 @@ $tile-type-block-color: $secondary;
 $tile-type-progress-bar-color: $secondary;
 a.tile-title { color: $secondary !important; }
 .card-body {  
-	a:not(.dropdown-item):not(.button):not([data-test=address_hash_link]):not(.alert-link):not([data-test=token_link]) {
+	a:not(.dropdown-item):not(.button):not([data-test=address_hash_link]):not(.alert-link):not([data-test=token_link]):not(#dropdown-tokens) {
 		color: $secondary;
 
 		&:hover {

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
@@ -12,35 +12,68 @@ defmodule Explorer.ExchangeRates.Source.CoinGecko do
 
   @impl Source
   def format_data(%{"market_data" => _} = json_data) do
-    {:ok, price} = get_btc_price()
-    btc_price = to_decimal(price)
-
     market_data = json_data["market_data"]
-    {:ok, last_updated, 0} = DateTime.from_iso8601(market_data["last_updated"])
 
-    current_price = to_decimal(market_data["current_price"]["usd"])
+    last_updated = get_last_updated(market_data)
+    current_price = get_current_price(market_data)
 
     id = json_data["id"]
-    btc_value = if id != "btc", do: Decimal.div(current_price, btc_price), else: 1
+    btc_value = get_btc_value(id, market_data)
+
+    circulating_supply_data = market_data && market_data["circulating_supply"]
+    total_supply_data = market_data && market_data["total_supply"]
+    market_cap_data_usd = market_data && market_data["market_cap"] && market_data["market_cap"]["usd"]
+    total_volume_data_usd = market_data && market_data["total_volume"] && market_data["total_volume"]["usd"]
 
     [
       %Token{
-        available_supply: to_decimal(market_data["circulating_supply"]),
-        total_supply: to_decimal(market_data["total_supply"]) || to_decimal(market_data["circulating_supply"]),
+        available_supply: to_decimal(circulating_supply_data),
+        total_supply: to_decimal(total_supply_data) || to_decimal(circulating_supply_data),
         btc_value: btc_value,
-        id: json_data["id"],
+        id: id,
         last_updated: last_updated,
-        market_cap_usd: to_decimal(market_data["market_cap"]["usd"]),
+        market_cap_usd: to_decimal(market_cap_data_usd),
         name: json_data["name"],
         symbol: String.upcase(json_data["symbol"]),
         usd_value: current_price,
-        volume_24h_usd: to_decimal(market_data["total_volume"]["usd"])
+        volume_24h_usd: to_decimal(total_volume_data_usd)
       }
     ]
   end
 
   @impl Source
   def format_data(_), do: []
+
+  defp get_last_updated(market_data) do
+    last_updated_data = market_data && market_data["last_updated"]
+
+    if last_updated_data do
+      {:ok, last_updated, 0} = DateTime.from_iso8601(last_updated_data)
+      last_updated
+    else
+      nil
+    end
+  end
+
+  defp get_current_price(market_data) do
+    if market_data["current_price"] do
+      to_decimal(market_data["current_price"]["usd"])
+    else
+      1
+    end
+  end
+
+  defp get_btc_value(id, market_data) do
+    {:ok, price} = get_btc_price()
+    btc_price = to_decimal(price)
+    current_price = get_current_price(market_data)
+
+    if id != "btc" && current_price && btc_price do
+      Decimal.div(current_price, btc_price)
+    else
+      1
+    end
+  end
 
   @impl Source
   def source_url do


### PR DESCRIPTION
## Motivation

CoinGecko returns nil `last_updated` property from some coins. We should handle it.

## Changelog

Handle nil values in the properties from the response on the request of the price of any token from CoinGecko.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
