### PR TITLE
Check ets table exists for known tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 
 ### Fixes
+- [#3382](https://github.com/poanetwork/blockscout/pull/3382) - Check ets table exists for know tokens
 - [#3376](https://github.com/poanetwork/blockscout/pull/3376) - Fix contract nested inputs
 - [#3375](https://github.com/poanetwork/blockscout/pull/3375) - Prevent terminating of tokens/contracts process
 - [#3374](https://github.com/poanetwork/blockscout/pull/3374) - Fix find block timestamp query

--- a/apps/explorer/lib/explorer/known_tokens/known_tokens.ex
+++ b/apps/explorer/lib/explorer/known_tokens/known_tokens.ex
@@ -94,11 +94,19 @@ defmodule Explorer.KnownTokens do
   @spec lookup(String.t()) :: {:ok, Hash.Address.t()} | :error | nil
   def lookup(symbol) do
     if store() == :ets && enabled?() do
-      case :ets.lookup(table_name(), symbol) do
-        [{_symbol, address} | _] -> Hash.Address.cast(address)
-        _ -> nil
+      if ets_table_exists?(table_name()) do
+        case :ets.lookup(table_name(), symbol) do
+          [{_symbol, address} | _] -> Hash.Address.cast(address)
+          _ -> nil
+        end
+      else
+        nil
       end
     end
+  end
+
+  defp ets_table_exists?(table) do
+    :ets.whereis(table) !== :undefined
   end
 
   @doc false


### PR DESCRIPTION
## Motivation

Eliminate error like this:

```
Request: GET /address/0xA6452911d5274e2717BC1Fa793b21aB600EC9133/token-balances
** (exit) an exception was raised:
    ** (ArgumentError) argument error
        (stdlib 3.12.1) :ets.lookup(:known_tokens, "CRC")
        (explorer 0.0.1) lib/explorer/known_tokens/known_tokens.ex:97: Explorer.KnownTokens.lookup/1
        (explorer 0.0.1) lib/explorer/market/market.ex:25: Explorer.Market.get_known_address/1
        (explorer 0.0.1) lib/explorer/market/market.ex:55: Explorer.Market.add_price/1
        (explorer 0.0.1) lib/explorer/market/market.ex:65: Explorer.Market.add_price/1
        (elixir 1.10.3) lib/enum.ex:1396: Enum."-map/2-lists^map/1-0-"/2
        (elixir 1.10.3) lib/enum.ex:1396: Enum."-map/2-lists^map/1-0-"/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/address_token_balance_controller.ex:13: BlockScoutWeb.AddressTokenBalanceController.index/2
2020-10-22T14:33:45.040 [error] GenServer #PID<0.5322.49> terminating
```

## Changelog

Check that ETS table exists before lookup


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
