### PR TITLE
Prevent update validator metadata with empty name from contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3600](https://github.com/poanetwork/blockscout/pull/3600) - Prevent update validator metadata with empty name from contract
 - [#3592](https://github.com/poanetwork/blockscout/pull/3592) - Contract interaction: fix nested tuples in the output view, add formatting
 - [#3583](https://github.com/poanetwork/blockscout/pull/3583) - Reduce RPC requests and DB changes by Staking DApp
 

--- a/apps/explorer/lib/explorer/validator/metadata_importer.ex
+++ b/apps/explorer/lib/explorer/validator/metadata_importer.ex
@@ -9,7 +9,12 @@ defmodule Explorer.Validator.MetadataImporter do
 
   def import_metadata(metadata_maps) do
     # Enforce Name ShareLocks order (see docs: sharelocks.md)
-    ordered_metadata_maps = Enum.sort_by(metadata_maps, &{&1.address_hash, &1.name})
+    ordered_metadata_maps =
+      metadata_maps
+      |> Enum.filter(fn metadata ->
+        String.trim(metadata.name) !== ""
+      end)
+      |> Enum.sort_by(&{&1.address_hash, &1.name})
 
     Repo.transaction(fn -> Enum.each(ordered_metadata_maps, &upsert_validator_metadata(&1)) end)
   end


### PR DESCRIPTION
## Motivation

If validator's name is not from the metadata contract (hardcoded in DB), it wipes with empty name on the next scheduled update of metadata

## Changelog

Do not update metadata if name in contract's is empty

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
