### PR TITLE
Fix total tx info icon placement in mobile view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Current
 
 ### Features
-- [#3385](https://github.com/poanetwork/blockscout/pull/3385) - Total gas usage at the main page
+- [#3385](https://github.com/poanetwork/blockscout/pull/3385), [#3397](https://github.com/poanetwork/blockscout/pull/3397) - Total gas usage at the main page
 - [#3384](https://github.com/poanetwork/blockscout/pull/3384), [#3386](https://github.com/poanetwork/blockscout/pull/3386) - Address total gas usage
 - [#3377](https://github.com/poanetwork/blockscout/pull/3377) - Add links to contract libraries
 - [#2292](https://github.com/poanetwork/blockscout/pull/2292), [#3356](https://github.com/poanetwork/blockscout/pull/3356), [#3359](https://github.com/poanetwork/blockscout/pull/3359), [#3360](https://github.com/poanetwork/blockscout/pull/3360), [#3365](https://github.com/poanetwork/blockscout/pull/3365) - Add Web UI for POSDAO Staking DApp

--- a/apps/block_scout_web/assets/css/components/_custom_tooltips.scss
+++ b/apps/block_scout_web/assets/css/components/_custom_tooltips.scss
@@ -69,6 +69,13 @@ $tooltip-background-color: $btn-line-color !default;
     margin-bottom: 10px;
 }
 
+.custom-tooltip-total-transactions {
+    margin-top: 6px;
+    @media (min-width: 992px) {
+        margin-top: 9px;
+    }
+}
+
 .custom-tooltip-description {
     .left {
         text-align: left;

--- a/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
@@ -129,7 +129,7 @@
                   data-html="true"
                   data-template="<div class='tooltip tooltip-inversed-color tooltip-gas-usage' role='tooltip'><div class='arrow'></div><div class='tooltip-inner'></div></div>"
                   title="<div class='custom-tooltip-header'>Total gas used</div><div class='custom-tooltip-description'><b><%= BlockScoutWeb.Cldr.Number.to_string!(@total_gas_usage, format: "#,###") %><b></div>"
-                  style="margin-top:8px;">
+                  class="custom-tooltip-total-transactions">
                   <i style="color: #ffffff;" class="fa fa-info-circle ml-2"></i>
                 </span>
               <% end %>


### PR DESCRIPTION
## Motivation

Total txs info icon is not vertically centred in mobile view:

![Screenshot 2020-10-26 at 10 57 41](https://user-images.githubusercontent.com/4341812/97147520-b1b7e500-177a-11eb-84bd-0c036acee40c.png)


## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
