### PR TITLE
Change Solc binary downloader path to official primary supported path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 ### Fixes
+- [#3341](https://github.com/poanetwork/blockscout/pull/3341) - Change Solc binary downloader path to official primary supported path
 - [#3339](https://github.com/poanetwork/blockscout/pull/3339) - Repair websocket subscription
 - [#3329](https://github.com/poanetwork/blockscout/pull/3329) - Fix pagination for bridged tokens list page
 - [#3335](https://github.com/poanetwork/blockscout/pull/3335) - MarketCap calculation: check that ETS tables exist before inserting new data or lookup from the table

--- a/apps/explorer/lib/explorer/smart_contract/solc_downloader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solc_downloader.ex
@@ -83,7 +83,7 @@ defmodule Explorer.SmartContract.SolcDownloader do
   end
 
   defp download(version) do
-    download_path = "https://ethereum.github.io/solc-bin/bin/soljson-#{version}.js"
+    download_path = "https://solc-bin.ethereum.org/bin/soljson-#{version}.js"
 
     download_path
     |> HTTPoison.get!([], timeout: 60_000, recv_timeout: 60_000)


### PR DESCRIPTION
## Motivation

`https://ethereum.github.io/solc-bin/bin/soljson-#{version}.js` URL to download Solc binary doesn't work for the version of compiler >= 0.7.2

## Changelog

Change Solc compiler download URL to `https://solc-bin.ethereum.org/bin/soljson-#{version}.js`. It is officially supported primary way https://gitter.im/ethereum/solidity-dev?at=5f8418f402e81701b017f522.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
