### PR TITLE
Do not hide filter at transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 - [#3551](https://github.com/poanetwork/blockscout/pull/3551) - Fix contract's method's output of tuple type
+- [#3559](https://github.com/poanetwork/blockscout/pull/3559) - Do not hide filter at address/transactions.
 
 ### Chore
 - [#3557](https://github.com/poanetwork/blockscout/pull/3557) - Single Staking menu

--- a/apps/block_scout_web/assets/js/pages/address/internal_transactions.js
+++ b/apps/block_scout_web/assets/js/pages/address/internal_transactions.js
@@ -75,15 +75,6 @@ const elements = {
       $channelBatching.show()
       $el[0].innerHTML = numeral(state.internalTransactionsBatch.length).format()
     }
-  },
-  '[data-test="filter_dropdown"]': {
-    render ($el, state) {
-      if (state.emptyResponse && !state.isSearch) {
-        return $el.hide()
-      }
-
-      return $el.show()
-    }
   }
 }
 

--- a/apps/block_scout_web/assets/js/pages/address/transactions.js
+++ b/apps/block_scout_web/assets/js/pages/address/transactions.js
@@ -50,15 +50,6 @@ const elements = {
     render ($el, state) {
       if (state.channelDisconnected) $el.show()
     }
-  },
-  '[data-test="filter_dropdown"]': {
-    render ($el, state) {
-      if (state.emptyResponse && !state.isSearch) {
-        return $el.hide()
-      }
-
-      return $el.show()
-    }
   }
 }
 


### PR DESCRIPTION
## Motivation
At transactions, the filter is hidden if there is no result for the filter. This forces the user to reload the page if he wants to see all transactions.
How to reproduce:
1. Go to transactions
![image](https://user-images.githubusercontent.com/12897448/104035306-46ef4500-51d2-11eb-8366-66f6ee10108c.png)
2. Select "To" on an account that has no "To" transactions.
![image](https://user-images.githubusercontent.com/12897448/104035416-638b7d00-51d2-11eb-9c51-e90c115c6759.png)
3. Now I am forced to refresh the page

The ideal solution would be that to only hide the filter if it was "All" otherwise show it, but until someone implements that I think this change is an improvement.

## Checklist for your Pull Request (PR)
  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools

### Reasons for missing checkmarks:
This is a trivial change and I am not sure you will accept it. I will write tests and read the docs if you are satisfied with my approach.