### PR TITLE
Ignore unrecognized messages in bridge counter processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
-- [#3622](https://github.com/poanetwork/blockscout/pull/3622) - Contract reader: fix int type output
+- [#3623](https://github.com/poanetwork/blockscout/pull/3623) - Ignore unrecognized messages in bridge counter processes
+- [#3622](https://github.com/poanetwork/blockscout/pull/3622) - Contract reader: fix int type output Ignore unrecognized messages in bridge counter processes
 - [#3621](https://github.com/poanetwork/blockscout/pull/3621) - Contract reader: :binary input/output fix
 - [#3620](https://github.com/poanetwork/blockscout/pull/3620) - Ignore unfamiliar messages by Explorer.Staking.ContractState module
 - [#3611](https://github.com/poanetwork/blockscout/pull/3611) - Fix logo size

--- a/apps/explorer/lib/explorer/counters/bridge.ex
+++ b/apps/explorer/lib/explorer/counters/bridge.ex
@@ -96,6 +96,11 @@ defmodule Explorer.Counters.Bridge do
     {:noreply, state}
   end
 
+  # don't handle other messages (e.g. :ssl_closed)
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
+
   def fetch_token_bridge_total_supply do
     if bridges_table_exists?() do
       do_fetch_token_bridge_total_supply(:ets.lookup(@bridges_table, @current_total_supply_from_token_bridge_cache_key))


### PR DESCRIPTION
## Motivation

```
2021-02-10T09:46:14.726 [error] GenServer Explorer.Counters.Bridge terminating
** (FunctionClauseError) no function clause matching in Explorer.Counters.Bridge.handle_info/2
    (explorer 0.0.1) lib/explorer/counters/bridge.ex:92: Explorer.Counters.Bridge.handle_info({:ssl_closed, {:sslsocket, {:gen_tcp, #Port<0.2302>, :tls_connection, :undefined}, [#PID<0.10152.0>, #PID<0.10150.0>]}}, %{consolidate?: true})
    (stdlib 3.13) gen_server.erl:680: :gen_server.try_dispatch/4
    (stdlib 3.13) gen_server.erl:756: :gen_server.handle_msg/6
    (stdlib 3.13) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {:ssl_closed, {:sslsocket, {:gen_tcp, #Port<0.2302>, :tls_connection, :undefined}, [#PID<0.10152.0>, #PID<0.10150.0>]}}
State: %{consolidate?: true}
```

## Changelog

Add default function clause for `handle_info`


## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
