### PR TITLE
Allow double quotes in input data of contract methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3531](https://github.com/poanetwork/blockscout/pull/3531) - Allow double quotes in input data of contract methods
 - [#3515](https://github.com/poanetwork/blockscout/pull/3515) - CRC total balance
 - [#3513](https://github.com/poanetwork/blockscout/pull/3513) - Allow square brackets for an array input data in contracts interaction
 - [#3480](https://github.com/poanetwork/blockscout/pull/3480) - Add support of Autonity client

--- a/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
@@ -183,6 +183,9 @@ function prepareMethodArgs ($functionInputs, inputs) {
     const inputType = inputs[ind] && inputs[ind].type
     let preparedVal
     if (isNonSpaceInputType(inputType)) { preparedVal = val.replace(/\s/g, '') } else { preparedVal = val }
+    if (isAddressInputType(inputType)) {
+      preparedVal = preparedVal.replaceAll('"', '')
+    }
     if (isArrayInputType(inputType)) {
       if (preparedVal === '') {
         return [[]]
@@ -200,8 +203,12 @@ function isArrayInputType (inputType) {
   return inputType && inputType.includes('[') && inputType.includes(']')
 }
 
+function isAddressInputType (inputType) {
+  return inputType.includes('address')
+}
+
 function isNonSpaceInputType (inputType) {
-  return inputType.includes('address') || inputType.includes('int') || inputType.includes('bool')
+  return isAddressInputType(inputType) || inputType.includes('int') || inputType.includes('bool')
 }
 
 function getTxValue ($functionInputs) {


### PR DESCRIPTION
Closes https://github.com/poanetwork/blockscout/issues/3486

## Motivation

Double quotes re not allowed in input data of contract methods


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
