### PR TITLE
Client-side fixes: fix Firefox styles, Node@14, var -> let, const

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.10.4
 erlang 22.2
-nodejs 12.18.4
+nodejs 14.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
-
+- [#3467](https://github.com/poanetwork/blockscout/pull/3467) - Fix Firefox styles
 - [#3464](https://github.com/poanetwork/blockscout/pull/3464) - Fix display of token transfers list at token page (fix unique identifier of a tile)
 
 ### Chore
+- [#3467](https://github.com/poanetwork/blockscout/pull/3467) - NodeJS engine upgrade up to 14
 - [#3460](https://github.com/poanetwork/blockscout/pull/3460) - Update Staking DApp scripts due to MetaMask breaking changes
 
 

--- a/apps/block_scout_web/assets/css/theme/_dai_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_dai_variables.scss
@@ -133,3 +133,15 @@ $dark-tertiary: #5a77ff;
         }
     }
 }
+
+.dark-theme-applied .dashboard-banner-chart-legend {
+    .dashboard-banner-chart-legend-item {
+      &:nth-child(1)::before {
+        background-color: $dashboard-line-color-price;
+      }
+  
+      &:nth-child(2)::before {
+        background-color: $dashboard-line-color-market;
+      }
+    }
+  }

--- a/apps/block_scout_web/assets/js/lib/async_listing_load.js
+++ b/apps/block_scout_web/assets/js/lib/async_listing_load.js
@@ -91,7 +91,7 @@ export function asyncReducer (state = asyncInitialState, action) {
       })
     }
     case 'ITEMS_FETCHED': {
-      var prevPagePath = null
+      let prevPagePath = null
 
       if (state.pagesStack.length >= 2) {
         prevPagePath = state.pagesStack[state.pagesStack.length - 2]

--- a/apps/block_scout_web/assets/js/lib/coin_balance_history_chart.js
+++ b/apps/block_scout_web/assets/js/lib/coin_balance_history_chart.js
@@ -18,11 +18,11 @@ export function createCoinBalanceHistoryChart (el) {
           y: balance.value
         }))
 
-      var stepSize = 3
+      let stepSize = 3
 
       if (data.length > 1) {
-        var diff = Math.abs(new Date(data[data.length - 1].date) - new Date(data[data.length - 2].date))
-        var periodInDays = diff / (1000 * 60 * 60 * 24)
+        const diff = Math.abs(new Date(data[data.length - 1].date) - new Date(data[data.length - 2].date))
+        const periodInDays = diff / (1000 * 60 * 60 * 24)
 
         stepSize = periodInDays
       }

