### PR TITLE
DarkForest: apply theme to token instance, differentiate versions of DF

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -23,6 +23,6 @@ lib/indexer/fetcher/token_total_supply_on_demand.ex:16
 lib/explorer/exchange_rates/source.ex:104
 lib/explorer/exchange_rates/source.ex:107
 lib/explorer/smart_contract/verifier.ex:89
-lib/block_scout_web/templates/address_contract/index.html.eex:117
+lib/block_scout_web/templates/address_contract/index.html.eex:118
 lib/explorer/staking/stake_snapshotting.ex:14: Function do_snapshotting/6 has no local return
 lib/explorer/staking/stake_snapshotting.ex:183

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## Current
 
 ### Features
+- [#3540](https://github.com/poanetwork/blockscout/pull/3540) - Apply DarkForest custom theme to NFT instances
 
 ### Fixes
 
 ### Chore
+- [#3540](https://github.com/poanetwork/blockscout/pull/3540) - Support different versions of DarkForest (0.4 - 0.5)
 
 
 ## 3.5.0-beta

--- a/apps/block_scout_web/assets/css/theme/custom_contracts/_dark-forest-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/custom_contracts/_dark-forest-theme.scss
@@ -269,12 +269,25 @@ $dark-primary-alternate: $dark-primary;
 		content: url(/images/custom-themes/dark-forest/qr.svg);
 	}
 
-	.btn-copy-icon, .btn-qr-icon, .btn-address-card-icon .btn-contract-icon {
+	.btn-copy-icon, .btn-qr-icon, .btn-address-card-icon {
 		border-radius: 0;
 		border: none;
 		border-color: $dark-primary;
 		&:hover {
 			background-color: rgba(117, 249, 77, 0.4);
+		}
+	}
+
+	.btn-contract-icon {
+		border-radius: 0;
+		border-color: $dark-primary;
+		&:hover {
+			background-color: rgba(117, 249, 77, 0.4);
+		}
+		svg {
+			path {
+				fill: $dark-primary;
+			}
 		}
 	}
 	

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -42,6 +42,7 @@ config :block_scout_web,
   restricted_list: System.get_env("RESTRICTED_LIST", nil),
   restricted_list_key: System.get_env("RESTRICTED_LIST_KEY", nil),
   dark_forest_addresses: System.get_env("CUSTOM_CONTRACT_ADDRESSES_DARK_FOREST"),
+  dark_forest_addresses_v_0_5: System.get_env("CUSTOM_CONTRACT_ADDRESSES_DARK_FOREST_V_0_5"),
   circles_addresses: System.get_env("CUSTOM_CONTRACT_ADDRESSES_CIRCLES")
 
 config :block_scout_web, BlockScoutWeb.Counters.BlocksIndexedCounter, enabled: true

--- a/apps/block_scout_web/lib/block_scout_web/controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controller.ex
@@ -13,7 +13,7 @@ defmodule BlockScoutWeb.Controller do
     conn
     |> put_status(:not_found)
     |> put_view(BlockScoutWeb.PageNotFoundView)
-    |> render(:index)
+    |> render(:index, token: nil)
     |> halt()
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/decompiled_smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/decompiled_smart_contract_controller.ex
@@ -12,7 +12,7 @@ defmodule BlockScoutWeb.API.V1.DecompiledSmartContractController do
              {:contract, Chain.check_decompiled_contract_exists(params["address_hash"], params["decompiler_version"])} do
         case Chain.create_decompiled_smart_contract(params) do
           {:ok, decompiled_smart_contract} ->
-            send_resp(conn, :created, Jason.encode!(decompiled_smart_contract))
+            send_resp(conn, :created, encode(decompiled_smart_contract))
 
           {:error, changeset} ->
             errors =

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/verified_smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/verified_smart_contract_controller.ex
@@ -13,7 +13,7 @@ defmodule BlockScoutWeb.API.V1.VerifiedSmartContractController do
 
       case Publisher.publish(hash, params, external_libraries) do
         {:ok, _} ->
-          send_resp(conn, :created, Jason.encode!(%{status: :success}))
+          send_resp(conn, :created, encode(%{status: :success}))
 
         {:error, changeset} ->
           errors =

--- a/apps/block_scout_web/lib/block_scout_web/controllers/page_not_found_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/page_not_found_controller.ex
@@ -4,6 +4,6 @@ defmodule BlockScoutWeb.PageNotFoundController do
   def index(conn, _params) do
     conn
     |> put_status(:not_found)
-    |> render("index.html")
+    |> render("index.html", token: nil)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_custom_view_df_title.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_custom_view_df_title.html.eex
@@ -1,0 +1,19 @@
+<div class="custom-dapp-header-container">
+    <img class="custom-address-icon"/>
+    <div class="custom-dapp-header-description-container">
+        <span class="address-detail-item custom-address-details">
+        <%= @title %>
+        </span>
+        <a href="https://zkga.me/" target="_blank" class="application-icon-link">
+            <span
+                aria-label='<%= gettext("Play") %>'
+                class="application-icon"
+                data-placement="top"
+                data-toggle="tooltip"
+                title='<%= gettext("Play") %>'
+            >
+                <img class="application-icon"/>
+            </span>
+        </a>
+    </div>
+</div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
@@ -1,4 +1,6 @@
-<% dark_forest_addresses_list = CustomContractsHelpers.get_custom_addresses_list(:dark_forest_addresses) %>
+<% dark_forest_addresses_list_0_4 = CustomContractsHelpers.get_custom_addresses_list(:dark_forest_addresses) %>
+<% dark_forest_addresses_list_0_5 = CustomContractsHelpers.get_custom_addresses_list(:dark_forest_addresses_v_0_5) %>
+<% dark_forest_addresses_list = dark_forest_addresses_list_0_4 ++ dark_forest_addresses_list_0_5 %>
 <% current_address = "0x" <> Base.encode16(@address.hash.bytes, case: :lower) %>
 <div class="card-tabs js-card-tabs">
   <%= link(

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -1,5 +1,6 @@
 <section class="address-overview" data-page="address-details" data-page-address-hash="<%= @address.hash %>" data-async-counters="<%= @counters_path %>">
-  <% dark_forest_addresses_list = CustomContractsHelpers.get_custom_addresses_list(:dark_forest_addresses) %>
+  <% dark_forest_addresses_list_0_4 = CustomContractsHelpers.get_custom_addresses_list(:dark_forest_addresses) %>
+  <% dark_forest_addresses_list_0_5 = CustomContractsHelpers.get_custom_addresses_list(:dark_forest_addresses_v_0_5) %>
   <% circles_addresses_list = CustomContractsHelpers.get_custom_addresses_list(:circles_addresses) %>
   <% current_address = "0x" <> Base.encode16(@address.hash.bytes, case: :lower) %>
   <% created_from_address_hash = if from_address_hash(@address), do: "0x" <> Base.encode16(from_address_hash(@address).bytes, case: :lower), else: nil %>
@@ -9,26 +10,10 @@
       <div class="card">
         <div class="card-body">
           <%= cond do %>
-            <% Enum.member?(dark_forest_addresses_list, current_address) -> %>
-              <div class="custom-dapp-header-container">
-                <img class="custom-address-icon"/>
-                <div class="custom-dapp-header-description-container">
-                  <span class="address-detail-item custom-address-details">
-                    <%= gettext "zkSnark space warfare (v0.4)" %>
-                  </span>
-                  <a href="https://zkga.me/" target="_blank" class="application-icon-link">
-                    <span
-                      aria-label='<%= gettext("Play") %>'
-                      class="application-icon"
-                      data-placement="top"
-                      data-toggle="tooltip"
-                      title='<%= gettext("Play") %>'
-                    >
-                      <img class="application-icon"/>
-                    </span>
-                  </a>
-                </div>
-              </div>
+            <% Enum.member?(dark_forest_addresses_list_0_4, current_address) -> %>
+              <%= render BlockScoutWeb.AddressView, "_custom_view_df_title.html", title: "zkSnark space warfare (v0.4)" %>
+            <% Enum.member?(dark_forest_addresses_list_0_5, current_address) -> %>
+              <%= render BlockScoutWeb.AddressView, "_custom_view_df_title.html", title: "zkSnark space warfare (v0.5)" %>
             <% Enum.member?(circles_addresses_list, current_address) -> %>
               <div class="custom-dapp-header-container">
                 <img class="custom-address-icon"/>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
@@ -1,5 +1,6 @@
 <% contract_creation_code = contract_creation_code(@address) %>
 <% metadata_for_verification = Chain.address_verified_twin_contract(@address.hash) %>
+<% smart_contract_verified = BlockScoutWeb.AddressView.smart_contract_verified?(@address) %>
 
 <section class="container">
   <%= render BlockScoutWeb.AddressView, "overview.html", assigns %>
@@ -7,17 +8,17 @@
   <div class="card">
     <%= render BlockScoutWeb.AddressView, "_tabs.html", assigns %>
     <div class="card-body">
-      <%= unless BlockScoutWeb.AddressView.smart_contract_verified?(@address) do %>
+      <%= unless smart_contract_verified do %>
         <%= if metadata_for_verification do %>
           <div class="mb-4">
-            <i style="color: #f7b32b;" class="fa fa-info-circle"></i><span> <%= gettext("Contract is not verified. However, we found a verified contract with the same bytecode in our DB") %> <%= link(
+            <i style="color: #f7b32b;" class="fa fa-info-circle"></i><span> <%= gettext("Contract is not verified. However, we found a verified contract with the same bytecode in Blockscout DB") %> <%= link(
       metadata_for_verification.address_hash,
       to: address_contract_path(@conn, :index, metadata_for_verification.address_hash)) %>.<br/> <%=  gettext("All metadata displayed below is from that contract. In order to verify current contract, click") %> <i><%= gettext("Verify & Publish") %></i> <%= gettext("button") %></span>
           </div>
         <% end %>
       <% end %>
-      <%= if BlockScoutWeb.AddressView.smart_contract_verified?(@address) || (!BlockScoutWeb.AddressView.smart_contract_verified?(@address) && metadata_for_verification) do %>
-        <% target_contract = if BlockScoutWeb.AddressView.smart_contract_verified?(@address), do: @address.smart_contract, else: metadata_for_verification %>
+      <%= if smart_contract_verified || (!smart_contract_verified && metadata_for_verification) do %>
+        <% target_contract = if smart_contract_verified, do: @address.smart_contract, else: metadata_for_verification %>
         <div class="mb-4">
           <dl class="row">
             <dt class="col-md-2 text-muted"><%= gettext "Contract name:" %></dt>
@@ -37,14 +38,14 @@
               <dd class="col-md-4"><%= target_contract.optimization_runs %></dd>
             <% end %>
           </dl>
-          <%= if BlockScoutWeb.AddressView.smart_contract_verified?(@address) && target_contract.evm_version do %>
+          <%= if smart_contract_verified && target_contract.evm_version do %>
             <dl class="row">
               <dt class="col-sm-4 col-md-2 text-muted"><%= gettext "EVM Version" %></dt>
               <dd class="col-sm-8 col-md-10"><%= target_contract.evm_version %></dd>
             </dl>
           <% end %>
         <hr/>
-        <%= if BlockScoutWeb.AddressView.smart_contract_verified?(@address) && target_contract.constructor_arguments do %>
+        <%= if smart_contract_verified && target_contract.constructor_arguments do %>
           <section>
             <div class="d-flex justify-content-between align-items-baseline">
               <h3><%= gettext "Constructor Arguments" %></h3>
@@ -98,7 +99,7 @@
               <pre class="pre-wrap pre-scrollable"><code class="nohighlight"><%= transaction_init %></code></pre>
             </div>
           <% {:ok, contract_code} -> %>
-            <%= if BlockScoutWeb.AddressView.smart_contract_verified?(@address) do %>
+            <%= if smart_contract_verified do %>
               <div class="d-flex justify-content-between align-items-baseline">
                 <h3><%= gettext "Contract Byte Code" %></h3>
                 <button type="button" class="btn-line" style="float: left;" id="button" data-clipboard-text="<%= contract_code %>" aria-label="copy contract creation code">
@@ -119,7 +120,7 @@
                       <%= gettext("Verify & Publish") %>
                     </div>
                   <% else %>
-                    <%= if !BlockScoutWeb.AddressView.smart_contract_verified?(@address) do %>
+                    <%= if !smart_contract_verified do %>
                       <%= link(
                             gettext("Verify & Publish"),
                             to: address_verify_contract_path(@conn, :new, @address.hash),
@@ -137,8 +138,8 @@
         <% end %>
       </section>
 
-      <%= if BlockScoutWeb.AddressView.smart_contract_verified?(@address) || (!BlockScoutWeb.AddressView.smart_contract_verified?(@address) && metadata_for_verification) do %>
-        <% target_contract = if BlockScoutWeb.AddressView.smart_contract_verified?(@address), do: @address.smart_contract, else: metadata_for_verification %>
+      <%= if smart_contract_verified || (!smart_contract_verified && metadata_for_verification) do %>
+        <% target_contract = if smart_contract_verified, do: @address.smart_contract, else: metadata_for_verification %>
         <%= if target_contract.external_libraries && target_contract.external_libraries != [] do %>
           <section>
             <div class="d-flex justify-content-between align-items-baseline">

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -37,7 +37,10 @@
   </head>
 
   <body>
-    <% raw_dark_forest_addresses = CustomContractsHelpers.get_raw_custom_addresses_list(:dark_forest_addresses) %>
+    <% raw_dark_forest_addresses_0_4 = CustomContractsHelpers.get_raw_custom_addresses_list(:dark_forest_addresses) || "" %>
+    <% raw_dark_forest_addresses_0_5 = CustomContractsHelpers.get_raw_custom_addresses_list(:dark_forest_addresses_v_0_5) || "" %>
+    <% raw_dark_forest_addresses = raw_dark_forest_addresses_0_4 <> "," <> raw_dark_forest_addresses_0_5 %>
+
     <% raw_circles_addresses = CustomContractsHelpers.get_raw_custom_addresses_list(:circles_addresses) %>
     <%= cond do %>
       <% (
@@ -116,9 +119,12 @@
       <% (
         @view_module == Elixir.BlockScoutWeb.Tokens.TransferView ||
         @view_module == Elixir.BlockScoutWeb.Tokens.ReadContractView ||
-        @view_module == Elixir.BlockScoutWeb.Tokens.HolderView
+        @view_module == Elixir.BlockScoutWeb.Tokens.HolderView ||
+        @view_module == Elixir.BlockScoutWeb.Tokens.Instance.TransferView ||
+        @view_module == Elixir.BlockScoutWeb.Tokens.Instance.MetadataView ||
+        @view_module == Elixir.BlockScoutWeb.PageNotFoundView
       ) -> %>
-        <% {:ok, created_from_address} = if @token.contract_address_hash, do: Chain.hash_to_address(@token.contract_address_hash), else: {:ok, nil} %>
+        <% {:ok, created_from_address} = if @token && @token.contract_address_hash, do: Chain.hash_to_address(@token.contract_address_hash), else: {:ok, nil} %>
         <% created_from_address_hash = if from_address_hash(created_from_address), do: "0x" <> Base.encode16(from_address_hash(created_from_address).bytes, case: :lower), else: nil %>
         <script>
           function applyCustomMode() {

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -2,7 +2,7 @@
 <%= unless BlockScoutWeb.AddressView.smart_contract_verified?(@address) do %>
   <%= if metadata_for_verification do %>
     <div class="mb-4">
-      <i style="color: #f7b32b;" class="fa fa-info-circle"></i><span> <%= gettext("Contract is not verified. However, we found a verified contract with the same bytecode in our DB") %> <%= link(
+      <i style="color: #f7b32b;" class="fa fa-info-circle"></i><span> <%= gettext("Contract is not verified. However, we found a verified contract with the same bytecode in Blockscout DB") %> <%= link(
 metadata_for_verification.address_hash,
 to: address_contract_path(@conn, :index, metadata_for_verification.address_hash)) %>.<br/> <%= gettext("All functions displayed below are from ABI of that contract. In order to verify current contract, proceed with") %> <%= link(
       gettext("Verify & Publish"),

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -72,7 +72,7 @@ msgid "(query)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:167
+#: lib/block_scout_web/templates/layout/app.html.eex:173
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
 
@@ -297,7 +297,7 @@ msgid "Compiler"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:31
+#: lib/block_scout_web/templates/address_contract/index.html.eex:32
 msgid "Compiler version"
 msgstr ""
 
@@ -330,12 +330,12 @@ msgid "Connection Lost, click to load newer validations"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:50
+#: lib/block_scout_web/templates/address_contract/index.html.eex:51
 msgid "Constructor Arguments"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:72
+#: lib/block_scout_web/templates/address_contract/index.html.eex:73
 msgid "Contract ABI"
 msgstr ""
 
@@ -353,8 +353,8 @@ msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:103
-#: lib/block_scout_web/templates/address_contract/index.html.eex:111
+#: lib/block_scout_web/templates/address_contract/index.html.eex:104
+#: lib/block_scout_web/templates/address_contract/index.html.eex:112
 msgid "Contract Byte Code"
 msgstr ""
 
@@ -369,7 +369,7 @@ msgid "Contract Creation"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:88
+#: lib/block_scout_web/templates/address_contract/index.html.eex:89
 msgid "Contract Creation Code"
 msgstr ""
 
@@ -384,17 +384,17 @@ msgid "Contract Name"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:23
+#: lib/block_scout_web/templates/address_contract/index.html.eex:24
 msgid "Contract name:"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:60
+#: lib/block_scout_web/templates/address_contract/index.html.eex:61
 msgid "Contract source code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:94
+#: lib/block_scout_web/templates/address_contract/index.html.eex:95
 msgid "Contracts that self destruct in their constructors have no contract code published and cannot be verified."
 msgstr ""
 
@@ -404,20 +404,20 @@ msgid "Contribute"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:74
+#: lib/block_scout_web/templates/address_contract/index.html.eex:75
 msgid "Copy ABI"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:49
-#: lib/block_scout_web/templates/address/overview.html.eex:53
+#: lib/block_scout_web/templates/address/overview.html.eex:34
+#: lib/block_scout_web/templates/address/overview.html.eex:38
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:32
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:36
 msgid "Copy Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:90
+#: lib/block_scout_web/templates/address_contract/index.html.eex:91
 msgid "Copy Contract Creation Code"
 msgstr ""
 
@@ -427,7 +427,7 @@ msgid "Copy Decompiled Contract Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:62
+#: lib/block_scout_web/templates/address_contract/index.html.eex:63
 msgid "Copy Source Code"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgid "Create2"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:136
+#: lib/block_scout_web/templates/address/overview.html.eex:121
 msgid "Created by"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgid "Decoded"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:73
+#: lib/block_scout_web/templates/address/_tabs.html.eex:75
 msgid "Decompiled code"
 msgstr ""
 
@@ -534,14 +534,14 @@ msgid "Description"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:44
+#: lib/block_scout_web/templates/address/overview.html.eex:29
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:166
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:127
 msgid "Details"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:95
+#: lib/block_scout_web/templates/address_contract/index.html.eex:96
 msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
 
@@ -572,7 +572,7 @@ msgid "ETH RPC API Documentation"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:42
+#: lib/block_scout_web/templates/address_contract/index.html.eex:43
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:82
 msgid "EVM Version"
 msgstr ""
@@ -625,7 +625,7 @@ msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:149
+#: lib/block_scout_web/templates/address/overview.html.eex:134
 msgid "Error: Could not determine contract creator."
 msgstr ""
 
@@ -665,7 +665,7 @@ msgid "Nonce"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:145
+#: lib/block_scout_web/templates/address_contract/index.html.eex:146
 msgid "External libraries"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgid "Token Transfer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:11
+#: lib/block_scout_web/templates/address/_tabs.html.eex:13
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:17
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
@@ -960,7 +960,7 @@ msgid "It could still be in the TX Pool of a different node, waiting to be broad
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:121
+#: lib/block_scout_web/templates/address/overview.html.eex:106
 msgid "Last Balance Update: Block #"
 msgstr ""
 
@@ -1105,12 +1105,12 @@ msgid "OUT"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:27
+#: lib/block_scout_web/templates/address_contract/index.html.eex:28
 msgid "Optimization enabled"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:36
+#: lib/block_scout_web/templates/address_contract/index.html.eex:37
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:114
 msgid "Optimization runs"
 msgstr ""
@@ -1172,8 +1172,8 @@ msgid "Price"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:69
-#: lib/block_scout_web/templates/address/overview.html.eex:173
+#: lib/block_scout_web/templates/address/overview.html.eex:54
+#: lib/block_scout_web/templates/address/overview.html.eex:158
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:51
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:107
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:52
@@ -1284,14 +1284,14 @@ msgid "Show"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:70
+#: lib/block_scout_web/templates/address/overview.html.eex:55
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:52
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:53
 msgid "Show QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:84
+#: lib/block_scout_web/templates/address/overview.html.eex:69
 msgid "Show Validator Info"
 msgstr ""
 
@@ -1557,7 +1557,7 @@ msgid "Validator Data"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:88
+#: lib/block_scout_web/templates/address/overview.html.eex:73
 msgid "Validator Info"
 msgstr ""
 
@@ -1568,9 +1568,9 @@ msgid "Value"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:15
-#: lib/block_scout_web/templates/address_contract/index.html.eex:119
-#: lib/block_scout_web/templates/address_contract/index.html.eex:124
+#: lib/block_scout_web/templates/address_contract/index.html.eex:16
+#: lib/block_scout_web/templates/address_contract/index.html.eex:120
+#: lib/block_scout_web/templates/address_contract/index.html.eex:125
 #: lib/block_scout_web/templates/smart_contract/_functions.html.eex:8
 msgid "Verify & Publish"
 msgstr ""
@@ -1658,7 +1658,7 @@ msgid "Yes"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:141
+#: lib/block_scout_web/templates/address/overview.html.eex:126
 msgid "at"
 msgstr ""
 
@@ -1716,8 +1716,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:37
-#: lib/block_scout_web/templates/address/overview.html.eex:174
-#: lib/block_scout_web/templates/address/overview.html.eex:182
+#: lib/block_scout_web/templates/address/overview.html.eex:159
+#: lib/block_scout_web/templates/address/overview.html.eex:167
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:108
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:116
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:138
@@ -1796,14 +1796,14 @@ msgid "Copy Txn Input"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:46
+#: lib/block_scout_web/templates/address/_tabs.html.eex:48
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
 #: lib/block_scout_web/views/address_view.ex:354
 msgid "Blocks Validated"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:56
+#: lib/block_scout_web/templates/address/_tabs.html.eex:58
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:165
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
@@ -1813,7 +1813,7 @@ msgid "Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:32
+#: lib/block_scout_web/templates/address/_tabs.html.eex:34
 #: lib/block_scout_web/views/address_view.ex:353
 msgid "Coin Balance History"
 msgstr ""
@@ -1824,7 +1824,7 @@ msgid "Decompiled Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:26
+#: lib/block_scout_web/templates/address/_tabs.html.eex:28
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
@@ -1834,7 +1834,7 @@ msgid "Internal Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:39
+#: lib/block_scout_web/templates/address/_tabs.html.eex:41
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
@@ -1844,7 +1844,7 @@ msgid "Logs"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:79
+#: lib/block_scout_web/templates/address/_tabs.html.eex:81
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
 #: lib/block_scout_web/views/address_view.ex:349
 #: lib/block_scout_web/views/tokens/overview_view.ex:42
@@ -1852,7 +1852,7 @@ msgid "Read Contract"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:19
+#: lib/block_scout_web/templates/address/_tabs.html.eex:21
 #: lib/block_scout_web/templates/address_token/index.html.eex:8
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:11
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:87
@@ -1863,7 +1863,7 @@ msgid "Tokens"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:5
+#: lib/block_scout_web/templates/address/_tabs.html.eex:7
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:15
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:10
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:18
@@ -1908,13 +1908,13 @@ msgid "Revert reason"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:86
+#: lib/block_scout_web/templates/address/_tabs.html.eex:88
 #: lib/block_scout_web/views/address_view.ex:350
 msgid "Read Proxy"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:93
+#: lib/block_scout_web/templates/address/_tabs.html.eex:95
 #: lib/block_scout_web/views/address_view.ex:351
 msgid "Write Contract"
 msgstr ""
@@ -1931,7 +1931,7 @@ msgid "Write"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:100
+#: lib/block_scout_web/templates/address/_tabs.html.eex:102
 #: lib/block_scout_web/views/address_view.ex:352
 msgid "Write Proxy"
 msgstr ""
@@ -1957,18 +1957,12 @@ msgid "All functions displayed below are from ABI of that contract. In order to 
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:15
+#: lib/block_scout_web/templates/address_contract/index.html.eex:16
 msgid "All metadata displayed below is from that contract. In order to verify current contract, click"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:13
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:5
-msgid "Contract is not verified. However, we found a verified contract with the same bytecode in our DB"
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:15
+#: lib/block_scout_web/templates/address_contract/index.html.eex:16
 msgid "button"
 msgstr ""
 
@@ -1988,19 +1982,14 @@ msgid "Bridged Tokens"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:17
-msgid "zkSnark space warfare (v0.4)"
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:21
-#: lib/block_scout_web/templates/address/overview.html.eex:25
+#: lib/block_scout_web/templates/address/_custom_view_df_title.html.eex:9
+#: lib/block_scout_web/templates/address/_custom_view_df_title.html.eex:13
 msgid "Play"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:105
-#: lib/block_scout_web/templates/address_contract/index.html.eex:115
+#: lib/block_scout_web/templates/address_contract/index.html.eex:106
+#: lib/block_scout_web/templates/address_contract/index.html.eex:116
 msgid "Copy Byte Code"
 msgstr ""
 
@@ -2661,4 +2650,10 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:149
 msgid "Stakes"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_contract/index.html.eex:14
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:5
+msgid "Contract is not verified. However, we found a verified contract with the same bytecode in Blockscout DB"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -72,7 +72,7 @@ msgid "(query)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:167
+#: lib/block_scout_web/templates/layout/app.html.eex:173
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
 
@@ -297,7 +297,7 @@ msgid "Compiler"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:31
+#: lib/block_scout_web/templates/address_contract/index.html.eex:32
 msgid "Compiler version"
 msgstr ""
 
@@ -330,12 +330,12 @@ msgid "Connection Lost, click to load newer validations"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:50
+#: lib/block_scout_web/templates/address_contract/index.html.eex:51
 msgid "Constructor Arguments"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:72
+#: lib/block_scout_web/templates/address_contract/index.html.eex:73
 msgid "Contract ABI"
 msgstr ""
 
@@ -353,8 +353,8 @@ msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:103
-#: lib/block_scout_web/templates/address_contract/index.html.eex:111
+#: lib/block_scout_web/templates/address_contract/index.html.eex:104
+#: lib/block_scout_web/templates/address_contract/index.html.eex:112
 msgid "Contract Byte Code"
 msgstr ""
 
@@ -369,7 +369,7 @@ msgid "Contract Creation"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:88
+#: lib/block_scout_web/templates/address_contract/index.html.eex:89
 msgid "Contract Creation Code"
 msgstr ""
 
@@ -384,17 +384,17 @@ msgid "Contract Name"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:23
+#: lib/block_scout_web/templates/address_contract/index.html.eex:24
 msgid "Contract name:"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:60
+#: lib/block_scout_web/templates/address_contract/index.html.eex:61
 msgid "Contract source code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:94
+#: lib/block_scout_web/templates/address_contract/index.html.eex:95
 msgid "Contracts that self destruct in their constructors have no contract code published and cannot be verified."
 msgstr ""
 
@@ -404,20 +404,20 @@ msgid "Contribute"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:74
+#: lib/block_scout_web/templates/address_contract/index.html.eex:75
 msgid "Copy ABI"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:49
-#: lib/block_scout_web/templates/address/overview.html.eex:53
+#: lib/block_scout_web/templates/address/overview.html.eex:34
+#: lib/block_scout_web/templates/address/overview.html.eex:38
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:32
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:36
 msgid "Copy Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:90
+#: lib/block_scout_web/templates/address_contract/index.html.eex:91
 msgid "Copy Contract Creation Code"
 msgstr ""
 
@@ -427,7 +427,7 @@ msgid "Copy Decompiled Contract Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:62
+#: lib/block_scout_web/templates/address_contract/index.html.eex:63
 msgid "Copy Source Code"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgid "Create2"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:136
+#: lib/block_scout_web/templates/address/overview.html.eex:121
 msgid "Created by"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgid "Decoded"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:73
+#: lib/block_scout_web/templates/address/_tabs.html.eex:75
 msgid "Decompiled code"
 msgstr ""
 
@@ -534,14 +534,14 @@ msgid "Description"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:44
+#: lib/block_scout_web/templates/address/overview.html.eex:29
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:166
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:127
 msgid "Details"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:95
+#: lib/block_scout_web/templates/address_contract/index.html.eex:96
 msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
 
@@ -572,7 +572,7 @@ msgid "ETH RPC API Documentation"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:42
+#: lib/block_scout_web/templates/address_contract/index.html.eex:43
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:82
 msgid "EVM Version"
 msgstr ""
@@ -625,7 +625,7 @@ msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:149
+#: lib/block_scout_web/templates/address/overview.html.eex:134
 msgid "Error: Could not determine contract creator."
 msgstr ""
 
@@ -665,7 +665,7 @@ msgid "Nonce"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:145
+#: lib/block_scout_web/templates/address_contract/index.html.eex:146
 msgid "External libraries"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgid "Token Transfer"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:11
+#: lib/block_scout_web/templates/address/_tabs.html.eex:13
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:17
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
@@ -960,7 +960,7 @@ msgid "It could still be in the TX Pool of a different node, waiting to be broad
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:121
+#: lib/block_scout_web/templates/address/overview.html.eex:106
 msgid "Last Balance Update: Block #"
 msgstr ""
 
@@ -1105,12 +1105,12 @@ msgid "OUT"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:27
+#: lib/block_scout_web/templates/address_contract/index.html.eex:28
 msgid "Optimization enabled"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:36
+#: lib/block_scout_web/templates/address_contract/index.html.eex:37
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:114
 msgid "Optimization runs"
 msgstr ""
@@ -1172,8 +1172,8 @@ msgid "Price"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:69
-#: lib/block_scout_web/templates/address/overview.html.eex:173
+#: lib/block_scout_web/templates/address/overview.html.eex:54
+#: lib/block_scout_web/templates/address/overview.html.eex:158
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:51
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:107
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:52
@@ -1284,14 +1284,14 @@ msgid "Show"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:70
+#: lib/block_scout_web/templates/address/overview.html.eex:55
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:52
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:53
 msgid "Show QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:84
+#: lib/block_scout_web/templates/address/overview.html.eex:69
 msgid "Show Validator Info"
 msgstr ""
 
@@ -1557,7 +1557,7 @@ msgid "Validator Data"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:88
+#: lib/block_scout_web/templates/address/overview.html.eex:73
 msgid "Validator Info"
 msgstr ""
 
@@ -1568,9 +1568,9 @@ msgid "Value"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:15
-#: lib/block_scout_web/templates/address_contract/index.html.eex:119
-#: lib/block_scout_web/templates/address_contract/index.html.eex:124
+#: lib/block_scout_web/templates/address_contract/index.html.eex:16
+#: lib/block_scout_web/templates/address_contract/index.html.eex:120
+#: lib/block_scout_web/templates/address_contract/index.html.eex:125
 #: lib/block_scout_web/templates/smart_contract/_functions.html.eex:8
 msgid "Verify & Publish"
 msgstr ""
@@ -1658,7 +1658,7 @@ msgid "Yes"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:141
+#: lib/block_scout_web/templates/address/overview.html.eex:126
 msgid "at"
 msgstr ""
 
@@ -1716,8 +1716,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:37
-#: lib/block_scout_web/templates/address/overview.html.eex:174
-#: lib/block_scout_web/templates/address/overview.html.eex:182
+#: lib/block_scout_web/templates/address/overview.html.eex:159
+#: lib/block_scout_web/templates/address/overview.html.eex:167
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:108
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:116
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:138
@@ -1796,14 +1796,14 @@ msgid "Copy Txn Input"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:46
+#: lib/block_scout_web/templates/address/_tabs.html.eex:48
 #: lib/block_scout_web/templates/address_validation/index.html.eex:13
 #: lib/block_scout_web/views/address_view.ex:354
 msgid "Blocks Validated"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:56
+#: lib/block_scout_web/templates/address/_tabs.html.eex:58
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:165
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
@@ -1813,7 +1813,7 @@ msgid "Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:32
+#: lib/block_scout_web/templates/address/_tabs.html.eex:34
 #: lib/block_scout_web/views/address_view.ex:353
 msgid "Coin Balance History"
 msgstr ""
@@ -1824,7 +1824,7 @@ msgid "Decompiled Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:26
+#: lib/block_scout_web/templates/address/_tabs.html.eex:28
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:19
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
@@ -1834,7 +1834,7 @@ msgid "Internal Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:39
+#: lib/block_scout_web/templates/address/_tabs.html.eex:41
 #: lib/block_scout_web/templates/address_logs/index.html.eex:8
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
@@ -1844,7 +1844,7 @@ msgid "Logs"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:79
+#: lib/block_scout_web/templates/address/_tabs.html.eex:81
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:25
 #: lib/block_scout_web/views/address_view.ex:349
 #: lib/block_scout_web/views/tokens/overview_view.ex:42
@@ -1852,7 +1852,7 @@ msgid "Read Contract"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:19
+#: lib/block_scout_web/templates/address/_tabs.html.eex:21
 #: lib/block_scout_web/templates/address_token/index.html.eex:8
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:11
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:87
@@ -1863,7 +1863,7 @@ msgid "Tokens"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:5
+#: lib/block_scout_web/templates/address/_tabs.html.eex:7
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:15
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:10
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:18
@@ -1908,13 +1908,13 @@ msgid "Revert reason"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:86
+#: lib/block_scout_web/templates/address/_tabs.html.eex:88
 #: lib/block_scout_web/views/address_view.ex:350
 msgid "Read Proxy"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:93
+#: lib/block_scout_web/templates/address/_tabs.html.eex:95
 #: lib/block_scout_web/views/address_view.ex:351
 msgid "Write Contract"
 msgstr ""
@@ -1931,7 +1931,7 @@ msgid "Write"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/_tabs.html.eex:100
+#: lib/block_scout_web/templates/address/_tabs.html.eex:102
 #: lib/block_scout_web/views/address_view.ex:352
 msgid "Write Proxy"
 msgstr ""
@@ -1957,18 +1957,12 @@ msgid "All functions displayed below are from ABI of that contract. In order to 
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:15
+#: lib/block_scout_web/templates/address_contract/index.html.eex:16
 msgid "All metadata displayed below is from that contract. In order to verify current contract, click"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:13
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:5
-msgid "Contract is not verified. However, we found a verified contract with the same bytecode in our DB"
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:15
+#: lib/block_scout_web/templates/address_contract/index.html.eex:16
 msgid "button"
 msgstr ""
 
@@ -1988,19 +1982,14 @@ msgid "Bridged Tokens"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:17
-msgid "zkSnark space warfare (v0.4)"
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:21
-#: lib/block_scout_web/templates/address/overview.html.eex:25
+#: lib/block_scout_web/templates/address/_custom_view_df_title.html.eex:9
+#: lib/block_scout_web/templates/address/_custom_view_df_title.html.eex:13
 msgid "Play"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:105
-#: lib/block_scout_web/templates/address_contract/index.html.eex:115
+#: lib/block_scout_web/templates/address_contract/index.html.eex:106
+#: lib/block_scout_web/templates/address_contract/index.html.eex:116
 msgid "Copy Byte Code"
 msgstr ""
 
@@ -2661,4 +2650,10 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:149
 msgid "Stakes"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/block_scout_web/templates/address_contract/index.html.eex:14
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:5
+msgid "Contract is not verified. However, we found a verified contract with the same bytecode in Blockscout DB"
 msgstr ""


### PR DESCRIPTION
## Motivation

- DarkForest theme is not intended to be applied to token's instance page
- Support (0.4, 0.5) versions of DarkForest

## Changelog

![Screenshot 2020-12-28 at 16 41 27](https://user-images.githubusercontent.com/4341812/103218242-93619780-492b-11eb-88f3-6228e4b9a96d.png)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
