### PR TITLE
Update Staking DApp scripts due to MetaMask breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 ### Chore
+- [#3460](https://github.com/poanetwork/blockscout/pull/3460) - Update Staking DApp scripts due to MetaMask breaking changes
 
 
 ## 3.4.0-beta

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -496,7 +496,7 @@ function updateFilters (store, filterType) {
 
   if (filterType === 'my' && !state.account) {
     filterMy.prop('checked', false)
-    openWarningModal('Unauthorized', 'You are not logged in. Please login with the latest version of MetaMask')
+    openWarningModal('Unauthorized', constants.METAMASK_PLEASE_LOGIN)
     return
   }
   store.dispatch({

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -18,6 +18,7 @@ import { openClaimRewardModal, claimRewardConnectionLost } from './stakes/claim_
 import { openClaimWithdrawalModal } from './stakes/claim_withdrawal'
 import { checkForTokenDefinition, isSupportedNetwork } from './stakes/utils'
 import { currentModal, openWarningModal, openErrorModal } from '../lib/modals'
+import constants from './stakes/constants'
 
 const stakesPageSelector = '[data-page="stakes"]'
 
@@ -306,8 +307,8 @@ async function getAccounts () {
   try {
     accounts = await window.ethereum.request({ method: 'eth_accounts' })
   } catch (e) {
-    console.error('eth_accounts request failed. Make sure you are using the latest version of MetaMask')
-    openErrorModal('Get account', 'Cannot get your account address. Make sure you are using the latest version of MetaMask')
+    console.error(`eth_accounts request failed. ${constants.METAMASK_VERSION_WARNING}`)
+    openErrorModal('Get account', `Cannot get your account address. ${constants.METAMASK_VERSION_WARNING}`)
   }
   return accounts
 }
@@ -315,7 +316,7 @@ async function getAccounts () {
 async function getNetId (web3) {
   let netId = null
   if (!window.ethereum.chainId) {
-    console.error('Cannot get chainId. Make sure you are using the latest MetaMask version')
+    console.error(`Cannot get chainId. ${constants.METAMASK_VERSION_WARNING}`)
   } else {
     const { chainId } = window.ethereum
     netId = web3.utils.isHex(chainId) ? web3.utils.hexToNumber(chainId) : chainId
@@ -385,8 +386,8 @@ async function loginByMetamask () {
   } catch (e) {
     console.log(e)
     if (e.code !== 4001) {
-      console.error('eth_requestAccounts failed. Make sure you are using the latest MetaMask version')
-      openErrorModal('Request account access', 'Cannot request access to your account in MetaMask. Make sure you are using the latest version of MetaMask')
+      console.error(`eth_requestAccounts failed. ${constants.METAMASK_VERSION_WARNING}`)
+      openErrorModal(`Request account access', 'Cannot request access to your account in MetaMask. ${constants.METAMASK_VERSION_WARNING}`)
     }
   }
 }

--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -3,6 +3,7 @@ import { BigNumber } from 'bignumber.js'
 import { openModal, openErrorModal, openWarningModal, lockModal } from '../../lib/modals'
 import { setupValidation, displayInputError } from '../../lib/validation'
 import { makeContractCall, isSupportedNetwork, isStakingAllowed } from './utils'
+import constants from './constants'
 
 let status = 'modalClosed'
 
@@ -10,7 +11,7 @@ export async function openBecomeCandidateModal (event, store) {
   const state = store.getState()
 
   if (!state.account) {
-    openWarningModal('Unauthorized', 'You haven\'t approved the reading of account list from your MetaMask or the latest MetaMask is not installed.')
+    openWarningModal('Unauthorized', constants.METAMASK_ACCOUNTS_EMPTY)
     return
   }
 

--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -10,7 +10,7 @@ export async function openBecomeCandidateModal (event, store) {
   const state = store.getState()
 
   if (!state.account) {
-    openWarningModal('Unauthorized', 'You haven\'t approved the reading of account list from your MetaMask or MetaMask is not installed.')
+    openWarningModal('Unauthorized', 'You haven\'t approved the reading of account list from your MetaMask or the latest MetaMask is not installed.')
     return
   }
 
@@ -93,6 +93,8 @@ async function becomeCandidate ($modal, store, msg) {
     }
 
     lockModal($modal)
+
+    console.log(`Call addPool(${stake.toString()}, ${miningAddress})`)
     makeContractCall(stakingContract.methods.addPool(stake.toString(), miningAddress), store)
   } catch (err) {
     openErrorModal('Error', err.message)

--- a/apps/block_scout_web/assets/js/pages/stakes/claim_reward.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/claim_reward.js
@@ -17,7 +17,7 @@ export function openClaimRewardModal (event, store) {
   const state = store.getState()
 
   if (!state.account) {
-    openWarningModal('Unauthorized', 'Please login with MetaMask')
+    openWarningModal('Unauthorized', 'You are not logged in. Please login with the latest version of MetaMask')
     return
   }
 

--- a/apps/block_scout_web/assets/js/pages/stakes/claim_reward.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/claim_reward.js
@@ -10,6 +10,7 @@ import {
 } from '../../lib/modals'
 import { displayInputError, hideInputError } from '../../lib/validation'
 import { isSupportedNetwork, makeContractCall } from './utils'
+import constants from './constants'
 
 let status = 'modalClosed'
 
@@ -17,7 +18,7 @@ export function openClaimRewardModal (event, store) {
   const state = store.getState()
 
   if (!state.account) {
-    openWarningModal('Unauthorized', 'You are not logged in. Please login with the latest version of MetaMask')
+    openWarningModal('Unauthorized', constants.METAMASK_PLEASE_LOGIN)
     return
   }
 

--- a/apps/block_scout_web/assets/js/pages/stakes/constants.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/constants.js
@@ -1,4 +1,5 @@
 module.exports = {
   METAMASK_ACCOUNTS_EMPTY: 'You haven\'t approved the reading of account list from your MetaMask or the latest MetaMask version is not installed.',
+  METAMASK_PLEASE_LOGIN: 'You are not logged in. Please login with the latest version of MetaMask.',
   METAMASK_VERSION_WARNING: 'Make sure you are using the latest version of MetaMask.'
 }

--- a/apps/block_scout_web/assets/js/pages/stakes/constants.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/constants.js
@@ -1,0 +1,4 @@
+module.exports = {
+  METAMASK_ACCOUNTS_EMPTY: 'You haven\'t approved the reading of account list from your MetaMask or the latest MetaMask version is not installed.',
+  METAMASK_VERSION_WARNING: 'Make sure you are using the latest version of MetaMask.'
+}

--- a/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
@@ -3,12 +3,13 @@ import { BigNumber } from 'bignumber.js'
 import { openErrorModal, openModal, openWarningModal, lockModal } from '../../lib/modals'
 import { setupValidation } from '../../lib/validation'
 import { makeContractCall, setupChart, isSupportedNetwork, isStakingAllowed } from './utils'
+import constants from './constants'
 
 export function openMakeStakeModal (event, store) {
   const state = store.getState()
 
   if (!state.account) {
-    openWarningModal('Unauthorized', 'You haven\'t approved the reading of account list from your MetaMask or the latest MetaMask is not installed.')
+    openWarningModal('Unauthorized', constants.METAMASK_ACCOUNTS_EMPTY)
     return
   }
 

--- a/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
@@ -8,7 +8,7 @@ export function openMakeStakeModal (event, store) {
   const state = store.getState()
 
   if (!state.account) {
-    openWarningModal('Unauthorized', 'You haven\'t approved the reading of account list from your MetaMask or MetaMask is not installed.')
+    openWarningModal('Unauthorized', 'You haven\'t approved the reading of account list from your MetaMask or the latest MetaMask is not installed.')
     return
   }
 

--- a/apps/block_scout_web/assets/js/pages/stakes/utils.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/utils.js
@@ -19,7 +19,7 @@ export async function makeContractCall (call, store, gasLimit, callbackFunc) {
   }
 
   if (!from) {
-    return callbackFunc('Your MetaMask account is undefined. Please, ensure you are using the latest MetaMask and connected it to the page')
+    return callbackFunc('Your MetaMask account is undefined. Please, ensure you are using the latest version of MetaMask and connected it to the page')
   } else if (!web3) {
     return callbackFunc('Web3 is undefined. Please, contact support.')
   }

--- a/apps/block_scout_web/assets/js/pages/stakes/utils.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/utils.js
@@ -19,7 +19,7 @@ export async function makeContractCall (call, store, gasLimit, callbackFunc) {
   }
 
   if (!from) {
-    return callbackFunc('Your MetaMask account is undefined. Please, contact support.')
+    return callbackFunc('Your MetaMask account is undefined. Please, ensure you are using the latest MetaMask and connected it to the page')
   } else if (!web3) {
     return callbackFunc('Web3 is undefined. Please, contact support.')
   }
@@ -30,6 +30,8 @@ export async function makeContractCall (call, store, gasLimit, callbackFunc) {
     try {
       gasLimit = await call.estimateGas({ from, gasPrice })
     } catch (e) {
+      console.log(`from = ${from}`)
+      console.error(e)
       return callbackFunc('Your transaction cannot be mined at the moment. Please, try again in a few blocks.')
     }
   }
@@ -128,7 +130,7 @@ export function isSupportedNetwork (store) {
   if (state.network && state.network.authorized) {
     return true
   }
-  openWarningModal('Unauthorized', 'Please, connect to the xDai Chain.<br /><a href="https://xdaichain.com" target="_blank">Instructions</a>')
+  openWarningModal('Unauthorized', 'Please, connect to the xDai Chain.<br /><a href="https://xdaichain.com" target="_blank">Instructions</a>. If you have already connected to, please update MetaMask to the latest version.')
   return false
 }
 


### PR DESCRIPTION
## Motivation

There are MetaMask breaking changes: https://docs.metamask.io/guide/provider-migration.html

This PR uses the latest changes for Staking DApp JavaScript code.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
