### PR TITLE
Fix pagination for bridged tokens list page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Current
 
+### Features
+
+
+### Fixes
+- [#3329](https://github.com/poanetwork/blockscout/pull/3329) - Fix pagination for bridged tokens list page
+
+### Chore
+
+
 
 ## 3.3.3-beta
 

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -220,6 +220,10 @@ defmodule BlockScoutWeb.Chain do
     %{"contract_address_hash" => contract_address_hash, "holder_count" => holder_count}
   end
 
+  defp paging_params([%Token{contract_address_hash: contract_address_hash, holder_count: holder_count}, _]) do
+    %{"contract_address_hash" => contract_address_hash, "holder_count" => holder_count}
+  end
+
   defp paging_params({%Reward{block: %{number: number}}, _}) do
     %{"block_number" => number, "index" => 0}
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/bridged_tokens_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/bridged_tokens_controller.ex
@@ -21,7 +21,7 @@ defmodule BlockScoutWeb.BridgedTokensController do
           nil
 
         next_page_params ->
-          tokens_path(
+          bridged_tokens_path(
             conn,
             :index,
             Map.delete(next_page_params, "type")

--- a/apps/block_scout_web/lib/block_scout_web/templates/bridged_tokens/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/bridged_tokens/index.html.eex
@@ -32,7 +32,7 @@
 	      </th>
 	    </tr>
 	  </thead>
-	  <tbody data-items data-selector="top-tokens-list">
+	  <tbody data-items data-selector="top-bridged-tokens-list">
 	    <%= render BlockScoutWeb.CommonComponentsView, "_table-loader.html", total_supply: @total_supply %>
 	  </tbody>
 	</table>


### PR DESCRIPTION
## Motivation

An error like this on loading of bridged tokens list with the length > *page_size*:
```
blockscout-xdai    | Request: GET /bridged-tokens?type=JSON
blockscout-xdai    | ** (exit) an exception was raised:
blockscout-xdai    |     ** (FunctionClauseError) no function clause matching in BlockScoutWeb.Chain.paging_params/1
blockscout-xdai    |         (block_scout_web 0.0.1) lib/block_scout_web/chain.ex:215: BlockScoutWeb.Chain.paging_params([%Explorer.Chain.Token{__meta__: #Ecto.Schema.Metadata<:loaded, "tokens">, bridged: true, cataloged: true, contract_address: %Explorer.Chain.Address{__meta__: #Ecto.Schema.Metadata<:loaded, "addresses">, contract_code: %Explorer.Chain.Data{bytes: <<96, 128, 96, 64, 82, 96, 4, 54, 16, 96, 62, 87, 99, 255, 255, 255, 255, 124, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...>>}, contracts_creation_internal_transaction: #Ecto.Association.NotLoaded<association :contracts_creation_internal_transaction is not loaded>, contracts_creation_transaction: #Ecto.Association.NotLoaded<association :contracts_creation_transaction is not loaded>, decompiled: false, decompiled_smart_contracts: #Ecto.Association.NotLoaded<association :decompiled_smart_contracts is not loaded>, fetched_coin_balance: #Explorer.Chain.Wei<0>, fetched_coin_balance_block_number: 12327760, has_decompiled_code?: nil, hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<152, 94, 20, 78, 179, 85, 39, 60, 75, 77, 81, 228, 72, 182, 139, 101, 127, 72, 46, 38>>}, inserted_at: ~U[2020-08-26 18:17:40.955820Z], names: #Ecto.Association.NotLoaded<association :names is not loaded>, nonce: nil, smart_contract: #Ecto.Association.NotLoaded<association :smart_contract is not loaded>, stale?: nil, token: #Ecto.Association.NotLoaded<association :token is not loaded>, updated_at: ~U[2020-08-26 18:17:40.955820Z], verified: false}, contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<152, 94, 20, 78, 179, 85, 39, 60, 75, 77, 81, 228, 72, 182, 139, 101, 127, 72, 46, 38>>}, decimals: #Decimal<18>, holder_count: 1, inserted_at: ~U[2020-08-26 18:17:40.955820Z], name: "POA ERC20 on Foundation on xDai", symbol: "POA20", total_supply: #Decimal<1000000000000000000>, type: "ERC-20", updated_at: ~U[2020-08-28 20:51:57.075848Z]}, %Explorer.Chain.BridgedToken{__meta__: #Ecto.Schema.Metadata<:loaded, "bridged_tokens">, custom_metadata: nil, foreign_chain_id: #Decimal<1>, foreign_token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<103, 88, 183, 212, 65, 169, 115, 155, 152, 85, 43, 55, 55, 3, 216, 211, 209, 79, 158, 98>>}, home_token_contract_address: #Ecto.Association.NotLoaded<association :home_token_contract_address is not loaded>, home_token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<152, 94, 20, 78, 179, 85, 39, 60, 75, 77, 81, 228, 72, 182, 139, 101, 127, 72, 46, 38>>}, inserted_at: ~U[2020-08-28 20:51:56.826848Z], type: "omni", updated_at: ~U[2020-08-28 20:51:56.826848Z]}])
blockscout-xdai    |         (block_scout_web 0.0.1) lib/block_scout_web/chain.ex:98: BlockScoutWeb.Chain.next_page_params/3
blockscout-xdai    |         (block_scout_web 0.0.1) lib/block_scout_web/controllers/tokens/bridged_tokens_controller.ex:19: BlockScoutWeb.BridgedTokensController.index/2
blockscout-xdai    |         (block_scout_web 0.0.1) lib/block_scout_web/controllers/tokens/bridged_tokens_controller.ex:1: BlockScoutWeb.BridgedTokensController.action/2
blockscout-xdai    |         (block_scout_web 0.0.1) lib/block_scout_web/controllers/tokens/bridged_tokens_controller.ex:1: BlockScoutWeb.BridgedTokensController.phoenix_controller_pipeline/2
blockscout-xdai    |         (phoenix 1.5.4) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
blockscout-xdai    |         (phoenix 1.5.4) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
blockscout-xdai    |         (phoenix 1.5.4) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
```

## Changelog

Add missing clause for *paging_params* function

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
