### PR TITLE
MarketCap calculation: check that ETS tables exist before inserting new data or lookup from the table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 - [#3329](https://github.com/poanetwork/blockscout/pull/3329) - Fix pagination for bridged tokens list page
+- [#3335](https://github.com/poanetwork/blockscout/pull/3335) - MarketCap calculation: check that ETS tables exist before inserting new data or lookup from the table
 
 ### Chore
 


### PR DESCRIPTION
## Motivation

The appearance of error like this
```
Request: GET /
** (exit) an exception was raised:
    ** (ArgumentError) argument error
        (stdlib 3.12.1) :ets.insert(:bridges_market_cap, {"current_market_cap_from_omni_bridge", #Decimal<0E-18>})
        (explorer 0.0.1) lib/explorer/counters/bridge.ex:152: Explorer.Counters.Bridge.update_total_omni_bridge_market_cap_cache/0
        (explorer 0.0.1) lib/explorer/chain/supply/token_bridge.ex:60: Explorer.Chain.Supply.TokenBridge.market_cap/1
        (block_scout_web 0.0.1) lib/block_scout_web/templates/chain/show.html.eex:66: BlockScoutWeb.ChainView."show.html"/1
        (phoenix 1.5.4) lib/phoenix/view.ex:310: Phoenix.View.render_within/3
        (phoenix 1.5.4) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.4) lib/phoenix/controller.ex:776: Phoenix.Controller.render_and_send/4
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/chain_controller.ex:1: BlockScoutWeb.ChainController.action/2
2020-10-07T13:47:23.725 [error] Task Explorer.ExchangeRates started from #PID<0.23441.0> terminating
```

## Changelog

Before inserting or lookup in ETS table, check that ETS table exists. Sometimes due to race conditions initialization of the process which creates those tables happens later than searching from/insertion to those tables requested from other processes.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
