### PR TITLE
Correct UNI token CoinGecko ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixes
 
 ### Chore
+- [#3574](https://github.com/poanetwork/blockscout/pull/3574) - Correct UNI token price
 - [#3567](https://github.com/poanetwork/blockscout/pull/3567) - Force to show filter at the page where filtered items list is empty
 - [#3565](https://github.com/poanetwork/blockscout/pull/3565) - Staking dapp: unhealthy state alert message
 

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
@@ -124,29 +124,35 @@ defmodule Explorer.ExchangeRates.Source.CoinGecko do
   end
 
   def coin_id(symbol) do
-    url = "#{base_url()}/coins/list"
+    id_mapping = bridged_token_symbol_to_id_mapping_to_get_price(symbol)
 
-    symbol_downcase = String.downcase(symbol)
+    if id_mapping do
+      {:ok, id_mapping}
+    else
+      url = "#{base_url()}/coins/list"
 
-    case Source.http_request(url) do
-      {:ok, data} = resp ->
-        if is_list(data) do
-          symbol_data =
-            Enum.find(data, fn item ->
-              item["symbol"] == symbol_downcase
-            end)
+      symbol_downcase = String.downcase(symbol)
 
-          if symbol_data do
-            {:ok, symbol_data["id"]}
+      case Source.http_request(url) do
+        {:ok, data} = resp ->
+          if is_list(data) do
+            symbol_data =
+              Enum.find(data, fn item ->
+                item["symbol"] == symbol_downcase
+              end)
+
+            if symbol_data do
+              {:ok, symbol_data["id"]}
+            else
+              {:error, :not_found}
+            end
           else
-            {:error, :not_found}
+            resp
           end
-        else
-          resp
-        end
 
-      resp ->
-        resp
+        resp ->
+          resp
+      end
     end
   end
 
@@ -171,5 +177,12 @@ defmodule Explorer.ExchangeRates.Source.CoinGecko do
   @spec config(atom()) :: term
   defp config(key) do
     Application.get_env(:explorer, __MODULE__, [])[key]
+  end
+
+  defp bridged_token_symbol_to_id_mapping_to_get_price(symbol) do
+    case symbol do
+      "UNI" -> "uniswap"
+      _symbol -> nil
+    end
   end
 end


### PR DESCRIPTION
## Motivation

Incorrect price of UNI token in xDai instance because of multiple tokens exist with UIN symbol from CoinGecko API list.

## Changelog

Create a mapping to correct token id for UNI token.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
