### PR TITLE
Store bridged token price in the DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#3577](https://github.com/poanetwork/blockscout/pull/3577) - Eliminate GraphiQL page XSS attack
 
 ### Chore
+- [#3667](https://github.com/poanetwork/blockscout/pull/3667) - Store bridged token price in the DB
 - [#3662](https://github.com/poanetwork/blockscout/pull/3662) - Order bridged tokens in descending order by tokens holder for Omni bridge cap calculation
 - [#3659](https://github.com/poanetwork/blockscout/pull/3659) - Staking Dapp new buttons: swap, bridge
 - [#3645](https://github.com/poanetwork/blockscout/pull/3645) - Change Twitter handle

--- a/apps/explorer/lib/explorer/chain/bridged_token.ex
+++ b/apps/explorer/lib/explorer/chain/bridged_token.ex
@@ -24,7 +24,8 @@ defmodule Explorer.Chain.BridgedToken do
           home_token_contract_address: %Ecto.Association.NotLoaded{} | Address.t(),
           home_token_contract_address_hash: Hash.Address.t(),
           custom_metadata: String.t(),
-          type: String.t()
+          type: String.t(),
+          exchange_rate: Decimal.t()
         }
 
   @derive {Poison.Encoder,
@@ -49,6 +50,7 @@ defmodule Explorer.Chain.BridgedToken do
     field(:foreign_token_contract_address_hash, Hash.Address)
     field(:custom_metadata, :string)
     field(:type, :string)
+    field(:exchange_rate, :decimal)
 
     belongs_to(
       :home_token_contract_address,
@@ -63,7 +65,7 @@ defmodule Explorer.Chain.BridgedToken do
   end
 
   @required_attrs ~w(home_token_contract_address_hash)a
-  @optional_attrs ~w(foreign_chain_id foreign_token_contract_address_hash custom_metadata type)a
+  @optional_attrs ~w(foreign_chain_id foreign_token_contract_address_hash custom_metadata type exchange_rate)a
 
   @doc false
   def changeset(%BridgedToken{} = bridged_token, params \\ %{}) do

--- a/apps/explorer/lib/explorer/chain/cache/token_exchange_rate.ex
+++ b/apps/explorer/lib/explorer/chain/cache/token_exchange_rate.ex
@@ -139,7 +139,7 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
   def put_into_db(token_hash, exchange_rate) do
     token = get_token(token_hash)
 
-    if token do
+    if token && !is_nil(exchange_rate) do
       token
       |> Changeset.change(%{exchange_rate: exchange_rate})
       |> Repo.update()

--- a/apps/explorer/lib/explorer/chain/supply/token_bridge.ex
+++ b/apps/explorer/lib/explorer/chain/supply/token_bridge.ex
@@ -194,12 +194,13 @@ defmodule Explorer.Chain.Supply.TokenBridge do
     omni_bridge_market_cap
   end
 
-  def get_current_price_for_bridged_token(symbol) when is_nil(symbol), do: nil
+  def get_current_price_for_bridged_token(_token_hash, symbol) when is_nil(symbol), do: nil
+  def get_current_price_for_bridged_token(token_hash, _symbol) when is_nil(token_hash), do: nil
 
-  def get_current_price_for_bridged_token(symbol) do
+  def get_current_price_for_bridged_token(token_hash, symbol) do
     bridged_token_symbol_for_price_fetching = bridged_token_symbol_mapping_to_get_price(symbol)
 
-    TokenExchangeRateCache.fetch(bridged_token_symbol_for_price_fetching)
+    TokenExchangeRateCache.fetch(token_hash, bridged_token_symbol_for_price_fetching)
   end
 
   def get_bridged_mainnet_tokens_list do
@@ -221,7 +222,7 @@ defmodule Explorer.Chain.Supply.TokenBridge do
     bridged_mainnet_tokens_with_supply =
       bridged_mainnet_tokens_list
       |> Enum.map(fn {bridged_token_hash, bridged_token_symbol} ->
-        bridged_token_price_from_cache = TokenExchangeRateCache.fetch(bridged_token_symbol)
+        bridged_token_price_from_cache = TokenExchangeRateCache.fetch(bridged_token_hash, bridged_token_symbol)
 
         bridged_token_price =
           if bridged_token_price_from_cache && Decimal.cmp(bridged_token_price_from_cache, 0) == :gt do

--- a/apps/explorer/lib/explorer/counters/bridge.ex
+++ b/apps/explorer/lib/explorer/counters/bridge.ex
@@ -166,8 +166,8 @@ defmodule Explorer.Counters.Bridge do
     bridged_mainnet_tokens_list = TokenBridge.get_bridged_mainnet_tokens_list()
 
     bridged_mainnet_tokens_list
-    |> Enum.each(fn {_bridged_token_hash, bridged_token_symbol} ->
-      bridged_token_price = TokenBridge.get_current_price_for_bridged_token(bridged_token_symbol)
+    |> Enum.each(fn {bridged_token_hash, bridged_token_symbol} ->
+      bridged_token_price = TokenBridge.get_current_price_for_bridged_token(bridged_token_hash, bridged_token_symbol)
       cache_key = TokenExchangeRate.cache_key(bridged_token_symbol)
       TokenExchangeRate.put_into_cache(cache_key, bridged_token_price)
     end)

--- a/apps/explorer/lib/explorer/market/market.ex
+++ b/apps/explorer/lib/explorer/market/market.ex
@@ -63,7 +63,7 @@ defmodule Explorer.Market do
           fetch_token_usd_value(matches_known_address, symbol)
 
         mainnet_bridged_token?(token) ->
-          TokenBridge.get_current_price_for_bridged_token(symbol)
+          TokenBridge.get_current_price_for_bridged_token(token.contract_address_hash, symbol)
 
         true ->
           nil

--- a/apps/explorer/priv/repo/migrations/20210226154732_add_exchange_rate_column_to_bridged_tokens.exs
+++ b/apps/explorer/priv/repo/migrations/20210226154732_add_exchange_rate_column_to_bridged_tokens.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddExchangeRateColumnToBridgedTokens do
+  use Ecto.Migration
+
+  def change do
+    alter table("bridged_tokens") do
+      add(:exchange_rate, :decimal)
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Bridge market cap updater can not get token price reliably from CoinGecko for the whole bridged tokens list

## Changelog

Save exchange rate of token to the DB and gets old value from DB, if it is nil or 0 at CoinGecko scheduled update.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
