### PR TITLE
Read contract: fix internal server error for method with empty output array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
+- [#3514](https://github.com/poanetwork/blockscout/pull/3514) - Read contract: fix internal server error
 - [#3513](https://github.com/poanetwork/blockscout/pull/3513) - Fix input data processing for method call (array type of data)
 - [#3509](https://github.com/poanetwork/blockscout/pull/3509) - Fix QR code tooltip appearance in mobile view
 - [#3507](https://github.com/poanetwork/blockscout/pull/3507), [#3510](https://github.com/poanetwork/blockscout/pull/3510) - Fix left margin of balance card in mobile view

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -454,6 +454,8 @@ defmodule Explorer.SmartContract.Reader do
     if String.contains?(number_rest, "[]") do
       values_array = Enum.at(values, index)
 
+      values_array = if is_list(values_array), do: values_array, else: []
+
       values_array_formatted =
         Enum.map(values_array, fn value ->
           bytes_to_string(value)


### PR DESCRIPTION
## Motivation

```
 Request: GET /smart-contracts?hash=0x47ed323d03cd3fff423f1200af2e2e3d823e8d0a&type=regular&action=read
blockscout     | ** (exit) an exception was raised:
blockscout     |     ** (Protocol.UndefinedError) protocol Enumerable not implemented for "" of type BitString. This protocol is implemented for the following type(s): Indexer.BoundQueue, Ecto.Adapters.SQL.Stream, Postgrex.Stream, DBConnection.PrepareStream, DBConnection.Stream, Timex.Interval, Flow, Map, MapSet, Function, HashDict, IO.Stream, File.Stream, List, Stream, Range, HashSet, Date.Range, GenEvent.Stream
blockscout     |         (elixir 1.10.4) lib/enum.ex:1: Enumerable.impl_for!/1
blockscout     |         (elixir 1.10.4) lib/enum.ex:141: Enumerable.reduce/3
blockscout     |         (elixir 1.10.4) lib/enum.ex:3383: Enum.map/2
blockscout     |         (explorer 0.0.1) lib/explorer/smart_contract/reader.ex:449: Explorer.SmartContract.Reader.new_value/3
blockscout     |         (explorer 0.0.1) lib/explorer/smart_contract/reader.ex:424: anonymous fn/3 in Explorer.SmartContract.Reader.link_outputs_and_values/3
blockscout     |         (elixir 1.10.4) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
blockscout     |         (explorer 0.0.1) lib/explorer/smart_contract/reader.ex:423: Explorer.SmartContract.Reader.link_outputs_and_values/3
blockscout     |         (explorer 0.0.1) lib/explorer/smart_contract/reader.ex:313: Explorer.SmartContract.Reader.fetch_current_value_from_blockchain/3
```


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
