### PR TITLE
Improve contracts verification: refine constructor arguments extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 
 ### Fixes
+- [#3370](https://github.com/poanetwork/blockscout/pull/3370) - Improve contracts verification: refine constructor arguments extractor
 - [#3368](https://github.com/poanetwork/blockscout/pull/3368) - Fix Verify contract loading button width
 - [#3357](https://github.com/poanetwork/blockscout/pull/3357) - Fix token transfer realtime fetcher
 - [#3353](https://github.com/poanetwork/blockscout/pull/3353) - Fix xDai buttons hover color

--- a/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier/constructor_arguments.ex
@@ -244,8 +244,18 @@ defmodule Explorer.SmartContract.Verifier.ConstructorArguments do
          metadata_hash_prefix
        ) do
     if is_constructor_arguments_still_has_metadata_prefix(constructor_arguments, metadata_hash_prefix) do
-      <<_::binary-size(2)>> <> rest = constructor_arguments
-      extract_constructor_arguments(rest, check_func, contract_source_code, contract_name)
+      {ind, _} = :binary.match(constructor_arguments, metadata_hash_prefix)
+      offset = if ind > 2, do: ind - 2, else: 0
+
+      processed_constructor_arguments =
+        if offset > 0 do
+          <<_::binary-size(offset)>> <> rest = constructor_arguments
+          rest
+        else
+          constructor_arguments
+        end
+
+      extract_constructor_arguments(processed_constructor_arguments, check_func, contract_source_code, contract_name)
     else
       extract_constructor_arguments_check_func(
         constructor_arguments,


### PR DESCRIPTION
## Motivation

Some contracts cannot be verified because of unmatched constructor arguments

## Changelog

Improve procedure to find constructor arguments

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
