### PR TITLE
Fix transaction decoding view: support tuple types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3634](https://github.com/poanetwork/blockscout/pull/3634) - Fix transaction decoding view: support tuple types
 - [#3623](https://github.com/poanetwork/blockscout/pull/3623) - Ignore unrecognized messages in bridge counter processes
 - [#3622](https://github.com/poanetwork/blockscout/pull/3622) - Contract reader: fix int type output Ignore unrecognized messages in bridge counter processes
 - [#3621](https://github.com/poanetwork/blockscout/pull/3621) - Contract reader: :binary input/output fix

--- a/apps/block_scout_web/lib/block_scout_web/views/abi_encoded_value_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/abi_encoded_value_view.ex
@@ -89,6 +89,20 @@ defmodule BlockScoutWeb.ABIEncodedValueView do
     ~E|<%= spacing %>[<%= "\n" %><%= delimited %><%= "\n" %><%= spacing %>]|
   end
 
+  defp do_value_html({:tuple, types}, values, _) do
+    values_list =
+      values
+      |> Tuple.to_list()
+      |> Enum.with_index()
+      |> Enum.map(fn {value, i} ->
+        type = Enum.at(types, i)
+        [_, {:safe, val}] = do_value_html(type, value)
+        val
+      end)
+
+    "(" <> Enum.join(values_list, ",") <> ")"
+  end
+
   defp do_value_html(type, value, depth) do
     spacing = String.duplicate(" ", depth * 2)
     ~E|<%= spacing %><%=base_value_html(type, value)%>|

--- a/apps/block_scout_web/test/block_scout_web/views/abi_encoded_value_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/abi_encoded_value_view_test.exs
@@ -95,6 +95,10 @@ defmodule BlockScoutWeb.ABIEncodedValueViewTest do
     test "it renders :dynamic values as bytes" do
       assert value_html("uint", {:dynamic, <<1>>}) == "0x01"
     end
+
+    test "it renders :tuple values as string" do
+      assert value_html("(uint256)", {123}) == "(123)"
+    end
   end
 
   describe "copy_text/2" do


### PR DESCRIPTION
## Motivation

Error rendering view inn transactions decoding view.

<img width="1244" alt="Screenshot 2021-02-15 at 20 36 39" src="https://user-images.githubusercontent.com/4341812/107978266-86793000-6fcd-11eb-912c-da7b7baf3553.png">



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
