### PR TITLE
Docker setup update to be compatible with Erlang OTP 23

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -213,6 +213,8 @@ jobs:
         with:
           otp-version: '23.0.1'
           elixir-version: '1.11.2'
+      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get
@@ -267,6 +269,8 @@ jobs:
         with:
           otp-version: '23.0.1'
           elixir-version: '1.11.2'
+      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get
@@ -323,6 +327,8 @@ jobs:
         with:
           otp-version: '23.0.1'
           elixir-version: '1.11.2'
+      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get
@@ -379,6 +385,8 @@ jobs:
         with:
           otp-version: '23.0.1'
           elixir-version: '1.11.2'
+      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#3457](https://github.com/poanetwork/blockscout/pull/3457) - Fix doubled token transfer on block's page if block has reorg
 
 ### Chore
+- [#3487](https://github.com/poanetwork/blockscout/pull/3487) - Docker setup update to be compatible with Erlang OTP 23
 - [#3484](https://github.com/poanetwork/blockscout/pull/3484) - Elixir upgrade to 11.2
 - [#3483](https://github.com/poanetwork/blockscout/pull/3483) - Update outdated dependencies
 - [#3483](https://github.com/poanetwork/blockscout/pull/3483) - Migrate to Erlang/OTP 23

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,12 @@
 FROM bitwalker/alpine-elixir-phoenix:latest
 
-RUN apk --no-cache --update add alpine-sdk gmp-dev automake libtool inotify-tools autoconf python
+RUN apk --no-cache --update add alpine-sdk gmp-dev automake libtool inotify-tools autoconf python3
+
+# Get Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="$HOME/.cargo/bin:${PATH}"
+ENV RUSTFLAGS="-C target-feature=-crt-static"
 
 EXPOSE 4000
 
@@ -33,12 +39,6 @@ RUN cd apps/block_scout_web/assets/ && \
 
 RUN cd apps/explorer/ && \
     npm install && \
-    apk update && apk del --force-broken-world alpine-sdk gmp-dev automake libtool inotify-tools autoconf python
-
-# RUN mix do ecto.drop --force, ecto.create, ecto.migrate
+    apk update && apk del --force-broken-world alpine-sdk gmp-dev automake libtool inotify-tools autoconf python3
 
 RUN mix phx.digest
-
-# USER default
-
-# CMD ["mix", "phx.server"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,7 +3,7 @@ HOST = host.docker.internal
 DOCKER_IMAGE = blockscout_prod
 BS_CONTAINER_NAME = blockscout
 PG_CONTAINER_NAME = postgres
-PG_CONTAINER_IMAGE = postgres:12.4
+PG_CONTAINER_IMAGE = postgres:12.5
 THIS_FILE = $(lastword $(MAKEFILE_LIST))
 
 ifeq ($(SYSTEM), Linux)
@@ -273,7 +273,7 @@ ifdef DISABLE_KNOWN_TOKENS
 	BLOCKSCOUT_CONTAINER_PARAMS += -e 'DISABLE_KNOWN_TOKENS=$(DISABLE_KNOWN_TOKENS)'
 endif
 
-HAS_BLOCKSCOUT_IMAGE := $(shell docker images | grep ${DOCKER_IMAGE})
+HAS_BLOCKSCOUT_IMAGE := $(shell docker images | grep -sw ${DOCKER_IMAGE})
 build: 
 	@echo "==> Checking for blockscout image $(DOCKER_IMAGE)"
 ifdef HAS_BLOCKSCOUT_IMAGE
@@ -283,11 +283,14 @@ else
 	@docker build --build-arg COIN="$(COIN)" -f ./Dockerfile -t $(DOCKER_IMAGE) ../
 endif
 
-migrate: build postgres
+migrate_only:
 	@echo "==> Running migrations"
 	@docker run --rm \
 					$(BLOCKSCOUT_CONTAINER_PARAMS) \
 					$(DOCKER_IMAGE) /bin/sh -c "echo $$MIX_ENV && mix do ecto.create, ecto.migrate"
+
+migrate: build postgres
+	@$(MAKE) -f $(THIS_FILE) migrate_only
 
 
 PG_EXIST := $(shell docker ps -a --filter name=${PG_CONTAINER_NAME} | grep ${PG_CONTAINER_NAME})
@@ -297,9 +300,11 @@ ifdef PG_EXIST
 	@echo "==> Checking PostrgeSQL container"
 ifdef PG_STARTED
 	@echo "==> PostgreSQL Already started"
+	@$(MAKE) -f $(THIS_FILE) migrate_only
 else
 	@echo "==> Starting PostgreSQL container"
 	@docker start $(PG_CONTAINER_NAME)
+	@$(MAKE) -f $(THIS_FILE) migrate_only
 endif
 else
 	@echo "==> Creating new PostgreSQL container"
@@ -310,7 +315,7 @@ else
 					-p 5432:5432 \
 					$(PG_CONTAINER_IMAGE)
 	@sleep 1
-	@$(MAKE) -f $(THIS_FILE) migrate
+	@$(MAKE) -f $(THIS_FILE) migrate_only
 endif
 
 start: build postgres 


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/2852

## Motivation

Update Docker setup to be compatible with Erlang OTP 23

## Changelog

- install `rustc` for `ex_keccak` dependency
- python -> python3
- Postgres 12.4 -> 12.5
- Run migrations with `start` command even if Postgres container exists/started


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
