### PR TITLE
Run token balance on-demand fetcher in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Fixes
 - [#3530](https://github.com/poanetwork/blockscout/pull/3530) - Allow trailing/leading whitespaces for inputs for contract read methods
 - [#3526](https://github.com/poanetwork/blockscout/pull/3526) - Order staking pools
-- [#3525](https://github.com/poanetwork/blockscout/pull/3525) - Address token balance on demand fetcher
+- [#3525](https://github.com/poanetwork/blockscout/pull/3525), [#3533](https://github.com/poanetwork/blockscout/pull/3533) - Address token balance on demand fetcher
 - [#3514](https://github.com/poanetwork/blockscout/pull/3514) - Read contract: fix internal server error
 - [#3513](https://github.com/poanetwork/blockscout/pull/3513) - Fix input data processing for method call (array type of data)
 - [#3509](https://github.com/poanetwork/blockscout/pull/3509) - Fix QR code tooltip appearance in mobile view

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_balance_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_balance_controller.ex
@@ -14,7 +14,9 @@ defmodule BlockScoutWeb.AddressTokenBalanceController do
         |> Chain.fetch_last_token_balances()
         |> Market.add_price()
 
-      TokenBalanceOnDemand.trigger_fetch(address_hash, token_balances)
+      Task.start_link(fn ->
+        TokenBalanceOnDemand.trigger_fetch(address_hash, token_balances)
+      end)
 
       circles_addresses_list = CustomContractsHelpers.get_custom_addresses_list(:circles_addresses)
 

--- a/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
@@ -65,8 +65,6 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
 
     if Enum.count(stale_current_token_balances) > 0 do
       GenServer.cast(__MODULE__, {:fetch_and_update, latest_block_number, address_hash, stale_current_token_balances})
-
-      {:stale, latest_block_number}
     else
       :current
     end


### PR DESCRIPTION
Finalization of https://github.com/poanetwork/blockscout/pull/3525

## Motivation

![Screenshot 2020-12-23 at 13 56 31](https://user-images.githubusercontent.com/4341812/102989447-af79c900-4526-11eb-99e6-f7fb49ac0e1a.png)


## Changelog

Run token balance on-demand fetcher in parallel non-blocking process via `Task. start_link`


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
