### PR TITLE
Standardize token name definition, if name is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [#3335](https://github.com/poanetwork/blockscout/pull/3335) - MarketCap calculation: check that ETS tables exist before inserting new data or lookup from the table
 
 ### Chore
+- [#3431](https://github.com/poanetwork/blockscout/pull/3431) - Standardize token name definition, if name is empty
 - [#3421](https://github.com/poanetwork/blockscout/pull/3421) - Functions to enable GnosisSafe app link
 - [#3414](https://github.com/poanetwork/blockscout/pull/3414) - Manage lis of other explorers in the footer via env var
 - [#3407](https://github.com/poanetwork/blockscout/pull/3407) - Add EthereumJSONRPC.HTTP.HTTPoison.json_rpc function clause when URL is null

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -255,9 +255,7 @@ defmodule BlockScoutWeb.AddressView do
   end
 
   def token_title(%Token{name: nil, contract_address_hash: contract_address_hash}) do
-    contract_address_hash
-    |> to_string
-    |> String.slice(0..5)
+    short_hash_left_right(contract_address_hash)
   end
 
   def token_title(%Token{name: name, symbol: symbol}), do: "#{name} (#{symbol})"
@@ -364,6 +362,34 @@ defmodule BlockScoutWeb.AddressView do
     >> = to_string(hash)
 
     "0x" <> short_address
+  end
+
+  def short_hash_left_right(hash) when not is_nil(hash) do
+    case hash do
+      "0x" <> rest ->
+        shortify_hash_string(rest)
+
+      %Chain.Hash{
+        byte_count: _,
+        bytes: bytes
+      } ->
+        shortify_hash_string(Base.encode16(bytes, case: :lower))
+
+      hash ->
+        shortify_hash_string(hash)
+    end
+  end
+
+  def short_hash_left_right(hash) when is_nil(hash), do: ""
+
+  defp shortify_hash_string(hash) do
+    <<
+      left::binary-size(6),
+      _middle::binary-size(28),
+      right::binary-size(6)
+    >> = to_string(hash)
+
+    "0x" <> left <> "-" <> right
   end
 
   def short_contract_name(name, max_length) do

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/helpers.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.Tokens.Helpers do
   Helper functions for interacting with `t:BlockScoutWeb.Chain.Token` attributes.
   """
 
-  alias BlockScoutWeb.CurrencyHelpers
+  alias BlockScoutWeb.{AddressView, CurrencyHelpers}
   alias Explorer.Chain.{Address, Token}
 
   @doc """
@@ -46,7 +46,7 @@ defmodule BlockScoutWeb.Tokens.Helpers do
   When the token's symbol is nil, the function will return the contract address hash.
   """
   def token_symbol(%Token{symbol: nil, contract_address_hash: address_hash}) do
-    "#{contract_address_hash_truncated(address_hash)}..."
+    AddressView.short_hash_left_right(address_hash)
   end
 
   def token_symbol(%Token{symbol: symbol}) do
@@ -62,16 +62,10 @@ defmodule BlockScoutWeb.Tokens.Helpers do
   def token_name(%Address.Token{} = address_token), do: build_token_name(address_token)
 
   defp build_token_name(%{name: nil, contract_address_hash: address_hash}) do
-    "#{contract_address_hash_truncated(address_hash)}..."
+    AddressView.short_hash_left_right(address_hash)
   end
 
   defp build_token_name(%{name: name}) do
     name
-  end
-
-  defp contract_address_hash_truncated(address_hash) do
-    address_hash
-    |> to_string()
-    |> String.slice(0..6)
   end
 end

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -899,7 +899,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:348
+#: lib/block_scout_web/views/address_view.ex:346
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:119
 #: lib/block_scout_web/views/tokens/overview_view.ex:40
 #: lib/block_scout_web/views/transaction_view.ex:395
@@ -1798,7 +1798,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:46
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
-#: lib/block_scout_web/views/address_view.ex:356
+#: lib/block_scout_web/views/address_view.ex:354
 msgid "Blocks Validated"
 msgstr ""
 
@@ -1808,18 +1808,18 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:349
+#: lib/block_scout_web/views/address_view.ex:347
 msgid "Code"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:32
-#: lib/block_scout_web/views/address_view.ex:355
+#: lib/block_scout_web/views/address_view.ex:353
 msgid "Coin Balance History"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_view.ex:350
+#: lib/block_scout_web/views/address_view.ex:348
 msgid "Decompiled Code"
 msgstr ""
 
@@ -1828,7 +1828,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:346
+#: lib/block_scout_web/views/address_view.ex:344
 #: lib/block_scout_web/views/transaction_view.ex:396
 msgid "Internal Transactions"
 msgstr ""
@@ -1838,7 +1838,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:357
+#: lib/block_scout_web/views/address_view.ex:355
 #: lib/block_scout_web/views/transaction_view.ex:397
 msgid "Logs"
 msgstr ""
@@ -1846,7 +1846,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:79
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
-#: lib/block_scout_web/views/address_view.ex:351
+#: lib/block_scout_web/views/address_view.ex:349
 #: lib/block_scout_web/views/tokens/overview_view.ex:42
 msgid "Read Contract"
 msgstr ""
@@ -1858,7 +1858,7 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:87
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:108
 #: lib/block_scout_web/templates/tokens/index.html.eex:4
-#: lib/block_scout_web/views/address_view.ex:345
+#: lib/block_scout_web/views/address_view.ex:343
 msgid "Tokens"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:18
 #: lib/block_scout_web/templates/chain/show.html.eex:238
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:53
-#: lib/block_scout_web/views/address_view.ex:347
+#: lib/block_scout_web/views/address_view.ex:345
 msgid "Transactions"
 msgstr ""
 
@@ -1909,13 +1909,13 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:86
-#: lib/block_scout_web/views/address_view.ex:352
+#: lib/block_scout_web/views/address_view.ex:350
 msgid "Read Proxy"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:93
-#: lib/block_scout_web/views/address_view.ex:353
+#: lib/block_scout_web/views/address_view.ex:351
 msgid "Write Contract"
 msgstr ""
 
@@ -1932,7 +1932,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:100
-#: lib/block_scout_web/views/address_view.ex:354
+#: lib/block_scout_web/views/address_view.ex:352
 msgid "Write Proxy"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -899,7 +899,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:348
+#: lib/block_scout_web/views/address_view.ex:346
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:119
 #: lib/block_scout_web/views/tokens/overview_view.ex:40
 #: lib/block_scout_web/views/transaction_view.ex:395
@@ -1798,7 +1798,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:46
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
-#: lib/block_scout_web/views/address_view.ex:356
+#: lib/block_scout_web/views/address_view.ex:354
 msgid "Blocks Validated"
 msgstr ""
 
@@ -1808,18 +1808,18 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:349
+#: lib/block_scout_web/views/address_view.ex:347
 msgid "Code"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:32
-#: lib/block_scout_web/views/address_view.ex:355
+#: lib/block_scout_web/views/address_view.ex:353
 msgid "Coin Balance History"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/address_view.ex:350
+#: lib/block_scout_web/views/address_view.ex:348
 msgid "Decompiled Code"
 msgstr ""
 
@@ -1828,7 +1828,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:346
+#: lib/block_scout_web/views/address_view.ex:344
 #: lib/block_scout_web/views/transaction_view.ex:396
 msgid "Internal Transactions"
 msgstr ""
@@ -1838,7 +1838,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:357
+#: lib/block_scout_web/views/address_view.ex:355
 #: lib/block_scout_web/views/transaction_view.ex:397
 msgid "Logs"
 msgstr ""
@@ -1846,7 +1846,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:79
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
-#: lib/block_scout_web/views/address_view.ex:351
+#: lib/block_scout_web/views/address_view.ex:349
 #: lib/block_scout_web/views/tokens/overview_view.ex:42
 msgid "Read Contract"
 msgstr ""
@@ -1858,7 +1858,7 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:87
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:108
 #: lib/block_scout_web/templates/tokens/index.html.eex:4
-#: lib/block_scout_web/views/address_view.ex:345
+#: lib/block_scout_web/views/address_view.ex:343
 msgid "Tokens"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:18
 #: lib/block_scout_web/templates/chain/show.html.eex:238
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:53
-#: lib/block_scout_web/views/address_view.ex:347
+#: lib/block_scout_web/views/address_view.ex:345
 msgid "Transactions"
 msgstr ""
 
@@ -1909,13 +1909,13 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:86
-#: lib/block_scout_web/views/address_view.ex:352
+#: lib/block_scout_web/views/address_view.ex:350
 msgid "Read Proxy"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:93
-#: lib/block_scout_web/views/address_view.ex:353
+#: lib/block_scout_web/views/address_view.ex:351
 msgid "Write Contract"
 msgstr ""
 
@@ -1932,7 +1932,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:100
-#: lib/block_scout_web/views/address_view.ex:354
+#: lib/block_scout_web/views/address_view.ex:352
 msgid "Write Proxy"
 msgstr ""
 

--- a/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
@@ -301,11 +301,12 @@ defmodule BlockScoutWeb.AddressViewTest do
   end
 
   describe "token_title/1" do
-    test "returns the 6 first chars of address hash when token has no name" do
+    test "returns the 6 first and 6 last chars of address hash when token has no name" do
       token = insert(:token, name: nil)
 
-      expected_hash = to_string(token.contract_address_hash)
-      assert String.starts_with?(expected_hash, AddressView.token_title(token))
+      hash = to_string(token.contract_address_hash)
+      expected_hash = String.slice(hash, 0, 8) <> "-" <> String.slice(hash, -6, 6)
+      assert expected_hash == AddressView.token_title(token)
     end
 
     test "returns name(symbol) when token has name" do

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/helpers_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/helpers_test.exs
@@ -51,7 +51,7 @@ defmodule BlockScoutWeb.Tokens.HelpersTest do
       address = build(:address, hash: "de3fa0f9f8d47790ce88c2b2b82ab81f79f2e65f")
       token = build(:token, symbol: nil, contract_address_hash: address.hash)
 
-      assert Helpers.token_symbol(token) == "de3fa0f..."
+      assert Helpers.token_symbol(token) == "0xde3fa0-f2e65f"
     end
   end
 
@@ -66,7 +66,7 @@ defmodule BlockScoutWeb.Tokens.HelpersTest do
       address = build(:address, hash: "de3fa0f9f8d47790ce88c2b2b82ab81f79f2e65f")
       token = build(:token, name: nil, contract_address_hash: address.hash)
 
-      assert Helpers.token_name(token) == "de3fa0f..."
+      assert Helpers.token_name(token) == "0xde3fa0-f2e65f"
     end
   end
 end


### PR DESCRIPTION
Closes https://github.com/poanetwork/blockscout/issues/2536

## Motivation

Standardize token name definition if there is no name:
"0x" + "left::binary-size(6)" + "-" + "right::binary-size(6)"

An example: *0x8a55f3-b3b9a5*

## Changelog

![Screenshot 2020-11-04 at 23 46 51](https://user-images.githubusercontent.com/4341812/98166459-7e9eef80-1ef8-11eb-872a-d6dc9185608a.png)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
