### PR TITLE
Fix Staking DApp first loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
+- [#3505](https://github.com/poanetwork/blockscout/pull/3505) - Fix Staking DApp first loading
 - [#3433](https://github.com/poanetwork/blockscout/pull/3433) - Token balances and rewards tables deadlocks elimination
 - [#3494](https://github.com/poanetwork/blockscout/pull/3494), [#3497](https://github.com/poanetwork/blockscout/pull/3497), [#3504](https://github.com/poanetwork/blockscout/pull/3504) - Contracts interaction: fix method call with array[] input
 - [#3494](https://github.com/poanetwork/blockscout/pull/3494), [#3495](https://github.com/poanetwork/blockscout/pull/3495) - Contracts interaction: fix tuple output display

--- a/apps/block_scout_web/assets/js/lib/async_listing_load.js
+++ b/apps/block_scout_web/assets/js/lib/async_listing_load.js
@@ -25,6 +25,9 @@ import '../app'
  *
  *   the data-async-load is the attribute responsible for binding the store.
  *
+ *   data-no-first-loading attribute can also be used along with data-async-load
+ *   to prevent loading items for the first time
+ *
  * If the page has a redux associated with, you need to connect the reducers instead of creating
  * the store using the `createStore`. For instance:
  *
@@ -38,6 +41,8 @@ import '../app'
  * to create a store and it is not necessary for this case.
  *
  */
+
+var enableFirstLoading = true
 
 export const asyncInitialState = {
   /* it will consider any query param in the current URI as paging */
@@ -310,7 +315,10 @@ function firstPageLoad (store) {
   function loadItemsPrev () {
     loadPage(store, store.getState().prevPagePath)
   }
-  loadItemsNext()
+
+  if (enableFirstLoading) {
+    loadItemsNext()
+  }
 
   $element.on('click', '[data-error-message]', (event) => {
     event.preventDefault()
@@ -334,7 +342,12 @@ function firstPageLoad (store) {
 
 const $element = $('[data-async-load]')
 if ($element.length) {
-  const store = createStore(asyncReducer)
-  connectElements({ store, elements })
-  firstPageLoad(store)
+  if (Object.prototype.hasOwnProperty.call($element.data(), 'noFirstLoading')) {
+    enableFirstLoading = false
+  }
+  if (enableFirstLoading) {
+    const store = createStore(asyncReducer)
+    connectElements({ store, elements })
+    firstPageLoad(store)
+  }
 }

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -29,6 +29,7 @@ export const initialState = {
   currentBlockNumber: 0, // current block number
   finishRequestResolve: null,
   lastEpochNumber: 0,
+  loading: true,
   network: null,
   refreshBlockNumber: 0, // last page refresh block number
   refreshInterval: null,

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/index.html.eex
@@ -2,7 +2,7 @@
   <%= raw(@top) %>
 </div>
 <section data-page="stakes" class="container" data-refresh-interval="<%= @refresh_interval %>">
-  <div class="card" data-async-load data-async-listing="<%= @current_path %>">
+  <div class="card" data-async-load data-async-listing="<%= @current_path %>" data-no-first-loading>
     <%= render BlockScoutWeb.StakesView, "_stakes_tabs.html", conn: @conn %>
 
     <%=


### PR DESCRIPTION
## Motivation

Currently, when loading the Staking DApp it makes an async call (request) to load items several times because of duplicated `firstPageLoad` calls in `apps/block_scout_web/assets/js/lib/async_listing_load.js`. This PR adds an ability to not call the `firstPageLoad` when we don't need it. It can be turned on by a separate HTML attribute `data-no-first-loading` in a `div` with `data-async-load` attr for any module. This PR turns this on only for the `staking` module.

Without this PR we observe the pool list disappearing when using any tab within the Staking DApp UI because of the excess calls. They visually disappear until the next block arrives.

I think this also relates to other modules but propose to optimize it in separate PRs by removing excess requests when using the `async_listing_load.js`.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
