### PR TITLE
Add :last_block_number realtime chain event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixes
 - [#3408](https://github.com/poanetwork/blockscout/pull/3408) - Fix (total) difficulty display
 - [#3401](https://github.com/poanetwork/blockscout/pull/3401) - Fix procedure of marking internal transactions as failed
+- [#3400](https://github.com/poanetwork/blockscout/pull/3400) - Add :last_block_number realtime chain event
 - [#3399](https://github.com/poanetwork/blockscout/pull/3399) - Fix Token transfers CSV export
 - [#3396](https://github.com/poanetwork/blockscout/pull/3396) - Handle exchange rates request throttled
 - [#3382](https://github.com/poanetwork/blockscout/pull/3382) - Check ets table exists for know tokens

--- a/apps/explorer/lib/explorer/chain/events/publisher.ex
+++ b/apps/explorer/lib/explorer/chain/events/publisher.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.Events.Publisher do
   Publishes events related to the Chain context.
   """
 
-  @allowed_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions token_transfers transactions contract_verification_result)a
+  @allowed_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions last_block_number token_transfers transactions contract_verification_result)a
 
   def broadcast(_data, false), do: :ok
 

--- a/apps/explorer/lib/explorer/chain/events/subscriber.ex
+++ b/apps/explorer/lib/explorer/chain/events/subscriber.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.Events.Subscriber do
   Subscribes to events related to the Chain context.
   """
 
-  @allowed_broadcast_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions token_transfers transactions contract_verification_result)a
+  @allowed_broadcast_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions last_block_number token_transfers transactions contract_verification_result)a
 
   @allowed_broadcast_types ~w(catchup realtime on_demand contract_verification_result)a
 

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -68,7 +68,7 @@ defmodule Explorer.Staking.ContractState do
       write_concurrency: true
     ])
 
-    Subscriber.to(:blocks, :realtime)
+    Subscriber.to(:last_block_number, :realtime)
 
     staking_abi = abi("StakingAuRa")
     validator_set_abi = abi("ValidatorSetAuRa")
@@ -126,12 +126,10 @@ defmodule Explorer.Staking.ContractState do
   end
 
   @doc "Handles new blocks and decides to fetch fresh chain info"
-  def handle_info({:chain_event, :blocks, :realtime, blocks}, state) do
-    latest_block = Enum.max_by(blocks, & &1.number, fn -> %{number: 0} end)
-
-    if latest_block.number > state.seen_block do
-      fetch_state(state.contracts, state.abi, latest_block.number)
-      {:noreply, %{state | seen_block: latest_block.number}}
+  def handle_info({:chain_event, :last_block_number, :realtime, block_number}, state) do
+    if block_number > state.seen_block do
+      fetch_state(state.contracts, state.abi, block_number)
+      {:noreply, %{state | seen_block: block_number}}
     else
       {:noreply, state}
     end

--- a/apps/explorer/test/explorer/staking/contract_state_test.exs
+++ b/apps/explorer/test/explorer/staking/contract_state_test.exs
@@ -30,7 +30,7 @@ defmodule Explorer.Staking.ContractStateTest do
 
     start_supervised!(ContractState)
 
-    Publisher.broadcast([{:blocks, [%Explorer.Chain.Block{number: 76}]}], :realtime)
+    Publisher.broadcast([{:last_block_number, 76}], :realtime)
 
     Process.sleep(500)
 

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -28,6 +28,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
   alias EthereumJSONRPC.{Blocks, FetchedBalances, Subscription}
   alias Explorer.Chain
   alias Explorer.Chain.Cache.Accounts
+  alias Explorer.Chain.Events.Publisher
   alias Explorer.Counters.AverageBlockTime
   alias Indexer.{Block, Tracer}
   alias Indexer.Block.Realtime.TaskSupervisor
@@ -85,6 +86,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
       )
       when is_binary(quantity) do
     number = quantity_to_integer(quantity)
+    Publisher.broadcast([{:last_block_number, number}], :realtime)
     # Subscriptions don't support getting all the blocks and transactions data,
     # so we need to go back and get the full block
     start_fetch_and_import(number, block_fetcher, previous_number, max_number_seen)


### PR DESCRIPTION
## Motivation

This PR adds an additional `:last_block_number` chain event which notifies subscribers about a new block immediately as soon as the block appears (using the existing `eth_subscribe` subscription).

This hotfix is mainly for Staking DApp that used `:blocks` chain event before. The `:blocks` is only broadcasted when a block is written to DB, so when there is a load to DB, the `:blocks` event appears with time delays. Due to that, the staking app may skip blocks which might lead to bugs in its UI. Since the Staking DApp doesn't use the block info from DB, it should receive a notification about the new block number immediately once the block appears through `eth_subscribe`.

These changes were successfully tested locally.

## Changelog

Add `last_block_number` to `@allowed_events` and `@allowed_broadcast_events` in `apps/explorer/lib/explorer/chain/events/publisher.ex` and `apps/explorer/lib/explorer/chain/events/subscriber.ex`.

Use `:last_block_number` instead of `:blocks` in `apps/explorer/lib/explorer/staking/contract_state.ex`.

Broadcast `:last_block_number` event by `apps/indexer/lib/indexer/block/realtime/fetcher.ex` when a new block header appears from the `eth_subscribe` subscription.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
