### PR TITLE
POSDAO refactoring: use zero address instead of staker address for certain cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3577](https://github.com/poanetwork/blockscout/pull/3577) - Eliminate GraphiQL page XSS attack
 
 ### Chore
+- [#3616](https://github.com/poanetwork/blockscout/pull/3616) - POSDAO refactoring: use zero address instead of staker address for certain cases
 - [#3612](https://github.com/poanetwork/blockscout/pull/3612) - POSDAO refactoring: use 'getDelegatorPools' getter instead of 'getStakerPools' in Staking DApp
 - [#3585](https://github.com/poanetwork/blockscout/pull/3585) - Add autoswitching from eth_subscribe to eth_blockNumber in Staking DApp
 - [#3574](https://github.com/poanetwork/blockscout/pull/3574) - Correct UNI token price

--- a/apps/explorer/lib/explorer/staking/contract_reader.ex
+++ b/apps/explorer/lib/explorer/staking/contract_reader.ex
@@ -370,7 +370,9 @@ defmodule Explorer.Staking.ContractReader do
     ]
   end
 
-  def pool_staking_requests(staking_address, block_number) do
+  def pool_staking_requests(staking_address, block_number, net_version) do
+    staking_address_or_zero = refine_staker_address(staking_address, staking_address, block_number, net_version)
+
     [
       active_delegators: active_delegators_request(staking_address, block_number)[:active_delegators],
       # 73c21803 = keccak256(poolDelegatorsInactive(address))
@@ -379,8 +381,7 @@ defmodule Explorer.Staking.ContractReader do
       is_active: {:staking, "a711e6a1", [staking_address], block_number},
       mining_address_hash: mining_by_staking_request(staking_address, block_number)[:mining_address],
       # a697ecff = keccak256(stakeAmount(address,address))
-      self_staked_amount:
-        {:staking, "a697ecff", [staking_address, "0x0000000000000000000000000000000000000000"], block_number},
+      self_staked_amount: {:staking, "a697ecff", [staking_address, staking_address_or_zero], block_number},
       # 5267e1d6 = keccak256(stakeAmountTotal(address))
       total_staked_amount: {:staking, "5267e1d6", [staking_address], block_number},
       # 527d8bc4 = keccak256(validatorRewardPercent(address))

--- a/apps/explorer/lib/explorer/staking/contract_reader.ex
+++ b/apps/explorer/lib/explorer/staking/contract_reader.ex
@@ -411,7 +411,7 @@ defmodule Explorer.Staking.ContractReader do
   def refine_staker_address(pool_staking_address, staker_address, block_number, net_version) do
     # this is a block number from which POSDAO on xDai chain started to use a zero address
     # instead of staking address for the cases when the staker is a pool staking address
-    zero_allowed = (net_version == 100 and block_number >= 14_389_081) or net_version != 100
+    zero_allowed = (net_version == 100 and block_number >= 14_474_689) or net_version != 100
 
     if staker_address == pool_staking_address and zero_allowed do
       "0x0000000000000000000000000000000000000000"

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -543,7 +543,7 @@ defmodule Explorer.Staking.ContractState do
     # read pool info from the contracts by its staking address
     pool_staking_responses =
       pools
-      |> Enum.map(&ContractReader.pool_staking_requests(&1, block_number))
+      |> Enum.map(&ContractReader.pool_staking_requests(&1, block_number, net_version))
       |> ContractReader.perform_grouped_requests(pools, contracts, abi)
 
     # read pool info from the contracts by its mining address

--- a/apps/explorer/test/explorer/staking/contract_state_test.exs
+++ b/apps/explorer/test/explorer/staking/contract_state_test.exs
@@ -73,6 +73,15 @@ defmodule Explorer.Staking.ContractStateTest do
       end
     )
 
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn _request, _opts ->
+        # net_version
+        {:ok, "101"}
+      end
+    )
+
     # get_token, fetch_token, MetadataRetriever.get_functions_of
     expect(
       EthereumJSONRPC.Mox,


### PR DESCRIPTION
## Motivation

This is a small refactoring PR that reflects the changes made in https://github.com/poanetwork/posdao-contracts/commit/73e04a44e74c4289c240d577d9cb6db2931e47c2 and https://github.com/poanetwork/posdao-contracts/commit/0f8bf7f61782abfadcebe0a5cc26e99305050894. It is part of big refactoring in POSDAO contracts to add there an ability for changing pool's stakingAddress/miningAddress. We'll be making the changes step-by-step in small portions like this one.

Please, don't merge and publish Blockscout release with these changes until we upgrade the `StakingAuRa` and `BlockRewardAuRa` contracts to apply the changes mentioned above. I'll let you know once that happens.

## Checklist for your Pull Request (PR)
  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
