### PR TITLE
Display method output parameter name at contract read page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3603](https://github.com/poanetwork/blockscout/pull/3603) -  Display method output parameter name at contract read page
 - [#3584](https://github.com/poanetwork/blockscout/pull/3584) - Token holders API endpoint
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -94,7 +94,7 @@ to: address_contract_path(@conn, :index, metadata_for_verification.address_hash)
             <%= if (queryable?(function["inputs"])), do: raw "&#8627;" %>
 
             <%= for output <- function["outputs"] do %>
-              <%= output["type"] %>
+              <%= if output["name"] && output["name"] !== "", do: "#{output["name"]}(#{output["type"]})", else: output["type"] %>
             <% end %>
           </div>
         <% end %>


### PR DESCRIPTION
Closes https://github.com/poanetwork/blockscout/issues/3538

## Motivation

Contract method output parameters names are not displayed at the read page:

<img width="358" alt="Screenshot 2021-02-02 at 16 18 12" src="https://user-images.githubusercontent.com/4341812/106605726-4a2be580-6572-11eb-9711-953385b31ed6.png">


## Changelog

<img width="415" alt="Screenshot 2021-02-02 at 16 18 22" src="https://user-images.githubusercontent.com/4341812/106605784-59ab2e80-6572-11eb-83cc-0e0c7ead7da8.png">



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
