### PR TITLE
Fix contract verification of precompiled contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
+- [#3476](https://github.com/poanetwork/blockscout/pull/3476) - Fix contract verification of precompiled contracts
 - [#3467](https://github.com/poanetwork/blockscout/pull/3467) - Fix Firefox styles
 - [#3464](https://github.com/poanetwork/blockscout/pull/3464) - Fix display of token transfers list at token page (fix unique identifier of a tile)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
@@ -11,7 +11,14 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
         %{}
       )
 
-    {:ok, compiler_versions} = CompilerVersion.fetch_versions()
+    compiler_versions =
+      case CompilerVersion.fetch_versions() do
+        {:ok, compiler_versions} ->
+          compiler_versions
+
+        {:error, _} ->
+          []
+      end
 
     render(conn, "new.html",
       changeset: changeset,

--- a/apps/explorer/lib/explorer/smart_contract/solc_downloader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solc_downloader.ex
@@ -15,7 +15,14 @@ defmodule Explorer.SmartContract.SolcDownloader do
     if File.exists?(path) && version !== "latest" do
       path
     else
-      {:ok, compiler_versions} = CompilerVersion.fetch_versions()
+      compiler_versions =
+        case CompilerVersion.fetch_versions() do
+          {:ok, compiler_versions} ->
+            compiler_versions
+
+          {:error, _} ->
+            []
+        end
 
       if version in compiler_versions do
         GenServer.call(__MODULE__, {:ensure_exists, version}, 60_000)

--- a/apps/explorer/lib/explorer/smart_contract/solidity/compiler_version.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/compiler_version.ex
@@ -63,7 +63,14 @@ defmodule Explorer.SmartContract.Solidity.CompilerVersion do
 
   def get_strict_compiler_version(compiler_version) do
     if compiler_version == "latest" do
-      {:ok, compiler_versions} = fetch_versions()
+      compiler_versions =
+        case fetch_versions() do
+          {:ok, compiler_versions} ->
+            compiler_versions
+
+          {:error, _} ->
+            []
+        end
 
       if Enum.count(compiler_versions) > 1 do
         latest_stable_version =

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4872,6 +4872,23 @@ defmodule Explorer.ChainTest do
 
       assert found_creation_data == ""
     end
+
+    test "fetches contract creation input data from contract byte code (if contract is pre-compiled)" do
+      input = %Data{
+        bytes: <<1, 2, 3, 4, 5>>
+      }
+
+      address =
+        insert(:address,
+          contract_code: %Data{
+            bytes: <<1, 2, 3, 4, 5>>
+          }
+        )
+
+      found_creation_data = Chain.contract_creation_input_data(address.hash)
+
+      assert found_creation_data == Data.to_string(input) |> String.replace("0x", "")
+    end
   end
 
   describe "transaction_token_transfer_type/1" do


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/3447

## Motivation

Contracts verification is broken for contracts from the genesis block.

## Changelog

If transaction and internal transaction are absent for a contract then use the contract's bytecode for verification.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
