### PR TITLE
POSDAO refactoring: use 'getDelegatorPools' getter instead of 'getStakerPools' in Staking DApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3577](https://github.com/poanetwork/blockscout/pull/3577) - Eliminate GraphiQL page XSS attack
 
 ### Chore
+- [#3612](https://github.com/poanetwork/blockscout/pull/3612) - POSDAO refactoring: use 'getDelegatorPools' getter instead of 'getStakerPools' in Staking DApp
 - [#3585](https://github.com/poanetwork/blockscout/pull/3585) - Add autoswitching from eth_subscribe to eth_blockNumber in Staking DApp
 - [#3574](https://github.com/poanetwork/blockscout/pull/3574) - Correct UNI token price
 - [#3569](https://github.com/poanetwork/blockscout/pull/3569) - Allow re-define cache period vars at runtime

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -483,21 +483,21 @@ defmodule BlockScoutWeb.StakesChannel do
 
       responses =
         staker
-        |> ContractReader.get_staker_pools_length_request()
+        |> ContractReader.get_delegator_pools_length_request()
         |> ContractReader.perform_requests(%{staking: staking_contract.address}, staking_contract.abi)
 
-      staker_pools_length = responses[:length]
+      delegator_pools_length = responses[:length]
 
       chunk_size = 100
 
       pools =
-        if staker_pools_length > 0 do
-          chunks = 0..trunc(ceil(staker_pools_length / chunk_size) - 1)
+        if delegator_pools_length > 0 do
+          chunks = 0..trunc(ceil(delegator_pools_length / chunk_size) - 1)
 
           Enum.reduce(chunks, [], fn i, acc ->
             responses =
               staker
-              |> ContractReader.get_staker_pools_request(i * chunk_size, chunk_size)
+              |> ContractReader.get_delegator_pools_request(i * chunk_size, chunk_size)
               |> ContractReader.perform_requests(%{staking: staking_contract.address}, staking_contract.abi)
 
             acc ++
@@ -508,6 +508,13 @@ defmodule BlockScoutWeb.StakesChannel do
         else
           []
         end
+
+      # if `staker` is a pool, prepend its address to the `pools` array
+      pools = if socket.assigns[:mining_address] != nil do
+        [staker | pools]
+      else
+        pools
+      end
 
       pools_amounts =
         Enum.map(pools, fn pool_staking_address ->

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -510,11 +510,12 @@ defmodule BlockScoutWeb.StakesChannel do
         end
 
       # if `staker` is a pool, prepend its address to the `pools` array
-      pools = if socket.assigns[:mining_address] != nil do
-        [staker | pools]
-      else
-        pools
-      end
+      pools =
+        if socket.assigns[:mining_address] != nil do
+          [staker | pools]
+        else
+          pools
+        end
 
       pools_amounts =
         Enum.map(pools, fn pool_staking_address ->

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -2183,7 +2183,7 @@ msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:761
+#: lib/block_scout_web/channels/stakes_channel.ex:762
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2258,7 +2258,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:817
+#: lib/block_scout_web/channels/stakes_channel.ex:818
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:858
+#: lib/block_scout_web/channels/stakes_channel.ex:859
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2358,7 +2358,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:861
+#: lib/block_scout_web/channels/stakes_channel.ex:862
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2453,19 +2453,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:824
-#: lib/block_scout_web/channels/stakes_channel.ex:871
+#: lib/block_scout_web/channels/stakes_channel.ex:825
+#: lib/block_scout_web/channels/stakes_channel.ex:872
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:864
+#: lib/block_scout_web/channels/stakes_channel.ex:865
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:820
-#: lib/block_scout_web/channels/stakes_channel.ex:867
+#: lib/block_scout_web/channels/stakes_channel.ex:821
+#: lib/block_scout_web/channels/stakes_channel.ex:868
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -2183,7 +2183,7 @@ msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:754
+#: lib/block_scout_web/channels/stakes_channel.ex:761
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2258,7 +2258,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:810
+#: lib/block_scout_web/channels/stakes_channel.ex:817
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:851
+#: lib/block_scout_web/channels/stakes_channel.ex:858
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2358,7 +2358,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:854
+#: lib/block_scout_web/channels/stakes_channel.ex:861
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2453,19 +2453,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:817
-#: lib/block_scout_web/channels/stakes_channel.ex:864
+#: lib/block_scout_web/channels/stakes_channel.ex:824
+#: lib/block_scout_web/channels/stakes_channel.ex:871
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:857
+#: lib/block_scout_web/channels/stakes_channel.ex:864
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:813
-#: lib/block_scout_web/channels/stakes_channel.ex:860
+#: lib/block_scout_web/channels/stakes_channel.ex:820
+#: lib/block_scout_web/channels/stakes_channel.ex:867
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -2183,7 +2183,7 @@ msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:761
+#: lib/block_scout_web/channels/stakes_channel.ex:762
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2258,7 +2258,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:817
+#: lib/block_scout_web/channels/stakes_channel.ex:818
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:858
+#: lib/block_scout_web/channels/stakes_channel.ex:859
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2358,7 +2358,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:861
+#: lib/block_scout_web/channels/stakes_channel.ex:862
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2453,19 +2453,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:824
-#: lib/block_scout_web/channels/stakes_channel.ex:871
+#: lib/block_scout_web/channels/stakes_channel.ex:825
+#: lib/block_scout_web/channels/stakes_channel.ex:872
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:864
+#: lib/block_scout_web/channels/stakes_channel.ex:865
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:820
-#: lib/block_scout_web/channels/stakes_channel.ex:867
+#: lib/block_scout_web/channels/stakes_channel.ex:821
+#: lib/block_scout_web/channels/stakes_channel.ex:868
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -2183,7 +2183,7 @@ msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:754
+#: lib/block_scout_web/channels/stakes_channel.ex:761
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2258,7 +2258,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:810
+#: lib/block_scout_web/channels/stakes_channel.ex:817
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:851
+#: lib/block_scout_web/channels/stakes_channel.ex:858
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2358,7 +2358,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:854
+#: lib/block_scout_web/channels/stakes_channel.ex:861
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2453,19 +2453,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:817
-#: lib/block_scout_web/channels/stakes_channel.ex:864
+#: lib/block_scout_web/channels/stakes_channel.ex:824
+#: lib/block_scout_web/channels/stakes_channel.ex:871
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:857
+#: lib/block_scout_web/channels/stakes_channel.ex:864
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:813
-#: lib/block_scout_web/channels/stakes_channel.ex:860
+#: lib/block_scout_web/channels/stakes_channel.ex:820
+#: lib/block_scout_web/channels/stakes_channel.ex:867
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 

--- a/apps/explorer/lib/explorer/staking/contract_reader.ex
+++ b/apps/explorer/lib/explorer/staking/contract_reader.ex
@@ -342,17 +342,17 @@ defmodule Explorer.Staking.ContractReader do
     ]
   end
 
-  def get_staker_pools_request(staker, offset, length) do
+  def get_delegator_pools_request(delegator, offset, length) do
     [
-      # 9dc77988 = keccak256(getStakerPools(address,uint256,uint256))
-      pools: {:staking, "9dc77988", [staker, offset, length]}
+      # 2ebfaf4e = keccak256(getDelegatorPools(address,uint256,uint256))
+      pools: {:staking, "2ebfaf4e", [delegator, offset, length]}
     ]
   end
 
-  def get_staker_pools_length_request(staker) do
+  def get_delegator_pools_length_request(delegator) do
     [
-      # a6a3a256 = keccak256(getStakerPoolsLength(address))
-      length: {:staking, "a6a3a256", [staker]}
+      # 8ba31a1c = keccak256(getDelegatorPoolsLength(address))
+      length: {:staking, "8ba31a1c", [delegator]}
     ]
   end
 

--- a/apps/explorer/priv/contracts_abi/posdao/StakingAuRa.json
+++ b/apps/explorer/priv/contracts_abi/posdao/StakingAuRa.json
@@ -40,7 +40,7 @@
     "constant": true,
     "inputs": [
       {
-        "name": "_staker",
+        "name": "_delegator",
         "type": "address"
       },
       {
@@ -52,7 +52,7 @@
         "type": "uint256"
       }
     ],
-    "name": "getStakerPools",
+    "name": "getDelegatorPools",
     "outputs": [
       {
         "name": "result",
@@ -67,11 +67,11 @@
     "constant": true,
     "inputs": [
       {
-        "name": "_staker",
+        "name": "_delegator",
         "type": "address"
       }
     ],
-    "name": "getStakerPoolsLength",
+    "name": "getDelegatorPoolsLength",
     "outputs": [
       {
         "name": "",


### PR DESCRIPTION
## Motivation

This is a small refactoring PR that reflects the changes made in https://github.com/poanetwork/posdao-contracts/commit/2994441358329e2e725edd0c4dccf6812e8fbea0. It is part of big refactoring in POSDAO contracts to add there an ability for changing pool's stakingAddress/miningAddress. We'll be making the changes step-by-step in small portions like this one.

Please, don't merge and publish Blockscout release with these changes until we upgrade the `StakingAuRa` contract to apply [the changes](https://github.com/poanetwork/posdao-contracts/commit/2994441358329e2e725edd0c4dccf6812e8fbea0). I'll let you know once that happens.

## Checklist for your Pull Request (PR)
  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
