### PR TITLE
Show APY for delegators in Staking DApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Current
 
 ### Features
-- [#3603](https://github.com/poanetwork/blockscout/pull/3603) -  Display method output parameter name at contract read page
+- [#3603](https://github.com/poanetwork/blockscout/pull/3603) - Display method output parameter name at contract read page
+- [#3597](https://github.com/poanetwork/blockscout/pull/3597) - Show APY for delegators in Staking DApp
 - [#3584](https://github.com/poanetwork/blockscout/pull/3584) - Token holders API endpoint
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 

--- a/apps/block_scout_web/assets/js/pages/stakes.js
+++ b/apps/block_scout_web/assets/js/pages/stakes.js
@@ -352,12 +352,14 @@ async function getAccounts () {
 }
 
 async function getNetId (web3) {
-  let netId = null
-  if (!window.ethereum.chainId) {
+  let netId = window.ethereum.chainId
+  if (!netId) {
+    netId = await window.ethereum.request({ method: 'eth_chainId' })
+  }
+  if (!netId) {
     console.error(`Cannot get chainId. ${constants.METAMASK_VERSION_WARNING}`)
   } else {
-    const { chainId } = window.ethereum
-    netId = web3.utils.isHex(chainId) ? web3.utils.hexToNumber(chainId) : chainId
+    netId = web3.utils.isHex(netId) ? web3.utils.hexToNumber(netId) : netId
   }
   return netId
 }

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -694,23 +694,20 @@ defmodule BlockScoutWeb.StakesChannel do
   defp calc_apy(pool, staker, pool_staking_address_downcased, pool_reward, average_block_time, staking_epoch_duration) do
     staker_address = String.downcase(to_string(staker.address_hash))
 
-    if staker_address == pool_staking_address_downcased do
-      ContractState.calc_apy(
-        pool.snapshotted_validator_reward_ratio,
-        pool_reward,
-        pool.snapshotted_self_staked_amount,
-        average_block_time,
-        staking_epoch_duration
-      )
-    else
-      ContractState.calc_apy(
-        staker.snapshotted_reward_ratio,
-        pool_reward,
-        staker.snapshotted_stake_amount,
-        average_block_time,
-        staking_epoch_duration
-      )
-    end
+    {reward_ratio, stake_amount} =
+      if staker_address == pool_staking_address_downcased do
+        {pool.snapshotted_validator_reward_ratio, pool.snapshotted_self_staked_amount}
+      else
+        {staker.snapshotted_reward_ratio, staker.snapshotted_stake_amount}
+      end
+
+    ContractState.calc_apy(
+      reward_ratio,
+      pool_reward,
+      stake_amount,
+      average_block_time,
+      staking_epoch_duration
+    )
   end
 
   defp claim_reward_long_op_active(socket) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
@@ -3,12 +3,11 @@ defmodule BlockScoutWeb.StakesController do
 
   alias BlockScoutWeb.StakesView
   alias Explorer.Chain
-  alias Explorer.Chain.Cache.BlockNumber
-  alias Explorer.Chain.Hash
-  alias Explorer.Chain.Token
+  alias Explorer.Chain.{Cache.BlockNumber, Hash, Token}
   alias Explorer.Counters.AverageBlockTime
   alias Explorer.Staking.ContractState
   alias Phoenix.View
+  alias Timex.Duration
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
@@ -104,33 +103,47 @@ defmodule BlockScoutWeb.StakesController do
           end
 
         average_block_time = AverageBlockTime.average_block_time()
+
+        average_block_time_seconds =
+          try do
+            Duration.to_seconds(average_block_time)
+          rescue
+            _ -> nil
+          end
+
+        staking_epoch_duration = ContractState.staking_epoch_duration()
         token = ContractState.get(:token, %Token{})
         epoch_number = ContractState.get(:epoch_number, 0)
         staking_allowed = ContractState.get(:staking_allowed, false)
         pool_rewards = ContractState.get(:pool_rewards, %{})
+        calc_apy_enabled = ContractState.calc_apy_enabled?()
+        snapshotted_delegator_data = snapshotted_delegator_data(filter, calc_apy_enabled)
 
         items =
           pools
           |> Enum.with_index(last_index + 1)
           |> Enum.map(fn {%{pool: pool, delegator: delegator}, index} ->
-            mining_address_str = String.downcase(Hash.to_string(pool.mining_address_hash))
-            require Logger
-            Logger.warn("#{mining_address_str}: #{pool_rewards[mining_address_str]}")
+            apy =
+              if calc_apy_enabled and snapshotted_delegator_data != nil do
+                calc_apy(
+                  pool,
+                  pool_rewards,
+                  snapshotted_delegator_data,
+                  average_block_time_seconds,
+                  staking_epoch_duration
+                )
+              end
+
             View.render_to_string(
               StakesView,
               "_rows.html",
               token: token,
-              pool: pool,
+              pool: Map.put(pool, :apy, apy),
               delegator: delegator,
               index: index,
               average_block_time: average_block_time,
               pools_type: filter,
-              buttons: %{
-                stake: staking_allowed and stake_allowed?(pool, delegator),
-                move: staking_allowed and move_allowed?(delegator),
-                withdraw: staking_allowed and withdraw_allowed?(delegator),
-                claim: staking_allowed and claim_allowed?(delegator, epoch_number)
-              }
+              buttons: staking_buttons(pool, delegator, staking_allowed, epoch_number)
             )
           end)
 
@@ -163,6 +176,58 @@ defmodule BlockScoutWeb.StakesController do
       refresh_interval: Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:staking_pool_list_refresh_interval]
     )
   end
+
+  defp staking_buttons(pool, delegator, staking_allowed, epoch_number) do
+    %{
+      stake: staking_allowed and stake_allowed?(pool, delegator),
+      move: staking_allowed and move_allowed?(delegator),
+      withdraw: staking_allowed and withdraw_allowed?(delegator),
+      claim: staking_allowed and claim_allowed?(delegator, epoch_number)
+    }
+  end
+
+  defp calc_apy(pool, pool_rewards, snapshotted_delegator_data, average_block_time, staking_epoch_duration) do
+    staking_address_str = String.downcase(Hash.to_string(pool.staking_address_hash))
+    mining_address_str = String.downcase(Hash.to_string(pool.mining_address_hash))
+
+    pool_reward =
+      case Map.fetch(pool_rewards, mining_address_str) do
+        {:ok, pool_reward} -> pool_reward
+        :error -> nil
+      end
+
+    case Map.fetch(snapshotted_delegator_data, staking_address_str) do
+      {:ok, data} ->
+        ContractState.calc_apy(
+          data.snapshotted_reward_ratio,
+          pool_reward,
+          data.snapshotted_stake_amount,
+          average_block_time,
+          staking_epoch_duration
+        )
+
+      :error ->
+        ContractState.calc_apy(
+          pool.snapshotted_validator_reward_ratio,
+          pool_reward,
+          pool.snapshotted_self_staked_amount,
+          average_block_time,
+          staking_epoch_duration
+        )
+    end
+  end
+
+  defp snapshotted_delegator_data(filter, calc_apy_enabled) do
+    if filter == :validator and calc_apy_enabled do
+      Chain.staking_pool_snapshotted_delegator_data_for_apy()
+      |> Enum.reduce(%{}, fn item, acc ->
+        staking_address_str = address_bytes_to_string(item.staking_address_hash)
+        Map.put(acc, staking_address_str, item)
+      end)
+    end
+  end
+
+  defp address_bytes_to_string(hash), do: "0x" <> Base.encode16(hash, case: :lower)
 
   defp next_page_path(:validator, conn, params) do
     validators_path(conn, :index, params)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
@@ -4,6 +4,7 @@ defmodule BlockScoutWeb.StakesController do
   alias BlockScoutWeb.StakesView
   alias Explorer.Chain
   alias Explorer.Chain.Cache.BlockNumber
+  alias Explorer.Chain.Hash
   alias Explorer.Chain.Token
   alias Explorer.Counters.AverageBlockTime
   alias Explorer.Staking.ContractState
@@ -106,11 +107,15 @@ defmodule BlockScoutWeb.StakesController do
         token = ContractState.get(:token, %Token{})
         epoch_number = ContractState.get(:epoch_number, 0)
         staking_allowed = ContractState.get(:staking_allowed, false)
+        pool_rewards = ContractState.get(:pool_rewards, %{})
 
         items =
           pools
           |> Enum.with_index(last_index + 1)
           |> Enum.map(fn {%{pool: pool, delegator: delegator}, index} ->
+            mining_address_str = String.downcase(Hash.to_string(pool.mining_address_hash))
+            require Logger
+            Logger.warn("#{mining_address_str}: #{pool_rewards[mining_address_str]}")
             View.render_to_string(
               StakesView,
               "_rows.html",

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_rows.html.eex
@@ -26,12 +26,21 @@
       <%= if @pool.is_active, do: "#{@pool.stakes_ratio}%", else: gettext("(inactive pool)") %>
     <% end %>
   </div>
+  <%= if @pools_type == :validator do %>
+    <div class="col-1 stakes-td stakes-cell">
+      <%= if @pool.apy do %>
+        <%= @pool.apy.apy %>
+      <% else %>
+        <%= gettext("N/A") %>
+      <% end %>
+    </div>
+  <% end %>
   <div class="col-2 stakes-td stakes-cell">
     <span class="stakes-td-link-style js-delegators-list" data-address="<%= @pool.staking_address_hash %>">
       <%= @pool.delegators_count %>
     </span>
   </div>
-  <div class="col-3 stakes-td stakes-cell justify-content-end">
+  <div class="<%= if @pools_type == :validator do %>col-2<% else %>col-3<% end %> stakes-td stakes-cell justify-content-end">
     <%= if @pool.is_banned do %>
       <span class="stakes-td-banned-info">
         <%= gettext("Banned until block #%{banned_until} (%{estimated_unban_day})", banned_until: @pool.banned_until, estimated_unban_day: estimated_unban_day(@pool.banned_until, @average_block_time)) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
@@ -73,7 +73,7 @@
                 render BlockScoutWeb.StakesView,
                   "_stakes_th.html",
                   title: gettext("APY & Predicted Reward"),
-                  tooltip: gettext("Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, reopen this popup in a few blocks (as APY cannot be calculated at the very start of staking epoch). Predicted Reward is amount which is going to be accrued at the end of staking epoch.")
+                  tooltip: gettext("Approximate Current Annual Percentage Yield. If you see N/A, please reopen the popup in a few blocks (APY cannot be calculated at the very beginning of a staking epoch). Predicted Reward is the amount of %{symbol} a participant will receive for staking and can claim once the current epoch ends.", symbol: @token.symbol)
               %>
             </div>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
@@ -9,7 +9,7 @@
         <div class="stakes-table-container">
           <div class="stakes-table-head">
             <div class="col-1"></div>
-            <div class="col-4">
+            <div class="col-2">
               <%=
                 pool_type = cond do
                   @pool.is_validator -> gettext("validator")
@@ -25,7 +25,7 @@
                 )
               %>
             </div>
-            <div class="col-4">
+            <div class="col-3">
               <%=
                 title =
                   if @show_snapshotted_data do
@@ -68,12 +68,20 @@
                   tooltip: tooltip
               %>
             </div>
+            <div class="col-3">
+              <%=
+                render BlockScoutWeb.StakesView,
+                  "_stakes_th.html",
+                  title: gettext("APY & Predicted Reward"),
+                  tooltip: gettext("Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, reopen this popup in a few blocks (as APY cannot be calculated at the very start of staking epoch). Predicted Reward is amount which is going to be accrued at the end of staking epoch.")
+              %>
+            </div>
           </div>
           <div class="stakes-table-body">
             <%= for {staker, index} <- Enum.with_index(@stakers, 1) do %>
               <div class="row">
                 <div class="col-1 stakes-td stakes-cell"><div class="stakes-td-order"><%= index %></div></div>
-                <div class="col-4 stakes-td stakes-cell">
+                <div class="col-2 stakes-td stakes-cell">
                   <div class="stakes-address-container">
                     <span class="stakes-address">
                       <%=
@@ -116,7 +124,7 @@
                     <% end %>
                   </div>
                 </div>
-                <div class="col-4 stakes-td stakes-cell">
+                <div class="col-3 stakes-td stakes-cell">
                   <%= format_token_amount(staker.stake_amount, @token, symbol: false) %>
                   <%= if @show_snapshotted_data do %>
                     (
@@ -160,6 +168,13 @@
                     <% end %>
                   <% else %>
                     -
+                  <% end %>
+                </div>
+                <div class="col-3 stakes-td stakes-cell">
+                  <%= if staker.apy do %>
+                    <%= staker.apy.apy %> (<%= format_token_amount(staker.apy.predicted_reward, @token, symbol: false, digits: 2) %>)
+                  <% else %>
+                    <%= gettext("N/A") %>
                   <% end %>
                 </div>
               </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
@@ -9,7 +9,7 @@
         <div class="stakes-table-container">
           <div class="stakes-table-head">
             <div class="col-1"></div>
-            <div class="col-2">
+            <div class="<%= if @pool.is_validator, do: "col-2", else: "col-4" %>">
               <%=
                 pool_type = cond do
                   @pool.is_validator -> gettext("validator")
@@ -25,7 +25,7 @@
                 )
               %>
             </div>
-            <div class="col-3">
+            <div class="<%= if @pool.is_validator, do: "col-3", else: "col-4" %>">
               <%=
                 title =
                   if @show_snapshotted_data do
@@ -68,20 +68,22 @@
                   tooltip: tooltip
               %>
             </div>
-            <div class="col-3">
-              <%=
-                render BlockScoutWeb.StakesView,
-                  "_stakes_th.html",
-                  title: gettext("APY & Predicted Reward"),
-                  tooltip: gettext("Approximate Current Annual Percentage Yield. If you see N/A, please reopen the popup in a few blocks (APY cannot be calculated at the very beginning of a staking epoch). Predicted Reward is the amount of %{symbol} a participant will receive for staking and can claim once the current epoch ends.", symbol: @token.symbol)
-              %>
-            </div>
+            <%= if @pool.is_validator do %>
+              <div class="col-3">
+                <%=
+                  render BlockScoutWeb.StakesView,
+                    "_stakes_th.html",
+                    title: gettext("APY & Predicted Reward"),
+                    tooltip: gettext("Approximate Current Annual Percentage Yield. If you see N/A, please reopen the popup in a few blocks (APY cannot be calculated at the very beginning of a staking epoch). Predicted Reward is the amount of %{symbol} a participant will receive for staking and can claim once the current epoch ends.", symbol: @token.symbol)
+                %>
+              </div>
+            <% end %>
           </div>
           <div class="stakes-table-body">
             <%= for {staker, index} <- Enum.with_index(@stakers, 1) do %>
               <div class="row">
                 <div class="col-1 stakes-td stakes-cell"><div class="stakes-td-order"><%= index %></div></div>
-                <div class="col-2 stakes-td stakes-cell">
+                <div class="<%= if @pool.is_validator, do: "col-2", else: "col-4" %> stakes-td stakes-cell">
                   <div class="stakes-address-container">
                     <span class="stakes-address">
                       <%=
@@ -124,7 +126,7 @@
                     <% end %>
                   </div>
                 </div>
-                <div class="col-3 stakes-td stakes-cell">
+                <div class="<%= if @pool.is_validator, do: "col-3", else: "col-4" %> stakes-td stakes-cell">
                   <%= format_token_amount(staker.stake_amount, @token, symbol: false) %>
                   <%= if @show_snapshotted_data do %>
                     (
@@ -170,16 +172,18 @@
                     -
                   <% end %>
                 </div>
-                <div class="col-3 stakes-td stakes-cell">
-                  <%= cond do %>
-                  <% staker.apy -> %>
-                    <%= staker.apy.apy %> (<%= format_token_amount(staker.apy.predicted_reward, @token, symbol: false, digits: 2) %>)
-                  <% @show_snapshotted_data and staker.snapshotted_stake_amount == nil -> %>
-                    <%= gettext("Pending") %>
-                  <% true -> %>
-                    <%= gettext("N/A") %>
-                  <% end %>
-                </div>
+                <%= if @pool.is_validator do %>
+                  <div class="col-3 stakes-td stakes-cell">
+                    <%= cond do %>
+                    <% staker.apy -> %>
+                      <%= staker.apy.apy %> (<%= format_token_amount(staker.apy.predicted_reward, @token, symbol: false, digits: 2) %>)
+                    <% @show_snapshotted_data and staker.snapshotted_stake_amount == nil -> %>
+                      <%= gettext("Pending") %>
+                    <% true -> %>
+                      <%= gettext("N/A") %>
+                    <% end %>
+                  </div>
+                <% end %>
               </div>
             <% end %>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex
@@ -171,9 +171,12 @@
                   <% end %>
                 </div>
                 <div class="col-3 stakes-td stakes-cell">
-                  <%= if staker.apy do %>
+                  <%= cond do %>
+                  <% staker.apy -> %>
                     <%= staker.apy.apy %> (<%= format_token_amount(staker.apy.predicted_reward, @token, symbol: false, digits: 2) %>)
-                  <% else %>
+                  <% @show_snapshotted_data and staker.snapshotted_stake_amount == nil -> %>
+                    <%= gettext("Pending") %>
+                  <% true -> %>
                     <%= gettext("N/A") %>
                   <% end %>
                 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_tabs.html.eex
@@ -1,21 +1,21 @@
 <div class="card-tabs js-card-tabs">
     <%=
     link(
-        gettext("Validators"),
+        list_title(:validator),
         class: "card-tab #{tab_status("validators", @conn.request_path)}",
         to: validators_path(@conn, :index)
         )
     %>
     <%=
     link(
-        gettext("Active Pools"),
+        list_title(:active),
         class: "card-tab #{tab_status("active-pools", @conn.request_path)}",
         to: active_pools_path(@conn, :index)
         )
     %>
     <%=
     link(
-        gettext("Inactive Pools"),
+        list_title(:inactive),
         class: "card-tab #{tab_status("inactive-pools", @conn.request_path)}",
         to: inactive_pools_path(@conn, :index)
         )

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_table.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_table.html.eex
@@ -36,7 +36,7 @@
     </div>
     <%= if @pools_type == :validator do %>
       <div class="col-1">
-        <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: gettext("APY"), tooltip: gettext("Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, wait for a few blocks (as APY cannot be calculated at the very start of staking epoch).") %>
+        <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: gettext("APY"), tooltip: gettext("Approximate Current Annual Percentage Yield. If you see N/A, please wait for a few blocks (APY cannot be calculated at the very beginning of a staking epoch).") %>
       </div>
     <% end %>
     <div class="col-2">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_table.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_table.html.eex
@@ -34,10 +34,15 @@
         <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: gettext("Stakes Ratio"), tooltip: gettext("The percentage of stake in a single pool relative to the total amount staked in all active pools. A higher ratio results in a greater likelihood of validator pool selection.") %>
       <% end %>
     </div>
+    <%= if @pools_type == :validator do %>
+      <div class="col-1">
+        <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: gettext("APY"), tooltip: gettext("Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, wait for a few blocks (as APY cannot be calculated at the very start of staking epoch).") %>
+      </div>
+    <% end %>
     <div class="col-2">
       <%= render BlockScoutWeb.StakesView, "_stakes_th.html", title: gettext("Delegators"), tooltip: gettext("The number of delegators providing stake to the pool. Click on the number to see more details.") %>
     </div>
-    <div class="col-3"></div>
+    <div class="<%= if @pools_type == :validator do %>col-2<% else %>col-3<% end %>"></div>
   </div>
   <div class="stakes-table-body">
     <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">

--- a/apps/block_scout_web/lib/block_scout_web/views/stakes_helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/stakes_helpers.ex
@@ -38,7 +38,7 @@ defmodule BlockScoutWeb.StakesHelpers do
   end
 
   def list_title(:validator), do: Gettext.dgettext(BlockScoutWeb.Gettext, "default", "Validators")
-  def list_title(:active), do: Gettext.dgettext(BlockScoutWeb.Gettext, "default", "Active Pools")
+  def list_title(:active), do: Gettext.dgettext(BlockScoutWeb.Gettext, "default", "Active Pools (Candidates)")
   def list_title(:inactive), do: Gettext.dgettext(BlockScoutWeb.Gettext, "default", "Inactive Pools")
 
   def from_wei(%Decimal{} = amount, %Token{} = token, to_string \\ true) do

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -2193,7 +2193,7 @@ msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:757
+#: lib/block_scout_web/channels/stakes_channel.ex:754
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2268,7 +2268,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:813
+#: lib/block_scout_web/channels/stakes_channel.ex:810
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2294,7 +2294,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:854
+#: lib/block_scout_web/channels/stakes_channel.ex:851
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2368,7 +2368,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:857
+#: lib/block_scout_web/channels/stakes_channel.ex:854
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2463,19 +2463,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:820
-#: lib/block_scout_web/channels/stakes_channel.ex:867
+#: lib/block_scout_web/channels/stakes_channel.ex:817
+#: lib/block_scout_web/channels/stakes_channel.ex:864
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:860
+#: lib/block_scout_web/channels/stakes_channel.ex:857
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:816
-#: lib/block_scout_web/channels/stakes_channel.ex:863
+#: lib/block_scout_web/channels/stakes_channel.ex:813
+#: lib/block_scout_web/channels/stakes_channel.ex:860
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1144,7 +1144,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:65
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:178
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:181
 #: lib/block_scout_web/views/transaction_view.ex:261
 #: lib/block_scout_web/views/transaction_view.ex:295
 msgid "Pending"
@@ -2178,7 +2178,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:120
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:122
 msgid "It's me!"
 msgstr ""
 
@@ -2194,7 +2194,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:122
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:124
 msgid "ME"
 msgstr ""
 
@@ -2404,7 +2404,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:100
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:102
 msgid "The rest addresses are delegators of its pool."
 msgstr ""
 
@@ -2426,7 +2426,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:97
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:99
 msgid "This is a %{pool_type}."
 msgstr ""
 
@@ -2656,19 +2656,19 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:75
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:76
 msgid "APY & Predicted Reward"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_rows.html.eex:34
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:180
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:183
 msgid "N/A"
 msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:76
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:77
 msgid "Approximate Current Annual Percentage Yield. If you see N/A, please reopen the popup in a few blocks (APY cannot be calculated at the very beginning of a staking epoch). Predicted Reward is the amount of %{symbol} a participant will receive for staking and can claim once the current epoch ends."
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1144,6 +1144,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:65
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:178
 #: lib/block_scout_web/views/transaction_view.ex:261
 #: lib/block_scout_web/views/transaction_view.ex:295
 msgid "Pending"
@@ -2687,6 +2688,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_rows.html.eex:34
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:177
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:180
 msgid "N/A"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1305,7 +1305,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/chain/show.html.eex:184
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:21
-#: lib/block_scout_web/templates/stakes/_table.html.eex:44
+#: lib/block_scout_web/templates/stakes/_table.html.eex:49
 #: lib/block_scout_web/templates/tokens/holder/index.html.eex:22
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:23
 #: lib/block_scout_web/templates/tokens/inventory/index.html.eex:22
@@ -2063,7 +2063,7 @@ msgid "Banned"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_rows.html.eex:37
+#: lib/block_scout_web/templates/stakes/_rows.html.eex:46
 msgid "Banned until block #%{banned_until} (%{estimated_unban_day})"
 msgstr ""
 
@@ -2145,7 +2145,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:31
-#: lib/block_scout_web/templates/stakes/_table.html.eex:38
+#: lib/block_scout_web/templates/stakes/_table.html.eex:43
 msgid "Delegators"
 msgstr ""
 
@@ -2187,12 +2187,12 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:112
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:120
 msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:702
+#: lib/block_scout_web/channels/stakes_channel.ex:757
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:114
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:122
 msgid "ME"
 msgstr ""
 
@@ -2267,7 +2267,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:758
+#: lib/block_scout_web/channels/stakes_channel.ex:813
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgid "Recalculate"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_table.html.eex:53
+#: lib/block_scout_web/templates/stakes/_table.html.eex:58
 msgid "Refresh now"
 msgstr ""
 
@@ -2293,7 +2293,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:799
+#: lib/block_scout_web/channels/stakes_channel.ex:854
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2367,7 +2367,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:802
+#: lib/block_scout_web/channels/stakes_channel.ex:857
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2402,7 +2402,7 @@ msgid "The first amount is the validator’s own stake, the second is the total 
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_table.html.eex:38
+#: lib/block_scout_web/templates/stakes/_table.html.eex:43
 msgid "The number of delegators providing stake to the pool. Click on the number to see more details."
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:92
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:100
 msgid "The rest addresses are delegators of its pool."
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgid "The staking epochs for which the reward could be claimed (read-only field
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_table.html.eex:53
+#: lib/block_scout_web/templates/stakes/_table.html.eex:58
 msgid "The table refreshed <span></span> block(s) ago."
 msgstr ""
 
@@ -2435,7 +2435,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:89
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:97
 msgid "This is a %{pool_type}."
 msgstr ""
 
@@ -2462,19 +2462,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:765
-#: lib/block_scout_web/channels/stakes_channel.ex:812
+#: lib/block_scout_web/channels/stakes_channel.ex:820
+#: lib/block_scout_web/channels/stakes_channel.ex:867
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:805
+#: lib/block_scout_web/channels/stakes_channel.ex:860
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:761
-#: lib/block_scout_web/channels/stakes_channel.ex:808
+#: lib/block_scout_web/channels/stakes_channel.ex:816
+#: lib/block_scout_web/channels/stakes_channel.ex:863
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgid "Withdraw Now"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_rows.html.eex:43
+#: lib/block_scout_web/templates/stakes/_rows.html.eex:52
 msgid "Withdraw after block #%{banned_delegators_until} (%{estimated_unban_day})"
 msgstr ""
 
@@ -2661,4 +2661,32 @@ msgstr ""
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:58
 msgid "Reward distribution is based on stake amount. Validator receives at least %{min}% of the pool reward."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_table.html.eex:39
+msgid "APY"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:75
+msgid "APY & Predicted Reward"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:76
+msgid "Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, reopen this popup in a few blocks (as APY cannot be calculated at the very start of staking epoch). Predicted Reward is amount which is going to be accrued at the end of staking epoch."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_table.html.eex:39
+msgid "Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, wait for a few blocks (as APY cannot be calculated at the very start of staking epoch)."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_rows.html.eex:34
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:177
+msgid "N/A"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -2023,11 +2023,6 @@ msgid "<p>To become a candidate, your staking address must be funded with %{toke
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_tabs.html.eex:11
-msgid "Active Pools"
-msgstr ""
-
-#, elixir-format
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:24
 msgid "All pool participant addresses. The top address belongs to the %{pool_type}."
@@ -2179,11 +2174,6 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_table.html.eex:12
 msgid "Inactive Pool Addresses. Current validator pools are specified by a checkmark."
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_tabs.html.eex:18
-msgid "Inactive Pools"
 msgstr ""
 
 #, elixir-format
@@ -2490,11 +2480,6 @@ msgid "Validator pools can be banned for misbehavior (such as not revealing secr
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_tabs.html.eex:4
-msgid "Validators"
-msgstr ""
-
-#, elixir-format
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_claim_reward_content.html.eex:2
 msgid "We found the following pools you can claim reward from:"
@@ -2676,18 +2661,18 @@ msgid "APY & Predicted Reward"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/stakes/_rows.html.eex:34
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:180
+msgid "N/A"
+msgstr ""
+
+#, elixir-format
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:76
-msgid "Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, reopen this popup in a few blocks (as APY cannot be calculated at the very start of staking epoch). Predicted Reward is amount which is going to be accrued at the end of staking epoch."
+msgid "Approximate Current Annual Percentage Yield. If you see N/A, please reopen the popup in a few blocks (APY cannot be calculated at the very beginning of a staking epoch). Predicted Reward is the amount of %{symbol} a participant will receive for staking and can claim once the current epoch ends."
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_table.html.eex:39
-msgid "Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, wait for a few blocks (as APY cannot be calculated at the very start of staking epoch)."
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/stakes/_rows.html.eex:34
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:180
-msgid "N/A"
+msgid "Approximate Current Annual Percentage Yield. If you see N/A, please wait for a few blocks (APY cannot be calculated at the very beginning of a staking epoch)."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1144,7 +1144,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:65
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:178
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:181
 #: lib/block_scout_web/views/transaction_view.ex:261
 #: lib/block_scout_web/views/transaction_view.ex:295
 msgid "Pending"
@@ -2178,7 +2178,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:120
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:122
 msgid "It's me!"
 msgstr ""
 
@@ -2194,7 +2194,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:122
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:124
 msgid "ME"
 msgstr ""
 
@@ -2404,7 +2404,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:100
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:102
 msgid "The rest addresses are delegators of its pool."
 msgstr ""
 
@@ -2426,7 +2426,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:97
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:99
 msgid "This is a %{pool_type}."
 msgstr ""
 
@@ -2656,19 +2656,19 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:75
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:76
 msgid "APY & Predicted Reward"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_rows.html.eex:34
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:180
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:183
 msgid "N/A"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:76
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:77
 msgid "Approximate Current Annual Percentage Yield. If you see N/A, please reopen the popup in a few blocks (APY cannot be calculated at the very beginning of a staking epoch). Predicted Reward is the amount of %{symbol} a participant will receive for staking and can claim once the current epoch ends."
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -2193,7 +2193,7 @@ msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:757
+#: lib/block_scout_web/channels/stakes_channel.ex:754
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2268,7 +2268,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:813
+#: lib/block_scout_web/channels/stakes_channel.ex:810
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2294,7 +2294,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:854
+#: lib/block_scout_web/channels/stakes_channel.ex:851
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2368,7 +2368,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:857
+#: lib/block_scout_web/channels/stakes_channel.ex:854
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2463,19 +2463,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:820
-#: lib/block_scout_web/channels/stakes_channel.ex:867
+#: lib/block_scout_web/channels/stakes_channel.ex:817
+#: lib/block_scout_web/channels/stakes_channel.ex:864
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:860
+#: lib/block_scout_web/channels/stakes_channel.ex:857
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:816
-#: lib/block_scout_web/channels/stakes_channel.ex:863
+#: lib/block_scout_web/channels/stakes_channel.ex:813
+#: lib/block_scout_web/channels/stakes_channel.ex:860
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1305,7 +1305,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/chain/show.html.eex:184
 #: lib/block_scout_web/templates/pending_transaction/index.html.eex:21
-#: lib/block_scout_web/templates/stakes/_table.html.eex:44
+#: lib/block_scout_web/templates/stakes/_table.html.eex:49
 #: lib/block_scout_web/templates/tokens/holder/index.html.eex:22
 #: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:23
 #: lib/block_scout_web/templates/tokens/inventory/index.html.eex:22
@@ -2063,7 +2063,7 @@ msgid "Banned"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_rows.html.eex:37
+#: lib/block_scout_web/templates/stakes/_rows.html.eex:46
 msgid "Banned until block #%{banned_until} (%{estimated_unban_day})"
 msgstr ""
 
@@ -2145,7 +2145,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_progress.html.eex:31
-#: lib/block_scout_web/templates/stakes/_table.html.eex:38
+#: lib/block_scout_web/templates/stakes/_table.html.eex:43
 msgid "Delegators"
 msgstr ""
 
@@ -2187,12 +2187,12 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:112
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:120
 msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:702
+#: lib/block_scout_web/channels/stakes_channel.ex:757
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:114
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:122
 msgid "ME"
 msgstr ""
 
@@ -2267,7 +2267,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:758
+#: lib/block_scout_web/channels/stakes_channel.ex:813
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgid "Recalculate"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_table.html.eex:53
+#: lib/block_scout_web/templates/stakes/_table.html.eex:58
 msgid "Refresh now"
 msgstr ""
 
@@ -2293,7 +2293,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:799
+#: lib/block_scout_web/channels/stakes_channel.ex:854
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2367,7 +2367,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:802
+#: lib/block_scout_web/channels/stakes_channel.ex:857
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2402,7 +2402,7 @@ msgid "The first amount is the validator’s own stake, the second is the total 
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_table.html.eex:38
+#: lib/block_scout_web/templates/stakes/_table.html.eex:43
 msgid "The number of delegators providing stake to the pool. Click on the number to see more details."
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:92
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:100
 msgid "The rest addresses are delegators of its pool."
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgid "The staking epochs for which the reward could be claimed (read-only field
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_table.html.eex:53
+#: lib/block_scout_web/templates/stakes/_table.html.eex:58
 msgid "The table refreshed <span></span> block(s) ago."
 msgstr ""
 
@@ -2435,7 +2435,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:89
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:97
 msgid "This is a %{pool_type}."
 msgstr ""
 
@@ -2462,19 +2462,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:765
-#: lib/block_scout_web/channels/stakes_channel.ex:812
+#: lib/block_scout_web/channels/stakes_channel.ex:820
+#: lib/block_scout_web/channels/stakes_channel.ex:867
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:805
+#: lib/block_scout_web/channels/stakes_channel.ex:860
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:761
-#: lib/block_scout_web/channels/stakes_channel.ex:808
+#: lib/block_scout_web/channels/stakes_channel.ex:816
+#: lib/block_scout_web/channels/stakes_channel.ex:863
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgid "Withdraw Now"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_rows.html.eex:43
+#: lib/block_scout_web/templates/stakes/_rows.html.eex:52
 msgid "Withdraw after block #%{banned_delegators_until} (%{estimated_unban_day})"
 msgstr ""
 
@@ -2633,32 +2633,60 @@ msgstr ""
 msgid "Press / and focus will be moved to the search field"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:52
 msgid "Current Reward Share"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:60
 msgid "Current Reward Share is calculated based on the Working Stake Amount."
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:5
 msgid "Delegators of "
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:52
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:54
 msgid "Potential Reward Share"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:58
 msgid "Reward distribution is based on stake amount. Validator receives at least %{min}% of the pool reward."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_table.html.eex:39
+msgid "APY"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:75
+msgid "APY & Predicted Reward"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:76
+msgid "Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, reopen this popup in a few blocks (as APY cannot be calculated at the very start of staking epoch). Predicted Reward is amount which is going to be accrued at the end of staking epoch."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_table.html.eex:39
+msgid "Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, wait for a few blocks (as APY cannot be calculated at the very start of staking epoch)."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_rows.html.eex:34
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:177
+msgid "N/A"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -2023,11 +2023,6 @@ msgid "<p>To become a candidate, your staking address must be funded with %{toke
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_tabs.html.eex:11
-msgid "Active Pools"
-msgstr ""
-
-#, elixir-format
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:24
 msgid "All pool participant addresses. The top address belongs to the %{pool_type}."
@@ -2179,11 +2174,6 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_table.html.eex:12
 msgid "Inactive Pool Addresses. Current validator pools are specified by a checkmark."
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_tabs.html.eex:18
-msgid "Inactive Pools"
 msgstr ""
 
 #, elixir-format
@@ -2490,11 +2480,6 @@ msgid "Validator pools can be banned for misbehavior (such as not revealing secr
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stakes/_stakes_tabs.html.eex:4
-msgid "Validators"
-msgstr ""
-
-#, elixir-format
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_claim_reward_content.html.eex:2
 msgid "We found the following pools you can claim reward from:"
@@ -2676,18 +2661,18 @@ msgid "APY & Predicted Reward"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/stakes/_rows.html.eex:34
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:180
+msgid "N/A"
+msgstr ""
+
+#, elixir-format, fuzzy
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:76
-msgid "Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, reopen this popup in a few blocks (as APY cannot be calculated at the very start of staking epoch). Predicted Reward is amount which is going to be accrued at the end of staking epoch."
+msgid "Approximate Current Annual Percentage Yield. If you see N/A, please reopen the popup in a few blocks (APY cannot be calculated at the very beginning of a staking epoch). Predicted Reward is the amount of %{symbol} a participant will receive for staking and can claim once the current epoch ends."
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_table.html.eex:39
-msgid "Approximate Annual Percentage Yield calculated for the current moment. If you see N/A, please, wait for a few blocks (as APY cannot be calculated at the very start of staking epoch)."
-msgstr ""
-
-#, elixir-format
-#: lib/block_scout_web/templates/stakes/_rows.html.eex:34
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:180
-msgid "N/A"
+msgid "Approximate Current Annual Percentage Yield. If you see N/A, please wait for a few blocks (APY cannot be calculated at the very beginning of a staking epoch)."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1144,6 +1144,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:65
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:178
 #: lib/block_scout_web/views/transaction_view.ex:261
 #: lib/block_scout_web/views/transaction_view.ex:295
 msgid "Pending"
@@ -2687,6 +2688,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_rows.html.eex:34
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:177
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:180
 msgid "N/A"
 msgstr ""

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4984,6 +4984,22 @@ defmodule Explorer.Chain do
     |> Repo.all()
   end
 
+  def staking_pool_snapshotted_delegator_data_for_apy do
+    query =
+      from(
+        d in StakingPoolsDelegator,
+        select: %{
+          :staking_address_hash => fragment("DISTINCT ON (?) ?", d.staking_address_hash, d.staking_address_hash),
+          :snapshotted_reward_ratio => d.snapshotted_reward_ratio,
+          :snapshotted_stake_amount => d.snapshotted_stake_amount
+        },
+        where: d.staking_address_hash != d.address_hash and d.snapshotted_stake_amount > 0
+      )
+
+    query
+    |> Repo.all()
+  end
+
   def staking_pool_snapshotted_inactive_delegators_count(staking_address_hash) do
     query =
       from(

--- a/apps/explorer/lib/explorer/staking/contract_reader.ex
+++ b/apps/explorer/lib/explorer/staking/contract_reader.ex
@@ -53,6 +53,131 @@ defmodule Explorer.Staking.ContractReader do
     ]
   end
 
+  # makes a raw `eth_call` for the `currentPoolRewards` function of the BlockReward contract:
+  # function currentPoolRewards(
+  #     uint256 _rewardToDistribute,
+  #     uint256[] memory _blocksCreatedShareNum,
+  #     uint256 _blocksCreatedShareDenom,
+  #     uint256 _stakingEpoch
+  # ) public view returns(uint256[] memory poolRewards);
+  def call_current_pool_rewards(block_reward_address, reward_to_distribute, staking_epoch, block_number) do
+    json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+
+    reward_to_distribute =
+      reward_to_distribute
+      |> Integer.to_string(16)
+      |> String.pad_leading(64, ["0"])
+
+    staking_epoch =
+      staking_epoch
+      |> Integer.to_string(16)
+      |> String.pad_leading(64, ["0"])
+
+    function_signature = "0x212329f3"
+    data = function_signature <> reward_to_distribute <> "00000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000" <> staking_epoch <> "0000000000000000000000000000000000000000000000000000000000000000"
+
+    request = %{
+      id: 0,
+      method: "eth_call",
+      params: [
+        %{
+          to: block_reward_address,
+          data: data
+        },
+        "0x" <> Integer.to_string(block_number, 16)
+      ]
+    }
+
+    result =
+      request
+      |> EthereumJSONRPC.request()
+      |> EthereumJSONRPC.json_rpc(json_rpc_named_arguments)
+
+    case result do
+      {:ok, response} ->
+        response = String.replace_leading(response, "0x", "")
+
+        offset =
+          response
+          |> String.slice(0..63)
+          |> String.to_integer(16)
+
+        length =
+          response
+          |> String.slice(offset * 2, 64)
+          |> String.to_integer(16)
+
+        if length > 0 do
+          Enum.reduce(Range.new(0, length - 1), [], fn x, acc ->
+            item =
+              response
+              |> String.slice(offset * 2 + 64 + x*64, 64)
+              |> String.to_integer(16)
+            acc ++ [item]
+          end)
+        else
+          []
+        end
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  # makes a raw `eth_call` for the `currentTokenRewardToDistribute` function of the BlockReward contract:
+  # function currentTokenRewardToDistribute(
+  #     address _stakingContract,
+  #     uint256 _stakingEpoch,
+  #     uint256 _totalRewardShareNum,
+  #     uint256 _totalRewardShareDenom,
+  #     address[] memory _validators
+  # ) public view returns(uint256 rewardToDistribute, uint256 totalReward);
+  def call_current_token_reward_to_distribute(block_reward_address, staking_contract_address, staking_epoch, block_number) do
+    json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+
+    staking_contract_address = address_pad_to_64(staking_contract_address)
+    staking_epoch =
+      staking_epoch
+      |> Integer.to_string(16)
+      |> String.pad_leading(64, ["0"])
+
+    function_signature = "0x46955281"
+    mandatory_params = staking_contract_address <> staking_epoch
+    optional_params = "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000"
+    data = function_signature <> mandatory_params <> optional_params
+
+    request = %{
+      id: 0,
+      method: "eth_call",
+      params: [
+        %{
+          to: block_reward_address,
+          data: data
+        },
+        "0x" <> Integer.to_string(block_number, 16)
+      ]
+    }
+
+    result =
+      request
+      |> EthereumJSONRPC.request()
+      |> EthereumJSONRPC.json_rpc(json_rpc_named_arguments)
+
+    case result do
+      {:ok, response} ->
+        response = String.replace_leading(response, "0x", "")
+        if String.length(response) != 64 * 2 do
+          0
+        else
+          {reward_to_distribute, _} = String.split_at(response, 64)
+          String.to_integer(reward_to_distribute, 16)
+        end
+
+      {:error, _} ->
+        0
+    end
+  end
+
   # makes a raw `eth_call` for the `getRewardAmount` function of the Staking contract:
   # function getRewardAmount(
   #   uint256[] memory _stakingEpochs,

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -290,7 +290,7 @@ defmodule Explorer.Staking.ContractState do
          is_positive(staking_epoch_duration) do
       epochs_per_year = floor(31_536_000 / average_block_time / staking_epoch_duration)
       predicted_reward = decimal_to_float(reward_ratio) * pool_reward / 100
-      apy = predicted_reward / decimal_to_integer(stake_amount) * epochs_per_year
+      apy = predicted_reward / decimal_to_integer(stake_amount) * epochs_per_year * 100
       %{apy: "#{floor(apy * 100) / 100}%", predicted_reward: floor(predicted_reward)}
     end
   end

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -289,7 +289,7 @@ defmodule Explorer.Staking.ContractState do
          is_positive(average_block_time) and
          is_positive(staking_epoch_duration) do
       epochs_per_year = floor(31_536_000 / average_block_time / staking_epoch_duration)
-      predicted_reward = decimal_to_float(reward_ratio) * pool_reward
+      predicted_reward = decimal_to_float(reward_ratio) * pool_reward / 100
       apy = predicted_reward / decimal_to_integer(stake_amount) * epochs_per_year
       %{apy: "#{floor(apy * 100) / 100}%", predicted_reward: floor(predicted_reward)}
     end

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -285,7 +285,8 @@ defmodule Explorer.Staking.ContractState do
   end
 
   def calc_apy(reward_ratio, pool_reward, stake_amount, average_block_time, staking_epoch_duration) do
-    if calc_apy_enabled?() and is_positive(reward_ratio) and pool_reward != nil and is_positive(stake_amount) and is_positive(average_block_time) and
+    if calc_apy_enabled?() and is_positive(reward_ratio) and pool_reward != nil and is_positive(stake_amount) and
+         is_positive(average_block_time) and
          is_positive(staking_epoch_duration) do
       epochs_per_year = floor(31_536_000 / average_block_time / staking_epoch_duration)
       predicted_reward = decimal_to_float(reward_ratio) * pool_reward

--- a/apps/explorer/test/explorer/staking/contract_state_test.exs
+++ b/apps/explorer/test/explorer/staking/contract_state_test.exs
@@ -145,6 +145,26 @@ defmodule Explorer.Staking.ContractStateTest do
       end
     )
 
+    # ContractReader.call_current_token_reward_to_distribute
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn _request, _opts ->
+        {:ok,
+         "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}
+      end
+    )
+
+    # ContractReader.call_current_pool_rewards
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn _request, _opts ->
+        {:ok,
+         "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"}
+      end
+    )
+
     # get_validator_min_reward_percent
     expect(
       EthereumJSONRPC.Mox,


### PR DESCRIPTION
## Motivation

This adds a new feature to Staking DApp to display `Annual Percentage Yield`. It will be shown in UI by separate columns (in the `Validators` tab and in the `Delegators` popup). For example (it is test screens without real values):

<img src="https://user-images.githubusercontent.com/33550681/106466539-7ed56980-64ac-11eb-9821-ab20c4d00dab.png" width="500" />

<img src="https://user-images.githubusercontent.com/33550681/106466354-446bcc80-64ac-11eb-9131-32af1e7bb893.png" width="500" />

The `Delegators` popup will also display an approximate expected reward which will be accrued in tokens at the end of the current staking epoch.

The feature doesn't require any additional fields in the database.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
