### PR TITLE
Fix logs search on address page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 ### Fixes
+- [#3344](https://github.com/poanetwork/blockscout/pull/3344) - Fix logs search on address page
 - [#3342](https://github.com/poanetwork/blockscout/pull/3342) - Fix mobile styles for contract code tab
 - [#3341](https://github.com/poanetwork/blockscout/pull/3341) - Change Solc binary downloader path to official primary supported path
 - [#3339](https://github.com/poanetwork/blockscout/pull/3339) - Repair websocket subscription

--- a/apps/block_scout_web/assets/js/pages/address/logs.js
+++ b/apps/block_scout_web/assets/js/pages/address/logs.js
@@ -67,13 +67,15 @@ if ($('[data-page="address-logs"]').length) {
     addressHash: addressHash
   })
 
-  $element.on('click', '[data-search-button]', (event) => {
+  $element.on('click', '[data-search-button]', (_event) => {
     store.dispatch({
       type: 'START_SEARCH',
       addressHash: addressHash
     })
-    var topic = $('[data-search-field]').val()
-    var path = '/search_logs?topic=' + topic + '&address_id=' + store.getState().addressHash
+    const topic = $('[data-search-field]').val()
+    const addressHashPlain = store.getState().addressHash
+    const addressHashChecksum = addressHashPlain && window.web3.toChecksumAddress(addressHashPlain)
+    const path = '/search-logs?topic=' + topic + '&address_id=' + addressHashChecksum
     store.dispatch({ type: 'START_REQUEST' })
     $.getJSON(path, { type: 'JSON' })
       .done(response => store.dispatch(Object.assign({ type: 'ITEMS_FETCHED' }, humps.camelizeKeys(response))))
@@ -81,7 +83,7 @@ if ($('[data-page="address-logs"]').length) {
       .always(() => store.dispatch({ type: 'FINISH_REQUEST' }))
   })
 
-  $element.on('click', '[data-cancel-search-button]', (event) => {
+  $element.on('click', '[data-cancel-search-button]', (_event) => {
     window.location.replace(window.location.href.split('?')[0])
   })
 }


### PR DESCRIPTION
## Motivation

Address' page logs search doesn't work causing `Failed to load resource: net::ERR_TOO_MANY_REDIRECTS`

## Changelog

Set checksummed address as a value for *address_id* param for `/search-logs` endpoint

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
