### PR TITLE
Fix working with big numbers in Staking DApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
+- [#3479](https://github.com/poanetwork/blockscout/pull/3479) - Fix working with big numbers in Staking DApp
 - [#3477](https://github.com/poanetwork/blockscout/pull/3477) - Contracts interaction: fix broken call of GnosisProxy contract methods with parameters
 - [#3477](https://github.com/poanetwork/blockscout/pull/3477) - Contracts interaction: fix broken call of fallback function
 - [#3476](https://github.com/poanetwork/blockscout/pull/3476) - Fix contract verification of precompiled contracts

--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -95,8 +95,8 @@ async function becomeCandidate ($modal, store, msg) {
 
     lockModal($modal)
 
-    console.log(`Call addPool(${stake.toString()}, ${miningAddress})`)
-    makeContractCall(stakingContract.methods.addPool(stake.toString(), miningAddress), store)
+    console.log(`Call addPool(${stake.toFixed()}, ${miningAddress})`)
+    makeContractCall(stakingContract.methods.addPool(stake.toFixed(), miningAddress), store)
   } catch (err) {
     openErrorModal('Error', err.message)
   }

--- a/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/make_stake.js
@@ -73,7 +73,7 @@ async function makeStake ($modal, address, store, msg) {
     return
   }
 
-  makeContractCall(stakingContract.methods.stake(address, stake.toString()), store)
+  makeContractCall(stakingContract.methods.stake(address, stake.toFixed()), store)
 }
 
 function isDelegatorStakeValid (value, store, msg, address) {

--- a/apps/block_scout_web/assets/js/pages/stakes/move_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/move_stake.js
@@ -66,7 +66,7 @@ function moveStake ($modal, fromAddress, store, msg) {
   const stake = new BigNumber($modal.find('[move-amount]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
 
   const toAddress = $modal.find('[pool-select]').val()
-  makeContractCall(stakingContract.methods.moveStake(fromAddress, toAddress, stake.toString()), store)
+  makeContractCall(stakingContract.methods.moveStake(fromAddress, toAddress, stake.toFixed()), store)
 }
 
 function isMoveAmountValid (value, store, msg) {

--- a/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/withdraw_stake.js
@@ -69,7 +69,7 @@ function withdrawStake ($modal, address, store, msg) {
   const decimals = store.getState().tokenDecimals
   const amount = new BigNumber($modal.find('[amount]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
 
-  makeContractCall(stakingContract.methods.withdraw(address, amount.toString()), store)
+  makeContractCall(stakingContract.methods.withdraw(address, amount.toFixed()), store)
 }
 
 function orderWithdraw ($modal, address, store, msg) {
@@ -85,7 +85,7 @@ function orderWithdraw ($modal, address, store, msg) {
     return false
   }
 
-  makeContractCall(stakingContract.methods.orderWithdraw(address, amount.toString()), store)
+  makeContractCall(stakingContract.methods.orderWithdraw(address, amount.toFixed()), store)
 }
 
 function isAmountValid (value, store, msg) {

--- a/apps/block_scout_web/lib/block_scout_web/views/stakes_helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/stakes_helpers.ex
@@ -41,12 +41,19 @@ defmodule BlockScoutWeb.StakesHelpers do
   def list_title(:active), do: Gettext.dgettext(BlockScoutWeb.Gettext, "default", "Active Pools")
   def list_title(:inactive), do: Gettext.dgettext(BlockScoutWeb.Gettext, "default", "Inactive Pools")
 
-  def from_wei(%Decimal{} = amount, %Token{} = token) do
+  def from_wei(%Decimal{} = amount, %Token{} = token, to_string \\ true) do
     decimals = if token.decimals, do: Decimal.to_integer(token.decimals), else: 0
 
-    amount.sign
-    |> Decimal.new(amount.coef, amount.exp - decimals)
-    |> Decimal.normalize()
+    result =
+      amount.sign
+      |> Decimal.new(amount.coef, amount.exp - decimals)
+      |> Decimal.normalize()
+
+    if to_string do
+      Decimal.to_string(result, :normal)
+    else
+      result
+    end
   end
 
   def format_token_amount(amount, token, options \\ [])
@@ -65,7 +72,7 @@ defmodule BlockScoutWeb.StakesHelpers do
     ellipsize = Keyword.get(options, :ellipsize, true)
     no_tooltip = Keyword.get(options, :no_tooltip, false)
 
-    reduced = from_wei(amount, token)
+    reduced = from_wei(amount, token, false)
 
     if digits >= -reduced.exp or not ellipsize do
       "#{Number.to_string!(reduced, fractional_digits: min(digits, -reduced.exp))}#{symbol}"


### PR DESCRIPTION
## Motivation

Some Staking DApp code incorrectly worked with big numbers: it returned a number with scientific notation instead of a long number (as a string) in some cases.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
