### PR TITLE
Fix broken call of fallback function and call of Gnosis contract methods with parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
+- [#3477](https://github.com/poanetwork/blockscout/pull/3477) - Contracts interaction: fix broken call of GnosisProxy contract methods with parameters
+- [#3477](https://github.com/poanetwork/blockscout/pull/3477) - Contracts interaction: fix broken call of fallback function
 - [#3476](https://github.com/poanetwork/blockscout/pull/3476) - Fix contract verification of precompiled contracts
 - [#3467](https://github.com/poanetwork/blockscout/pull/3467) - Fix Firefox styles
 - [#3464](https://github.com/poanetwork/blockscout/pull/3464) - Fix display of token transfers list at token page (fix unique identifier of a tile)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -5525,7 +5525,8 @@ defmodule Explorer.Chain do
     implementation_method_abi =
       abi
       |> Enum.find(fn method ->
-        Map.get(method, "name") == "implementation"
+        Map.get(method, "name") == "implementation" ||
+          master_copy_pattern?(method)
       end)
 
     if implementation_method_abi do


### PR DESCRIPTION
## Motivation

1. Call of a contract's fallback function returns an alert

![image](https://user-images.githubusercontent.com/4341812/99985898-96fb7f00-2dbf-11eb-889b-959a2a44f250.png)

2. Calls of GnosisProxy contract functions with parameters return the error:
```
2020-11-17T16:50:13.031 [error] #PID<0.6835.0> running BlockScoutWeb.Endpoint (connection #PID<0.6713.0>, stream id 9) terminated
Request: GET /smart-contracts/0x52a0110990C2047B1354b53Ef576f93f471D124F?function_name=isOwner&method_id=2f54bf6e&args%5B%5D=0xBDFdb9F56e7E11D51DB3c80604D09970C97445Fa
** (exit) an exception was raised:
    ** (MatchError) no match of right hand side value: nil
        (explorer 0.0.1) lib/explorer/smart_contract/reader.ex:353: Explorer.SmartContract.Reader.query_function/3
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/smart_contract_controller.ex:95: BlockScoutWeb.SmartContractController.show/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/smart_contract_controller.ex:1: BlockScoutWeb.SmartContractController.action/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/smart_contract_controller.ex:1: BlockScoutWeb.SmartContractController.phoenix_controller_pipeline/2
        (phoenix 1.5.4) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (phoenix 1.5.4) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
        (phoenix 1.5.4) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (block_scout_web 0.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.plug_builder_call/2
        (block_scout_web 0.0.1) lib/plug/debugger.ex:132: BlockScoutWeb.Endpoint."call (overridable 3)"/2
        (block_scout_web 0.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint."call (overridable 4)"/2
        (block_scout_web 0.0.1) lib/spandex_phoenix.ex:156: BlockScoutWeb.Endpoint.call/2
        (phoenix 1.5.4) lib/phoenix/endpoint/cowboy2_handler.ex:65: Phoenix.Endpoint.Cowboy2Handler.init/4
        (cowboy 2.8.0) /Users/viktor/Documents/POANetwork/blockscout/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
        (cowboy 2.8.0) /Users/viktor/Documents/POANetwork/blockscout/deps/cowboy/src/cowboy_stream_h.erl:300: :cowboy_stream_h.execute/3
        (cowboy 2.8.0) /Users/viktor/Documents/POANetwork/blockscout/deps/cowboy/src/cowboy_stream_h.erl:291: :cowboy_stream_h.request_process/3
        (stdlib 3.12.1) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```



## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
