### PR TITLE
Revert reason in the result of contract's method call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3536](https://github.com/poanetwork/blockscout/pull/3536) - Revert reason in the result of contract's method call
 - [#3532](https://github.com/poanetwork/blockscout/pull/3532) - Contract interaction: an easy setting of precision for integer input
 - [#3531](https://github.com/poanetwork/blockscout/pull/3531) - Allow double quotes in input data of contract methods
 - [#3515](https://github.com/poanetwork/blockscout/pull/3515) - CRC total balance

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -4,6 +4,8 @@ defmodule BlockScoutWeb.SmartContractController do
   alias Explorer.Chain
   alias Explorer.SmartContract.{Reader, Writer}
 
+  @burn_address "0x0000000000000000000000000000000000000000"
+
   def index(conn, %{"hash" => address_hash_string, "type" => contract_type, "action" => action}) do
     address_options = [
       necessity_by_association: %{
@@ -17,9 +19,9 @@ defmodule BlockScoutWeb.SmartContractController do
       implementation_address_hash_string =
         if contract_type == "proxy" do
           Chain.get_implementation_address_hash(address.hash, address.smart_contract.abi) ||
-            "0x0000000000000000000000000000000000000000"
+            @burn_address
         else
-          "0x0000000000000000000000000000000000000000"
+          @burn_address
         end
 
       functions =

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
@@ -47,6 +47,10 @@ defmodule EthereumJSONRPC.Encoder do
   """
   @spec decode_result(map(), %ABI.FunctionSelector{} | [%ABI.FunctionSelector{}]) ::
           {String.t(), {:ok, any()} | {:error, String.t() | :invalid_data}}
+  def decode_result(%{error: %{code: code, data: data, message: message}, id: id}, _selector) do
+    {id, {:error, "(#{code}) #{message} (#{data})"}}
+  end
+
   def decode_result(%{error: %{code: code, message: message}, id: id}, _selector) do
     {id, {:error, "(#{code}) #{message}"}}
   end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/contract_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/contract_test.exs
@@ -82,7 +82,7 @@ defmodule EthereumJSONRPC.ContractTest do
       blockchain_result = [
         {:ok, [42]},
         {:ok, [52]},
-        {:error, "(-32015) Some error"}
+        {:error, "(-32015) Some error (something)"}
       ]
 
       assert EthereumJSONRPC.execute_contract_functions(

--- a/apps/explorer/test/explorer/token/balance_reader_test.exs
+++ b/apps/explorer/test/explorer/token/balance_reader_test.exs
@@ -55,7 +55,7 @@ defmodule Explorer.Token.BalanceReaderTest do
           }
         ])
 
-      assert result == [{:error, "(-32015) VM execution error."}]
+      assert result == [{:error, "(-32015) VM execution error. (Reverted 0x)"}]
     end
   end
 


### PR DESCRIPTION
## Motivation

Display revert reason in the result of the contract method call.

## Changelog

![Screenshot 2020-12-24 at 13 35 02](https://user-images.githubusercontent.com/4341812/103083453-82441e00-45ed-11eb-9794-6d9338486008.png)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
