### PR TITLE
Allow re-define cache period vars at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Chore
 - [#3585](https://github.com/poanetwork/blockscout/pull/3585) - Add autoswitching from eth_subscribe to eth_blockNumber in Staking DApp
 - [#3574](https://github.com/poanetwork/blockscout/pull/3574) - Correct UNI token price
+- [#3569](https://github.com/poanetwork/blockscout/pull/3569) - Allow re-define cache period vars at runtime
 - [#3567](https://github.com/poanetwork/blockscout/pull/3567) - Force to show filter at the page where filtered items list is empty
 - [#3565](https://github.com/poanetwork/blockscout/pull/3565) - Staking dapp: unhealthy state alert message
 

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -23,15 +23,7 @@ config :explorer,
       else: Explorer.Chain.Events.DBSender
     )
 
-average_block_period =
-  case Integer.parse(System.get_env("AVERAGE_BLOCK_CACHE_PERIOD", "")) do
-    {secs, ""} -> :timer.seconds(secs)
-    _ -> :timer.minutes(30)
-  end
-
-config :explorer, Explorer.Counters.AverageBlockTime,
-  enabled: true,
-  period: average_block_period
+config :explorer, Explorer.Counters.AverageBlockTime, enabled: true
 
 config :explorer, Explorer.Chain.Events.Listener,
   enabled:
@@ -88,71 +80,29 @@ config :explorer, Explorer.Counters.AddressesCounter,
   enable_consolidation: true,
   update_interval_in_seconds: balances_update_interval || 30 * 60
 
-address_transactions_counter_cache_period =
-  case Integer.parse(System.get_env("ADDRESS_TRANSACTIONS_COUNTER_CACHE_PERIOD", "")) do
-    {secs, ""} -> :timer.seconds(secs)
-    _ -> :timer.hours(1)
-  end
-
-address_transactions_gas_usage_counter_cache_period =
-  case Integer.parse(System.get_env("ADDRESS_TRANSACTIONS_GAS_USAGE_COUNTER_CACHE_PERIOD", "")) do
-    {secs, ""} -> :timer.seconds(secs)
-    _ -> :timer.hours(1)
-  end
-
 config :explorer, Explorer.Counters.AddressTransactionsGasUsageCounter,
   enabled: true,
-  enable_consolidation: true,
-  period: address_transactions_gas_usage_counter_cache_period
-
-address_tokens_usd_sum_cache_period =
-  case Integer.parse(System.get_env("ADDRESS_TOKENS_USD_SUM_CACHE_PERIOD", "")) do
-    {secs, ""} -> :timer.seconds(secs)
-    _ -> :timer.hours(1)
-  end
+  enable_consolidation: true
 
 config :explorer, Explorer.Counters.AddressTokenUsdSum,
   enabled: true,
-  enable_consolidation: true,
-  period: address_tokens_usd_sum_cache_period
-
-token_exchange_rate_cache_period =
-  case Integer.parse(System.get_env("TOKEN_EXCHANGE_RATE_CACHE_PERIOD", "")) do
-    {secs, ""} -> :timer.seconds(secs)
-    _ -> :timer.hours(1)
-  end
+  enable_consolidation: true
 
 config :explorer, Explorer.Chain.Cache.TokenExchangeRate,
   enabled: true,
-  enable_consolidation: true,
-  period: token_exchange_rate_cache_period
-
-token_holders_counter_cache_period =
-  case Integer.parse(System.get_env("TOKEN_HOLDERS_COUNTER_CACHE_PERIOD", "")) do
-    {secs, ""} -> :timer.seconds(secs)
-    _ -> :timer.hours(1)
-  end
+  enable_consolidation: true
 
 config :explorer, Explorer.Counters.TokenHoldersCounter,
   enabled: true,
-  enable_consolidation: true,
-  period: token_holders_counter_cache_period
-
-token_transfers_counter_cache_period =
-  case Integer.parse(System.get_env("TOKEN_TRANSFERS_COUNTER_CACHE_PERIOD", "")) do
-    {secs, ""} -> :timer.seconds(secs)
-    _ -> :timer.hours(1)
-  end
+  enable_consolidation: true
 
 config :explorer, Explorer.Counters.TokenTransfersCounter,
   enabled: true,
-  enable_consolidation: true,
-  period: token_transfers_counter_cache_period
+  enable_consolidation: true
 
 config :explorer, Explorer.Counters.AddressTransactionsCounter,
   enabled: true,
-  enable_consolidation: true,
-  period: address_transactions_counter_cache_period
+  enable_consolidation: true
 
 bridge_market_cap_update_interval =
   if System.get_env("BRIDGE_MARKET_CAP_UPDATE_INTERVAL") do
@@ -262,14 +212,6 @@ config :spandex_ecto, SpandexEcto.EctoLogger,
   service: :ecto,
   tracer: Explorer.Tracer,
   otp_app: :explorer
-
-market_history_cache_period =
-  case Integer.parse(System.get_env("MARKET_HISTORY_CACHE_PERIOD", "")) do
-    {secs, ""} -> :timer.seconds(secs)
-    _ -> :timer.hours(6)
-  end
-
-config :explorer, Explorer.Market.MarketHistoryCache, period: market_history_cache_period
 
 config :explorer, Explorer.Chain.Cache.Blocks,
   ttl_check_interval: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(1), else: false),

--- a/apps/explorer/lib/explorer/chain/cache/token_exchange_rate.ex
+++ b/apps/explorer/lib/explorer/chain/cache/token_exchange_rate.ex
@@ -8,7 +8,6 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
 
   @cache_name :token_exchange_rate
   @last_update_key "last_update"
-  @cache_period Application.compile_env(:explorer, __MODULE__)[:period]
 
   @ets_opts [
     :set,
@@ -64,11 +63,12 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
   def cache_name, do: @cache_name
 
   defp cache_expired?(symbol) do
+    cache_period = token_exchange_rate_cache_period()
     updated_at = fetch_from_cache("#{cache_key(symbol)}_#{@last_update_key}")
 
     cond do
       is_nil(updated_at) -> true
-      current_time() - updated_at > @cache_period -> true
+      current_time() - updated_at > cache_period -> true
       true -> false
     end
   end
@@ -129,4 +129,11 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
   end
 
   def enable_consolidation?, do: @enable_consolidation
+
+  defp token_exchange_rate_cache_period do
+    case Integer.parse(System.get_env("TOKEN_EXCHANGE_RATE_CACHE_PERIOD", "")) do
+      {secs, ""} -> :timer.seconds(secs)
+      _ -> :timer.hours(1)
+    end
+  end
 end

--- a/apps/explorer/lib/explorer/counters/address_gas_usage_counter.ex
+++ b/apps/explorer/lib/explorer/counters/address_gas_usage_counter.ex
@@ -8,7 +8,6 @@ defmodule Explorer.Counters.AddressTransactionsGasUsageCounter do
 
   @cache_name :address_transactions_gas_usage_counter
   @last_update_key "last_update"
-  @cache_period Application.compile_env(:explorer, __MODULE__)[:period]
 
   @ets_opts [
     :set,
@@ -61,12 +60,13 @@ defmodule Explorer.Counters.AddressTransactionsGasUsageCounter do
   def cache_name, do: @cache_name
 
   defp cache_expired?(address) do
+    cache_period = address_transactions_gas_usage_counter_cache_period()
     address_hash_string = get_address_hash_string(address)
     updated_at = fetch_from_cache("hash_#{address_hash_string}_#{@last_update_key}")
 
     cond do
       is_nil(updated_at) -> true
-      current_time() - updated_at > @cache_period -> true
+      current_time() - updated_at > cache_period -> true
       true -> false
     end
   end
@@ -109,4 +109,11 @@ defmodule Explorer.Counters.AddressTransactionsGasUsageCounter do
   end
 
   def enable_consolidation?, do: @enable_consolidation
+
+  defp address_transactions_gas_usage_counter_cache_period do
+    case Integer.parse(System.get_env("ADDRESS_TRANSACTIONS_GAS_USAGE_COUNTER_CACHE_PERIOD", "")) do
+      {secs, ""} -> :timer.seconds(secs)
+      _ -> :timer.hours(1)
+    end
+  end
 end

--- a/apps/explorer/lib/explorer/counters/address_tokens_usd_sum.ex
+++ b/apps/explorer/lib/explorer/counters/address_tokens_usd_sum.ex
@@ -8,7 +8,6 @@ defmodule Explorer.Counters.AddressTokenUsdSum do
 
   @cache_name :address_tokens_usd_value
   @last_update_key "last_update"
-  @cache_period Application.compile_env(:explorer, __MODULE__)[:period]
 
   @ets_opts [
     :set,
@@ -61,12 +60,13 @@ defmodule Explorer.Counters.AddressTokenUsdSum do
   def cache_name, do: @cache_name
 
   defp cache_expired?(address_hash) do
+    cache_period = address_tokens_usd_sum_cache_period()
     address_hash_string = get_address_hash_string(address_hash)
     updated_at = fetch_from_cache("hash_#{address_hash_string}_#{@last_update_key}")
 
     cond do
       is_nil(updated_at) -> true
-      current_time() - updated_at > @cache_period -> true
+      current_time() - updated_at > cache_period -> true
       true -> false
     end
   end
@@ -109,4 +109,11 @@ defmodule Explorer.Counters.AddressTokenUsdSum do
   end
 
   def enable_consolidation?, do: @enable_consolidation
+
+  defp address_tokens_usd_sum_cache_period do
+    case Integer.parse(System.get_env("ADDRESS_TOKENS_USD_SUM_CACHE_PERIOD", "")) do
+      {secs, ""} -> :timer.seconds(secs)
+      _ -> :timer.hours(1)
+    end
+  end
 end

--- a/apps/explorer/lib/explorer/counters/address_transactions_counter.ex
+++ b/apps/explorer/lib/explorer/counters/address_transactions_counter.ex
@@ -8,7 +8,6 @@ defmodule Explorer.Counters.AddressTransactionsCounter do
 
   @cache_name :address_transactions_counter
   @last_update_key "last_update"
-  @cache_period Application.compile_env(:explorer, __MODULE__)[:period]
 
   @ets_opts [
     :set,
@@ -61,12 +60,13 @@ defmodule Explorer.Counters.AddressTransactionsCounter do
   def cache_name, do: @cache_name
 
   defp cache_expired?(address) do
+    cache_period = address_transactions_counter_cache_period()
     address_hash_string = get_address_hash_string(address)
     updated_at = fetch_from_cache("hash_#{address_hash_string}_#{@last_update_key}")
 
     cond do
       is_nil(updated_at) -> true
-      current_time() - updated_at > @cache_period -> true
+      current_time() - updated_at > cache_period -> true
       true -> false
     end
   end
@@ -109,4 +109,11 @@ defmodule Explorer.Counters.AddressTransactionsCounter do
   end
 
   def enable_consolidation?, do: @enable_consolidation
+
+  defp address_transactions_counter_cache_period do
+    case Integer.parse(System.get_env("ADDRESS_TRANSACTIONS_COUNTER_CACHE_PERIOD", "")) do
+      {secs, ""} -> :timer.seconds(secs)
+      _ -> :timer.hours(1)
+    end
+  end
 end

--- a/apps/explorer/lib/explorer/counters/average_block_time.ex
+++ b/apps/explorer/lib/explorer/counters/average_block_time.ex
@@ -11,8 +11,6 @@ defmodule Explorer.Counters.AverageBlockTime do
   alias Explorer.Repo
   alias Timex.Duration
 
-  @refresh_period Application.compile_env(:explorer, __MODULE__)[:period]
-
   @doc """
   Starts a process to periodically update the counter of the token holders.
   """
@@ -41,7 +39,8 @@ defmodule Explorer.Counters.AverageBlockTime do
   ## Server
   @impl true
   def init(_) do
-    Process.send_after(self(), :refresh_timestamps, @refresh_period)
+    refresh_period = average_block_cache_period()
+    Process.send_after(self(), :refresh_timestamps, refresh_period)
 
     {:ok, refresh_timestamps()}
   end
@@ -56,7 +55,8 @@ defmodule Explorer.Counters.AverageBlockTime do
 
   @impl true
   def handle_info(:refresh_timestamps, _) do
-    Process.send_after(self(), :refresh_timestamps, @refresh_period)
+    refresh_period = Application.get_env(:explorer, __MODULE__)[:period]
+    Process.send_after(self(), :refresh_timestamps, refresh_period)
 
     {:noreply, refresh_timestamps()}
   end
@@ -127,5 +127,12 @@ defmodule Explorer.Counters.AverageBlockTime do
       end
     end)
     |> elem(0)
+  end
+
+  defp average_block_cache_period do
+    case Integer.parse(System.get_env("AVERAGE_BLOCK_CACHE_PERIOD", "")) do
+      {secs, ""} -> :timer.seconds(secs)
+      _ -> :timer.minutes(30)
+    end
   end
 end

--- a/apps/explorer/lib/explorer/counters/token_holders_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_holders_counter.ex
@@ -8,7 +8,6 @@ defmodule Explorer.Counters.TokenHoldersCounter do
 
   @cache_name :token_holders_counter
   @last_update_key "last_update"
-  @cache_period Application.compile_env(:explorer, __MODULE__)[:period]
 
   @ets_opts [
     :set,
@@ -61,12 +60,13 @@ defmodule Explorer.Counters.TokenHoldersCounter do
   def cache_name, do: @cache_name
 
   defp cache_expired?(address_hash) do
+    cache_period = token_holders_counter_cache_period()
     address_hash_string = get_address_hash_string(address_hash)
     updated_at = fetch_from_cache("hash_#{address_hash_string}_#{@last_update_key}")
 
     cond do
       is_nil(updated_at) -> true
-      current_time() - updated_at > @cache_period -> true
+      current_time() - updated_at > cache_period -> true
       true -> false
     end
   end
@@ -109,4 +109,11 @@ defmodule Explorer.Counters.TokenHoldersCounter do
   end
 
   def enable_consolidation?, do: @enable_consolidation
+
+  defp token_holders_counter_cache_period do
+    case Integer.parse(System.get_env("TOKEN_HOLDERS_COUNTER_CACHE_PERIOD", "")) do
+      {secs, ""} -> :timer.seconds(secs)
+      _ -> :timer.hours(1)
+    end
+  end
 end

--- a/apps/explorer/lib/explorer/counters/token_transfers_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_transfers_counter.ex
@@ -8,7 +8,6 @@ defmodule Explorer.Counters.TokenTransfersCounter do
 
   @cache_name :token_holders_counter
   @last_update_key "last_update"
-  @cache_period Application.compile_env(:explorer, __MODULE__)[:period]
 
   @ets_opts [
     :set,
@@ -61,12 +60,13 @@ defmodule Explorer.Counters.TokenTransfersCounter do
   def cache_name, do: @cache_name
 
   defp cache_expired?(address_hash) do
+    cache_period = token_transfers_counter_cache_period()
     address_hash_string = get_address_hash_string(address_hash)
     updated_at = fetch_from_cache("hash_#{address_hash_string}_#{@last_update_key}")
 
     cond do
       is_nil(updated_at) -> true
-      current_time() - updated_at > @cache_period -> true
+      current_time() - updated_at > cache_period -> true
       true -> false
     end
   end
@@ -109,4 +109,11 @@ defmodule Explorer.Counters.TokenTransfersCounter do
   end
 
   def enable_consolidation?, do: @enable_consolidation
+
+  defp token_transfers_counter_cache_period do
+    case Integer.parse(System.get_env("TOKEN_TRANSFERS_COUNTER_CACHE_PERIOD", "")) do
+      {secs, ""} -> :timer.seconds(secs)
+      _ -> :timer.hours(1)
+    end
+  end
 end

--- a/apps/explorer/lib/explorer/market/market_history_cache.ex
+++ b/apps/explorer/lib/explorer/market/market_history_cache.ex
@@ -12,7 +12,6 @@ defmodule Explorer.Market.MarketHistoryCache do
   @last_update_key :last_update
   @history_key :history
   # 6 hours
-  @cache_period Application.compile_env(:explorer, __MODULE__)[:period]
   @recent_days 30
 
   def fetch do
@@ -32,11 +31,12 @@ defmodule Explorer.Market.MarketHistoryCache do
   def recent_days_count, do: @recent_days
 
   defp cache_expired? do
+    cache_period = market_history_cache_period()
     updated_at = fetch_from_cache(@last_update_key)
 
     cond do
       is_nil(updated_at) -> true
-      current_time() - updated_at > @cache_period -> true
+      current_time() - updated_at > cache_period -> true
       true -> false
     end
   end
@@ -75,5 +75,12 @@ defmodule Explorer.Market.MarketHistoryCache do
     utc_now = DateTime.utc_now()
 
     DateTime.to_unix(utc_now, :millisecond)
+  end
+
+  defp market_history_cache_period do
+    case Integer.parse(System.get_env("MARKET_HISTORY_CACHE_PERIOD", "")) do
+      {secs, ""} -> :timer.seconds(secs)
+      _ -> :timer.hours(6)
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/poanetwork/blockscout/issues/3544

## Motivation

Currently, the application should be recompiled after changing ETS cache period variables for various of caching processes.

```
    ADDRESS_TOKENS_USD_SUM_CACHE_PERIOD = "31536000" // seconds: 1y (def 1h)
    ADDRESS_TRANSACTIONS_COUNTER_CACHE_PERIOD = "31536000" // seconds: 1y (def 1h)
    ADDRESS_TRANSACTIONS_GAS_USAGE_COUNTER_CACHE_PERIOD = "31536000" // seconds: 1y (def 1h)
    MARKET_HISTORY_CACHE_PERIOD = "31536000" // seconds: 1y (def 1h)
    TOKEN_EXCHANGE_RATE_CACHE_PERIOD = "31536000" // seconds: 1y (def 1h)
    TOKEN_TRANSFERS_COUNTER_CACHE_PERIOD = "31536000" // seconds: 1y (def 1h)
    TOKEN_HOLDERS_COUNTER_CACHE_PERIOD = "31536000" // seconds: 1y (def 1h)
    AVERAGE_BLOCK_CACHE_PERIOD (def 30min)
```

## Changelog

Allow redefining ETS cache period variables at runtime


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
