### PR TITLE
Force to show filter at the page where filtered items list is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixes
 
 ### Chore
+- [#3567](https://github.com/poanetwork/blockscout/pull/3567) - Force to show filter at the page where filtered items list is empty
 - [#3565](https://github.com/poanetwork/blockscout/pull/3565) - Staking dapp: unhealthy state alert message
 
 

--- a/apps/block_scout_web/assets/css/components/_btn_dropdown_line.scss
+++ b/apps/block_scout_web/assets/css/components/_btn_dropdown_line.scss
@@ -9,6 +9,9 @@ $btn-dropdown-line-font: #333;
   color: $btn-dropdown-line-font;
   outline: none !important;
   margin-right: 20px;
+  &.no-rm {
+    margin-right: 0;
+  }
 
   &:hover {
     background-color: $btn-dropdown-line-color-hover;

--- a/apps/block_scout_web/assets/js/lib/async_listing_load.js
+++ b/apps/block_scout_web/assets/js/lib/async_listing_load.js
@@ -255,6 +255,15 @@ export const elements = {
       $el.hide()
     }
   },
+  '[data-async-listing] [data-pagination-container]': {
+    render ($el, state) {
+      if (state.emptyResponse) {
+        return $el.hide()
+      }
+
+      $el.show()
+    }
+  },
   '[csv-download]': {
     render ($el, state) {
       if (state.emptyResponse) {

--- a/apps/block_scout_web/assets/js/pages/address/internal_transactions.js
+++ b/apps/block_scout_web/assets/js/pages/address/internal_transactions.js
@@ -7,6 +7,7 @@ import { batchChannel } from '../../lib/utils'
 import { connectElements } from '../../lib/redux_helpers.js'
 import { createAsyncLoadStore } from '../../lib/async_listing_load'
 import '../address'
+import { isFiltered } from './utils'
 
 const BATCH_THRESHOLD = 10
 
@@ -79,7 +80,13 @@ const elements = {
   '[data-test="filter_dropdown"]': {
     render ($el, state) {
       if (state.emptyResponse && !state.isSearch) {
-        return $el.hide()
+        if (isFiltered(state.filter)) {
+          $el.addClass('no-rm')
+        } else {
+          return $el.hide()
+        }
+      } else {
+        $el.removeClass('no-rm')
       }
 
       return $el.show()

--- a/apps/block_scout_web/assets/js/pages/address/token_transfers.js
+++ b/apps/block_scout_web/assets/js/pages/address/token_transfers.js
@@ -6,6 +6,7 @@ import { subscribeChannel } from '../../socket'
 import { connectElements } from '../../lib/redux_helpers.js'
 import { createAsyncLoadStore } from '../../lib/async_listing_load'
 import '../address'
+import { isFiltered } from './utils'
 
 export const initialState = {
   addressHash: null,
@@ -54,7 +55,13 @@ const elements = {
   '[data-test="filter_dropdown"]': {
     render ($el, state) {
       if (state.emptyResponse && !state.isSearch) {
-        return $el.hide()
+        if (isFiltered(state.filter)) {
+          $el.addClass('no-rm')
+        } else {
+          return $el.hide()
+        }
+      } else {
+        $el.removeClass('no-rm')
       }
 
       return $el.show()

--- a/apps/block_scout_web/assets/js/pages/address/transactions.js
+++ b/apps/block_scout_web/assets/js/pages/address/transactions.js
@@ -6,6 +6,7 @@ import { subscribeChannel } from '../../socket'
 import { connectElements } from '../../lib/redux_helpers.js'
 import { createAsyncLoadStore } from '../../lib/async_listing_load'
 import '../address'
+import { isFiltered } from './utils'
 
 export const initialState = {
   addressHash: null,
@@ -54,7 +55,13 @@ const elements = {
   '[data-test="filter_dropdown"]': {
     render ($el, state) {
       if (state.emptyResponse && !state.isSearch) {
-        return $el.hide()
+        if (isFiltered(state.filter)) {
+          $el.addClass('no-rm')
+        } else {
+          return $el.hide()
+        }
+      } else {
+        $el.removeClass('no-rm')
       }
 
       return $el.show()

--- a/apps/block_scout_web/assets/js/pages/address/utils.js
+++ b/apps/block_scout_web/assets/js/pages/address/utils.js
@@ -1,0 +1,5 @@
+function isFiltered (filter) {
+  return (filter === 'to' || filter === 'from')
+}
+
+export { isFiltered }

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_pagination_container.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_pagination_container.html.eex
@@ -1,4 +1,6 @@
-<div class='pagination-container <%= if assigns[:position] == "top" do %>position-top<% end %> <%= if assigns[:position] == "bottom" do %>position-bottom<% end %>'>
+<div 
+class='pagination-container <%= if assigns[:position] == "top" do %>position-top<% end %> <%= if assigns[:position] == "bottom" do %>position-bottom<% end %>'
+data-pagination-container>
     <%= if false do %>
     <!-- Pagination limit -->
     <div class="pagination-limit">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1133,7 +1133,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:39
+#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:41
 msgid "Page"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:11
+#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:13
 msgid "Records"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:5
+#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:7
 msgid "Show"
 msgstr ""
 
@@ -1691,7 +1691,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:39
+#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:41
 msgid "of"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1133,7 +1133,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:39
+#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:41
 msgid "Page"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:11
+#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:13
 msgid "Records"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:5
+#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:7
 msgid "Show"
 msgstr ""
 
@@ -1691,7 +1691,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:39
+#: lib/block_scout_web/templates/common_components/_pagination_container.html.eex:41
 msgid "of"
 msgstr ""
 


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/pull/3559

## Motivation

Force to show a filter at filtered items list page if the items list is empty. It improves UX: users don't need anymore to refresh the page in order to see all items.

## Changelog

![Screenshot 2021-01-14 at 13 25 54](https://user-images.githubusercontent.com/4341812/104578695-155ff900-566c-11eb-8c56-6f25a9881db8.png)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
