### PR TITLE
Allow brackets for arrays for contract input data, fix decoding for multiple inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## Current
 
 ### Features
+- [#3513](https://github.com/poanetwork/blockscout/pull/3513) - Allow square brackets for an array input data in contracts interaction
 - [#3480](https://github.com/poanetwork/blockscout/pull/3480) - Add support of Autonity client
 - [#3470](https://github.com/poanetwork/blockscout/pull/3470) - Display sum of tokens' USD value at tokens holder's address page
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
+- [#3513](https://github.com/poanetwork/blockscout/pull/3513) - Fix input data processing for method call (array type of data)
 - [#3509](https://github.com/poanetwork/blockscout/pull/3509) - Fix QR code tooltip appearance in mobile view
 - [#3507](https://github.com/poanetwork/blockscout/pull/3507), [#3510](https://github.com/poanetwork/blockscout/pull/3510) - Fix left margin of balance card in mobile view
 - [#3506](https://github.com/poanetwork/blockscout/pull/3506) - Fix token trasfer's tile styles: prevent overlapping of long names

--- a/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
@@ -135,6 +135,9 @@ function callMethod (isWalletEnabled, $functionInputs, explorerChainId, $form, f
     let preparedVal
     if (isNonSpaceInputType(inputType)) { preparedVal = val.replace(/\s/g, '') } else { preparedVal = val }
     if (isArrayInputType(inputType)) {
+      if (preparedVal.startsWith('[') && preparedVal.endsWith(']')) {
+        preparedVal = preparedVal.substring(1, preparedVal.length - 1)
+      }
       return preparedVal.split(',')
     } else { return preparedVal }
   })

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -259,18 +259,18 @@ defmodule Explorer.SmartContract.Reader do
     |> Enum.with_index()
     |> Enum.all?(fn {target_type, index} ->
       type_to_compare = Map.get(Enum.at(Map.get(target_method, "inputs"), index), "type")
-      target_type_formatted = format_input_type(target_type)
+      target_type_formatted = format_type(target_type)
       target_type_formatted == type_to_compare
     end)
   end
 
-  defp format_input_type(input_type) do
+  defp format_type(input_type) do
     case input_type do
       {:array, type, array_size} ->
-        format_input_type(type) <> "[" <> Integer.to_string(array_size) <> "]"
+        format_type(type) <> "[" <> Integer.to_string(array_size) <> "]"
 
       {:array, type} ->
-        format_input_type(type) <> "[]"
+        format_type(type) <> "[]"
 
       {:tuple, tuple} ->
         format_tuple_type(tuple)
@@ -288,9 +288,9 @@ defmodule Explorer.SmartContract.Reader do
       tuple
       |> Enum.reduce(nil, fn tuple_item, acc ->
         if acc do
-          acc <> "," <> format_input_type(tuple_item)
+          acc <> "," <> format_type(tuple_item)
         else
-          format_input_type(tuple_item)
+          format_type(tuple_item)
         end
       end)
 
@@ -378,6 +378,15 @@ defmodule Explorer.SmartContract.Reader do
     returns
     |> Enum.map(fn output ->
       case output do
+        {:array, type, array_size} ->
+          %{"type" => format_type(type) <> "[" <> Integer.to_string(array_size) <> "]"}
+
+        {:array, type} ->
+          %{"type" => format_type(type) <> "[]"}
+
+        {:tuple, tuple} ->
+          %{"type" => format_tuple_type(tuple)}
+
         {type, size} ->
           full_type = Atom.to_string(type) <> Integer.to_string(size)
           %{"type" => full_type}


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/3486

## Motivation

1. https://gitter.im/poanetwork/blockscout?at=5fcdf6f567bf4438e12d0a52 internal server error when calling a method with multiple inputs

2. Square brackets are not allowed for an array input type. In order to provide the same experience for Remix users, it is suggested to allow square brackets.

## Changelog

1. Fix input data processing
2. Allow square brackets for an array input type

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
