### PR TITLE
Fix tokens list pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 ### Fixes
+- [#3350](https://github.com/poanetwork/blockscout/pull/3350) - Fix tokens list pagination
 - [#3347](https://github.com/poanetwork/blockscout/pull/3347) - Contract interaction: fix encoding of bytes output
 - [#3346](https://github.com/poanetwork/blockscout/pull/3346) - Fix inventory tab pagination
 - [#3344](https://github.com/poanetwork/blockscout/pull/3344) - Fix logs search on address page

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -95,7 +95,18 @@ defmodule BlockScoutWeb.Chain do
   def next_page_params([], _list, _params), do: nil
 
   def next_page_params(_, list, params) do
-    Map.merge(params, paging_params(List.last(list)))
+    next_page_params = Map.merge(params, paging_params(List.last(list)))
+    current_items_count_str = Map.get(next_page_params, "items_count")
+
+    items_count =
+      if current_items_count_str do
+        {current_items_count, _} = Integer.parse(current_items_count_str)
+        current_items_count + Enum.count(list)
+      else
+        Enum.count(list)
+      end
+
+    Map.put(next_page_params, "items_count", items_count)
   end
 
   def paging_options(%{"hash" => hash, "fetched_coin_balance" => fetched_coin_balance}) do
@@ -108,11 +119,11 @@ defmodule BlockScoutWeb.Chain do
     end
   end
 
-  def paging_options(%{"contract_address_hash" => contract_address_hash, "holder_count" => holder_count}) do
-    with {holder_count, ""} <- Integer.parse(holder_count),
-         {:ok, contract_address_hash} <- string_to_address_hash(contract_address_hash) do
-      [paging_options: %{@default_paging_options | key: {holder_count, contract_address_hash}}]
-    else
+  def paging_options(%{"holder_count" => holder_count, "name" => token_name}) do
+    case Integer.parse(holder_count) do
+      {holder_count, ""} ->
+        [paging_options: %{@default_paging_options | key: {holder_count, token_name}}]
+
       _ ->
         [paging_options: @default_paging_options]
     end
@@ -216,12 +227,12 @@ defmodule BlockScoutWeb.Chain do
     %{"hash" => hash, "fetched_coin_balance" => Decimal.to_string(fetched_coin_balance.value)}
   end
 
-  defp paging_params(%Token{contract_address_hash: contract_address_hash, holder_count: holder_count}) do
-    %{"contract_address_hash" => contract_address_hash, "holder_count" => holder_count}
+  defp paging_params(%Token{holder_count: holder_count, name: token_name}) do
+    %{"holder_count" => holder_count, "name" => token_name}
   end
 
-  defp paging_params([%Token{contract_address_hash: contract_address_hash, holder_count: holder_count}, _]) do
-    %{"contract_address_hash" => contract_address_hash, "holder_count" => holder_count}
+  defp paging_params([%Token{holder_count: holder_count, name: token_name}, _]) do
+    %{"holder_count" => holder_count, "name" => token_name}
   end
 
   defp paging_params({%Reward{block: %{number: number}}, _}) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
@@ -33,6 +33,16 @@ defmodule BlockScoutWeb.AddressController do
     exchange_rate = Market.get_exchange_rate(Explorer.coin()) || Token.null()
     total_supply = Chain.total_supply()
 
+    items_count_str = Map.get(params, "items_count")
+
+    items_count =
+      if items_count_str do
+        {items_count, _} = Integer.parse(items_count_str)
+        items_count
+      else
+        0
+      end
+
     items =
       addresses_page
       |> Enum.with_index(1)
@@ -41,7 +51,7 @@ defmodule BlockScoutWeb.AddressController do
           AddressView,
           "_tile.html",
           address: address,
-          index: index,
+          index: items_count + index,
           exchange_rate: exchange_rate,
           total_supply: total_supply,
           tx_count: tx_count

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/bridged_tokens_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/bridged_tokens_controller.ex
@@ -28,6 +28,16 @@ defmodule BlockScoutWeb.BridgedTokensController do
           )
       end
 
+    items_count_str = Map.get(params, "items_count")
+
+    items_count =
+      if items_count_str do
+        {items_count, _} = Integer.parse(items_count_str)
+        items_count
+      else
+        0
+      end
+
     items =
       tokens_page
       |> Enum.with_index(1)
@@ -37,7 +47,7 @@ defmodule BlockScoutWeb.BridgedTokensController do
           "_tile.html",
           token: token,
           bridged_token: bridged_token,
-          index: index
+          index: items_count + index
         )
       end)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/tokens_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/tokens_controller.ex
@@ -28,6 +28,16 @@ defmodule BlockScoutWeb.TokensController do
           )
       end
 
+    items_count_str = Map.get(params, "items_count")
+
+    items_count =
+      if items_count_str do
+        {items_count, _} = Integer.parse(items_count_str)
+        items_count
+      else
+        0
+      end
+
     items =
       tokens_page
       |> Enum.with_index(1)
@@ -36,7 +46,7 @@ defmodule BlockScoutWeb.TokensController do
           TokensView,
           "_tile.html",
           token: token,
-          index: index
+          index: items_count + index
         )
       end)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
@@ -364,7 +364,8 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
         address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, address.hash, %{
           "block_number" => number,
           "index" => 11,
-          "transaction_index" => transaction_index
+          "transaction_index" => transaction_index,
+          "items_count" => "50"
         })
 
       assert expected_response == json_response(conn, 200)["next_page_path"]

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_token_transfer_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_token_transfer_controller_test.exs
@@ -209,7 +209,8 @@ defmodule BlockScoutWeb.AddressTokenTransferControllerTest do
           Address.checksum(token.contract_address_hash),
           %{
             block_number: page_last_transfer.block_number,
-            index: page_last_transfer.index
+            index: page_last_transfer.index,
+            items_count: "50"
           }
         )
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/block_controller_test.exs
@@ -101,7 +101,8 @@ defmodule BlockScoutWeb.BlockControllerTest do
       expected_path =
         block_path(conn, :index, %{
           block_number: number,
-          block_type: "Block"
+          block_type: "Block",
+          items_count: "50"
         })
 
       assert Map.get(json_response(conn, 200), "next_page_path") == expected_path

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3374,10 +3374,10 @@ defmodule Explorer.Chain do
 
   defp page_tokens(query, %PagingOptions{key: nil}), do: query
 
-  defp page_tokens(query, %PagingOptions{key: {holder_count, contract_address_hash}}) do
+  defp page_tokens(query, %PagingOptions{key: {holder_count, token_name}}) do
     from(token in query,
       where:
-        (token.holder_count == ^holder_count and token.contract_address_hash > ^contract_address_hash) or
+        (token.holder_count == ^holder_count and token.name > ^token_name) or
           token.holder_count < ^holder_count
     )
   end


### PR DESCRIPTION
## Motivation

- Some tokens are missing on the 2nd page of bridged tokens list
- Numeration of the items starts with 1 on every page (tokens list, bridged tokens list, addresses list)

## Changelog

- Fix pagination query filtering by ordered token name
- Add items count on the previous pages in the query for the next page to account it in numeration

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
