### PR TITLE
Fix token trasfer's tile styles: prevent overlapping of long names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
+- [#3506](https://github.com/poanetwork/blockscout/pull/3506) - Fix token trasfer's tile styles: prevent overlapping of long names
 - [#3505](https://github.com/poanetwork/blockscout/pull/3505) - Fix Staking DApp first loading
 - [#3433](https://github.com/poanetwork/blockscout/pull/3433) - Token balances and rewards tables deadlocks elimination
 - [#3494](https://github.com/poanetwork/blockscout/pull/3494), [#3497](https://github.com/poanetwork/blockscout/pull/3497), [#3504](https://github.com/poanetwork/blockscout/pull/3504) - Contracts interaction: fix method call with array[] input

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
@@ -1,5 +1,5 @@
 <div class="text-nowrap row mt-3 mt-sm-0" data-test="token_transfer">
-  <span class="col-xs-12 col-lg-5">
+  <span class="col-xs-12 col-lg-5" style="display: inline-table;">
     <%= if from_or_to_address?(@token_transfer, @address) do %>
       <%= if @token_transfer.from_address_hash == @address.hash do %>
         <span data-test="transaction_type" class="text-danger">


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/2396

## Motivation

Overlapping of to/from address and value of token transfer inside a tile

![Tokens  AllianceBlock Token on xDai](https://user-images.githubusercontent.com/4341812/101058321-11858500-359e-11eb-8fed-df8f77f1bca7.png)

## Changelog

<img width="1207" alt="Screenshot 2020-12-03 at 19 31 50" src="https://user-images.githubusercontent.com/4341812/101058497-3da10600-359e-11eb-95bc-53f5ef394381.png">


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
