### PR TITLE
Staking dapp: unhealthy state message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixes
 
 ### Chore
+- [#3565](https://github.com/poanetwork/blockscout/pull/3565) - Staking dapp: unhealthy state alert message
 
 
 ## 3.5.1-beta

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -48,7 +48,8 @@ export const initialState = {
   tokenSymbol: '',
   validatorSetApplyBlock: 0,
   validatorSetContract: null,
-  web3: null
+  web3: null,
+  stakingErrorShown: false
 }
 
 // 100 - id of xDai network, 101 - id of xDai test network
@@ -128,6 +129,11 @@ export function reducer (state = initialState, action) {
         })
       }
       return state
+    }
+    case 'UNHEALTHY_APP_ERROR_SHOWN': {
+      return Object.assign({}, state, {
+        stakingErrorShown: true
+      })
     }
     default:
       return state
@@ -213,6 +219,11 @@ if ($stakesPage.length) {
         await reloadPoolList(msg, store)
       }
     })
+
+    if (msg.epoch_end_block === 0 && !state.stakingErrorShown) {
+      openErrorModal('Staking DApp is currently unavailable', 'Not all functions are active at the moment. Please try again later.')
+      store.dispatch({ type: 'UNHEALTHY_APP_ERROR_SHOWN' })
+    }
 
     updating = false
   }

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -72,6 +72,7 @@ defmodule BlockScoutWeb.StakesChannel do
           %{
             block_number: BlockNumber.get_max(),
             epoch_number: ContractState.get(:epoch_number, 0),
+            epoch_end_block: ContractState.get(:epoch_end_block, 0),
             staking_allowed: ContractState.get(:staking_allowed, false),
             staking_token_defined: ContractState.get(:token, nil) != nil,
             validator_set_apply_block: ContractState.get(:validator_set_apply_block, 0)
@@ -423,11 +424,14 @@ defmodule BlockScoutWeb.StakesChannel do
         assign(socket, :staking_update_data, data)
       end
 
+    epoch_end_block = if Map.has_key?(data, :epoch_end_block), do: data.epoch_end_block, else: 0
+
     push(socket, "staking_update", %{
       account: socket.assigns[:account],
       block_number: data.block_number,
       by_set_account: by_set_account,
       epoch_number: data.epoch_number,
+      epoch_end_block: epoch_end_block,
       staking_allowed: data.staking_allowed,
       staking_token_defined: data.staking_token_defined,
       validator_set_apply_block: data.validator_set_apply_block,

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -2211,7 +2211,7 @@ msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:698
+#: lib/block_scout_web/channels/stakes_channel.ex:702
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2286,7 +2286,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:754
+#: lib/block_scout_web/channels/stakes_channel.ex:758
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2319,7 +2319,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:795
+#: lib/block_scout_web/channels/stakes_channel.ex:799
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:798
+#: lib/block_scout_web/channels/stakes_channel.ex:802
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2494,19 +2494,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:761
-#: lib/block_scout_web/channels/stakes_channel.ex:808
+#: lib/block_scout_web/channels/stakes_channel.ex:765
+#: lib/block_scout_web/channels/stakes_channel.ex:812
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:801
+#: lib/block_scout_web/channels/stakes_channel.ex:805
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:757
-#: lib/block_scout_web/channels/stakes_channel.ex:804
+#: lib/block_scout_web/channels/stakes_channel.ex:761
+#: lib/block_scout_web/channels/stakes_channel.ex:808
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -2211,7 +2211,7 @@ msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:698
+#: lib/block_scout_web/channels/stakes_channel.ex:702
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2286,7 +2286,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:754
+#: lib/block_scout_web/channels/stakes_channel.ex:758
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2319,7 +2319,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:795
+#: lib/block_scout_web/channels/stakes_channel.ex:799
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:798
+#: lib/block_scout_web/channels/stakes_channel.ex:802
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2494,19 +2494,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:761
-#: lib/block_scout_web/channels/stakes_channel.ex:808
+#: lib/block_scout_web/channels/stakes_channel.ex:765
+#: lib/block_scout_web/channels/stakes_channel.ex:812
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:801
+#: lib/block_scout_web/channels/stakes_channel.ex:805
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:757
-#: lib/block_scout_web/channels/stakes_channel.ex:804
+#: lib/block_scout_web/channels/stakes_channel.ex:761
+#: lib/block_scout_web/channels/stakes_channel.ex:808
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 


### PR DESCRIPTION
## Motivation

Display error if staking dapp is unhealthy (including a partial case of archive node is unhealthy).

## Changelog

Display error message if epoch_end_block is equal to 0.

![Screenshot 2021-01-14 at 12 09 03](https://user-images.githubusercontent.com/4341812/104568599-57377200-5661-11eb-8fad-a65c15e33143.png)



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
