### PR TITLE
Fix unnecessary tx error status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - [#3424](https://github.com/poanetwork/blockscout/pull/3424) - Fix display of long NFT IDs
 - [#3422](https://github.com/poanetwork/blockscout/pull/3422) - Fix contract reader: tuple type
 - [#3408](https://github.com/poanetwork/blockscout/pull/3408) - Fix (total) difficulty display
-- [#3401](https://github.com/poanetwork/blockscout/pull/3401) - Fix procedure of marking internal transactions as failed
+- [#3401](https://github.com/poanetwork/blockscout/pull/3401), [#3432](https://github.com/poanetwork/blockscout/pull/3432) - Fix procedure of marking internal transactions as failed
 - [#3400](https://github.com/poanetwork/blockscout/pull/3400) - Add :last_block_number realtime chain event
 - [#3399](https://github.com/poanetwork/blockscout/pull/3399) - Fix Token transfers CSV export
 - [#3396](https://github.com/poanetwork/blockscout/pull/3396) - Handle exchange rates request throttled

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -241,11 +241,13 @@ defmodule Indexer.Fetcher.InternalTransaction do
     internal_transactions_params
     |> Enum.map(fn internal_transaction_param ->
       transaction_index = internal_transaction_param[:transaction_index]
+      block_number = internal_transaction_param[:block_number]
 
       failed_parent =
         internal_transactions_params
         |> Enum.filter(fn internal_transactions_param ->
-          internal_transactions_param[:transaction_index] == transaction_index &&
+          internal_transactions_param[:block_number] == block_number &&
+            internal_transactions_param[:transaction_index] == transaction_index &&
             internal_transactions_param[:trace_address] == [] && !is_nil(internal_transactions_param[:error])
         end)
         |> Enum.at(0)


### PR DESCRIPTION
## Motivation

Some transactions are marked with error status. Though, they are successful.

## Changelog

Check block_number in the process of setting the error from parent trace for the child traces.

## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
