### PR TITLE
Order bridged tokens in descending order by tokens holder for Omni bridge cap calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#3577](https://github.com/poanetwork/blockscout/pull/3577) - Eliminate GraphiQL page XSS attack
 
 ### Chore
+- [#3662](https://github.com/poanetwork/blockscout/pull/3662) - Order bridged tokens in descending order by tokens holder for Omni bridge cap calculation
 - [#3659](https://github.com/poanetwork/blockscout/pull/3659) - Staking Dapp new buttons: swap, bridge
 - [#3645](https://github.com/poanetwork/blockscout/pull/3645) - Change Twitter handle
 - [#3644](https://github.com/poanetwork/blockscout/pull/3644) - Correct exchange rate for SURF.finance token

--- a/apps/explorer/lib/explorer/chain/supply/token_bridge.ex
+++ b/apps/explorer/lib/explorer/chain/supply/token_bridge.ex
@@ -208,7 +208,9 @@ defmodule Explorer.Chain.Supply.TokenBridge do
         left_join: t in Token,
         on: t.contract_address_hash == bt.home_token_contract_address_hash,
         where: bt.foreign_chain_id == ^1,
-        select: {bt.home_token_contract_address_hash, t.symbol}
+        where: t.bridged == true,
+        select: {bt.home_token_contract_address_hash, t.symbol},
+        order_by: [desc: t.holder_count]
       )
 
     query


### PR DESCRIPTION
## Motivation

Tokens with more holders should get the price first from CoinGecko. Requests of the price for other tokens may be rate-limited by CoinGecko.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
