### PR TITLE
fix lock use fragment for ecto_sql

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -504,7 +504,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         # Enforce Reward ShareLocks order (see docs: sharelocks.md)
         order_by: [asc: :address_hash, asc: :address_type, asc: :block_hash],
         # acquire locks for `reward`s only
-        lock: "FOR UPDATE OF b0"
+        lock: fragment("FOR UPDATE OF ?", reward)
       )
 
     delete_query =


### PR DESCRIPTION
## Motivation

fix errors when running, the postgresql.log shows:
```
2020-10-13 18:58:25.400 CST [14377] ERROR:  relation "b0" in FOR UPDATE clause not found in FROM clause at character 477
2020-10-13 18:58:25.400 CST [14377] STATEMENT:  DELETE FROM "block_rewards" AS b0 USING (SELECT sb0."address_type" AS "address_type", sb0."reward" AS "reward", sb0."address_hash" AS "address_hash", sb0."block_hash" AS "block_hash", sb0."inserted_at" AS "inserted_at", sb0."updated_at" AS "updated_at" FROM "block_rewards" AS sb0 INNER JOIN "blocks" AS sb1 ON sb1."hash" = sb0."block_hash" WHERE (sb1."hash" = ANY($1) OR sb1."number" = ANY($2)) ORDER BY sb0."address_hash", sb0."address_type", sb0."block_hash" FOR UPDATE OF b0) AS s1 WHERE (((b0."address_hash" = s1."address_hash") AND (b0."address_type" = s1."address_type")) AND (b0."block_hash" = s1."block_hash"))
```

## Changelog

### Enhancements
I don't know how to write regression test (for this).

### Bug Fixes

### Incompatible Changes
support only ecto_sql >= 3.4.4

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
