### PR TITLE
Token balances and rewards tables deadlocks elimination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - [#3440](https://github.com/poanetwork/blockscout/pull/3440) - Rewrite missing blocks range query
 - [#3439](https://github.com/poanetwork/blockscout/pull/3439) - Dark mode color fixes (search, charts)
 - [#3437](https://github.com/poanetwork/blockscout/pull/3437) - Fix Postgres Docker container
+- [#3433](https://github.com/poanetwork/blockscout/pull/3433) - Token balances and rewards tables deadlocks elimination
 - [#3428](https://github.com/poanetwork/blockscout/pull/3428) - Fix address tokens search
 - [#3424](https://github.com/poanetwork/blockscout/pull/3424) - Fix display of long NFT IDs
 - [#3422](https://github.com/poanetwork/blockscout/pull/3422) - Fix contract reader: tuple type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
+- [#3433](https://github.com/poanetwork/blockscout/pull/3433) - Token balances and rewards tables deadlocks elimination
 - [#3494](https://github.com/poanetwork/blockscout/pull/3494), [#3497](https://github.com/poanetwork/blockscout/pull/3497) - Contracts interaction: fix method call with array[] input
 - [#3494](https://github.com/poanetwork/blockscout/pull/3494), [#3495](https://github.com/poanetwork/blockscout/pull/3495) - Contracts interaction: fix tuple output display
 - [#3479](https://github.com/poanetwork/blockscout/pull/3479) - Fix working with big numbers in Staking DApp
@@ -56,7 +57,6 @@
 - [#3440](https://github.com/poanetwork/blockscout/pull/3440) - Rewrite missing blocks range query
 - [#3439](https://github.com/poanetwork/blockscout/pull/3439) - Dark mode color fixes (search, charts)
 - [#3437](https://github.com/poanetwork/blockscout/pull/3437) - Fix Postgres Docker container
-- [#3433](https://github.com/poanetwork/blockscout/pull/3433) - Token balances and rewards tables deadlocks elimination
 - [#3428](https://github.com/poanetwork/blockscout/pull/3428) - Fix address tokens search
 - [#3424](https://github.com/poanetwork/blockscout/pull/3424) - Fix display of long NFT IDs
 - [#3422](https://github.com/poanetwork/blockscout/pull/3422) - Fix contract reader: tuple type

--- a/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
@@ -201,7 +201,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # Enforce CurrentTokenBalance ShareLocks order (see docs: sharelocks.md)
-    ordered_changes_list = Enum.sort_by(changes_list, &{&1.address_hash, &1.token_contract_address_hash})
+    ordered_changes_list = Enum.sort_by(changes_list, &{&1.token_contract_address_hash, &1.address_hash})
 
     Import.insert_changes_list(
       repo,

--- a/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
@@ -61,7 +61,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
 
     # Enforce TokenBalance ShareLocks order (see docs: sharelocks.md)
     ordered_changes_list =
-      Enum.sort_by(changes_list, &{&1.address_hash, &1.token_contract_address_hash, &1.block_number})
+      Enum.sort_by(changes_list, &{&1.token_contract_address_hash, &1.address_hash, &1.block_number})
 
     {:ok, _} =
       Import.insert_changes_list(

--- a/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
@@ -53,7 +53,7 @@ defmodule Explorer.Chain.Import.Runner.Block.Rewards do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # Enforce Reward ShareLocks order (see docs: sharelocks.md)
-    ordered_changes_list = Enum.sort_by(changes_list, &{&1.address_hash, &1.address_type, &1.block_hash})
+    ordered_changes_list = Enum.sort_by(changes_list, &{&1.block_hash, &1.address_hash, &1.address_type})
 
     Import.insert_changes_list(
       repo,

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -117,10 +117,10 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
   defp acquire_contract_address_tokens(repo, consensus_block_numbers) do
     query =
-      from(address_current_token_balance in Address.CurrentTokenBalance,
-        where: address_current_token_balance.block_number in ^consensus_block_numbers,
-        select: address_current_token_balance.token_contract_address_hash,
-        distinct: address_current_token_balance.token_contract_address_hash
+      from(ctb in Address.CurrentTokenBalance,
+        where: ctb.block_number in ^consensus_block_numbers,
+        select: ctb.token_contract_address_hash,
+        distinct: ctb.token_contract_address_hash
       )
 
     contract_address_hashes = repo.all(query)
@@ -339,27 +339,27 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
   defp delete_address_token_balances(repo, consensus_block_numbers, %{timeout: timeout}) do
     ordered_query =
-      from(address_token_balance in Address.TokenBalance,
-        where: address_token_balance.block_number in ^consensus_block_numbers,
-        select: map(address_token_balance, [:address_hash, :token_contract_address_hash, :block_number]),
+      from(tb in Address.TokenBalance,
+        where: tb.block_number in ^consensus_block_numbers,
+        select: map(tb, [:address_hash, :token_contract_address_hash, :block_number]),
         # Enforce TokenBalance ShareLocks order (see docs: sharelocks.md)
         order_by: [
-          address_token_balance.address_hash,
-          address_token_balance.token_contract_address_hash,
-          address_token_balance.block_number
+          tb.address_hash,
+          tb.token_contract_address_hash,
+          tb.block_number
         ],
         lock: "FOR UPDATE"
       )
 
     query =
-      from(address_token_balance in Address.TokenBalance,
-        select: map(address_token_balance, [:address_hash, :token_contract_address_hash, :block_number]),
+      from(tb in Address.TokenBalance,
+        select: map(tb, [:address_hash, :token_contract_address_hash, :block_number]),
         inner_join: ordered_address_token_balance in subquery(ordered_query),
         on:
-          ordered_address_token_balance.address_hash == address_token_balance.address_hash and
+          ordered_address_token_balance.address_hash == tb.address_hash and
             ordered_address_token_balance.token_contract_address_hash ==
-              address_token_balance.token_contract_address_hash and
-            ordered_address_token_balance.block_number == address_token_balance.block_number
+              tb.token_contract_address_hash and
+            ordered_address_token_balance.block_number == tb.block_number
       )
 
     try do
@@ -376,21 +376,21 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
   defp delete_address_current_token_balances(repo, consensus_block_numbers, %{timeout: timeout}) do
     ordered_query =
-      from(address_current_token_balance in Address.CurrentTokenBalance,
-        where: address_current_token_balance.block_number in ^consensus_block_numbers,
-        select: map(address_current_token_balance, [:address_hash, :token_contract_address_hash]),
+      from(ctb in Address.CurrentTokenBalance,
+        where: ctb.block_number in ^consensus_block_numbers,
+        select: map(ctb, [:address_hash, :token_contract_address_hash]),
         # Enforce CurrentTokenBalance ShareLocks order (see docs: sharelocks.md)
         order_by: [
-          address_current_token_balance.address_hash,
-          address_current_token_balance.token_contract_address_hash
+          ctb.address_hash,
+          ctb.token_contract_address_hash
         ],
         lock: "FOR UPDATE"
       )
 
     query =
-      from(address_current_token_balance in Address.CurrentTokenBalance,
+      from(ctb in Address.CurrentTokenBalance,
         select:
-          map(address_current_token_balance, [
+          map(ctb, [
             :address_hash,
             :token_contract_address_hash,
             # Used to determine if `address_hash` was a holder of `token_contract_address_hash` before
@@ -400,9 +400,9 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
           ]),
         inner_join: ordered_address_current_token_balance in subquery(ordered_query),
         on:
-          ordered_address_current_token_balance.address_hash == address_current_token_balance.address_hash and
+          ordered_address_current_token_balance.address_hash == ctb.address_hash and
             ordered_address_current_token_balance.token_contract_address_hash ==
-              address_current_token_balance.token_contract_address_hash
+              ctb.token_contract_address_hash
       )
 
     try do
@@ -420,13 +420,13 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   defp derive_address_current_token_balances(repo, deleted_address_current_token_balances, %{timeout: timeout})
        when is_list(deleted_address_current_token_balances) do
     initial_query =
-      from(address_token_balance in Address.TokenBalance,
+      from(tb in Address.TokenBalance,
         select: %{
-          address_hash: address_token_balance.address_hash,
-          token_contract_address_hash: address_token_balance.token_contract_address_hash,
-          block_number: max(address_token_balance.block_number)
+          address_hash: tb.address_hash,
+          token_contract_address_hash: tb.token_contract_address_hash,
+          block_number: max(tb.block_number)
         },
-        group_by: [address_token_balance.address_hash, address_token_balance.token_contract_address_hash]
+        group_by: [tb.address_hash, tb.token_contract_address_hash]
       )
 
     final_query =
@@ -436,30 +436,30 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
                                                                                 token_contract_address_hash
                                                                             },
                                                                             acc_query ->
-        from(address_token_balance in acc_query,
+        from(tb in acc_query,
           or_where:
-            address_token_balance.address_hash == ^address_hash and
-              address_token_balance.token_contract_address_hash == ^token_contract_address_hash
+            tb.address_hash == ^address_hash and
+              tb.token_contract_address_hash == ^token_contract_address_hash
         )
       end)
 
     new_current_token_balance_query =
       from(new_current_token_balance in subquery(final_query),
-        inner_join: address_token_balance in Address.TokenBalance,
+        inner_join: tb in Address.TokenBalance,
         on:
-          address_token_balance.address_hash == new_current_token_balance.address_hash and
-            address_token_balance.token_contract_address_hash == new_current_token_balance.token_contract_address_hash and
-            address_token_balance.block_number == new_current_token_balance.block_number,
+          tb.address_hash == new_current_token_balance.address_hash and
+            tb.token_contract_address_hash == new_current_token_balance.token_contract_address_hash and
+            tb.block_number == new_current_token_balance.block_number,
         select: %{
           address_hash: new_current_token_balance.address_hash,
           token_contract_address_hash: new_current_token_balance.token_contract_address_hash,
           block_number: new_current_token_balance.block_number,
-          value: address_token_balance.value,
-          inserted_at: over(min(address_token_balance.inserted_at), :w),
-          updated_at: over(max(address_token_balance.updated_at), :w)
+          value: tb.value,
+          inserted_at: over(min(tb.inserted_at), :w),
+          updated_at: over(max(tb.updated_at), :w)
         },
         windows: [
-          w: [partition_by: [address_token_balance.address_hash, address_token_balance.token_contract_address_hash]]
+          w: [partition_by: [tb.address_hash, tb.token_contract_address_hash]]
         ]
       )
 

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -344,8 +344,8 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         select: map(tb, [:address_hash, :token_contract_address_hash, :block_number]),
         # Enforce TokenBalance ShareLocks order (see docs: sharelocks.md)
         order_by: [
-          tb.address_hash,
           tb.token_contract_address_hash,
+          tb.address_hash,
           tb.block_number
         ],
         lock: "FOR UPDATE"
@@ -381,8 +381,8 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         select: map(ctb, [:address_hash, :token_contract_address_hash]),
         # Enforce CurrentTokenBalance ShareLocks order (see docs: sharelocks.md)
         order_by: [
-          ctb.address_hash,
-          ctb.token_contract_address_hash
+          ctb.token_contract_address_hash,
+          ctb.address_hash
         ],
         lock: "FOR UPDATE"
       )
@@ -467,7 +467,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
       new_current_token_balance_query
       |> repo.all()
       # Enforce CurrentTokenBalance ShareLocks order (see docs: sharelocks.md)
-      |> Enum.sort_by(&{&1.address_hash, &1.token_contract_address_hash})
+      |> Enum.sort_by(&{&1.token_contract_address_hash, &1.address_hash})
 
     {_total, result} =
       repo.insert_all(

--- a/apps/indexer/lib/indexer/token_balances.ex
+++ b/apps/indexer/lib/indexer/token_balances.ex
@@ -57,6 +57,7 @@ defmodule Indexer.TokenBalances do
     |> Enum.map(fn {_, grouped_address_token_balances} ->
       Enum.max_by(grouped_address_token_balances, fn %{block_number: block_number} -> block_number end)
     end)
+    |> Enum.sort_by(&{&1.token_contract_address_hash, &1.address_hash})
   end
 
   defp set_token_balance_value({:ok, balance}, token_balance) do


### PR DESCRIPTION
Closes https://github.com/poanetwork/blockscout/issues/3334

## Motivation

Eliminate deadlocks of 3 kinds on rows insertion to the next tables:

1. TokenBalances
 Application logs:
```
2020-11-03T08:28:20.676 [error] Task Indexer.Block.Realtime.Fetcher started from #PID<0.23370.336> terminating
** (Postgrex.Error) ERROR 40P01 (deadlock_detected) deadlock detected

    hint: See server log for query details.

Process 10575 waits for ShareLock on transaction 29941763; blocked by process 11516.
Process 11516 waits for ShareLock on transaction 29941630; blocked by process 10575.
    (ecto_sql 3.3.4) lib/ecto/adapters/sql.ex:612: Ecto.Adapters.SQL.raise_sql_call_error/1
    (ecto_sql 3.3.4) lib/ecto/adapters/sql.ex:521: Ecto.Adapters.SQL.insert_all/8
    (ecto 3.3.4) lib/ecto/repo/schema.ex:54: Ecto.Repo.Schema.do_insert_all/6
    (explorer 0.0.1) lib/explorer/repo.ex:45: anonymous fn/5 in Explorer.Repo.safe_insert_all/3
    (elixir 1.10.3) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
    (explorer 0.0.1) lib/explorer/chain/import.ex:299: Explorer.Chain.Import.insert_changes_list/3
    (explorer 0.0.1) lib/explorer/chain/import/runner/address/token_balances.ex:67: Explorer.Chain.Import.Runner.Address.TokenBalances.insert/3
    (ecto 3.3.4) lib/ecto/multi.ex:585: Ecto.Multi.apply_operation/5
Function: &Indexer.Block.Realtime.Fetcher.fetch_and_import_block/3
    Args: [12837041, %Indexer.Block.Fetcher{broadcast: :realtime, callback_module: Indexer.Block.Realtime.Fetcher, json_rpc_named_arguments: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.HTTPoison, url: "https://zip01-ovh.xdaichain.com", method_to_url: [eth_getBalance: "https://zip01-ovh.xdaichain.com", trace_block: "https://zip01-ovh.xdaichain.com", trace_replayTransaction: "https://zip01-ovh.xdaichain.com"], http_options: [recv_timeout: 600000, timeout: 600000, hackney: [pool: :ethereum_jsonrpc]]], variant: EthereumJSONRPC.Parity], receipts_batch_size: 250, receipts_concurrency: 10}, false]
```

2. Rewards
DB logs:
```
2020-11-03 11:55:46 UTC:10.0.0.100(55811):poa@sokol:[4746]:ERROR:  deadlock detected
2020-11-03 11:55:46 UTC:10.0.0.100(55811):poa@sokol:[4746]:DETAIL:  Process 4746 waits for ShareLock on transaction 125405921; blocked by process 2668.
	Process 2668 waits for ShareLock on transaction 125405918; blocked by process 4746.
	Process 4746: INSERT INTO "block_rewards" AS b0 ("address_hash","address_type","block_hash","inserted_at","reward","updated_at") VALUES ($1,$2,$3,$4,$5,$6),($7,$8,$9,$10,$11,$12),($13,$14,$15,$16,$17,$18),($19,$20,$21,$22,$23,$24),($25,$26,$27,$28,$29,$30),($31,$32,$33,$34,$35,$36),($37,$38,$39,$40,$41,$42),($43,$44,$45,$46,$47,$48),($49,$50,$51,$52,$53,$54) ON CONFLICT ("address_hash","address_type","block_hash") DO UPDATE SET "reward" = EXCLUDED.reward WHERE (EXCLUDED.reward IS DISTINCT FROM b0."reward") RETURNING "updated_at", "inserted_at", "block_hash", "address_hash", "reward", "address_type"
	Process 2668: SELECT b0."hash" FROM "blocks" AS b0 WHERE (b0."number" = ANY($1) AND b0."consensus") ORDER BY b0."hash" FOR UPDATE
```


3. CurrentTokenBalances

Application logs:
```

2020-11-06T07:48:55.551 application=indexer fetcher=block_catchup first_block_number=12884135 last_block_number=12884131 [error] ** (Postgrex.Error) ERROR 40P01 (deadlock_detected) deadlock detected

    hint: See server log for query details.

Process 19014 waits for ShareLock on transaction 31051784; blocked by process 19407.
Process 19407 waits for ShareLock on transaction 31051463; blocked by process 19014.
    (ecto_sql 3.3.4) lib/ecto/adapters/sql.ex:612: Ecto.Adapters.SQL.raise_sql_call_error/1
    (ecto_sql 3.3.4) lib/ecto/adapters/sql.ex:521: Ecto.Adapters.SQL.insert_all/8
    (ecto 3.3.4) lib/ecto/repo/schema.ex:54: Ecto.Repo.Schema.do_insert_all/6
    (explorer 0.0.1) lib/explorer/chain/import/runner/blocks.ex:473: Explorer.Chain.Import.Runner.Blocks.derive_address_current_token_balances/3
    (ecto 3.3.4) lib/ecto/multi.ex:585: Ecto.Multi.apply_operation/5
    (elixir 1.10.3) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto 3.3.4) lib/ecto/multi.ex:569: anonymous fn/5 in Ecto.Multi.apply_operations/5
    (ecto_sql 3.3.4) lib/ecto/adapters/sql.ex:886: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4


Retrying.
```


DB logs:
```
2020-11-06 07:48:55 UTC:147.135.46.163(45933):poa@dai:[19014]:ERROR:  deadlock detected
2020-11-06 07:48:55 UTC:147.135.46.163(45933):poa@dai:[19014]:DETAIL:  Process 19014 waits for ShareLock on transaction 31051784; blocked by process 19407.
	Process 19407 waits for ShareLock on transaction 31051463; blocked by process 19014.
	Process 19014: INSERT INTO "address_current_token_balances" ("address_hash","block_number","inserted_at","token_contract_address_hash","updated_at","value") VALUES ($1,$2,$3,$4,$5,$6),($7,$8,$9,$10,$11,$12),($13,$14,$15,$16,$17,$18),($19,$20,$21,$22,$23,$24),($25,$26,$27,$28,$29,$30),($31,$32,$33,$34,$35,$36) RETURNING "value", "block_number", "token_contract_address_hash", "address_hash"
	Process 19407: INSERT INTO "address_current_token_balances" AS a0 ("address_hash","block_number","inserted_at","token_contract_address_hash","updated_at","value","value_fetched_at") VALUES ($1,$2,$3,$4,$5,$6,$7),($8,$9,$10,$11,$12,$13,$14),($15,$16,$17,$18,$19,$20,$21),($22,$23,$24,$25,$26,$27,$28),($29,$30,$31,$32,$33,$34,$35),($36,$37,$38,$39,$40,$41,$42),($43,$44,$45,$46,$47,$48,$49),($50,$51,$52,$53,$54,$55,$56),($57,$58,$59,$60,$61,$62,$63) ON CONFLICT ("address_hash","token_contract_address_hash") DO UPDATE SET "block_number" = EXCLUDED.block_number, "value" = EXCLUDED.value, "value_fetched_at" = EXCLUDED.value_fetched_at, "old_value" = a0."value", "inserted_at" = LEAST(EXCLUDED.inserted_at, a0."inserted_at"), "updated_at" = GREATEST(EXCLUDED.updated_at, a0."updated_at") WHERE (a0."block_number" < EXCLUDED.block_number OR ((EXCLUDED.value IS NOT NULL AND (a0."value_fetched_at" IS NULL)) AND a0."block_number" = EXCLUDED.block_number)) RETURNING "updated_at", "inserted_at", "token_contract_address_hash", "address_hash", "old_value", "value_fetched_at", "block_number", "value", "id"
```

## Changelog

Change the order of token balances and rewards on insertion

Chore:
- shortify some vars names

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
