### PR TITLE
Allow trailing/leading whitespaces for inputs for contract read methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
+- [#3530](https://github.com/poanetwork/blockscout/pull/3530) - Allow trailing/leading whitespaces for inputs for contract read methods
 - [#3526](https://github.com/poanetwork/blockscout/pull/3526) - Order staking pools
 - [#3525](https://github.com/poanetwork/blockscout/pull/3525) - Address token balance on demand fetcher
 - [#3514](https://github.com/poanetwork/blockscout/pull/3514) - Read contract: fix internal server error

--- a/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
@@ -119,32 +119,6 @@ const readWriteFunction = (element) => {
   })
 }
 
-function getMethodInputs (contractAbi, functionName) {
-  const functionAbi = contractAbi.find(abi =>
-    abi.name === functionName
-  )
-  return functionAbi && functionAbi.inputs
-}
-
-function prepareMethodArgs ($functionInputs, inputs) {
-  return $.map($functionInputs, (element, ind) => {
-    const val = $(element).val()
-    const inputType = inputs[ind] && inputs[ind].type
-    let preparedVal
-    if (isNonSpaceInputType(inputType)) { preparedVal = val.replace(/\s/g, '') } else { preparedVal = val }
-    if (isArrayInputType(inputType)) {
-      if (preparedVal === '') {
-        return [[]]
-      } else {
-        if (preparedVal.startsWith('[') && preparedVal.endsWith(']')) {
-          preparedVal = preparedVal.substring(1, preparedVal.length - 1)
-        }
-        return [preparedVal.split(',')]
-      }
-    } else { return preparedVal }
-  })
-}
-
 function callMethod (isWalletEnabled, $functionInputs, explorerChainId, $form, functionName, $element) {
   if (!isWalletEnabled) {
     const warningMsg = 'You haven\'t approved the reading of account list from your MetaMask or MetaMask/Nifty wallet is locked or is not installed.'
@@ -196,12 +170,37 @@ function callMethod (isWalletEnabled, $functionInputs, explorerChainId, $form, f
     })
 }
 
+function getMethodInputs (contractAbi, functionName) {
+  const functionAbi = contractAbi.find(abi =>
+    abi.name === functionName
+  )
+  return functionAbi && functionAbi.inputs
+}
+
+function prepareMethodArgs ($functionInputs, inputs) {
+  return $.map($functionInputs, (element, ind) => {
+    const val = $(element).val()
+    const inputType = inputs[ind] && inputs[ind].type
+    let preparedVal
+    if (isNonSpaceInputType(inputType)) { preparedVal = val.replace(/\s/g, '') } else { preparedVal = val }
+    if (isArrayInputType(inputType)) {
+      if (preparedVal === '') {
+        return [[]]
+      } else {
+        if (preparedVal.startsWith('[') && preparedVal.endsWith(']')) {
+          preparedVal = preparedVal.substring(1, preparedVal.length - 1)
+        }
+        return [preparedVal.split(',')]
+      }
+    } else { return preparedVal }
+  })
+}
+
 function isArrayInputType (inputType) {
   return inputType && inputType.includes('[') && inputType.includes(']')
 }
 
 function isNonSpaceInputType (inputType) {
-  console.log('Gimme isNonSpaceInputType')
   return inputType.includes('address') || inputType.includes('int') || inputType.includes('bool')
 }
 

--- a/apps/explorer/package-lock.json
+++ b/apps/explorer/package-lock.json
@@ -33,9 +33,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
     },
     "fs-extra": {
       "version": "0.30.0",
@@ -130,7 +130,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "path-is-absolute": {
@@ -157,9 +157,9 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "solc": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.7.5.tgz",
-      "integrity": "sha512-RdcYGj2qjg+maWYRZPW65QvOOYbwexDT9xaOEQJtRI0TIYfzTJmslJ4f9S56VNjJsIR1zHdUIiPyuhF7wGIylw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.0.tgz",
+      "integrity": "sha512-ypgvqYZhb/i5BM6cw9/5QkSlDJm/rLynsbWGP3kz6HeB6oNxPK6UMiB7jMr+tNVbQbBM/8l47vrI3XaDCHShjQ==",
       "requires": {
         "command-exists": "^1.2.8",
         "commander": "3.0.2",

--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -13,6 +13,6 @@
   },
   "scripts": {},
   "dependencies": {
-    "solc": "^0.7.5"
+    "solc": "^0.8.0"
   }
 }


### PR DESCRIPTION
## Motivation

Blockscout returns `odd-length string error` if a user provides trailing/leading whitespaces in input data when interacts with contract's reading methods.

![image](https://user-images.githubusercontent.com/4341812/102803523-6bbd7d00-43c9-11eb-86c9-8a5a8775e698.png)


## Changelog

Allow trailing/leading whitespace in input data of read-only methods of contracts

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
