### PR TITLE
Eliminate dark background except Dark forest theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#3335](https://github.com/poanetwork/blockscout/pull/3335) - MarketCap calculation: check that ETS tables exist before inserting new data or lookup from the table
 
 ### Chore
+- [#3371](https://github.com/poanetwork/blockscout/pull/3371) - Eliminate dark background except Dark forest theme
 - [#3366](https://github.com/poanetwork/blockscout/pull/3366) - Stabilize tests execution in Github Actions CI
 - [#3343](https://github.com/poanetwork/blockscout/pull/3343) - Make (Bridged) Tokens' list page's header more compact
 

--- a/apps/block_scout_web/assets/css/theme/custom_contracts/_dark-forest-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/custom_contracts/_dark-forest-theme.scss
@@ -1016,6 +1016,6 @@ $dark-primary-alternate: $dark-primary;
     background-color: $dark-light !important;
 }
 
-.modal-open .modal {
+.dark-forest-theme-applied.modal-open .modal {
 	background-color: $dark-bg !important;
 }


### PR DESCRIPTION
## Motivation

Dark background applied for opened modal window.

![Screenshot 2020-10-20 at 10 44 32](https://user-images.githubusercontent.com/4341812/96556304-7cfee600-12c1-11eb-8505-546094915bea.png)


## Changelog

Apply dark background for modals only for Dark forest game theme

## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
