### PR TITLE
Contract reader: Address output fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Current
 
 ### Features
-- [#2292](https://github.com/poanetwork/blockscout/pull/2292), [#3356](https://github.com/poanetwork/blockscout/pull/3356), [#3360](https://github.com/poanetwork/blockscout/pull/3360) - Add Web UI for POSDAO Staking DApp
+- [#2292](https://github.com/poanetwork/blockscout/pull/2292), [#3356](https://github.com/poanetwork/blockscout/pull/3356), [#3359](https://github.com/poanetwork/blockscout/pull/3359), [#3360](https://github.com/poanetwork/blockscout/pull/3360) - Add Web UI for POSDAO Staking DApp
 - [#3354](https://github.com/poanetwork/blockscout/pull/3354) - Tx hash in EOA coin balance history
 - [#3333](https://github.com/poanetwork/blockscout/pull/3333), [#3337](https://github.com/poanetwork/blockscout/pull/3337) - Dark forest contract custom theme
 - [#3330](https://github.com/poanetwork/blockscout/pull/3330) - Caching of address transactions counter, remove query 10_000 rows limit

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -415,19 +415,19 @@ defmodule Explorer.SmartContract.Reader do
   end
 
   defp new_value(%{"type" => "address"} = output, [value], _index) do
-    Map.put_new(output, "value", bytes_to_string(value))
+    Map.put_new(output, "value", value)
   end
 
   defp new_value(%{"type" => :address} = output, [value], _index) do
-    Map.put_new(output, "value", bytes_to_string(value))
+    Map.put_new(output, "value", value)
   end
 
   defp new_value(%{"type" => "address"} = output, values, index) do
-    Map.put_new(output, "value", bytes_to_string(Enum.at(values, index)))
+    Map.put_new(output, "value", Enum.at(values, index))
   end
 
   defp new_value(%{"type" => :address} = output, values, index) do
-    Map.put_new(output, "value", bytes_to_string(Enum.at(values, index)))
+    Map.put_new(output, "value", Enum.at(values, index))
   end
 
   defp new_value(%{"type" => "bytes" <> number_rest} = output, values, index) do

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -302,8 +302,7 @@ defmodule Explorer.SmartContract.ReaderTest do
   describe "link_outputs_and_values/2" do
     test "links the ABI outputs with the values retrieved from the blockchain" do
       blockchain_values = %{
-        "getOwner" =>
-          {:ok, "0x6937cb25eb54bc013b9c13c47ab38eb63edd1493"}
+        "getOwner" => {:ok, "0x6937cb25eb54bc013b9c13c47ab38eb63edd1493"}
       }
 
       outputs = [%{"name" => "", "type" => "address"}]

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -303,7 +303,7 @@ defmodule Explorer.SmartContract.ReaderTest do
     test "links the ABI outputs with the values retrieved from the blockchain" do
       blockchain_values = %{
         "getOwner" =>
-          {:ok, <<105, 55, 203, 37, 235, 84, 188, 1, 59, 156, 19, 196, 122, 179, 142, 182, 62, 221, 20, 147>>}
+          {:ok, "0x6937cb25eb54bc013b9c13c47ab38eb63edd1493"}
       }
 
       outputs = [%{"name" => "", "type" => "address"}]


### PR DESCRIPTION
## Motivation

<img width="817" alt="Screenshot 2020-10-16 at 14 01 26" src="https://user-images.githubusercontent.com/4341812/96255667-fe9ffc80-0fbf-11eb-980d-072267be4478.png">

Caused by changing of implementation of Contract reader for Staking Dapp


## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
