### PR TITLE
Fix horizontal scroll in Tokens table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 
 ### Fixes
+- [#3373](https://github.com/poanetwork/blockscout/pull/3373) - Fix horizontal scroll in Tokens table
 - [#3370](https://github.com/poanetwork/blockscout/pull/3370) - Improve contracts verification: refine constructor arguments extractor
 - [#3368](https://github.com/poanetwork/blockscout/pull/3368) - Fix Verify contract loading button width
 - [#3357](https://github.com/poanetwork/blockscout/pull/3357) - Fix token transfer realtime fetcher

--- a/apps/block_scout_web/assets/css/_helpers.scss
+++ b/apps/block_scout_web/assets/css/_helpers.scss
@@ -37,3 +37,12 @@
 .word-break-all {
   word-break: break-all;
 }
+
+.centered-container {
+  display: flex;
+  align-items: center;
+}
+
+.pre-wrap {
+  white-space: pre-wrap;
+}

--- a/apps/block_scout_web/assets/css/components/_label.scss
+++ b/apps/block_scout_web/assets/css/components/_label.scss
@@ -6,6 +6,7 @@
     border-radius: 5px;
     font-size: 10px;
     &.right {
+        margin-left: auto;
         float: right;
     }
     &.omni {

--- a/apps/block_scout_web/lib/block_scout_web/templates/bridged_tokens/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/bridged_tokens/_tile.html.eex
@@ -7,14 +7,11 @@
   </td>
   <td class="stakes-td">
     <% token = token_display_name(@token) %>
-    <div>
+    <div class="centered-container">
       <%= link(token,
         to: token_path(BlockScoutWeb.Endpoint, :show, @token.contract_address_hash),
         "data-test": "token_link",
-        class: "text-truncate") %>
-      <%= if @bridged_token.type do %>
-        <div class="bs-label right <%= @bridged_token.type %>"><%= String.upcase(@bridged_token.type) %></div>
-      <% end %>
+        class: "text-truncate pre-wrap") %>
       <%= if owl_token_amb?(@token.contract_address.hash) do %>
         <span
           data-toggle="tooltip"
@@ -32,6 +29,9 @@
           title="<%= owl_token_omni_info() %>">
           <i style="color: #f7b32b;" class="fa fa-info-circle ml-1" data-test="owl_info"></i>
         </span>
+      <% end %>
+      <%= if @bridged_token.type do %>
+        <div class="bs-label right <%= @bridged_token.type %>"><%= String.upcase(@bridged_token.type) %></div>
       <% end %>
     </div>
   </td>


### PR DESCRIPTION
## Motivation

Horizontal scroll in Tokens table if a long token name appears in the list

![image](https://user-images.githubusercontent.com/4341812/96569929-6e6cfa80-12d2-11eb-86de-2c999653974f.png)



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