--- a/apps/block_scout_web/assets/js/lib/history_chart.js
+++ b/apps/block_scout_web/assets/js/lib/history_chart.js
@@ -122,7 +122,7 @@ function getTxHistoryData (transactionHistory) {
 
   // it should be empty value for tx history the current day
   const prevDayStr = data[0].x
-  var prevDay = moment(prevDayStr)
+  const prevDay = moment(prevDayStr)
   let curDay = prevDay.add(1, 'days')
   curDay = curDay.format('YYYY-MM-DD')
   data.unshift({ x: curDay, y: null })
@@ -146,21 +146,19 @@ function getMarketCapData (marketHistoryData, availableSupply) {
 }
 
 // colors for light and dark theme
-var priceLineColor
-var mcapLineColor
-priceLineColor = sassVariables.dashboardLineColorPrice
-mcapLineColor = sassVariables.dashboardLineColorMarket
+const priceLineColor = sassVariables.dashboardLineColorPrice
+const mcapLineColor = sassVariables.dashboardLineColorMarket
 
 class MarketHistoryChart {
   constructor (el, availableSupply, _marketHistoryData, dataConfig) {
-    var axes = config.options.scales.yAxes.reduce(function (solution, elem) {
+    const axes = config.options.scales.yAxes.reduce(function (solution, elem) {
       solution[elem.id] = elem
       return solution
     },
     {})
 
-    var priceActivated = true
-    var marketCapActivated = true
+    let priceActivated = true
+    let marketCapActivated = true
 
     this.price = {
       label: window.localized.Price,

--- a/apps/block_scout_web/assets/js/lib/transaction_input_dropdown.js
+++ b/apps/block_scout_web/assets/js/lib/transaction_input_dropdown.js
@@ -3,8 +3,8 @@ import $ from 'jquery'
 $('.tx-input-dropdown').click(function (e) {
   e.preventDefault()
 
-  var el = $(e.currentTarget)
-  var target = $(el.attr('data-target'))
+  const el = $(e.currentTarget)
+  const target = $(el.attr('data-target'))
 
   target.show()
   target.siblings('.transaction-input').hide()

--- a/apps/block_scout_web/assets/js/pages/favorites.js
+++ b/apps/block_scout_web/assets/js/pages/favorites.js
@@ -1,7 +1,7 @@
 import $ from 'jquery'
 
-var favoritesContainer = $('.js-favorites-tab')
-var favoritesNetworksUrls = []
+const favoritesContainer = $('.js-favorites-tab')
+let favoritesNetworksUrls = []
 
 if (localStorage.getItem('favoritesNetworksUrls') === null) {
   localStorage.setItem('favoritesNetworksUrls', JSON.stringify(favoritesNetworksUrls))
@@ -10,29 +10,29 @@ if (localStorage.getItem('favoritesNetworksUrls') === null) {
 }
 
 $(document).on('change', ".network-selector-item-favorite input[type='checkbox']", function () {
-  var networkUrl = $(this).attr('data-url')
-  var thisStatus = $(this).is(':checked')
-  var workWith = $(".network-selector-item[data-url='" + networkUrl + "'")
+  const networkUrl = $(this).attr('data-url')
+  const thisStatus = $(this).is(':checked')
+  const workWith = $(".network-selector-item[data-url='" + networkUrl + "'")
 
   // Add new checkbox status to same network in another tabs
   $(".network-selector-item-favorite input[data-url='" + networkUrl + "']").prop('checked', thisStatus)
 
   // Clone
-  var parent = $(".network-selector-item[data-url='" + networkUrl + "'").clone()
+  const parent = $(".network-selector-item[data-url='" + networkUrl + "'").clone()
 
   // Push or remove favorite networks to array
-  var found = $.inArray(networkUrl, favoritesNetworksUrls)
+  const found = $.inArray(networkUrl, favoritesNetworksUrls)
   if (found < 0 && thisStatus === true) {
     favoritesNetworksUrls.push(networkUrl)
   } else {
-    var index = favoritesNetworksUrls.indexOf(networkUrl)
+    const index = favoritesNetworksUrls.indexOf(networkUrl)
     if (index !== -1) {
       favoritesNetworksUrls.splice(index, 1)
     }
   }
 
   // Push to localstorage
-  var willBePushed = JSON.stringify(favoritesNetworksUrls)
+  const willBePushed = JSON.stringify(favoritesNetworksUrls)
   localStorage.setItem('favoritesNetworksUrls', willBePushed)
 
   // Append or remove item from 'favorites' tab
@@ -40,7 +40,7 @@ $(document).on('change', ".network-selector-item-favorite input[type='checkbox']
     favoritesContainer.append(parent[0])
     $('.js-favorites-tab .network-selector-tab-content-empty').hide()
   } else {
-    var willRemoved = favoritesContainer.find(workWith)
+    const willRemoved = favoritesContainer.find(workWith)
     willRemoved.remove()
     if (favoritesNetworksUrls.length === 0) {
       $('.js-favorites-tab .network-selector-tab-content-empty').show()
@@ -50,9 +50,9 @@ $(document).on('change', ".network-selector-item-favorite input[type='checkbox']
 
 if (favoritesNetworksUrls.length > 0) {
   $('.js-favorites-tab .network-selector-tab-content-empty').hide()
-  for (var i = 0; i < favoritesNetworksUrls.length + 1; i++) {
+  for (let i = 0; i < favoritesNetworksUrls.length + 1; i++) {
     $(".network-selector-item[data-url='" + favoritesNetworksUrls[i] + "'").find('input[data-url]').prop('checked', true)
-    var parent = $(".network-selector-item[data-url='" + favoritesNetworksUrls[i] + "'").clone()
+    const parent = $(".network-selector-item[data-url='" + favoritesNetworksUrls[i] + "'").clone()
     favoritesContainer.append(parent[0])
   }
 }

--- a/apps/block_scout_web/assets/js/pages/layout.js
+++ b/apps/block_scout_web/assets/js/pages/layout.js
@@ -1,8 +1,8 @@
 import $ from 'jquery'
 
 $(document).click(function (event) {
-  var clickover = $(event.target)
-  var _opened = $('.navbar-collapse').hasClass('show')
+  const clickover = $(event.target)
+  const _opened = $('.navbar-collapse').hasClass('show')
   if (_opened === true && $('.navbar').find(clickover).length < 1) {
     $('.navbar-toggler').click()
   }

--- a/apps/block_scout_web/assets/js/pages/network-search.js
+++ b/apps/block_scout_web/assets/js/pages/network-search.js
@@ -1,7 +1,7 @@
 import $ from 'jquery'
 
-var networkSearchInput = $('.network-selector-search-input')
-var networkSearchInputVal = ''
+const networkSearchInput = $('.network-selector-search-input')
+let networkSearchInputVal = ''
 
 $(networkSearchInput).on('input', function () {
   networkSearchInputVal = $(this).val()

--- a/apps/block_scout_web/assets/js/pages/verification_form.js
+++ b/apps/block_scout_web/assets/js/pages/verification_form.js
@@ -90,11 +90,10 @@ const elements = {
 const $contractVerificationPage = $('[data-page="contract-verification"]')
 
 function filterNightlyBuilds (filter) {
-  var select, options
-  select = document.getElementById('smart_contract_compiler_version')
-  options = select.getElementsByTagName('option')
+  const select = document.getElementById('smart_contract_compiler_version')
+  const options = select.getElementsByTagName('option')
   for (const option of options) {
-    var txtValue = option.textContent || option.innerText
+    const txtValue = option.textContent || option.innerText
     if (filter) {
       if (txtValue.toLowerCase().indexOf('nightly') > -1) {
         option.style.display = 'none'

--- a/apps/block_scout_web/assets/package.json
+++ b/apps/block_scout_web/assets/package.json
@@ -8,7 +8,7 @@
   "author": "POA Network",
   "license": "GPL-3.0",
   "engines": {
-    "node": "12.x",
+    "node": "14.x",
     "npm": "6.x"
   },
   "scripts": {

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -261,7 +261,7 @@
 </nav>
 <script>
   if (localStorage.getItem("current-color-mode") === "dark") {
-    var modeChanger = document.getElementById("dark-mode-changer");
+    let modeChanger = document.getElementById("dark-mode-changer");
     modeChanger.className += " " + "dark-mode-changer--dark";
   }
 </script> 

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -7,7 +7,7 @@
 
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
     <link rel="preload" href="<%= static_path(@conn, "/css/non-critical.css") %>" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="<%= static_path(@conn, "/css/non-critical.css") %>"></noscript>
+    <link rel="stylesheet" href="<%= static_path(@conn, "/css/non-critical.css") %>">
     <%= render_existing(@view_module, "styles.html", assigns) %>
 
     <link rel="apple-touch-icon" sizes="180x180" href="<%= static_path(@conn, "/apple-touch-icon.png") %>">


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/3456

## Motivation

Broken Firefox styles. Originally, the fix was introduced here https://github.com/poanetwork/blockscout/commit/b65d4672f12f12ed6e3e9d93a0db49fa79642819#diff-55e55e74851b2d314637173c23930a2fc6958746ad35d4da53b2271baf628aa7 but was lost during the manual merging of conflicts while rebasing Staking Dapp branch.


## Changelog

- Fix Firefox styles
- Node@14 as a default version
- var -> let, const


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
