### PR TITLE
Contracts verification up to 10 libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3577](https://github.com/poanetwork/blockscout/pull/3577) - Eliminate GraphiQL page XSS attack
 
 ### Chore
+- [#3618](https://github.com/poanetwork/blockscout/pull/3618) - Contracts verification up to 10 libraries
 - [#3612](https://github.com/poanetwork/blockscout/pull/3612) - POSDAO refactoring: use 'getDelegatorPools' getter instead of 'getStakerPools' in Staking DApp
 - [#3585](https://github.com/poanetwork/blockscout/pull/3585) - Add autoswitching from eth_subscribe to eth_blockNumber in Staking DApp
 - [#3574](https://github.com/poanetwork/blockscout/pull/3574) - Correct UNI token price

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -227,7 +227,7 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
   defp parse_optimization_runs(other), do: other
 
   defp fetch_external_libraries(params) do
-    Enum.reduce(1..5, %{}, fn number, acc ->
+    Enum.reduce(1..10, %{}, fn number, acc ->
       case Map.fetch(params, "library#{number}Name") do
         {:ok, library_name} ->
           library_address = Map.get(params, "library#{number}Address")

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/verified_smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/verified_smart_contract_controller.ex
@@ -52,7 +52,7 @@ defmodule BlockScoutWeb.API.V1.VerifiedSmartContractController do
   end
 
   defp fetch_external_libraries(params) do
-    keys = Enum.flat_map(1..5, fn i -> ["library#{i}_name", "library#{i}_address"] end)
+    keys = Enum.flat_map(1..10, fn i -> ["library#{i}_name", "library#{i}_address"] end)
 
     Map.take(params, keys)
   end

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
@@ -176,7 +176,7 @@
                 <div class="center-column">
                   <%= text_input :external_libraries, :library1_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
                 </div>
-                <div class="smart-contract-form-group-tooltip">A library name called in the .sol file. Multiple libraries (up to 5) may be added for each contract. Click the Add Library button to add an additional one.</div>
+                <div class="smart-contract-form-group-tooltip">A library name called in the .sol file. Multiple libraries (up to 10) may be added for each contract. Click the Add Library button to add an additional one.</div>
               </div>
             </div>
 
@@ -270,9 +270,119 @@
 
             <div class="smart-contract-form-group">
               <div class="smart-contract-form-group-inner-wrapper">
-                <%= label f, :library5, gettext("Library Address") %>
+                <%= label :external_libraries, :library5, gettext("Library Address") %>
                 <div class="center-column">
-                  <%= text_input f, :library5_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+                  <%= text_input :external_libraries, :library5_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+                </div>
+                <div class="smart-contract-form-group-tooltip"></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="contract-library-form-group js-contract-library-form-group">
+            <div class="smart-contract-form-group">
+              <div class="smart-contract-form-group-inner-wrapper">
+                <%= label :external_libraries, :library6, gettext("Library Name") %>
+                <div class="center-column">
+                  <%= text_input :external_libraries, :library6_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+                </div>
+                <div class="smart-contract-form-group-tooltip"></div>
+              </div>
+            </div>
+
+            <div class="smart-contract-form-group">
+              <div class="smart-contract-form-group-inner-wrapper">
+                <%= label :external_libraries, :library6, gettext("Library Address") %>
+                <div class="center-column">
+                  <%= text_input :external_libraries, :library6_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+                </div>
+                <div class="smart-contract-form-group-tooltip"></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="contract-library-form-group js-contract-library-form-group">
+            <div class="smart-contract-form-group">
+              <div class="smart-contract-form-group-inner-wrapper">
+                <%= label :external_libraries, :library7, gettext("Library Name") %>
+                <div class="center-column">
+                  <%= text_input :external_libraries, :library7_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+                </div>
+                <div class="smart-contract-form-group-tooltip"></div>
+              </div>
+            </div>
+
+            <div class="smart-contract-form-group">
+              <div class="smart-contract-form-group-inner-wrapper">
+                <%= label :external_libraries, :library7, gettext("Library Address") %>
+                <div class="center-column">
+                  <%= text_input :external_libraries, :library7_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+                </div>
+                <div class="smart-contract-form-group-tooltip"></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="contract-library-form-group js-contract-library-form-group">
+            <div class="smart-contract-form-group">
+              <div class="smart-contract-form-group-inner-wrapper">
+                <%= label :external_libraries, :library8, gettext("Library Name") %>
+                <div class="center-column">
+                  <%= text_input :external_libraries, :library8_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+                </div>
+                <div class="smart-contract-form-group-tooltip"></div>
+              </div>
+            </div>
+
+            <div class="smart-contract-form-group">
+              <div class="smart-contract-form-group-inner-wrapper">
+                <%= label :external_libraries, :library8, gettext("Library Address") %>
+                <div class="center-column">
+                  <%= text_input :external_libraries, :library8_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+                </div>
+                <div class="smart-contract-form-group-tooltip"></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="contract-library-form-group js-contract-library-form-group">
+            <div class="smart-contract-form-group">
+              <div class="smart-contract-form-group-inner-wrapper">
+                <%= label :external_libraries, :library9, gettext("Library Name") %>
+                <div class="center-column">
+                  <%= text_input :external_libraries, :library9_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+                </div>
+                <div class="smart-contract-form-group-tooltip"></div>
+              </div>
+            </div>
+
+            <div class="smart-contract-form-group">
+              <div class="smart-contract-form-group-inner-wrapper">
+                <%= label :external_libraries, :library9, gettext("Library Address") %>
+                <div class="center-column">
+                  <%= text_input :external_libraries, :library9_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+                </div>
+                <div class="smart-contract-form-group-tooltip"></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="contract-library-form-group js-contract-library-form-group">
+            <div class="smart-contract-form-group">
+              <div class="smart-contract-form-group-inner-wrapper">
+                <%= label :external_libraries, :library10, gettext("Library Name") %>
+                <div class="center-column">
+                  <%= text_input :external_libraries, :library10_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+                </div>
+                <div class="smart-contract-form-group-tooltip"></div>
+              </div>
+            </div>
+
+            <div class="smart-contract-form-group">
+              <div class="smart-contract-form-group-inner-wrapper">
+                <%= label f, :library10, gettext("Library Address") %>
+                <div class="center-column">
+                  <%= text_input f, :library10_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
                 </div>
                 <div class="smart-contract-form-group-tooltip"></div>
               </div>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -263,7 +263,7 @@ msgid "Call Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:305
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:415
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:47
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:54
 msgid "Cancel"
@@ -969,6 +969,11 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:229
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:251
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:273
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:295
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:317
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:339
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:361
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:383
 msgid "Library Address"
 msgstr ""
 
@@ -978,6 +983,11 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:219
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:241
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:263
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:285
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:307
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:329
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:351
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:373
 msgid "Library Name"
 msgstr ""
 
@@ -1006,7 +1016,7 @@ msgid "Loading..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:299
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:409
 msgid "Loading...."
 msgstr ""
 
@@ -1210,7 +1220,7 @@ msgid "Request URL"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:302
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:412
 msgid "Reset"
 msgstr ""
 
@@ -1571,7 +1581,7 @@ msgid "Verify & Publish"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:301
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:411
 msgid "Verify & publish"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -263,7 +263,7 @@ msgid "Call Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:305
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:415
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:47
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:54
 msgid "Cancel"
@@ -969,6 +969,11 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:229
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:251
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:273
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:295
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:317
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:339
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:361
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:383
 msgid "Library Address"
 msgstr ""
 
@@ -978,6 +983,11 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:219
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:241
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:263
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:285
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:307
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:329
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:351
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:373
 msgid "Library Name"
 msgstr ""
 
@@ -1006,7 +1016,7 @@ msgid "Loading..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:299
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:409
 msgid "Loading...."
 msgstr ""
 
@@ -1210,7 +1220,7 @@ msgid "Request URL"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:302
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:412
 msgid "Reset"
 msgstr ""
 
@@ -1571,7 +1581,7 @@ msgid "Verify & Publish"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:301
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:411
 msgid "Verify & publish"
 msgstr ""
 

--- a/apps/explorer/lib/explorer/smart_contract/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/publisher.ex
@@ -104,7 +104,7 @@ defmodule Explorer.SmartContract.Publisher do
 
   defp add_external_libraries(params, external_libraries) do
     clean_external_libraries =
-      Enum.reduce(1..5, %{}, fn number, acc ->
+      Enum.reduce(1..10, %{}, fn number, acc ->
         address_key = "library#{number}_address"
         name_key = "library#{number}_name"
 


### PR DESCRIPTION
## Motivation

For some contracts, the max limit of 5 libraries for verification is not enough.

## Changelog

Increase max number of libraries up to 10 in contracts verification

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
