### PR TITLE
Add extra logging to Staking DApp

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -107,9 +107,13 @@ defmodule BlockScoutWeb.Notifier do
     })
   end
 
-  def handle_event({:chain_event, :staking_update}) do
+  def handle_event({:chain_event, :staking_update, :realtime, passed_block_number}) do
+    block_number = BlockNumber.get_max()
+    last_known_block_number = ContractState.get(:last_known_block_number, 0)
+    require Logger
+    Logger.warn("notifier.ex: received :staking_update and broadcasts stakes:staking_update to Endpoint. BlockNumber.get_max() = #{block_number}. last_known_block_number = #{last_known_block_number}. passed_block_number = #{passed_block_number}")
     Endpoint.broadcast("stakes:staking_update", "staking_update", %{
-      block_number: BlockNumber.get_max(),
+      block_number: block_number,
       epoch_number: ContractState.get(:epoch_number, 0),
       staking_allowed: ContractState.get(:staking_allowed, false),
       staking_token_defined: ContractState.get(:token, nil) != nil,

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -111,7 +111,13 @@ defmodule BlockScoutWeb.Notifier do
     block_number = BlockNumber.get_max()
     last_known_block_number = ContractState.get(:last_known_block_number, 0)
     require Logger
-    Logger.warn("notifier.ex: received :staking_update and broadcasts stakes:staking_update to Endpoint. BlockNumber.get_max() = #{block_number}. last_known_block_number = #{last_known_block_number}. passed_block_number = #{passed_block_number}")
+
+    Logger.warn(
+      "notifier.ex: received :staking_update and broadcasts stakes:staking_update to Endpoint. BlockNumber.get_max() = #{
+        block_number
+      }. last_known_block_number = #{last_known_block_number}. passed_block_number = #{passed_block_number}"
+    )
+
     Endpoint.broadcast("stakes:staking_update", "staking_update", %{
       block_number: block_number,
       epoch_number: ContractState.get(:epoch_number, 0),

--- a/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
+++ b/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
@@ -28,7 +28,7 @@ defmodule BlockScoutWeb.RealtimeEventHandler do
     # Does not come from the indexer
     Subscriber.to(:exchange_rate)
     Subscriber.to(:transaction_stats)
-    Subscriber.to(:staking_update)
+    Subscriber.to(:staking_update, :realtime)
     {:ok, []}
   end
 

--- a/apps/block_scout_web/test/block_scout_web/channels/stakes_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/stakes_channel_test.exs
@@ -7,7 +7,7 @@ defmodule BlockScoutWeb.StakesChannelTest do
     topic = "stakes:staking_update"
     @endpoint.subscribe(topic)
 
-    Notifier.handle_event({:chain_event, :staking_update})
+    Notifier.handle_event({:chain_event, :staking_update, :realtime, 76})
 
     receive do
       %Phoenix.Socket.Broadcast{topic: ^topic, event: "staking_update", payload: %{epoch_number: _}} ->

--- a/apps/explorer/lib/explorer/chain/events/publisher.ex
+++ b/apps/explorer/lib/explorer/chain/events/publisher.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.Events.Publisher do
   Publishes events related to the Chain context.
   """
 
-  @allowed_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions last_block_number token_transfers transactions contract_verification_result)a
+  @allowed_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions last_block_number staking_update token_transfers transactions contract_verification_result)a
 
   def broadcast(_data, false), do: :ok
 

--- a/apps/explorer/lib/explorer/chain/events/subscriber.ex
+++ b/apps/explorer/lib/explorer/chain/events/subscriber.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.Events.Subscriber do
   Subscribes to events related to the Chain context.
   """
 
-  @allowed_broadcast_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions last_block_number token_transfers transactions contract_verification_result)a
+  @allowed_broadcast_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions last_block_number staking_update token_transfers transactions contract_verification_result)a
 
   @allowed_broadcast_types ~w(catchup realtime on_demand contract_verification_result)a
 

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -131,6 +131,7 @@ defmodule Explorer.Staking.ContractState do
   @doc "Handles new blocks and decides to fetch fresh chain info"
   def handle_info({:chain_event, :last_block_number, :realtime, block_number}, state) do
     Logger.warn("contract_state.ex: last_block_number = #{block_number}")
+
     if block_number > state.seen_block do
       fetch_state(state.contracts, state.abi, block_number)
       {:noreply, %{state | seen_block: block_number}}
@@ -142,10 +143,11 @@ defmodule Explorer.Staking.ContractState do
   def handle_info({:chain_event, :blocks, :realtime, blocks}, state) do
     try do
       blocks = Enum.map(blocks, fn block -> block.number end)
-      Logger.warn("contract_state.ex: blocks = #{inspect blocks}")
+      Logger.warn("contract_state.ex: blocks = #{inspect(blocks, charlists: :as_lists)}")
     rescue
       _ -> Logger.warn("contract_state.ex: blocks = unknown")
     end
+
     {:noreply, state}
   end
 
@@ -284,7 +286,6 @@ defmodule Explorer.Staking.ContractState do
 
     # notify the UI about new block
     Logger.warn("contract_state.ex: broadcast :staking_update")
-    #Publisher.broadcast(:staking_update)
     Publisher.broadcast([{:staking_update, block_number}], :realtime)
   end
 

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -86,6 +86,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
       )
       when is_binary(quantity) do
     number = quantity_to_integer(quantity)
+    Logger.warn("fetcher.ex: last_block_number = #{number}")
     Publisher.broadcast([{:last_block_number, number}], :realtime)
     # Subscriptions don't support getting all the blocks and transactions data,
     # so we need to go back and get the full block


### PR DESCRIPTION
## Motivation

This doesn't change any functionality nor fixes bugs, but adds a few additional logs on the server-side for further analyzing block delays and skips in Staking DApp. We can remove this logging later after we analyze the logs.

## Checklist for your Pull Request (PR)
  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
