### PR TITLE
Add EthereumJSONRPC.HTTP.HTTPoison.json_rpc function clause when URL is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [#3335](https://github.com/poanetwork/blockscout/pull/3335) - MarketCap calculation: check that ETS tables exist before inserting new data or lookup from the table
 
 ### Chore
+- [#3407](https://github.com/poanetwork/blockscout/pull/3407) - Add EthereumJSONRPC.HTTP.HTTPoison.json_rpc function clause when URL is null
 - [#3405](https://github.com/poanetwork/blockscout/pull/3405) - N/A instead of 0 for market cap if it is not fetched
 - [#3404](https://github.com/poanetwork/blockscout/pull/3404) - DISABLE_KNOWN_TOKENS env var
 - [#3403](https://github.com/poanetwork/blockscout/pull/3403) - Refactor Coingecko interaction

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
@@ -17,4 +17,6 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
         {:error, reason}
     end
   end
+
+  def json_rpc(url, _json, _options) when is_nil(url), do: {:error, "URL is nil"}
 end


### PR DESCRIPTION
## Motivation

Eliminate error:

```
2020-10-27T10:30:05.660 fetcher=block_catchup [error] Task Indexer.Block.Catchup.BoundIntervalSupervisor started from #PID<0.739.0> terminating
** (FunctionClauseError) no function clause matching in EthereumJSONRPC.HTTP.HTTPoison.json_rpc/3
    (ethereum_jsonrpc 0.1.0) lib/ethereum_jsonrpc/http/httpoison.ex:11: EthereumJSONRPC.HTTP.HTTPoison.json_rpc(nil, ["{\"", [[] | "id"], "\":", "0", ",\"", [[] | "jsonrpc"], "\":", [34, [[] | "2.0"], 34], ",\"", [[] | "method"], "\":", [34, [[] | "eth_getBlockByNumber"], 34], ",\"", [[] | "params"], "\":", [91, [34, [[] | "latest"], 34], 44, "false", 93], 125], [recv_timeout: 600000, timeout: 600000, hackney: [pool: :ethereum_jsonrpc]])
    (ethereum_jsonrpc 0.1.0) lib/ethereum_jsonrpc/http.ex:29: EthereumJSONRPC.HTTP.json_rpc/2
    (ethereum_jsonrpc 0.1.0) lib/ethereum_jsonrpc/request_coordinator.ex:86: anonymous fn/3 in EthereumJSONRPC.RequestCoordinator.perform/4
    (ethereum_jsonrpc 0.1.0) lib/ethereum_jsonrpc/request_coordinator.ex:106: EthereumJSONRPC.RequestCoordinator.trace_request/2
    (ethereum_jsonrpc 0.1.0) lib/ethereum_jsonrpc.ex:291: EthereumJSONRPC.fetch_block_number_by_tag/2
    (indexer 0.1.0) lib/indexer/block/catchup/fetcher.ex:79: Indexer.Block.Catchup.Fetcher.task/1
    (elixir 1.10.3) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (elixir 1.10.3) lib/task/supervised.ex:35: Task.Supervised.reply/5
Function: &Indexer.Block.Catchup.Fetcher.task/1
    Args: [%Indexer.Block.Catchup.Fetcher{block_fetcher: %Indexer.Block.Fetcher{broadcast: :catchup, callback_module: Indexer.Block.Catchup.Fetcher, json_rpc_named_arguments: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.HTTPoison, url: nil, method_to_url: [eth_getBalance: nil, trace_block: nil, trace_replayTransaction: nil], http_options: [recv_timeout: 600000, timeout: 600000, hackney: [pool: :ethereum_jsonrpc]]], variant: EthereumJSONRPC.Parity], receipts_batch_size: 250, receipts_concurrency: 10}, blocks_batch_size: 5, blocks_concurrency: 5, memory_monitor: Indexer.Memory.Monitor}]
```

## Changelog

Add missing *json_rpc* function caluse

## Checklist for your Pull Request (PR)


  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
