### PR TITLE
Contract interaction: fix encoding of bytes output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 ### Fixes
+- [#3347](https://github.com/poanetwork/blockscout/pull/3347) - Contract interaction: fix encoding of bytes output
 - [#3346](https://github.com/poanetwork/blockscout/pull/3346) - Fix inventory tab pagination
 - [#3344](https://github.com/poanetwork/blockscout/pull/3344) - Fix logs search on address page
 - [#3342](https://github.com/poanetwork/blockscout/pull/3342) - Fix mobile styles for contract code tab

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -449,6 +449,10 @@ defmodule Explorer.SmartContract.Reader do
     Map.put_new(output, "value", bytes_to_string(Enum.at(values, index)))
   end
 
+  defp new_value(%{"type" => :bytes} = output, values, index) do
+    Map.put_new(output, "value", bytes_to_string(Enum.at(values, index)))
+  end
+
   defp new_value(output, [value], _index) do
     Map.put_new(output, "value", value)
   end


### PR DESCRIPTION
## Motivation

Wrong encoding of *bytes* output

![Screenshot 2020-10-12 at 19 23 06](https://user-images.githubusercontent.com/4341812/95769346-69032500-0cc0-11eb-93a3-f7c77f647493.png)


## Changelog

![Screenshot 2020-10-12 at 19 27 44](https://user-images.githubusercontent.com/4341812/95769752-09f1e000-0cc1-11eb-882e-845eeb080f9a.png)



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
