### PR TITLE
Set infinity timeout and increase cache invalidation period for counters on the main page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [#3335](https://github.com/poanetwork/blockscout/pull/3335) - MarketCap calculation: check that ETS tables exist before inserting new data or lookup from the table
 
 ### Chore
+- [#3446](https://github.com/poanetwork/blockscout/pull/3446) - Change default ttl_check_interval for counters on the main page
 - [#3431](https://github.com/poanetwork/blockscout/pull/3431) - Standardize token name definition, if name is empty
 - [#3421](https://github.com/poanetwork/blockscout/pull/3421) - Functions to enable GnosisSafe app link
 - [#3414](https://github.com/poanetwork/blockscout/pull/3414) - Manage lis of other explorers in the footer via env var

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 - [#3335](https://github.com/poanetwork/blockscout/pull/3335) - MarketCap calculation: check that ETS tables exist before inserting new data or lookup from the table
 
 ### Chore
-- [#3446](https://github.com/poanetwork/blockscout/pull/3446) - Change default ttl_check_interval for counters on the main page
+- [#3446](https://github.com/poanetwork/blockscout/pull/3446) - Set infinity timeout and increase cache invalidation period for counters on the main page
 - [#3431](https://github.com/poanetwork/blockscout/pull/3431) - Standardize token name definition, if name is empty
 - [#3421](https://github.com/poanetwork/blockscout/pull/3421) - Functions to enable GnosisSafe app link
 - [#3414](https://github.com/poanetwork/blockscout/pull/3414) - Manage lis of other explorers in the footer via env var

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1614,7 +1614,7 @@ defmodule Explorer.Chain do
         where: block.consensus == true
       )
 
-    Repo.one!(query) || 0
+    Repo.one!(query, timeout: :infinity) || 0
   end
 
   @spec fetch_sum_coin_total_supply_minus_burnt() :: non_neg_integer
@@ -1629,7 +1629,7 @@ defmodule Explorer.Chain do
         where: a0.fetched_coin_balance > ^0
       )
 
-    Repo.one!(query) || 0
+    Repo.one!(query, timeout: :infinity) || 0
   end
 
   @spec fetch_sum_coin_total_supply() :: non_neg_integer
@@ -1641,7 +1641,7 @@ defmodule Explorer.Chain do
         where: a0.fetched_coin_balance > ^0
       )
 
-    Repo.one!(query) || 0
+    Repo.one!(query, timeout: :infinity) || 0
   end
 
   @spec fetch_sum_gas_used() :: non_neg_integer
@@ -1652,7 +1652,7 @@ defmodule Explorer.Chain do
         select: fragment("SUM(t0.gas_used)")
       )
 
-    Repo.one!(query) || 0
+    Repo.one!(query, timeout: :infinity) || 0
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/cache/block_count.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block_count.ex
@@ -3,17 +3,17 @@ defmodule Explorer.Chain.Cache.BlockCount do
   Cache for block count.
   """
 
-  require Logger
-
-  @default_cache_period :timer.minutes(10)
+  @default_cache_period :timer.hours(2)
 
   use Explorer.Chain.MapCache,
     name: :block_count,
     key: :count,
     key: :async_task,
     global_ttl: cache_period(),
-    ttl_check_interval: :timer.minutes(1),
+    ttl_check_interval: :timer.minutes(15),
     callback: &async_task_on_deletion(&1)
+
+  require Logger
 
   alias Explorer.Chain
 

--- a/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
@@ -5,14 +5,14 @@ defmodule Explorer.Chain.Cache.GasUsage do
 
   require Logger
 
-  @default_cache_period :timer.minutes(30)
+  @default_cache_period :timer.hours(2)
 
   use Explorer.Chain.MapCache,
     name: :gas_usage,
     key: :sum,
     key: :async_task,
     global_ttl: cache_period(),
-    ttl_check_interval: :timer.minutes(1),
+    ttl_check_interval: :timer.minutes(15),
     callback: &async_task_on_deletion(&1)
 
   alias Explorer.Chain

--- a/apps/explorer/lib/explorer/chain/cache/transaction_count.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction_count.ex
@@ -10,7 +10,7 @@ defmodule Explorer.Chain.Cache.TransactionCount do
     key: :count,
     key: :async_task,
     global_ttl: cache_period(),
-    ttl_check_interval: :timer.minutes(10),
+    ttl_check_interval: :timer.minutes(15),
     callback: &async_task_on_deletion(&1)
 
   require Logger


### PR DESCRIPTION
## Motivation

Default cache invalidation interval is too small for counters on the main page and request is dropped after 1 minute

## Changelog

Increase default cache invalidation interval up to 15 minutes, set an infinite timeout for counters queries.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
