### PR TITLE
Fix Verify contract loading button width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 
 ### Fixes
+- [#3368](https://github.com/poanetwork/blockscout/pull/3368) - Fix Verify contract loading button width
 - [#3357](https://github.com/poanetwork/blockscout/pull/3357) - Fix token transfer realtime fetcher
 - [#3353](https://github.com/poanetwork/blockscout/pull/3353) - Fix xDai buttons hover color
 - [#3352](https://github.com/poanetwork/blockscout/pull/3352) - Fix dark body background

--- a/apps/block_scout_web/assets/css/components/_new_smart_contract.scss
+++ b/apps/block_scout_web/assets/css/components/_new_smart_contract.scss
@@ -187,6 +187,9 @@ $new-smart-contract-center-column-margin-right: 30px;
       z-index: 12;
     }
   }
+  .w-118 {
+    width: 117.828px;
+  }
 }
 
 .smart-contract-libraries-wrapper {

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
@@ -286,7 +286,7 @@
 
         <div class="smart-contract-form-buttons">
           <button
-            class="position-absolute btn-full-primary d-none mr-2"
+            class="position-absolute w-118 btn-full-primary d-none mr-2"
             disabled="true"
             id="loading"
             name="button"


### PR DESCRIPTION
## Motivation

Width of Loading button is less than *Verify & Publish*:
![image](https://user-images.githubusercontent.com/4341812/96456369-11683a80-1227-11eb-8be2-88c72a40c4fc.png)



## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
