### PR TITLE
Order staking pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
+- [#3526](https://github.com/poanetwork/blockscout/pull/3526) - Order staking pools
 - [#3525](https://github.com/poanetwork/blockscout/pull/3525) - Address token balance on demand fetcher
 - [#3514](https://github.com/poanetwork/blockscout/pull/3514) - Read contract: fix internal server error
 - [#3513](https://github.com/poanetwork/blockscout/pull/3513) - Fix input data processing for method call (array type of data)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4870,11 +4870,6 @@ defmodule Explorer.Chain do
       |> where(is_deleted: false)
       |> staking_pool_filter(filter)
       |> staking_pools_paging_query(paging_options)
-      |> order_by(
-        [sp],
-        desc: sp.stakes_ratio,
-        asc: sp.staking_address_hash
-      )
 
     delegator_query =
       if address_hash do
@@ -4916,7 +4911,7 @@ defmodule Explorer.Chain do
     paging_query =
       base_query
       |> limit(^paging_options.page_size)
-      |> order_by(desc: :stakes_ratio, desc: :is_active)
+      |> order_by(desc: :stakes_ratio, desc: :is_active, asc: :staking_address_hash)
 
     case paging_options.key do
       {value, address_hash} ->

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4870,6 +4870,11 @@ defmodule Explorer.Chain do
       |> where(is_deleted: false)
       |> staking_pool_filter(filter)
       |> staking_pools_paging_query(paging_options)
+      |> order_by(
+        [sp],
+        desc: sp.stakes_ratio,
+        asc: sp.staking_address_hash
+      )
 
     delegator_query =
       if address_hash do

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -5044,6 +5044,38 @@ defmodule Explorer.ChainTest do
       assert pool3.staking_address_hash == address3
     end
 
+    test "staking pools ordered by stakes_ratio, is_active, and staking_address_hash" do
+      address1 = Factory.address_hash()
+      address2 = Factory.address_hash()
+      address3 = Factory.address_hash()
+      address4 = Factory.address_hash()
+      address5 = Factory.address_hash()
+      address6 = Factory.address_hash()
+
+      assert address1 < address2 and address2 < address3 and address3 < address4 and address4 < address5 and address5 < address6
+
+      # insert pools in descending order
+      insert(:staking_pool, is_validator: true, is_active: false, staking_address_hash: address6, stakes_ratio: 0)
+      insert(:staking_pool, is_validator: true, is_active: false, staking_address_hash: address5, stakes_ratio: 0)
+      insert(:staking_pool, is_validator: true, is_active: true, staking_address_hash: address4, stakes_ratio: 30)
+      insert(:staking_pool, is_validator: true, is_active: true, staking_address_hash: address3, stakes_ratio: 60)
+      insert(:staking_pool, is_validator: true, is_active: true, staking_address_hash: address2, stakes_ratio: 5)
+      insert(:staking_pool, is_validator: true, is_active: true, staking_address_hash: address1, stakes_ratio: 5)
+
+      # get all pools in the order `desc: :stakes_ratio, desc: :is_active, asc: :staking_address_hash`
+      options = %PagingOptions{page_size: 20, page_number: 1}
+      assert [
+        %{pool: pool1}, %{pool: pool2}, %{pool: pool3},
+        %{pool: pool4}, %{pool: pool5}, %{pool: pool6}
+      ] = Chain.staking_pools(:validator, options)
+      assert pool1.staking_address_hash == address3
+      assert pool2.staking_address_hash == address4
+      assert pool3.staking_address_hash == address1
+      assert pool4.staking_address_hash == address2
+      assert pool5.staking_address_hash == address5
+      assert pool6.staking_address_hash == address6
+    end
+
     test "inactive staking pools" do
       insert(:staking_pool, is_active: true)
       inserted_pool = insert(:staking_pool, is_active: false)

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -5052,7 +5052,8 @@ defmodule Explorer.ChainTest do
       address5 = Factory.address_hash()
       address6 = Factory.address_hash()
 
-      assert address1 < address2 and address2 < address3 and address3 < address4 and address4 < address5 and address5 < address6
+      assert address1 < address2 and address2 < address3 and address3 < address4 and address4 < address5 and
+               address5 < address6
 
       # insert pools in descending order
       insert(:staking_pool, is_validator: true, is_active: false, staking_address_hash: address6, stakes_ratio: 0)
@@ -5064,10 +5065,16 @@ defmodule Explorer.ChainTest do
 
       # get all pools in the order `desc: :stakes_ratio, desc: :is_active, asc: :staking_address_hash`
       options = %PagingOptions{page_size: 20, page_number: 1}
+
       assert [
-        %{pool: pool1}, %{pool: pool2}, %{pool: pool3},
-        %{pool: pool4}, %{pool: pool5}, %{pool: pool6}
-      ] = Chain.staking_pools(:validator, options)
+               %{pool: pool1},
+               %{pool: pool2},
+               %{pool: pool3},
+               %{pool: pool4},
+               %{pool: pool5},
+               %{pool: pool6}
+             ] = Chain.staking_pools(:validator, options)
+
       assert pool1.staking_address_hash == address3
       assert pool2.staking_address_hash == address4
       assert pool3.staking_address_hash == address1


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/3523

## Motivation

Pools with the same stake are not ordered

## Changelog

Add descending order by stakes ration and ascending order by staking_address_hash in DB query

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
