### PR TITLE
Fix address tokens search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 
 ### Fixes
+- [#3428](https://github.com/poanetwork/blockscout/pull/3428) - Fix address tokens search
 - [#3424](https://github.com/poanetwork/blockscout/pull/3424) - Fix display of long NFT IDs
 - [#3422](https://github.com/poanetwork/blockscout/pull/3422) - Fix contract reader: tuple type
 - [#3408](https://github.com/poanetwork/blockscout/pull/3408) - Fix (total) difficulty display

--- a/apps/block_scout_web/assets/js/lib/token_balance_dropdown.js
+++ b/apps/block_scout_web/assets/js/lib/token_balance_dropdown.js
@@ -1,5 +1,6 @@
 import $ from 'jquery'
 import { formatAllUsdValues } from './currency'
+import { TokenBalanceDropdownSearch } from './token_balance_dropdown_search'
 
 const tokenBalanceDropdown = (element) => {
   const $element = $(element)
@@ -20,4 +21,12 @@ const tokenBalanceDropdown = (element) => {
 
 export function loadTokenBalanceDropdown () {
   $('[data-token-balance-dropdown]').each((_index, element) => tokenBalanceDropdown(element))
+
+  $('[data-token-balance-dropdown]').on('hidden.bs.dropdown', _event => {
+    $('[data-filter-dropdown-tokens]').val('').trigger('input')
+  })
+
+  $('[data-token-balance-dropdown]').on('input', function (event) {
+    TokenBalanceDropdownSearch(this, event)
+  })
 }

--- a/apps/block_scout_web/assets/js/lib/token_balance_dropdown_search.js
+++ b/apps/block_scout_web/assets/js/lib/token_balance_dropdown_search.js
@@ -29,7 +29,7 @@ const hideEmptyType = (container) => {
   }
 }
 
-const TokenBalanceDropdownSearch = (element, event) => {
+export function TokenBalanceDropdownSearch (element, event) {
   const $element = $(element)
   const $tokensCount = $element.find('[data-tokens-count]')
   const $tokens = $element.find('[data-token-name]')
@@ -41,11 +41,3 @@ const TokenBalanceDropdownSearch = (element, event) => {
 
   $tokensCount.html($tokensCount.html().replace(/\d+/g, $tokens.not('.d-none').length))
 }
-
-$('[data-token-balance-dropdown]').on('hidden.bs.dropdown', _event => {
-  $('[data-filter-dropdown-tokens]').val('').trigger('input')
-})
-
-$('[data-token-balance-dropdown]').on('input', function (event) {
-  TokenBalanceDropdownSearch(this, event)
-})

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
@@ -373,8 +373,8 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
       next
       |> AddressPage.click_balance_dropdown_toggle()
       |> AddressPage.fill_balance_dropdown_search("ato")
-      |> assert_has(AddressPage.token_balance(count: 2))
-      |> assert_has(AddressPage.token_type(count: 2))
+      |> assert_has(AddressPage.token_balance(count: 1))
+      |> assert_has(AddressPage.token_type(count: 1))
       |> assert_has(AddressPage.token_type_count(type: "ERC-721", text: "1"))
     end
 
@@ -388,8 +388,8 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
       next
       |> AddressPage.click_balance_dropdown_toggle()
       |> AddressPage.fill_balance_dropdown_search("T2")
-      |> assert_has(AddressPage.token_balance(count: 2))
-      |> assert_has(AddressPage.token_type(count: 2))
+      |> assert_has(AddressPage.token_balance(count: 1))
+      |> assert_has(AddressPage.token_type(count: 1))
       |> assert_has(AddressPage.token_type_count(type: "ERC-20", text: "1"))
     end
 


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/1994

## Motivation

Tokens search functionality doesn't work in address tokens dropdown


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
