### PR TITLE
Add extra logging to Staking DApp

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/staking_event_handler.ex
+++ b/apps/block_scout_web/lib/block_scout_web/staking_event_handler.ex
@@ -7,6 +7,7 @@ defmodule BlockScoutWeb.StakingEventHandler do
 
   alias BlockScoutWeb.Endpoint
   alias Explorer.Chain.Events.Subscriber
+  alias Explorer.Staking.ContractState
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -20,6 +21,15 @@ defmodule BlockScoutWeb.StakingEventHandler do
 
   @impl true
   def handle_info({:chain_event, :staking_update, :realtime, data}, state) do
+    last_known_block_number = ContractState.get(:last_known_block_number, 0)
+    require Logger
+
+    Logger.warn(
+      "staking_event_handler.ex: received :staking_update and broadcasts stakes:staking_update to Endpoint. last_known_block_number = #{
+        last_known_block_number
+      }. passed_block_number = #{data.block_number}"
+    )
+
     Endpoint.broadcast("stakes:staking_update", "staking_update", data)
     {:noreply, state}
   end

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -86,6 +86,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
       )
       when is_binary(quantity) do
     number = quantity_to_integer(quantity)
+    Logger.warn("fetcher.ex: last_block_number = #{number}")
     Publisher.broadcast([{:last_block_number, number}], :realtime)
     # Subscriptions don't support getting all the blocks and transactions data,
     # so we need to go back and get the full block


### PR DESCRIPTION
## Motivation

This doesn't change any functionality nor fixes bugs, but adds a few additional logs on the server-side for further analyzing block delays in Staking DApp. We can remove this logging later after we analyze the logs.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
