### PR TITLE
Environment variable to disable Bridge market cap updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#3256](https://github.com/poanetwork/blockscout/pull/3256) - Fix for invisible validator address at block page and wrong alert text color at xDai
 
 ### Chore
+- [#3315](https://github.com/poanetwork/blockscout/pull/3315) - Environment variable to disable Bridge market cap updater
 - [#3308](https://github.com/poanetwork/blockscout/pull/3308) - Fixate latest stable release of Elixir, Node, Postgres
 - [#3297](https://github.com/poanetwork/blockscout/pull/3297) - Actualize names of default chains
 - [#3285](https://github.com/poanetwork/blockscout/pull/3285) - Switch to RPC endpoint polling if ETHEREUM_JSONRPC_WS_URL is an empty string

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -98,7 +98,7 @@ bridge_market_cap_update_interval =
 
 config :explorer, Explorer.Counters.Bridge,
   enabled: if(System.get_env("SUPPLY_MODULE") === "TokenBridge", do: true, else: false),
-  enable_consolidation: true,
+  enable_consolidation: System.get_env("DISABLE_BRIDGE_MARKET_CAP_UPDATER") !== "true",
   update_interval_in_seconds: bridge_market_cap_update_interval || 30 * 60
 
 config :explorer, Explorer.ExchangeRates, enabled: System.get_env("DISABLE_EXCHANGE_RATES") != "true", store: :ets

--- a/apps/explorer/lib/explorer/counters/bridge.ex
+++ b/apps/explorer/lib/explorer/counters/bridge.ex
@@ -134,6 +134,7 @@ defmodule Explorer.Counters.Bridge do
   end
 
   defp update_total_supply_from_token_bridge_cache do
+    create_bridges_table()
     current_total_supply_from_token_bridge = TokenBridge.get_current_total_supply_from_token_bridge()
 
     :ets.insert(
@@ -145,6 +146,7 @@ defmodule Explorer.Counters.Bridge do
   end
 
   defp update_total_omni_bridge_market_cap_cache do
+    create_bridges_table()
     current_total_supply_from_omni_bridge = TokenBridge.get_current_market_cap_from_omni_bridge()
 
     :ets.insert(


### PR DESCRIPTION
## Motivation

Absence of allowability to easily disable bridge market cap updater

## Changelog

`DISABLE_BRIDGE_MARKET_CAP_UPDATER ` introduced

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
