### PR TITLE
Handle exchange rates request throttled

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -23,7 +23,7 @@ lib/block_scout_web/controllers/api/rpc/transaction_controller.ex:21
 lib/block_scout_web/controllers/api/rpc/transaction_controller.ex:22
 lib/explorer/smart_contract/reader.ex:330
 lib/indexer/fetcher/token_total_supply_on_demand.ex:16
-lib/explorer/exchange_rates/source.ex:41
+lib/explorer/exchange_rates/source.ex:45
 lib/explorer/exchange_rates/source/coin_gecko.ex:148
 lib/explorer/exchange_rates/source/coin_gecko.ex:169
 lib/explorer/smart_contract/verifier.ex:89

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 
 ### Fixes
+- [#3396](https://github.com/poanetwork/blockscout/pull/3396) - Handle exchange rates request throttled
 - [#3382](https://github.com/poanetwork/blockscout/pull/3382) - Check ets table exists for know tokens
 - [#3376](https://github.com/poanetwork/blockscout/pull/3376) - Fix contract nested inputs
 - [#3375](https://github.com/poanetwork/blockscout/pull/3375) - Prevent terminating of tokens/contracts process

--- a/apps/explorer/lib/explorer/exchange_rates/source.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source.ex
@@ -33,7 +33,11 @@ defmodule Explorer.ExchangeRates.Source do
         {:ok, result}
 
       {:ok, %Response{body: body, status_code: status_code}} when status_code in 400..499 ->
-        {:error, decode_json(body)["error"]}
+        if is_map(decode_json(body)) do
+          {:error, decode_json(body)["error"]}
+        else
+          {:error, body}
+        end
 
       {:error, %Error{reason: reason}} ->
         {:error, reason}
@@ -41,8 +45,6 @@ defmodule Explorer.ExchangeRates.Source do
       {:error, :nxdomain} ->
         {:error, "CoinGecko is not responsive"}
     end
-  after
-    {:error, ""}
   end
 
   @doc """

--- a/apps/explorer/test/explorer/exchange_rates/exchange_rates_test.exs
+++ b/apps/explorer/test/explorer/exchange_rates/exchange_rates_test.exs
@@ -106,7 +106,10 @@ defmodule Explorer.ExchangeRatesTest do
 
       assert {:noreply, ^state} = ExchangeRates.handle_info({nil, {:error, "some error"}}, state)
 
-      assert_receive {_, {:ok, _}}
+      assert_receive :update
+
+      assert {:noreply, ^state} = ExchangeRates.handle_info(:update, state)
+      assert_receive {_, {:ok, [%Token{}]}}
     end
   end
 


### PR DESCRIPTION
## Motivation

Eliminate error and process terminating when exchange rates request is throttled:
```
** (FunctionClauseError) no function clause matching in Access.get/3
    (elixir 1.10.3) lib/access.ex:284: Access.get("Throttled\n", "error", nil)
    (explorer 0.0.1) lib/explorer/exchange_rates/source.ex:36: Explorer.ExchangeRates.Source.fetch_exchange_rates_request/2
    (explorer 0.0.1) lib/explorer/chain/supply/token_bridge.ex:191: Explorer.Chain.Supply.TokenBridge.get_current_price_for_bridged_token/1
    (explorer 0.0.1) lib/explorer/counters/bridge.ex:193: anonymous fn/1 in Explorer.Counters.Bridge.consolidate/0
    (elixir 1.10.3) lib/enum.ex:783: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir 1.10.3) lib/enum.ex:783: Enum.each/2
    (explorer 0.0.1) lib/explorer/counters/bridge.ex:192: Explorer.Counters.Bridge.consolidate/0
    (explorer 0.0.1) lib/explorer/counters/bridge.ex:107: Explorer.Counters.Bridge.handle_info/2
Last message: :consolidate
```

## Changelog

Check that response from coin gecko can be parsed as a JSON object

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
