### PR TITLE
Staking dapp stats: total number of delegators, total staked amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3541](https://github.com/poanetwork/blockscout/pull/3541) - Staking dapp stats: total number of delegators, total staked amount 
 - [#3540](https://github.com/poanetwork/blockscout/pull/3540) - Apply DarkForest custom theme to NFT instances
 
 ### Fixes

--- a/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
+++ b/apps/block_scout_web/assets/css/components/stakes/_stakes.scss
@@ -189,3 +189,11 @@ $stakes-stats-item-border-color: #fff !default;
     padding-top: 30px;
   }
 }
+
+.stake-stats-container {
+  @include media-breakpoint-up(lg) {
+    margin-bottom: -30px;
+  }
+  margin-top: 10px;
+  font-size: 12px;
+}

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_title.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_title.html.eex
@@ -1,5 +1,14 @@
 <div class="card-title-container">
-  <div class="card-title"><%= @title %></div>
+  <div class="card-title">
+    <%= @title %>
+    <%= if @is_validator do%>
+      <div class="stake-stats-container">
+        <span><b><%= Chain.staking_pools_count(:validator) %></b> validator pools</span>
+        <span> and <b><%= Chain.delegators_count_sum(:validator) %></b> delegators</span>
+        <span> staking a total of <b><%= format_token_amount(Chain.total_staked_amount_sum(:validator), @token, digits: 0, ellipsize: false, symbol: false) %></b> STAKE</span>
+      </div>
+    <% end %>
+  </div>
   <div class="card-title-controls">
     <%= if @show_banned_checkbox do %>
       <div class="check card-title-control">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/index.html.eex
@@ -9,7 +9,9 @@
       render BlockScoutWeb.StakesView,
       "_stakes_title.html",
       title: list_title(@pools_type),
-      show_banned_checkbox: @pools_type == :inactive
+      token: @token,
+      show_banned_checkbox: @pools_type == :inactive,
+      is_validator: @pools_type == :validator
     %>
 
     <div class="card-title-paging">

--- a/apps/block_scout_web/lib/block_scout_web/views/stakes_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/stakes_view.ex
@@ -1,6 +1,7 @@
 defmodule BlockScoutWeb.StakesView do
   use BlockScoutWeb, :view
   import BlockScoutWeb.StakesHelpers
+  alias Explorer.Chain
 
   def render("styles.html", _) do
     ~E(<link rel="stylesheet" href="/css/stakes.css">)

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -2342,12 +2342,12 @@ msgid "Share of Pool’s Reward"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_title.html.eex:8
+#: lib/block_scout_web/templates/stakes/_stakes_title.html.eex:17
 msgid "Show banned only"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_title.html.eex:14
+#: lib/block_scout_web/templates/stakes/_stakes_title.html.eex:23
 msgid "Show only those I have stake in"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -2342,12 +2342,12 @@ msgid "Share of Pool’s Reward"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_title.html.eex:8
+#: lib/block_scout_web/templates/stakes/_stakes_title.html.eex:17
 msgid "Show banned only"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_title.html.eex:14
+#: lib/block_scout_web/templates/stakes/_stakes_title.html.eex:23
 msgid "Show only those I have stake in"
 msgstr ""
 
@@ -2652,7 +2652,7 @@ msgstr ""
 msgid "Stakes"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/block_scout_web/templates/address_contract/index.html.eex:14
 #: lib/block_scout_web/templates/smart_contract/_functions.html.eex:5
 msgid "Contract is not verified. However, we found a verified contract with the same bytecode in Blockscout DB"

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4936,6 +4936,24 @@ defmodule Explorer.Chain do
     |> Repo.aggregate(:count, :staking_address_hash)
   end
 
+  @doc "Get sum of delegators count from the DB"
+  @spec delegators_count_sum(filter :: :validator | :active | :inactive) :: integer
+  def delegators_count_sum(filter) do
+    StakingPool
+    |> where(is_deleted: false)
+    |> staking_pool_filter(filter)
+    |> Repo.aggregate(:sum, :delegators_count)
+  end
+
+  @doc "Get sum of total staked amount from the DB"
+  @spec total_staked_amount_sum(filter :: :validator | :active | :inactive) :: integer
+  def total_staked_amount_sum(filter) do
+    StakingPool
+    |> where(is_deleted: false)
+    |> staking_pool_filter(filter)
+    |> Repo.aggregate(:sum, :total_staked_amount)
+  end
+
   defp staking_pool_filter(query, :validator) do
     where(query, is_validator: true)
   end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -5117,6 +5117,60 @@ defmodule Explorer.ChainTest do
     end
   end
 
+  describe "delegators_count_sum/1" do
+    test "validators pools" do
+      insert(:staking_pool, is_active: true, is_validator: true, delegators_count: 10)
+      insert(:staking_pool, is_active: true, is_validator: false, delegators_count: 7)
+      insert(:staking_pool, is_active: true, is_validator: true, delegators_count: 5)
+
+      assert Chain.delegators_count_sum(:validator) == 15
+    end
+
+    test "active staking pools" do
+      insert(:staking_pool, is_active: true, delegators_count: 10)
+      insert(:staking_pool, is_active: true, delegators_count: 7)
+      insert(:staking_pool, is_active: false, delegators_count: 5)
+
+      assert Chain.delegators_count_sum(:active) == 17
+    end
+
+    test "inactive staking pools" do
+      insert(:staking_pool, is_active: true, delegators_count: 10)
+      insert(:staking_pool, is_active: true, delegators_count: 7)
+      insert(:staking_pool, is_active: false, delegators_count: 5)
+      insert(:staking_pool, is_active: false, delegators_count: 1)
+
+      assert Chain.delegators_count_sum(:inactive) == 6
+    end
+  end
+
+  describe "total_staked_amount_sum/1" do
+    test "validators pools" do
+      insert(:staking_pool, is_active: true, is_validator: true, total_staked_amount: 10)
+      insert(:staking_pool, is_active: true, is_validator: false, total_staked_amount: 7)
+      insert(:staking_pool, is_active: true, is_validator: true, total_staked_amount: 5)
+
+      assert Chain.total_staked_amount_sum(:validator) == Decimal.new("15")
+    end
+
+    test "active staking pools" do
+      insert(:staking_pool, is_active: true, total_staked_amount: 10)
+      insert(:staking_pool, is_active: true, total_staked_amount: 7)
+      insert(:staking_pool, is_active: false, total_staked_amount: 5)
+
+      assert Chain.total_staked_amount_sum(:active) == Decimal.new("17")
+    end
+
+    test "inactive staking pools" do
+      insert(:staking_pool, is_active: true, total_staked_amount: 10)
+      insert(:staking_pool, is_active: true, total_staked_amount: 7)
+      insert(:staking_pool, is_active: false, total_staked_amount: 5)
+      insert(:staking_pool, is_active: false, total_staked_amount: 1)
+
+      assert Chain.total_staked_amount_sum(:inactive) == Decimal.new("6")
+    end
+  end
+
   describe "extract_db_name/1" do
     test "extracts correct db name" do
       db_url = "postgresql://viktor:@localhost:5432/blockscout-dev-1"


### PR DESCRIPTION
## Motivation

Display total number of delegators and total staked amount in Staking dApp

## Changelog

![Screenshot 2020-12-29 at 19 02 10](https://user-images.githubusercontent.com/4341812/103297757-06d9d680-4a0a-11eb-9a35-804e3c739248.png)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
