### PR TITLE
Contract reader: fix int type output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3622](https://github.com/poanetwork/blockscout/pull/3622) - Contract reader: fix int type output
 - [#3621](https://github.com/poanetwork/blockscout/pull/3621) - Contract reader: :binary input/output fix
 - [#3620](https://github.com/poanetwork/blockscout/pull/3620) - Ignore unfamiliar messages by Explorer.Staking.ContractState module
 - [#3611](https://github.com/poanetwork/blockscout/pull/3611) - Fix logo size

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -109,11 +109,7 @@ defmodule BlockScoutWeb.SmartContractView do
   def values_with_type(value, :bool, _components), do: render_type_value("bool", to_string(value))
 
   def values_with_type(value, type, _components) do
-    if String.starts_with?(type, "uint") do
-      render_type_value(type, to_string(value))
-    else
-      render_type_value(type, binary_to_utf_string(value))
-    end
+    render_type_value(type, binary_to_utf_string(value))
   end
 
   def values_only(value, type, components) when is_list(value) do
@@ -180,12 +176,8 @@ defmodule BlockScoutWeb.SmartContractView do
 
   def values_only(value, :bool, _components), do: to_string(value)
 
-  def values_only(value, type, _components) do
-    if String.starts_with?(type, "uint") do
-      to_string(value)
-    else
-      binary_to_utf_string(value)
-    end
+  def values_only(value, _type, _components) do
+    binary_to_utf_string(value)
   end
 
   defp tuple_array_to_array(value, type) do
@@ -265,14 +257,20 @@ defmodule BlockScoutWeb.SmartContractView do
   end
 
   defp binary_to_utf_string(item) do
-    if is_binary(item) do
-      if String.starts_with?(item, "0x") do
-        item
-      else
-        "0x" <> Base.encode16(item, case: :lower)
-      end
-    else
-      item
+    case Integer.parse(to_string(item)) do
+      {item_integer, ""} ->
+        to_string(item_integer)
+
+      _ ->
+        if is_binary(item) do
+          if String.starts_with?(item, "0x") do
+            item
+          else
+            "0x" <> Base.encode16(item, case: :lower)
+          end
+        else
+          to_string(item)
+        end
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
@@ -326,5 +326,11 @@ defmodule BlockScoutWeb.SmartContractViewTest do
 
       assert SmartContractView.values_only(value, "uint64", nil) == "0"
     end
+
+    test "returns the value when the type is int(n) and value is 0" do
+      value = "0"
+
+      assert SmartContractView.values_only(value, "int64", nil) == "0"
+    end
   end
 end


### PR DESCRIPTION
## Motivation

Resolve Internal server error caused by Int(x) type "0" value in the output of the contract method

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
