### PR TITLE
Stabilize tests execution in Github Actions CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#3335](https://github.com/poanetwork/blockscout/pull/3335) - MarketCap calculation: check that ETS tables exist before inserting new data or lookup from the table
 
 ### Chore
+- [#3366](https://github.com/poanetwork/blockscout/pull/3366) - Stabilize tests execution in Github Actions CI
 - [#3343](https://github.com/poanetwork/blockscout/pull/3343) - Make (Bridged) Tokens' list page's header more compact
 
 

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
@@ -378,7 +378,6 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
       |> assert_has(AddressPage.token_type_count(type: "ERC-721", text: "1"))
     end
 
-    # flaky test
     test "filter token balances by token symbol", %{session: session, lincoln: lincoln} do
       next =
         session

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1372,6 +1372,7 @@ defmodule Explorer.ChainTest do
     test "returns 1.0 if fully indexed blocks" do
       for index <- 0..9 do
         insert(:block, number: index)
+        Process.sleep(200)
       end
 
       assert Decimal.cmp(Chain.indexed_ratio(), 1) == :eq
@@ -1382,6 +1383,7 @@ defmodule Explorer.ChainTest do
     test "fetches min block numbers" do
       for index <- 5..9 do
         insert(:block, number: index)
+        Process.sleep(200)
       end
 
       assert 5 = Chain.fetch_min_block_number()
@@ -3372,14 +3374,20 @@ defmodule Explorer.ChainTest do
 
     # 0101
     test "0..0 with blocks 1,3" do
-      Enum.each([1, 3], &insert(:block, number: &1))
+      Enum.each([1, 3], fn num ->
+        insert(:block, number: num)
+        Process.sleep(200)
+      end)
 
       assert Chain.missing_block_number_ranges(0..0) == [0..0]
     end
 
     # 0111
     test "0..0 with blocks 1..3" do
-      Enum.each(1..3, &insert(:block, number: &1))
+      Enum.each(1..3, fn num ->
+        insert(:block, number: num)
+        Process.sleep(200)
+      end)
 
       assert Chain.missing_block_number_ranges(0..0) == [0..0]
     end
@@ -3421,7 +3429,10 @@ defmodule Explorer.ChainTest do
 
     # 1101
     test "0..0 with blocks 0,1,3" do
-      Enum.each([0, 1, 3], &insert(:block, number: &1))
+      Enum.each([0, 1, 3], fn num ->
+        insert(:block, number: num)
+        Process.sleep(200)
+      end)
 
       assert Chain.missing_block_number_ranges(0..0) == []
     end
@@ -3435,7 +3446,10 @@ defmodule Explorer.ChainTest do
 
     # 1111
     test "0..0 with blocks 0..3" do
-      Enum.each(0..2, &insert(:block, number: &1))
+      Enum.each(0..2, fn num ->
+        insert(:block, number: num)
+        Process.sleep(200)
+      end)
 
       assert Chain.missing_block_number_ranges(0..0) == []
     end

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -553,7 +553,8 @@ defmodule Explorer.EtherscanTest do
 
       inserted_at_order = Enum.map(found_transactions, & &1.inserted_at)
 
-      assert inserted_at_order == Enum.sort(inserted_at_order, &(&1 >= &2))
+      assert inserted_at_order ==
+               Enum.sort(inserted_at_order, &(DateTime.compare(&1, &2) == :gt || DateTime.compare(&1, &2) == :eq))
     end
 
     test "with page_size and page_number options" do


### PR DESCRIPTION
## Motivation

There are some tests which are unstable in Github Actions CI



## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
