### PR TITLE
Token instance image IPFS link display fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3683](https://github.com/poanetwork/blockscout/pull/3683) - Token instance image IPFS link display fix
 - [#3655](https://github.com/poanetwork/blockscout/pull/3655) - Handle absence of readAll function in some old/legacy browsers
 - [#3634](https://github.com/poanetwork/blockscout/pull/3634) - Fix transaction decoding view: support tuple types
 - [#3623](https://github.com/poanetwork/blockscout/pull/3623) - Ignore unrecognized messages in bridge counter processes

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
@@ -23,7 +23,7 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewView do
     result =
       cond do
         instance.metadata && instance.metadata["image_url"] ->
-          instance.metadata["image_url"]
+          retrieve_image(instance.metadata["image_url"])
 
         instance.metadata && instance.metadata["image"] ->
           retrieve_image(instance.metadata["image"])
@@ -112,8 +112,13 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewView do
     image["description"]
   end
 
-  defp retrieve_image(image) do
-    image
+  defp retrieve_image(image_url) do
+    if image_url =~ "ipfs://ipfs" do
+      "ipfs://ipfs" <> ipfs_uid = image_url
+      "https://ipfs.io/ipfs/" <> ipfs_uid
+    else
+      image_url
+    end
   end
 
   defp tab_name(["token-transfers"]), do: gettext("Token Transfers")

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -894,7 +894,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/address_view.ex:346
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:119
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:124
 #: lib/block_scout_web/views/tokens/overview_view.ex:40
 #: lib/block_scout_web/views/transaction_view.ex:405
 msgid "Token Transfers"
@@ -1775,7 +1775,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/metadata/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:10
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:120
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:125
 msgid "Metadata"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -894,7 +894,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/address_view.ex:346
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:119
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:124
 #: lib/block_scout_web/views/tokens/overview_view.ex:40
 #: lib/block_scout_web/views/transaction_view.ex:405
 msgid "Token Transfers"
@@ -1775,7 +1775,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/metadata/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:10
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:120
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:125
 msgid "Metadata"
 msgstr ""
 
@@ -2692,7 +2692,7 @@ msgstr ""
 msgid "Bridged from BSC"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_top.html.eex:34
 msgid "Bridge to Ethereum"
 msgstr ""


### PR DESCRIPTION
## Motivation

Images from IPFS doesn't show on the token instance page

<img width="1371" alt="Screenshot 2021-03-04 at 16 09 04" src="https://user-images.githubusercontent.com/4341812/109968808-38219c00-7d04-11eb-8221-720a94526c31.png">


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
