### PR TITLE
Fix find block timestamp query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 
 ### Fixes
+- [#3374](https://github.com/poanetwork/blockscout/pull/3374) - Fix find block timestamp query
 - [#3373](https://github.com/poanetwork/blockscout/pull/3373) - Fix horizontal scroll in Tokens table
 - [#3370](https://github.com/poanetwork/blockscout/pull/3370) - Improve contracts verification: refine constructor arguments extractor
 - [#3368](https://github.com/poanetwork/blockscout/pull/3368) - Fix Verify contract loading button width

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -5488,6 +5488,7 @@ defmodule Explorer.Chain do
     Block
     |> where([b], b.number == ^number)
     |> select([b], b.timestamp)
+    |> limit(1)
     |> Repo.one()
   end
 end


### PR DESCRIPTION
## Motivation

An error like this:

```
2020-10-20T12:47:04.925 [error] #PID<0.629.6> running BlockScoutWeb.Endpoint (connection #PID<0.628.6>, stream id 1) terminated
Server: 147.135.46.163:80 (http)
Request: GET /address/0x0B02534634092077Fbf73431867DB83A7B008084/coin-balances?type=JSON
** (exit) an exception was raised:
    ** (Ecto.MultipleResultsError) expected at most one result but got 2 in query:

from b0 in Explorer.Chain.Block,
  where: b0.number == ^12609315,
  select: b0.timestamp

        (ecto 3.3.4) lib/ecto/repo/queryable.ex:115: Ecto.Repo.Queryable.one/3
        (explorer 0.0.1) lib/explorer/chain.ex:4390: Explorer.Chain.address_to_coin_balances/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/address_coin_balance_controller.ex:23: BlockScoutWeb.AddressCoinBalanceController.index/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/address_coin_balance_controller.ex:1: BlockScoutWeb.AddressCoinBalanceController.action/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/address_coin_balance_controller.ex:1: BlockScoutWeb.AddressCoinBalanceController.phoenix_controller_pipeline/2
        (phoenix 1.5.4) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (phoenix 1.5.4) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
        (phoenix 1.5.4) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
```

## Changelog

Limit query results to one

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
