### PR TITLE
Make (Bridged) Tokens' list page's header more compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [#3335](https://github.com/poanetwork/blockscout/pull/3335) - MarketCap calculation: check that ETS tables exist before inserting new data or lookup from the table
 
 ### Chore
-
+- [#3343](https://github.com/poanetwork/blockscout/pull/3343) - Make (Bridged) Tokens' list page's header more compact
 
 
 ## 3.3.3-beta

--- a/apps/block_scout_web/assets/css/components/_card.scss
+++ b/apps/block_scout_web/assets/css/components/_card.scss
@@ -282,3 +282,15 @@ $card-tab-icon-color-active: #fff !default;
   height: 31px !important;
   font-size: 11px;
 }
+
+.tokens-description {
+  @media (min-width: 992px) {
+    display: inline-block;
+  }
+}
+
+.tokens-top-pagination-container-wrapper {
+  @media (min-width: 992px) {
+    float: right;
+  }
+}

--- a/apps/block_scout_web/lib/block_scout_web/templates/bridged_tokens/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/bridged_tokens/index.html.eex
@@ -2,9 +2,12 @@
   <div class="card">
     <div class="card-body" data-async-load data-async-listing="<%= @current_path %>">
       <h1 class="card-title"><%= gettext "Bridged Tokens" %></h1>
-	  <p class="card-subtitle">List of the tokens bridged through OmniBridge <span class="bridged-token-label omni">OMNI</span> and Arbitrary Message Bridge <span class="bridged-token-label amb">AMB</span> extensions</p>
-
-    <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
+	  <div>
+	  	<p class="card-subtitle tokens-description">List of the tokens bridged through OmniBridge <span class="bridged-token-label omni">OMNI</span> and Arbitrary Message Bridge <span class="bridged-token-label amb">AMB</span> extensions</p>
+	  	<div class="tokens-top-pagination-container-wrapper">
+		  <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
+	  	</div>
+	  </div>
 
     <div class="addresses-table-container">
       <div class="stakes-table-container">

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/index.html.eex
@@ -1,9 +1,11 @@
 <section class="container">
   <div class="card">
     <div class="card-body" data-async-load data-async-listing="<%= @current_path %>">
-      <h1 class="card-title"><%= gettext "Tokens" %></h1>
+      <h1 class="card-title tokens-description"><%= gettext "Tokens" %></h1>
 
-    <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
+	<div class="tokens-top-pagination-container-wrapper">
+    	<%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
+	</div>
 
     <div class="addresses-table-container">
       <div class="stakes-table-container">


### PR DESCRIPTION
## Motivation

Too much white space on (Bridged) Token's list page's header:

![Screenshot 2020-10-12 at 15 00 39](https://user-images.githubusercontent.com/4341812/95745307-8672c780-0c9d-11eb-8647-02dd403a64b1.png)
![Screenshot 2020-10-12 at 15 00 27](https://user-images.githubusercontent.com/4341812/95745361-a3a79600-0c9d-11eb-829b-f9665731c6f0.png)


## Changelog

![Screenshot 2020-10-12 at 14 59 39](https://user-images.githubusercontent.com/4341812/95745420-b7eb9300-0c9d-11eb-94f0-291839265e45.png)
![Screenshot 2020-10-12 at 14 50 38](https://user-images.githubusercontent.com/4341812/95745422-b8842980-0c9d-11eb-9df2-c5f328203d76.png)


## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
