### PR TITLE
Reduce RPC requests and DB changes by Staking DApp

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -24,5 +24,5 @@ lib/explorer/exchange_rates/source.ex:104
 lib/explorer/exchange_rates/source.ex:107
 lib/explorer/smart_contract/verifier.ex:89
 lib/block_scout_web/templates/address_contract/index.html.eex:118
-lib/explorer/staking/stake_snapshotting.ex:14: Function do_snapshotting/6 has no local return
-lib/explorer/staking/stake_snapshotting.ex:183
+lib/explorer/staking/stake_snapshotting.ex:15: Function do_snapshotting/6 has no local return
+lib/explorer/staking/stake_snapshotting.ex:184

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3581](https://github.com/poanetwork/blockscout/pull/3581) - Reduce RPC requests and DB changes by Staking DApp
 
 ### Chore
 - [#3574](https://github.com/poanetwork/blockscout/pull/3574) - Correct UNI token price

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
-- [#3581](https://github.com/poanetwork/blockscout/pull/3581) - Reduce RPC requests and DB changes by Staking DApp
+- [#3583](https://github.com/poanetwork/blockscout/pull/3583) - Reduce RPC requests and DB changes by Staking DApp
 
 ### Chore
 - [#3574](https://github.com/poanetwork/blockscout/pull/3574) - Correct UNI token price

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/index.html.eex
@@ -2,7 +2,7 @@
   <%= raw(@top) %>
 </div>
 <%= render BlockScoutWeb.StakesView, "_learn-more.html", conn: @conn %>
-<%= render BlockScoutWeb.StakesView, "_warning.html", conn: @conn %>
+<%= # render BlockScoutWeb.StakesView, "_warning.html", conn: @conn %>
 <section data-page="stakes" class="container" data-refresh-interval="<%= @refresh_interval %>">
   <div class="card" data-async-load data-async-listing="<%= @current_path %>" data-no-first-loading>
     <%= render BlockScoutWeb.StakesView, "_stakes_tabs.html", conn: @conn %>

--- a/apps/explorer/lib/explorer/chain/events/subscriber.ex
+++ b/apps/explorer/lib/explorer/chain/events/subscriber.ex
@@ -7,7 +7,7 @@ defmodule Explorer.Chain.Events.Subscriber do
 
   @allowed_broadcast_types ~w(catchup realtime on_demand contract_verification_result)a
 
-  @allowed_events ~w(exchange_rate transaction_stats)a
+  @allowed_events ~w(exchange_rate stake_snapshotting_finished transaction_stats)a
 
   @type broadcast_type :: :realtime | :catchup | :on_demand
 

--- a/apps/explorer/lib/explorer/staking/contract_reader.ex
+++ b/apps/explorer/lib/explorer/staking/contract_reader.ex
@@ -29,6 +29,8 @@ defmodule Explorer.Staking.ContractReader do
       pools_to_be_elected: {:staking, "a5d54f65", [], block_number},
       # f4942501 = keccak256(areStakeAndWithdrawAllowed())
       staking_allowed: {:staking, "f4942501", [], block_number},
+      # 74bdb372 = keccak256(lastChangeBlock())
+      staking_last_change_block: {:staking, "74bdb372", [], block_number},
       # 2d21d217 = keccak256(erc677TokenContract())
       token_contract_address: {:staking, "2d21d217", [], block_number},
       # 704189ca = keccak256(unremovableValidator())
@@ -36,7 +38,9 @@ defmodule Explorer.Staking.ContractReader do
       # b7ab4db5 = keccak256(getValidators())
       validators: {:validator_set, "b7ab4db5", [], block_number},
       # b927ef43 = keccak256(validatorSetApplyBlock())
-      validator_set_apply_block: {:validator_set, "b927ef43", [], block_number}
+      validator_set_apply_block: {:validator_set, "b927ef43", [], block_number},
+      # 74bdb372 = keccak256(lastChangeBlock())
+      validator_set_last_change_block: {:validator_set, "74bdb372", [], block_number}
     ]
   end
 

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -161,11 +161,12 @@ defmodule Explorer.Staking.ContractState do
 
       fetch_state(state, global_responses, block_number, epoch_very_beginning)
 
-      state = if state.snapshotting_finished do
-        %{state | snapshotting_finished: false}
-      else
-        state
-      end
+      state =
+        if state.snapshotting_finished do
+          %{state | snapshotting_finished: false}
+        else
+          state
+        end
 
       {:noreply, %{state | seen_block: block_number}}
     else

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -131,12 +131,12 @@ defmodule Explorer.Staking.ContractState do
     {:noreply, state}
   end
 
-  @doc "Handles an event about snapshotting finishing"
+  # handles an event about snapshotting finishing
   def handle_info({:chain_event, :stake_snapshotting_finished}, state) do
     {:noreply, %{state | snapshotting_finished: true}}
   end
 
-  @doc "Handles new blocks and decides to fetch fresh chain info"
+  # handles new blocks and decides to fetch fresh chain info
   def handle_info({:chain_event, :last_block_number, :realtime, block_number}, state) do
     if block_number > state.seen_block do
       # read general info from the contracts (including pool list and validator list)

--- a/apps/explorer/lib/explorer/staking/stake_snapshotting.ex
+++ b/apps/explorer/lib/explorer/staking/stake_snapshotting.ex
@@ -8,8 +8,8 @@ defmodule Explorer.Staking.StakeSnapshotting do
   require Logger
 
   alias Explorer.Chain
-  alias Explorer.Chain.{StakingPool, StakingPoolsDelegator}
   alias Explorer.Chain.Events.Publisher
+  alias Explorer.Chain.{StakingPool, StakingPoolsDelegator}
   alias Explorer.Staking.ContractReader
 
   def do_snapshotting(

--- a/apps/explorer/lib/explorer/staking/stake_snapshotting.ex
+++ b/apps/explorer/lib/explorer/staking/stake_snapshotting.ex
@@ -9,6 +9,7 @@ defmodule Explorer.Staking.StakeSnapshotting do
 
   alias Explorer.Chain
   alias Explorer.Chain.{StakingPool, StakingPoolsDelegator}
+  alias Explorer.Chain.Events.Publisher
   alias Explorer.Staking.ContractReader
 
   def do_snapshotting(
@@ -194,6 +195,8 @@ defmodule Explorer.Staking.StakeSnapshotting do
     end
 
     :ets.insert(ets_table_name, is_snapshotting: false)
+
+    Publisher.broadcast(:stake_snapshotting_finished)
   end
 
   defp address_bytes_to_string(hash), do: "0x" <> Base.encode16(hash, case: :lower)

--- a/apps/explorer/priv/contracts_abi/posdao/StakingAuRa.json
+++ b/apps/explorer/priv/contracts_abi/posdao/StakingAuRa.json
@@ -1074,5 +1074,19 @@
     "payable": false,
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "lastChangeBlock",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/apps/explorer/priv/contracts_abi/posdao/ValidatorSetAuRa.json
+++ b/apps/explorer/priv/contracts_abi/posdao/ValidatorSetAuRa.json
@@ -694,5 +694,19 @@
     "payable": false,
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "lastChangeBlock",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/apps/explorer/test/explorer/staking/contract_state_test.exs
+++ b/apps/explorer/test/explorer/staking/contract_state_test.exs
@@ -99,7 +99,7 @@ defmodule Explorer.Staking.ContractStateTest do
       EthereumJSONRPC.Mox,
       :json_rpc,
       fn requests, _opts ->
-        assert length(requests) == 15
+        assert length(requests) == 17
 
         {:ok,
          format_responses([
@@ -125,13 +125,17 @@ defmodule Explorer.Staking.ContractStateTest do
            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000b916e7e1f4bcb13549602ed042d36746fd0d96c9000000000000000000000000db9cb2478d917719c53862008672166808258577000000000000000000000000b6695f5c2e3f5eff8036b5f5f3a9d83a5310e51e",
            # 11 StakingAuRa.areStakeAndWithdrawAllowed
            "0x0000000000000000000000000000000000000000000000000000000000000000",
-           # 12 StakingAuRa.erc677TokenContract
+           # 12 StakingAuRa.lastChangeBlock
+           "0x0000000000000000000000000000000000000000000000000000000000000000",
+           # 13 StakingAuRa.erc677TokenContract
            "0x0000000000000000000000006f7a73c96bd56f8b0debc795511eda135e105ea3",
-           # 13 ValidatorSetAuRa.unremovableValidator
+           # 14 ValidatorSetAuRa.unremovableValidator
            "0x0000000000000000000000000b2f5e2f3cbd864eaa2c642e3769c1582361caf6",
-           # 14 ValidatorSetAuRa.getValidators
+           # 15 ValidatorSetAuRa.getValidators
            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000bbcaa8d48289bb1ffcf9808d9aa4b1d215054c7800000000000000000000000075df42383afe6bf5194aa8fa0e9b3d5f9e869441000000000000000000000000522df396ae70a058bd69778408630fdb023389b2",
-           # 15 ValidatorSetAuRa.validatorSetApplyBlock
+           # 16 ValidatorSetAuRa.validatorSetApplyBlock
+           "0x0000000000000000000000000000000000000000000000000000000000000000",
+           # 17 ValidatorSetAuRa.lastChangeBlock
            "0x0000000000000000000000000000000000000000000000000000000000000000"
          ])}
       end
@@ -148,6 +152,44 @@ defmodule Explorer.Staking.ContractStateTest do
          format_responses([
            # BlockRewardAuRa.validatorMinRewardPercent
            "0x000000000000000000000000000000000000000000000000000000000000001e"
+         ])}
+      end
+    )
+
+    # invoke update_block_reward_balance()
+
+    ## BalanceReader.get_balances_of
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn requests, _opts ->
+        assert length(requests) == 1
+
+        {:ok,
+         format_responses([
+           # ERC677BridgeTokenRewardable.balanceOf(BlockRewardAuRa)
+           "0x0000000000000000000000000000000000000000000000000000000000000000"
+         ])}
+      end
+    )
+
+    ## MetadataRetriever.get_functions_of
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn requests, _opts ->
+        assert length(requests) == 4
+
+        {:ok,
+         format_responses([
+           # ERC677BridgeTokenRewardable.decimals
+           "0x0000000000000000000000000000000000000000000000000000000000000012",
+           # ERC677BridgeTokenRewardable.name
+           "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000055354414b45000000000000000000000000000000000000000000000000000000",
+           # ERC677BridgeTokenRewardable.symbol
+           "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000055354414b45000000000000000000000000000000000000000000000000000000",
+           # ERC677BridgeTokenRewardable.totalSupply
+           "0x000000000000000000000000000000000000000000000001f399b1438a100000"
          ])}
       end
     )
@@ -640,44 +682,6 @@ defmodule Explorer.Staking.ContractStateTest do
            "0x0000000000000000000000000000000000000000000000000000000000012fd1",
            # 10 BlockRewardAuRa.delegatorShare
            "0x0000000000000000000000000000000000000000000000000000000000012fd1"
-         ])}
-      end
-    )
-
-    # invoke at_start_snapshotting()
-
-    ## BalanceReader.get_balances_of
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # ERC677BridgeTokenRewardable.balanceOf(BlockRewardAuRa)
-           "0x0000000000000000000000000000000000000000000000000000000000000000"
-         ])}
-      end
-    )
-
-    ## MetadataRetriever.get_functions_of
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 4
-
-        {:ok,
-         format_responses([
-           # ERC677BridgeTokenRewardable.decimals
-           "0x0000000000000000000000000000000000000000000000000000000000000012",
-           # ERC677BridgeTokenRewardable.name
-           "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000055354414b45000000000000000000000000000000000000000000000000000000",
-           # ERC677BridgeTokenRewardable.symbol
-           "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000055354414b45000000000000000000000000000000000000000000000000000000",
-           # ERC677BridgeTokenRewardable.totalSupply
-           "0x000000000000000000000000000000000000000000000001f399b1438a100000"
          ])}
       end
     )


### PR DESCRIPTION
## Motivation

Staking DApp requests information about pools and delegators (and rewrites the corresponding DB tables) on every block even when there are no changes in StakingAuRa and ValidatorSetAuRa contracts. This PR makes DApp only do that when some changes occurred. For that purpose, it uses the `lastChangeBlock` field from the contracts introduced in https://github.com/poanetwork/posdao-contracts/commit/ef9ccff0f11f09cf7671982ed6a035f7a9ce1e62

Also, this PR comments out the warning added in https://github.com/poanetwork/blockscout/pull/3576 (but doesn't remove it completely).

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
