### PR TITLE
Do not check supported networks on application loading page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#3464](https://github.com/poanetwork/blockscout/pull/3464) - Fix display of token transfers list at token page (fix unique identifier of a tile)
 
 ### Chore
+- [#3468](https://github.com/poanetwork/blockscout/pull/3468) - Do not check supported networks on application loading page
 - [#3467](https://github.com/poanetwork/blockscout/pull/3467) - NodeJS engine upgrade up to 14
 - [#3460](https://github.com/poanetwork/blockscout/pull/3460) - Update Staking DApp scripts due to MetaMask breaking changes
 

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -341,7 +341,7 @@ function initialize (store) {
 
     window.ethereum.on('chainChanged', async (chainId) => {
       const newNetId = web3.utils.isHex(chainId) ? web3.utils.hexToNumber(chainId) : chainId
-      setNetwork(newNetId, store)
+      setNetwork(newNetId, store, true)
     })
 
     window.ethereum.on('accountsChanged', async (accs) => {
@@ -363,7 +363,7 @@ async function initNetworkAndAccount (store, web3) {
   const networkId = await getNetId(web3)
 
   if (!state.network || (networkId !== state.network.id)) {
-    setNetwork(networkId, store)
+    setNetwork(networkId, store, false)
   }
 
   const accounts = await getAccounts()
@@ -462,7 +462,7 @@ function setAccount (account, store) {
   })
 }
 
-function setNetwork (networkId, store) {
+function setNetwork (networkId, store, checkSupportedNetwork) {
   hideCurrentModal()
 
   const network = {
@@ -476,7 +476,9 @@ function setNetwork (networkId, store) {
 
   store.dispatch({ type: 'NETWORK_UPDATED', network })
 
-  isSupportedNetwork(store)
+  if (checkSupportedNetwork) {
+    isSupportedNetwork(store)
+  }
 }
 
 function updateFilters (store, filterType) {


### PR DESCRIPTION
## Motivation

If MetaMask/Nifty wallet is not installed or not connected to xDai chain and someone opens Staking Dapp page, a warning appears. Let's remove it and leave it only on the buttons' click in order to not prevent to see validators list.

## Changelog

Add an additional input parameter `checkSupportedNetwork` for function `setNetwork` which enables/disables check of the supported network.

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
