### PR TITLE
Correct avg time calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 
 ### Fixes
+- [#3449](https://github.com/poanetwork/blockscout/pull/3449) - Correct avg time calculation
 - [#3440](https://github.com/poanetwork/blockscout/pull/3440) - Rewrite missing blocks range query
 - [#3439](https://github.com/poanetwork/blockscout/pull/3439) - Dark mode color fixes (search, charts)
 - [#3437](https://github.com/poanetwork/blockscout/pull/3437) - Fix Postgres Docker container

--- a/apps/explorer/lib/explorer/counters/average_block_time.ex
+++ b/apps/explorer/lib/explorer/counters/average_block_time.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Counters.AverageBlockTime do
   Caches the number of token holders of a token.
   """
 
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query, only: [from: 2, where: 2]
 
   alias Explorer.Chain.Block
   alias Explorer.Repo
@@ -62,27 +62,28 @@ defmodule Explorer.Counters.AverageBlockTime do
   end
 
   defp refresh_timestamps do
+    base_query =
+      from(block in Block,
+        limit: 100,
+        offset: 100,
+        order_by: [desc: block.number],
+        select: {block.number, block.timestamp}
+      )
+
     timestamps_query =
       if Application.get_env(:explorer, :include_uncles_in_average_block_time) do
-        from(block in Block,
-          limit: 100,
-          offset: 100,
-          order_by: [desc: block.number],
-          select: {block.number, block.timestamp}
-        )
+        base_query
       else
-        from(block in Block,
-          limit: 100,
-          offset: 100,
-          order_by: [desc: block.number],
-          where: block.consensus == true,
-          select: {block.number, block.timestamp}
-        )
+        base_query
+        |> where(consensus: true)
       end
 
-    timestamps =
+    timestamps_row =
       timestamps_query
       |> Repo.all()
+
+    timestamps =
+      timestamps_row
       |> Enum.sort_by(fn {_, timestamp} -> timestamp end, &>=/2)
       |> Enum.map(fn {number, timestamp} ->
         {number, DateTime.to_unix(timestamp, :millisecond)}
@@ -111,12 +112,13 @@ defmodule Explorer.Counters.AverageBlockTime do
 
   defp durations(timestamps) do
     timestamps
-    |> Enum.reduce({[], nil}, fn {_, timestamp}, {durations, last_timestamp} ->
+    |> Enum.reduce({[], nil, nil}, fn {block_number, timestamp}, {durations, last_block_number, last_timestamp} ->
       if last_timestamp do
-        duration = last_timestamp - timestamp
-        {[duration | durations], timestamp}
+        block_numbers_range = last_block_number - block_number
+        duration = (last_timestamp - timestamp) / block_numbers_range
+        {[duration | durations], block_number, timestamp}
       else
-        {durations, timestamp}
+        {durations, block_number, timestamp}
       end
     end)
     |> elem(0)

--- a/apps/explorer/lib/explorer/counters/average_block_time.ex
+++ b/apps/explorer/lib/explorer/counters/average_block_time.ex
@@ -103,7 +103,7 @@ defmodule Explorer.Counters.AverageBlockTime do
         {sum + duration, count + 1}
       end)
 
-    average = sum / count
+    average = if count == 0, do: 0, else: sum / count
 
     average
     |> round()
@@ -115,8 +115,13 @@ defmodule Explorer.Counters.AverageBlockTime do
     |> Enum.reduce({[], nil, nil}, fn {block_number, timestamp}, {durations, last_block_number, last_timestamp} ->
       if last_timestamp do
         block_numbers_range = last_block_number - block_number
-        duration = (last_timestamp - timestamp) / block_numbers_range
-        {[duration | durations], block_number, timestamp}
+
+        if block_numbers_range == 0 do
+          {durations, block_number, timestamp}
+        else
+          duration = (last_timestamp - timestamp) / block_numbers_range
+          {[duration | durations], block_number, timestamp}
+        end
       else
         {durations, block_number, timestamp}
       end

--- a/apps/explorer/test/explorer/counters/average_block_time_test.exs
+++ b/apps/explorer/test/explorer/counters/average_block_time_test.exs
@@ -34,19 +34,27 @@ defmodule Explorer.Counters.AverageBlockTimeTest do
 
       first_timestamp = Timex.now()
 
-      insert(:block, number: block_number, consensus: true, timestamp: Timex.shift(first_timestamp, seconds: -100 - 3))
+      insert(:block, number: block_number, consensus: true, timestamp: Timex.shift(first_timestamp, seconds: -100 - 6))
+
+      insert(:block, number: block_number, consensus: false, timestamp: Timex.shift(first_timestamp, seconds: -100 - 12))
+
       insert(:block, number: block_number, consensus: false, timestamp: Timex.shift(first_timestamp, seconds: -100 - 9))
-      insert(:block, number: block_number, consensus: false, timestamp: Timex.shift(first_timestamp, seconds: -100 - 6))
+
+      insert(:block,
+        number: block_number + 1,
+        consensus: true,
+        timestamp: Timex.shift(first_timestamp, seconds: -100 - 3)
+      )
 
       Enum.each(1..100, fn i ->
         insert(:block,
-          number: block_number + i,
+          number: block_number + 1 + i,
           consensus: true,
-          timestamp: Timex.shift(first_timestamp, seconds: -(101 - i) - 9)
+          timestamp: Timex.shift(first_timestamp, seconds: -(101 - i) - 12)
         )
       end)
 
-      assert Repo.aggregate(Block, :count, :hash) == 103
+      assert Repo.aggregate(Block, :count, :hash) == 104
 
       AverageBlockTime.refresh()
 


### PR DESCRIPTION
## Motivation

The current average block time calculation procedure doesn't account whether there are some missing blocks in the range causing an increase in average block time.

## Changelog

Current calculation function assumes that each block in the range is present and calculates the duration between those blocks. For instance, if we have block A and next block C with the _number_C_ = _number_A_ + 2 and block B is missing (or non-consensus) with the number = _number_A_ + 1, then the duration between A and C _duration_A_C_ ~= 2 * _duration_A_B_ which gives increasing in total duration.

In order to fix that it is suggested to divide the duration between two blocks into the diff between blocks numbers. It will allow avoiding increasing of avg block time if blocks are missing in the range.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
