### PR TITLE
Contract interaction: fix nested tuples in the output view, add formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
-- [#3592](https://github.com/poanetwork/blockscout/pull/3592) - Contract interaction: fix nested tuples in the output view
+- [#3592](https://github.com/poanetwork/blockscout/pull/3592) - Contract interaction: fix nested tuples in the output view, add formatting
 - [#3583](https://github.com/poanetwork/blockscout/pull/3583) - Reduce RPC requests and DB changes by Staking DApp
 
 ### Chore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3592](https://github.com/poanetwork/blockscout/pull/3592) - Contract interaction: fix nested tuples in the output view
 - [#3583](https://github.com/poanetwork/blockscout/pull/3583) - Reduce RPC requests and DB changes by Staking DApp
 
 ### Chore

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_function_response.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_function_response.html.eex
@@ -3,8 +3,8 @@
 [ <strong><%= @function_name %></strong> method Response ]
 
 [<%= for item <- @outputs do %>
-<span class="function-response-item"><%= if named_argument?(item) do %><%= item["name"] %>
-<% end %>
-<span class="text-muted">(<%= item["type"] %>)</span> : <%= values(item["value"], item["type"]) %></span><% end %>]
+<%= if named_argument?(item) do %><span class="function-response-item"><%= item["name"] %></span><% end %>
+<span class="text-muted"><%= raw(values_with_type(item["value"], item["type"])) %></span>
+<% end %>]
 </pre>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -121,7 +121,7 @@ to: address_contract_path(@conn, :index, metadata_for_verification.address_hash)
                     </span>
                   </div>
                 <% else %>
-                  <%= values(output["value"], output["type"]) %>
+                  <%= raw(values_only(output["value"], output["type"])) %>
                 <% end %>
             <% end %>
           <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -121,7 +121,7 @@ to: address_contract_path(@conn, :index, metadata_for_verification.address_hash)
                     </span>
                   </div>
                 <% else %>
-                  <%= raw(values_only(output["value"], output["type"])) %>
+                  <%= raw(values_only(output["value"], output["type"], output["components"])) %>
                 <% end %>
             <% end %>
           <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -41,21 +41,26 @@ defmodule BlockScoutWeb.SmartContractView do
   def named_argument?(%{"name" => _}), do: true
   def named_argument?(_), do: false
 
-  def values(addresses, type) when is_list(addresses) and type == "address[]" do
-    addresses
-    |> Enum.map(&values(&1, "address"))
-    |> Enum.join(", ")
+  def values(value, type) when is_list(value) do
+    if String.starts_with?(type, "tuple") do
+      array_from_tuple = tuple_array_to_array(value, type)
+
+      array_from_tuple
+      |> Enum.join(",")
+    else
+      item_type =
+        type
+        |> String.split("[")
+        |> Enum.at(0)
+
+      value
+      |> Enum.map(&values(&1, item_type))
+      |> Enum.join(",")
+    end
   end
 
-  def values(values, type) when is_list(values) and type == "tuple[]" do
-    array_from_tuple = tuple_array_to_array(values)
-
-    array_from_tuple
-    |> Enum.join(", ")
-  end
-
-  def values(value, _type) when is_tuple(value) do
-    tuple_to_array(value)
+  def values(value, type) when is_tuple(value) do
+    tuple_to_array(value, type)
   end
 
   def values(value, type) when type in ["address", "address payable"] do
@@ -63,21 +68,80 @@ defmodule BlockScoutWeb.SmartContractView do
     to_string(address)
   end
 
-  def values(values, _) when is_list(values), do: Enum.join(values, ",")
-  def values(value, _), do: value
+  def values(value, "string"), do: value
 
-  defp tuple_array_to_array(values) do
-    values
-    |> Enum.map(fn value ->
-      tuple_to_array(value)
+  def values(value, _), do: binary_to_utf_string(value)
+
+  defp tuple_array_to_array(value, type) do
+    type = type |> String.slice(0..-3)
+
+    value
+    |> Enum.map(fn item ->
+      tuple_to_array(item, type)
     end)
   end
 
-  defp tuple_to_array(value) do
-    value
-    |> Tuple.to_list()
-    |> Enum.map(&binary_to_utf_string(&1))
+  defp tuple_to_array(value, type) do
+    types_string =
+      type
+      |> String.slice(6..-2)
+      |> String.split(",")
+
+    {tuple_types, _} =
+      types_string
+      |> Enum.reduce({[], nil}, fn val, acc ->
+        {arr, to_merge} = acc
+
+        if to_merge do
+          if count_string_symbols(val)["]"] > count_string_symbols(val)["["] do
+            updated_arr = update_last_list_item(arr, val)
+            {updated_arr, !to_merge}
+          else
+            updated_arr = update_last_list_item(arr, val)
+            {updated_arr, to_merge}
+          end
+        else
+          if count_string_symbols(val)["["] > count_string_symbols(val)["]"] do
+            # credo:disable-for-next-line
+            {arr ++ [val], !to_merge}
+          else
+            # credo:disable-for-next-line
+            {arr ++ [val], to_merge}
+          end
+        end
+      end)
+
+    values_list =
+      value
+      |> Tuple.to_list()
+
+    values_types_list = Enum.zip(tuple_types, values_list)
+
+    values_types_list
+    |> Enum.map(fn {type, value} ->
+      values(value, type)
+    end)
     |> Enum.join(",")
+  end
+
+  defp update_last_list_item(arr, new_val) do
+    arr
+    |> Enum.with_index()
+    |> Enum.map(fn {item, index} ->
+      if index == Enum.count(arr) - 1 do
+        item <> "," <> new_val
+      else
+        item
+      end
+    end)
+  end
+
+  defp count_string_symbols(str) do
+    str
+    |> String.graphemes()
+    |> Enum.reduce(%{"[" => 0, "]" => 0}, fn char, acc ->
+      Map.update(acc, char, 1, &(&1 + 1))
+    end)
   end
 
   defp binary_to_utf_string(item) do

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -41,47 +41,119 @@ defmodule BlockScoutWeb.SmartContractView do
   def named_argument?(%{"name" => _}), do: true
   def named_argument?(_), do: false
 
-  def values(value, type) when is_list(value) do
-    if String.starts_with?(type, "tuple") do
-      array_from_tuple = tuple_array_to_array(value, type)
+  def values_with_type(value, type) when is_list(value) do
+    cond do
+      String.starts_with?(type, "tuple") ->
+        values =
+          value
+          |> tuple_array_to_array(type)
+          |> Enum.join(", ")
 
-      array_from_tuple
-      |> Enum.join(",")
-    else
-      item_type =
-        type
-        |> String.split("[")
-        |> Enum.at(0)
+        render_array_type_value(type, values)
 
-      value
-      |> Enum.map(&values(&1, item_type))
-      |> Enum.join(",")
+      String.starts_with?(type, "address") ->
+        values =
+          value
+          |> Enum.map(&to_string(&1))
+          |> Enum.join(", ")
+
+        render_array_type_value(type, values)
+
+      String.starts_with?(type, "bytes") ->
+        values =
+          value
+          |> Enum.map(&binary_to_utf_string(&1))
+          |> Enum.join(", ")
+
+        render_array_type_value(type, values)
+
+      true ->
+        values =
+          value
+          |> Enum.join(", ")
+
+        render_array_type_value(type, values)
     end
   end
 
-  def values(value, type) when is_tuple(value) do
-    tuple_to_array(value, type)
+  def values_with_type(value, type) when is_tuple(value) do
+    values =
+      value
+      |> tuple_to_array(type)
+      |> Enum.join(", ")
+
+    render_type_value(type, values)
   end
 
-  def values(value, type) when type in ["address", "address payable"] do
+  def values_with_type(value, type) when type in ["address", "address payable"] do
+    {:ok, address} = Explorer.Chain.Hash.Address.cast(value)
+    render_type_value("address", to_string(address))
+  end
+
+  def values_with_type(value, "string"), do: render_type_value("string", value)
+
+  def values_with_type(value, type), do: render_type_value(type, binary_to_utf_string(value))
+
+  def values_only(value, type) when is_list(value) do
+    with_type? = false
+
+    cond do
+      String.starts_with?(type, "tuple") ->
+        values =
+          value
+          |> tuple_array_to_array(type, with_type?)
+          |> Enum.join(", ")
+
+        render_array_value(values)
+
+      String.starts_with?(type, "address") ->
+        values =
+          value
+          |> Enum.map(&binary_to_utf_string(&1))
+          |> Enum.join(", ")
+
+        render_array_value(values)
+
+      String.starts_with?(type, "bytes") ->
+        values =
+          value
+          |> Enum.map(&binary_to_utf_string(&1))
+          |> Enum.join(", ")
+
+        render_array_value(values)
+
+      true ->
+        values =
+          value
+          |> Enum.join(", ")
+
+        render_array_value(values)
+    end
+  end
+
+  def values_only(value, "address") do
     {:ok, address} = Explorer.Chain.Hash.Address.cast(value)
     to_string(address)
   end
 
-  def values(value, "string"), do: value
+  def values_only(value, "string") do
+    value
+  end
 
-  def values(value, _), do: binary_to_utf_string(value)
+  def values_only(value, _type) do
+    binary_to_utf_string(value)
+  end
 
-  defp tuple_array_to_array(value, type) do
+  defp tuple_array_to_array(value, type, with_type? \\ true) do
     type = type |> String.slice(0..-3)
 
     value
     |> Enum.map(fn item ->
-      tuple_to_array(item, type)
+      tuple_to_array(item, type, with_type?)
     end)
   end
 
-  defp tuple_to_array(value, type) do
+  defp tuple_to_array(value, type, with_type? \\ true) do
     types_string =
       type
       |> String.slice(6..-2)
@@ -119,9 +191,12 @@ defmodule BlockScoutWeb.SmartContractView do
 
     values_types_list
     |> Enum.map(fn {type, value} ->
-      values(value, type)
+      if with_type? do
+        values_with_type(value, type)
+      else
+        values_only(value, type)
+      end
     end)
-    |> Enum.join(",")
   end
 
   defp update_last_list_item(arr, new_val) do
@@ -146,5 +221,21 @@ defmodule BlockScoutWeb.SmartContractView do
 
   defp binary_to_utf_string(item) do
     if is_binary(item), do: "0x" <> Base.encode16(item, case: :lower), else: item
+  end
+
+  defp render_type_value(type, value) do
+    "<div style=\"padding-left: 20px\">(#{type}) : #{value}</div>"
+  end
+
+  defp render_array_type_value(type, values) do
+    value_to_display = "[" <> values <> "]"
+
+    render_type_value(type, value_to_display)
+  end
+
+  defp render_array_value(values) do
+    value_to_display = "[" <> values <> "]"
+
+    value_to_display
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
@@ -244,17 +244,19 @@ defmodule BlockScoutWeb.SmartContractViewTest do
     test "joins the values when it is a list of a given type" do
       values = [8, 6, 9, 2, 2, 37]
 
-      assert SmartContractView.values_only(values, "type") == "[8, 6, 9, 2, 2, 37]"
+      assert SmartContractView.values_only(values, "type", nil) == "[8, 6, 9, 2, 2, 37]"
     end
 
     test "convert the value to string receiving a value and the 'address' type" do
       value = <<95, 38, 9, 115, 52, 182, 163, 43, 121, 81, 223, 97, 253, 12, 88, 3, 236, 93, 131, 84>>
-      assert SmartContractView.values_only(value, "address") == "0x5f26097334b6a32b7951df61fd0c5803ec5d8354"
+      assert SmartContractView.values_only(value, "address", nil) == "0x5f26097334b6a32b7951df61fd0c5803ec5d8354"
     end
 
     test "convert the value to string receiving a value and the 'address payable' type" do
       value = <<95, 38, 9, 115, 52, 182, 163, 43, 121, 81, 223, 97, 253, 12, 88, 3, 236, 93, 131, 84>>
-      assert SmartContractView.values_only(value, "address payable") == "0x5f26097334b6a32b7951df61fd0c5803ec5d8354"
+
+      assert SmartContractView.values_only(value, "address payable", nil) ==
+               "0x5f26097334b6a32b7951df61fd0c5803ec5d8354"
     end
 
     test "convert each value to string and join them when receiving 'address[]' as the type" do
@@ -263,14 +265,35 @@ defmodule BlockScoutWeb.SmartContractViewTest do
         <<207, 38, 14, 163, 23, 85, 86, 55, 197, 95, 112, 229, 93, 186, 141, 90, 216, 65, 76, 176>>
       ]
 
-      assert SmartContractView.values_only(value, "address[]") ==
+      assert SmartContractView.values_only(value, "address[]", nil) ==
                "[0x5f26097334b6a32b7951df61fd0c5803ec5d8354, 0xcf260ea317555637c55f70e55dba8d5ad8414cb0]"
     end
 
     test "returns the value when the type is neither 'address' nor 'address payable'" do
       value = "POA"
 
-      assert SmartContractView.values_only(value, "string") == "POA"
+      assert SmartContractView.values_only(value, "string", nil) == "POA"
+    end
+
+    test "returns the value when the type is boolean" do
+      value = "true"
+
+      assert SmartContractView.values_only(value, "bool", nil) == "true"
+    end
+
+    test "returns the value when the type is bytes4" do
+      value = <<228, 184, 12, 77>>
+
+      assert SmartContractView.values_only(value, "bytes4", nil) == "0xe4b80c4d"
+    end
+
+    test "returns the value when the type is bytes32" do
+      value =
+        <<156, 209, 70, 119, 249, 170, 85, 105, 179, 187, 179, 81, 252, 214, 125, 17, 21, 170, 86, 58, 225, 98, 66, 118,
+          211, 212, 230, 127, 179, 214, 249, 38>>
+
+      assert SmartContractView.values_only(value, "bytes32", nil) ==
+               "0x9cd14677f9aa5569b3bbb351fcd67d1115aa563ae1624276d3d4e67fb3d6f926"
     end
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
@@ -240,21 +240,21 @@ defmodule BlockScoutWeb.SmartContractViewTest do
     end
   end
 
-  describe "values/2" do
+  describe "values_only/2" do
     test "joins the values when it is a list of a given type" do
       values = [8, 6, 9, 2, 2, 37]
 
-      assert SmartContractView.values(values, "type") == "8,6,9,2,2,37"
+      assert SmartContractView.values_only(values, "type") == "[8, 6, 9, 2, 2, 37]"
     end
 
     test "convert the value to string receiving a value and the 'address' type" do
       value = <<95, 38, 9, 115, 52, 182, 163, 43, 121, 81, 223, 97, 253, 12, 88, 3, 236, 93, 131, 84>>
-      assert SmartContractView.values(value, "address") == "0x5f26097334b6a32b7951df61fd0c5803ec5d8354"
+      assert SmartContractView.values_only(value, "address") == "0x5f26097334b6a32b7951df61fd0c5803ec5d8354"
     end
 
     test "convert the value to string receiving a value and the 'address payable' type" do
       value = <<95, 38, 9, 115, 52, 182, 163, 43, 121, 81, 223, 97, 253, 12, 88, 3, 236, 93, 131, 84>>
-      assert SmartContractView.values(value, "address payable") == "0x5f26097334b6a32b7951df61fd0c5803ec5d8354"
+      assert SmartContractView.values_only(value, "address payable") == "0x5f26097334b6a32b7951df61fd0c5803ec5d8354"
     end
 
     test "convert each value to string and join them when receiving 'address[]' as the type" do
@@ -263,14 +263,14 @@ defmodule BlockScoutWeb.SmartContractViewTest do
         <<207, 38, 14, 163, 23, 85, 86, 55, 197, 95, 112, 229, 93, 186, 141, 90, 216, 65, 76, 176>>
       ]
 
-      assert SmartContractView.values(value, "address[]") ==
-               "0x5f26097334b6a32b7951df61fd0c5803ec5d8354,0xcf260ea317555637c55f70e55dba8d5ad8414cb0"
+      assert SmartContractView.values_only(value, "address[]") ==
+               "[0x5f26097334b6a32b7951df61fd0c5803ec5d8354, 0xcf260ea317555637c55f70e55dba8d5ad8414cb0]"
     end
 
     test "returns the value when the type is neither 'address' nor 'address payable'" do
       value = "POA"
 
-      assert SmartContractView.values(value, "string") == "POA"
+      assert SmartContractView.values_only(value, "string") == "POA"
     end
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
@@ -264,13 +264,13 @@ defmodule BlockScoutWeb.SmartContractViewTest do
       ]
 
       assert SmartContractView.values(value, "address[]") ==
-               "0x5f26097334b6a32b7951df61fd0c5803ec5d8354, 0xcf260ea317555637c55f70e55dba8d5ad8414cb0"
+               "0x5f26097334b6a32b7951df61fd0c5803ec5d8354,0xcf260ea317555637c55f70e55dba8d5ad8414cb0"
     end
 
     test "returns the value when the type is neither 'address' nor 'address payable'" do
       value = "POA"
 
-      assert SmartContractView.values(value, "not address") == "POA"
+      assert SmartContractView.values(value, "string") == "POA"
     end
   end
 end


### PR DESCRIPTION
## Motivation

Nested tuple outputs cause 500 server error.

## Changelog

- Process method call output recursively
- Add formatting of nested output types

<img width="1098" alt="Screenshot 2021-02-01 at 01 42 23" src="https://user-images.githubusercontent.com/4341812/106400831-f5815100-6431-11eb-9d67-136d9964b599.png">



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
