### PR TITLE
Fix procedure of marking internal transactions as failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 
 ### Fixes
+- [#3401](https://github.com/poanetwork/blockscout/pull/3401) - Fix procedure of marking internal transactions as failed
 - [#3399](https://github.com/poanetwork/blockscout/pull/3399) - Fix Token transfers CSV export
 - [#3396](https://github.com/poanetwork/blockscout/pull/3396) - Handle exchange rates request throttled
 - [#3382](https://github.com/poanetwork/blockscout/pull/3382) - Check ets table exists for know tokens

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1554,6 +1554,7 @@ defmodule Explorer.Chain do
 
       iex> for index <- 5..9 do
       ...>   insert(:block, number: index)
+      ...>   Process.sleep(200)
       ...> end
       iex> Explorer.Chain.indexed_ratio()
       Decimal.new(1, 50, -2)

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -239,27 +239,26 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   defp remove_failed_creations(internal_transactions_params) do
     internal_transactions_params
-    |> Enum.map(fn internal_transaction_params ->
-      internal_transaction_params[:trace_address]
+    |> Enum.map(fn internal_transaction_param ->
+      transaction_index = internal_transaction_param[:transaction_index]
 
-      failed_parent_index =
-        Enum.find(internal_transaction_params[:trace_address], fn trace_address ->
-          parent = Enum.at(internal_transactions_params, trace_address)
-
-          !is_nil(parent[:error])
+      failed_parent =
+        internal_transactions_params
+        |> Enum.filter(fn internal_transactions_param ->
+          internal_transactions_param[:transaction_index] == transaction_index &&
+            internal_transactions_param[:trace_address] == [] && !is_nil(internal_transactions_param[:error])
         end)
-
-      failed_parent = failed_parent_index && Enum.at(internal_transactions_params, failed_parent_index)
+        |> Enum.at(0)
 
       if failed_parent do
-        internal_transaction_params
+        internal_transaction_param
         |> Map.delete(:created_contract_address_hash)
         |> Map.delete(:created_contract_code)
         |> Map.delete(:gas_used)
         |> Map.delete(:output)
         |> Map.put(:error, failed_parent[:error])
       else
-        internal_transaction_params
+        internal_transaction_param
       end
     end)
   end


### PR DESCRIPTION
## Motivation

If a block has multiple transactions and block's first transaction is failed Blockscout marks all internal transactions in that block as failed too even if their parent transactions are not failed.

## Changelog

Fix function of searching failed parent trace to mark child traces as failed.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
