### PR TITLE
Fix contract's method's output of tuple type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#3540](https://github.com/poanetwork/blockscout/pull/3540) - Apply DarkForest custom theme to NFT instances
 
 ### Fixes
+- [#3551](https://github.com/poanetwork/blockscout/pull/3551) - Fix contract's method's output of tuple type
 
 ### Chore
 - [#3540](https://github.com/poanetwork/blockscout/pull/3540), [#3545](https://github.com/poanetwork/blockscout/pull/3545) - Support different versions of DarkForest (0.4 - 0.5)

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -48,10 +48,14 @@ defmodule BlockScoutWeb.SmartContractView do
   end
 
   def values(values, type) when is_list(values) and type == "tuple[]" do
-    array_from_tuple = tupple_to_array(values)
+    array_from_tuple = tuple_array_to_array(values)
 
     array_from_tuple
     |> Enum.join(", ")
+  end
+
+  def values(value, _type) when is_tuple(value) do
+    tuple_to_array(value)
   end
 
   def values(value, type) when type in ["address", "address payable"] do
@@ -62,14 +66,18 @@ defmodule BlockScoutWeb.SmartContractView do
   def values(values, _) when is_list(values), do: Enum.join(values, ",")
   def values(value, _), do: value
 
-  defp tupple_to_array(values) do
+  defp tuple_array_to_array(values) do
     values
     |> Enum.map(fn value ->
-      value
-      |> Tuple.to_list()
-      |> Enum.map(&binary_to_utf_string(&1))
-      |> Enum.join(",")
+      tuple_to_array(value)
     end)
+  end
+
+  defp tuple_to_array(value) do
+    value
+    |> Tuple.to_list()
+    |> Enum.map(&binary_to_utf_string(&1))
+    |> Enum.join(",")
   end
 
   defp binary_to_utf_string(item) do


### PR DESCRIPTION
## Motivation

Method `getArtifact ` of DarkForest NFT contract returns internal server error:
```
2021-01-04T11:19:45.103 [error] #PID<0.1431.0> running BlockScoutWeb.Endpoint (connection #PID<0.1248.0>, stream id 10) terminated
Server: localhost:4000 (http)
Request: GET /smart-contracts/0x5cFbC3e179C48ccB3B3d35bAD6361972F2C5603B?function_name=getArtifact&method_id=8465ad44&args%5B%5D=80655615332912814281286268613438042255103875506825830758019774624527142298860
** (exit) an exception was raised:
    ** (Protocol.UndefinedError) protocol Phoenix.HTML.Safe not implemented for {80655615332912814281286268613438042255103875506825830758019774624527142298860, 996040386519514455547369964248641440971718171905442664266757499782684832, 2, 1, 1609747540, <<101, 112, 77, 187, 192, 10, 168, 130, 225, 223, 247, 185, 210, 111, 250, 61, 131, 95, 42, 109>>, 1} of type Tuple. This protocol is implemented for the following type(s): Explorer.Chain.Address, Explorer.Chain.Transaction, Explorer.Chain.Data, Explorer.Chain.Block, Explorer.Chain.Hash, Decimal, Time, Integer, Tuple, List, DateTime, NaiveDateTime, Float, Atom, Phoenix.HTML.Form, BitString, Date
        (phoenix_html 2.14.2) lib/phoenix_html/safe.ex:99: Phoenix.HTML.Safe.Tuple.to_iodata/1
        (block_scout_web 0.0.1) lib/block_scout_web/templates/smart_contract/_function_response.html.eex:8: anonymous fn/2 in BlockScoutWeb.SmartContractView."_function_response.html"/1
        (elixir 1.11.2) lib/enum.ex:2181: Enum."-reduce/3-lists^foldl/2-0-"/3
        (block_scout_web 0.0.1) lib/block_scout_web/templates/smart_contract/_function_response.html.eex:5: BlockScoutWeb.SmartContractView."_function_response.html"/1
        (phoenix 1.5.6) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.6) lib/phoenix/controller.ex:776: Phoenix.Controller.render_and_send/4
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/smart_contract_controller.ex:1: BlockScoutWeb.SmartContractController.action/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/smart_contract_controller.ex:1: BlockScoutWeb.SmartContractController.phoenix_controller_pipeline/2
        (phoenix 1.5.6) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (phoenix 1.5.6) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
        (phoenix 1.5.6) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (block_scout_web 0.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.plug_builder_call/2
        (block_scout_web 0.0.1) lib/plug/debugger.ex:132: BlockScoutWeb.Endpoint."call (overridable 3)"/2
        (block_scout_web 0.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint."call (overridable 4)"/2
        (block_scout_web 0.0.1) lib/spandex_phoenix.ex:156: BlockScoutWeb.Endpoint.call/2
        (phoenix 1.5.6) lib/phoenix/endpoint/cowboy2_handler.ex:65: Phoenix.Endpoint.Cowboy2Handler.init/4
        (cowboy 2.8.0) /Users/viktor/Documents/POANetwork/blockscout/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
        (cowboy 2.8.0) /Users/viktor/Documents/POANetwork/blockscout/deps/cowboy/src/cowboy_stream_h.erl:300: :cowboy_stream_h.execute/3
        (cowboy 2.8.0) /Users/viktor/Documents/POANetwork/blockscout/deps/cowboy/src/cowboy_stream_h.erl:291: :cowboy_stream_h.request_process/3
        (stdlib 3.13.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
