### PR TITLE
Fix token transfer realtime fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 
 ### Fixes
+- [#3357](https://github.com/poanetwork/blockscout/pull/3357) - Fix token transfer realtime fetcher
 - [#3353](https://github.com/poanetwork/blockscout/pull/3353) - Fix xDai buttons hover color
 - [#3352](https://github.com/poanetwork/blockscout/pull/3352) - Fix dark body background
 - [#3350](https://github.com/poanetwork/blockscout/pull/3350) - Fix tokens list pagination

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -142,6 +142,7 @@ defmodule BlockScoutWeb.Notifier do
         |> Stream.map(
           &(TokenTransfer
             |> Repo.get_by(
+              block_hash: &1.block_hash,
               transaction_hash: &1.transaction_hash,
               token_contract_address_hash: &1.token_contract_address_hash,
               log_index: &1.log_index


### PR DESCRIPTION
## Motivation

Fix errors like this:
```
2020-10-15T15:27:31.081 [error] GenServer BlockScoutWeb.RealtimeEventHandler terminating
** (Ecto.MultipleResultsError) expected at most one result but got 2 in query:

from t0 in Explorer.Chain.TokenTransfer,
  where: t0.transaction_hash == ^%Explorer.Chain.Hash{byte_count: 32, bytes: <<110, 29, 80, 134, 186, 27, 182, 59, 198, 16, 180, 207, 190, 124, 60, 247, 170, 147, 92, 7, 10, 117, 1, 68, 75, 74, 82, 59, 168, 25, 239, 184>>} and t0.token_contract_address_hash == ^%Explorer.Chain.Hash{byte_count: 20, bytes: <<106, 2, 60, 205, 31, 246, 242, 4, 92, 51, 9, 118, 142, 173, 158, 104, 249, 120, 246, 225>>} and t0.log_index == ^3

    (ecto 3.3.4) lib/ecto/repo/queryable.ex:115: Ecto.Repo.Queryable.one/3
    (block_scout_web 0.0.1) lib/block_scout_web/notifier.ex:144: anonymous fn/1 in BlockScoutWeb.Notifier.handle_event/1
    (elixir 1.10.3) lib/stream.ex:572: anonymous fn/4 in Stream.map/2
    (elixir 1.10.3) lib/enum.ex:3686: Enumerable.List.reduce/3
    (elixir 1.10.3) lib/stream.ex:1609: Enumerable.Stream.do_each/4
    (elixir 1.10.3) lib/enum.ex:3383: Enum.each/2
    (block_scout_web 0.0.1) lib/block_scout_web/notifier.ex:153: anonymous fn/2 in BlockScoutWeb.Notifier.handle_event/1
    (stdlib 3.12.1) maps.erl:232: :maps.fold_1/3
```

## Changelog

Add additional check by *block_hash* to the query

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
