### PR TITLE
Prevent terminating of tokens/contracts process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 
 ### Fixes
+- [#3375](https://github.com/poanetwork/blockscout/pull/3375) - Prevent terminating of tokens/contracts process
 - [#3374](https://github.com/poanetwork/blockscout/pull/3374) - Fix find block timestamp query
 - [#3373](https://github.com/poanetwork/blockscout/pull/3373) - Fix horizontal scroll in Tokens table
 - [#3370](https://github.com/poanetwork/blockscout/pull/3370) - Improve contracts verification: refine constructor arguments extractor

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1058,6 +1058,7 @@ defmodule Explorer.Chain do
   def search_token(word) do
     term =
       word
+      |> String.replace(~r/[^a-zA-Z0-9]/, " ")
       |> String.replace(~r/ +/, " & ")
 
     term_final = term <> ":*"
@@ -1086,6 +1087,7 @@ defmodule Explorer.Chain do
   def search_contract(word) do
     term =
       word
+      |> String.replace(~r/[^a-zA-Z0-9]/, " ")
       |> String.replace(~r/ +/, " & ")
 
     term_final = term <> ":*"


### PR DESCRIPTION
## Motivation

Prevent terminating of tokens/contracts process
```
Request: GET /token-autocomplete?q=https%3A%2F%2Fcircles.garden%2Fprofile0x4625d7b6ba483734f629d2f2d95d6b589dba4cd3
** (exit) an exception was raised:
    ** (Postgrex.Error) ERROR 42601 (syntax_error) syntax error in tsquery: "https://circles.garden/profile0x4625d7b6ba483734f629d2f2d95d6b589dba4cd3:*"
        (ecto_sql 3.3.4) lib/ecto/adapters/sql.ex:612: Ecto.Adapters.SQL.raise_sql_call_error/1
        (ecto_sql 3.3.4) lib/ecto/adapters/sql.ex:545: Ecto.Adapters.SQL.execute/5
        (ecto 3.3.4) lib/ecto/repo/queryable.ex:192: Ecto.Repo.Queryable.execute/4
        (ecto 3.3.4) lib/ecto/repo/queryable.ex:17: Ecto.Repo.Queryable.all/3
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/chain_controller.ex:101: BlockScoutWeb.ChainController.token_autocomplete/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/chain_controller.ex:1: BlockScoutWeb.ChainController.action/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/chain_controller.ex:1: BlockScoutWeb.ChainController.phoenix_controller_pipeline/2
        (phoenix 1.5.4) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
```

## Changelog

Remove special symbols from a searching pattern before making a full-text search query.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
