### PR TITLE
Fix dark body background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 ### Fixes
+- [#3352](https://github.com/poanetwork/blockscout/pull/3352) - Fix dark body background
 - [#3350](https://github.com/poanetwork/blockscout/pull/3350) - Fix tokens list pagination
 - [#3347](https://github.com/poanetwork/blockscout/pull/3347) - Contract interaction: fix encoding of bytes output
 - [#3346](https://github.com/poanetwork/blockscout/pull/3346) - Fix inventory tab pagination

--- a/apps/block_scout_web/assets/css/app.scss
+++ b/apps/block_scout_web/assets/css/app.scss
@@ -1,13 +1,5 @@
 @import "./mixins";
 
-html {
-  background-color: #080808;
-}
-
-body {
-  background-color: #080808;
-}
-
 /* Phoenix flash messages */
 .alert:empty {
   display: none;

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -37,45 +37,61 @@
 
   <body>
     <% raw_dark_forest_addresses = CustomContractsHelpers.get_raw_dark_forest_addresses_list() %>
-    <script>
-      function applyCustomMode() {
-        const darkForestContractAddressHashesRaw = "<%= raw_dark_forest_addresses %>"
-        if (darkForestContractAddressHashesRaw !== "") {
-          const darkForestContractAddressHashes = darkForestContractAddressHashesRaw.split(',').map(hash => hash.toLowerCase())
-          darkForestContractAddressHashes.forEach(darkForestContractAddressHash => {
-            if (window.location.pathname.toLowerCase().includes(darkForestContractAddressHash)) {
-              document.body.className += " " + "dark-forest-theme-applied";
-              document.documentElement.className += " " + "dark-forest-theme-applied";
-              return;
+    <%= cond do %>
+      <% (
+        @view_module == Elixir.BlockScoutWeb.TransactionInternalTransactionView ||
+        @view_module == Elixir.BlockScoutWeb.TransactionLogView ||
+        @view_module == Elixir.BlockScoutWeb.TransactionRawTraceView ||
+        @view_module == Elixir.BlockScoutWeb.TransactionTokenTransferView
+      ) -> %>
+        <% to_address = @transaction && @transaction.to_address && "0x" <> Base.encode16(@transaction.to_address.hash.bytes, case: :lower) %>
+        <script>
+          function applyCustomMode() {
+            const darkForestContractAddressHashesRaw = "<%= raw_dark_forest_addresses %>"
+            if (darkForestContractAddressHashesRaw !== "") {
+              const darkForestContractAddressHashes = darkForestContractAddressHashesRaw.split(',').map(hash => hash.toLowerCase())
+              const to_address = "<%= to_address %>"
+
+              darkForestContractAddressHashes.forEach(darkForestContractAddressHash => {
+                if (to_address == darkForestContractAddressHash) {
+                  document.body.className += " " + "dark-forest-theme-applied";
+                  return;
+                }
+              })
             }
-          })
-        }
-      }
+
+          }
+
+          window.onload = applyCustomMode()
+        </script>
+      <% true -> %>
+        <script>
+          function applyCustomMode() {
+            const darkForestContractAddressHashesRaw = "<%= raw_dark_forest_addresses %>"
+            if (darkForestContractAddressHashesRaw !== "") {
+              const darkForestContractAddressHashes = darkForestContractAddressHashesRaw.split(',').map(hash => hash.toLowerCase())
+              darkForestContractAddressHashes.forEach(darkForestContractAddressHash => {
+                if (window.location.pathname.toLowerCase().includes(darkForestContractAddressHash)) {
+                  document.body.className += " " + "dark-forest-theme-applied";
+                  return;
+                }
+              })
+            }
+          }
+
+          window.onload = applyCustomMode()
+        </script>
+    <% end %>
+    <script>
       function applyDarkMode() {
         if (localStorage.getItem("current-color-mode") === "dark") {
           document.body.className += " " + "dark-theme-applied";
           document.body.style.backgroundColor = "#1c1d31";
         }
       }
+
       window.onload = applyDarkMode()
-      window.onload = applyCustomMode()
     </script>
-    <%= cond do %>
-      <% (
-        @view_module == Elixir.BlockScoutWeb.TransactionView ||
-        @view_module == Elixir.BlockScoutWeb.TransactionInternalTransactionView ||
-        @view_module == Elixir.BlockScoutWeb.TransactionLogView ||
-        @view_module == Elixir.BlockScoutWeb.TransactionRawTraceView ||
-        @view_module == Elixir.BlockScoutWeb.TransactionTokenTransferView
-      ) -> %>
-        <script>
-          if (document.getElementsByClassName("layout-container")[0]) {
-            document.getElementsByClassName("layout-container")[0].style.visibility = "hidden";
-          }
-        </script>
-      <% true -> %>
-        <%= nil %>
-    <% end %>
     <div class="layout-container">
       <%= if not Explorer.Chain.finished_indexing?() do %>
         <div class="alert alert-warning text-center mb-0 p-3" data-selector="indexed-status">

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -1,25 +1,6 @@
 <% block = @transaction.block %>
 <% decoded_input_data = decoded_input_data(@transaction) %>
 <% status = transaction_status(@transaction) %>
-<% raw_dark_forest_addresses = CustomContractsHelpers.get_raw_dark_forest_addresses_list() %>
-<% to_address = @transaction.to_address && "0x" <> Base.encode16(@transaction.to_address.hash.bytes, case: :lower) %>
-<script>
-  function applyCustomMode() {
-    const darkForestContractAddressHashes = "<%= raw_dark_forest_addresses %>".split(',').map(hash => hash.toLowerCase())
-    const to_address = "<%= to_address %>"
-
-    darkForestContractAddressHashes.forEach(darkForestContractAddressHash => {
-      if (to_address == darkForestContractAddressHash) {
-        document.body.className += " " + "dark-forest-theme-applied";
-        document.documentElement.className += " " + "dark-forest-theme-applied";
-        return;
-      }
-    })
-
-    document.getElementsByClassName("layout-container")[0].style.visibility = "visible";
-  }
-  window.onload = applyCustomMode()
-</script>
 <section data-page="transaction-details" data-page-transaction-hash="<%= @transaction %>">
   <div class="row">
     <div class="col-md-12 col-lg-8 pr-0-md">

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.TransactionView do
   use BlockScoutWeb, :view
 
-  alias BlockScoutWeb.{AccessHelpers, AddressView, BlockView, CustomContractsHelpers, TabHelpers}
+  alias BlockScoutWeb.{AccessHelpers, AddressView, BlockView, TabHelpers}
   alias BlockScoutWeb.Cldr.Number
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Block.Reward

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -13,7 +13,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:223
+#: lib/block_scout_web/templates/transaction/overview.html.eex:204
 msgid " Token Transfer"
 msgstr ""
 
@@ -72,7 +72,7 @@ msgid "(query)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:87
+#: lib/block_scout_web/templates/layout/app.html.eex:103
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
 
@@ -194,7 +194,7 @@ msgid "Block %{block_number} - %{subnetwork} Explorer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:99
+#: lib/block_scout_web/templates/transaction/overview.html.eex:80
 msgid "Block Confirmations"
 msgstr ""
 
@@ -214,7 +214,7 @@ msgid "Block Mined, awaiting import..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:85
+#: lib/block_scout_web/templates/transaction/overview.html.eex:66
 msgid "Block Number"
 msgstr ""
 
@@ -430,12 +430,12 @@ msgid "Copy Source Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:35
+#: lib/block_scout_web/templates/transaction/overview.html.eex:16
 msgid "Copy Transaction Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:39
+#: lib/block_scout_web/templates/transaction/overview.html.eex:20
 msgid "Copy Txn Hash"
 msgstr ""
 
@@ -638,8 +638,8 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/app.html.eex:32
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:20
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:29
-#: lib/block_scout_web/templates/transaction/overview.html.eex:208
-#: lib/block_scout_web/templates/transaction/overview.html.eex:282
+#: lib/block_scout_web/templates/transaction/overview.html.eex:189
+#: lib/block_scout_web/templates/transaction/overview.html.eex:263
 #: lib/block_scout_web/views/wei_helpers.ex:78
 msgid "Ether"
 msgstr ""
@@ -658,7 +658,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/overview.html.eex:73
-#: lib/block_scout_web/templates/transaction/overview.html.eex:106
+#: lib/block_scout_web/templates/transaction/overview.html.eex:87
 msgid "Nonce"
 msgstr ""
 
@@ -746,8 +746,8 @@ msgid "Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:142
-#: lib/block_scout_web/templates/transaction/overview.html.eex:146
+#: lib/block_scout_web/templates/transaction/overview.html.eex:123
+#: lib/block_scout_web/templates/transaction/overview.html.eex:127
 msgid "Hex (Default)"
 msgstr ""
 
@@ -782,7 +782,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:21
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:32
-#: lib/block_scout_web/templates/transaction/overview.html.eex:111
+#: lib/block_scout_web/templates/transaction/overview.html.eex:92
 msgid "TX Fee"
 msgstr ""
 
@@ -844,7 +844,7 @@ msgid "There are no transfers for this Token."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:54
+#: lib/block_scout_web/templates/transaction/overview.html.eex:35
 msgid "This transaction is pending confirmation."
 msgstr ""
 
@@ -995,7 +995,7 @@ msgid "License ID"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:310
+#: lib/block_scout_web/templates/transaction/overview.html.eex:291
 msgid "Limit"
 msgstr ""
 
@@ -1188,7 +1188,7 @@ msgid "RPC"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:136
+#: lib/block_scout_web/templates/transaction/overview.html.eex:117
 msgid "Raw Input"
 msgstr ""
 
@@ -1463,7 +1463,7 @@ msgid "Transaction %{transaction}, %{subnetwork} %{transaction}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:30
+#: lib/block_scout_web/templates/transaction/overview.html.eex:11
 msgid "Transaction Details"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgid "Transaction Inputs"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:128
+#: lib/block_scout_web/templates/transaction/overview.html.eex:109
 msgid "Transaction Speed"
 msgstr ""
 
@@ -1501,7 +1501,7 @@ msgid "Type"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:149
+#: lib/block_scout_web/templates/transaction/overview.html.eex:130
 msgid "UTF-8"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgid "Use the search box to find a hosted network, or select from the list of a
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:304
+#: lib/block_scout_web/templates/transaction/overview.html.eex:285
 msgid "Used"
 msgstr ""
 
@@ -1557,8 +1557,8 @@ msgid "Validator Info"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:208
-#: lib/block_scout_web/templates/transaction/overview.html.eex:282
+#: lib/block_scout_web/templates/transaction/overview.html.eex:189
+#: lib/block_scout_web/templates/transaction/overview.html.eex:263
 msgid "Value"
 msgstr ""
 
@@ -1737,7 +1737,7 @@ msgid "Decimals"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:300
+#: lib/block_scout_web/templates/transaction/overview.html.eex:281
 msgid "Gas"
 msgstr ""
 
@@ -1784,8 +1784,8 @@ msgid "Transfers"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:161
-#: lib/block_scout_web/templates/transaction/overview.html.eex:174
+#: lib/block_scout_web/templates/transaction/overview.html.eex:142
+#: lib/block_scout_web/templates/transaction/overview.html.eex:155
 msgid "Copy Txn Input"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgid "Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:259
+#: lib/block_scout_web/templates/transaction/overview.html.eex:240
 msgid " Token Burning"
 msgstr ""
 
@@ -1881,7 +1881,7 @@ msgid "Token Burning"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:241
+#: lib/block_scout_web/templates/transaction/overview.html.eex:222
 msgid " Token Minting"
 msgstr ""
 
@@ -1898,7 +1898,7 @@ msgid "Chore Reward"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:77
+#: lib/block_scout_web/templates/transaction/overview.html.eex:58
 msgid "Revert reason"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -13,7 +13,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:223
+#: lib/block_scout_web/templates/transaction/overview.html.eex:204
 msgid " Token Transfer"
 msgstr ""
 
@@ -72,7 +72,7 @@ msgid "(query)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:87
+#: lib/block_scout_web/templates/layout/app.html.eex:103
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
 
@@ -194,7 +194,7 @@ msgid "Block %{block_number} - %{subnetwork} Explorer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:99
+#: lib/block_scout_web/templates/transaction/overview.html.eex:80
 msgid "Block Confirmations"
 msgstr ""
 
@@ -214,7 +214,7 @@ msgid "Block Mined, awaiting import..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:85
+#: lib/block_scout_web/templates/transaction/overview.html.eex:66
 msgid "Block Number"
 msgstr ""
 
@@ -430,12 +430,12 @@ msgid "Copy Source Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:35
+#: lib/block_scout_web/templates/transaction/overview.html.eex:16
 msgid "Copy Transaction Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:39
+#: lib/block_scout_web/templates/transaction/overview.html.eex:20
 msgid "Copy Txn Hash"
 msgstr ""
 
@@ -638,8 +638,8 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/app.html.eex:32
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:20
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:29
-#: lib/block_scout_web/templates/transaction/overview.html.eex:208
-#: lib/block_scout_web/templates/transaction/overview.html.eex:282
+#: lib/block_scout_web/templates/transaction/overview.html.eex:189
+#: lib/block_scout_web/templates/transaction/overview.html.eex:263
 #: lib/block_scout_web/views/wei_helpers.ex:78
 msgid "Ether"
 msgstr ""
@@ -658,7 +658,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/overview.html.eex:73
-#: lib/block_scout_web/templates/transaction/overview.html.eex:106
+#: lib/block_scout_web/templates/transaction/overview.html.eex:87
 msgid "Nonce"
 msgstr ""
 
@@ -746,8 +746,8 @@ msgid "Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:142
-#: lib/block_scout_web/templates/transaction/overview.html.eex:146
+#: lib/block_scout_web/templates/transaction/overview.html.eex:123
+#: lib/block_scout_web/templates/transaction/overview.html.eex:127
 msgid "Hex (Default)"
 msgstr ""
 
@@ -782,7 +782,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:21
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:32
-#: lib/block_scout_web/templates/transaction/overview.html.eex:111
+#: lib/block_scout_web/templates/transaction/overview.html.eex:92
 msgid "TX Fee"
 msgstr ""
 
@@ -844,7 +844,7 @@ msgid "There are no transfers for this Token."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:54
+#: lib/block_scout_web/templates/transaction/overview.html.eex:35
 msgid "This transaction is pending confirmation."
 msgstr ""
 
@@ -995,7 +995,7 @@ msgid "License ID"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:310
+#: lib/block_scout_web/templates/transaction/overview.html.eex:291
 msgid "Limit"
 msgstr ""
 
@@ -1188,7 +1188,7 @@ msgid "RPC"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:136
+#: lib/block_scout_web/templates/transaction/overview.html.eex:117
 msgid "Raw Input"
 msgstr ""
 
@@ -1463,7 +1463,7 @@ msgid "Transaction %{transaction}, %{subnetwork} %{transaction}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:30
+#: lib/block_scout_web/templates/transaction/overview.html.eex:11
 msgid "Transaction Details"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgid "Transaction Inputs"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:128
+#: lib/block_scout_web/templates/transaction/overview.html.eex:109
 msgid "Transaction Speed"
 msgstr ""
 
@@ -1501,7 +1501,7 @@ msgid "Type"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:149
+#: lib/block_scout_web/templates/transaction/overview.html.eex:130
 msgid "UTF-8"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgid "Use the search box to find a hosted network, or select from the list of a
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:304
+#: lib/block_scout_web/templates/transaction/overview.html.eex:285
 msgid "Used"
 msgstr ""
 
@@ -1557,8 +1557,8 @@ msgid "Validator Info"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:208
-#: lib/block_scout_web/templates/transaction/overview.html.eex:282
+#: lib/block_scout_web/templates/transaction/overview.html.eex:189
+#: lib/block_scout_web/templates/transaction/overview.html.eex:263
 msgid "Value"
 msgstr ""
 
@@ -1737,7 +1737,7 @@ msgid "Decimals"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:300
+#: lib/block_scout_web/templates/transaction/overview.html.eex:281
 msgid "Gas"
 msgstr ""
 
@@ -1784,8 +1784,8 @@ msgid "Transfers"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:161
-#: lib/block_scout_web/templates/transaction/overview.html.eex:174
+#: lib/block_scout_web/templates/transaction/overview.html.eex:142
+#: lib/block_scout_web/templates/transaction/overview.html.eex:155
 msgid "Copy Txn Input"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgid "Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:259
+#: lib/block_scout_web/templates/transaction/overview.html.eex:240
 msgid " Token Burning"
 msgstr ""
 
@@ -1881,7 +1881,7 @@ msgid "Token Burning"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:241
+#: lib/block_scout_web/templates/transaction/overview.html.eex:222
 msgid " Token Minting"
 msgstr ""
 
@@ -1898,7 +1898,7 @@ msgid "Chore Reward"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:77
+#: lib/block_scout_web/templates/transaction/overview.html.eex:58
 msgid "Revert reason"
 msgstr ""
 


### PR DESCRIPTION
Caused by the implementation of https://github.com/poanetwork/blockscout/pull/3333

## Motivation

Eliminate permanent all pages' dark body background together with eliminating of flickering at transactions page of Dark forest contract


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
