### PR TITLE
Increase LP tokens calc process re-check interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#3577](https://github.com/poanetwork/blockscout/pull/3577) - Eliminate GraphiQL page XSS attack
 
 ### Chore
+- [#3701](https://github.com/poanetwork/blockscout/pull/3701) - Increase LP tokens calc process re-check interval
 - [#3697](https://github.com/poanetwork/blockscout/pull/3697) - Update hackney dependency
 - [#3696](https://github.com/poanetwork/blockscout/pull/3696) - Table loader fix
 - [#3688](https://github.com/poanetwork/blockscout/pull/3688) - Reorganize staking buttons

--- a/apps/indexer/lib/indexer/calc_lp_tokens_total_liquidity.ex
+++ b/apps/indexer/lib/indexer/calc_lp_tokens_total_liquidity.ex
@@ -9,7 +9,7 @@ defmodule Indexer.CalcLpTokensTotalLiqudity do
 
   alias Explorer.Chain
 
-  @interval :timer.minutes(10)
+  @interval :timer.minutes(20)
 
   def start_link([init_opts, gen_server_opts]) do
     start_link(init_opts, gen_server_opts)

--- a/apps/indexer/lib/indexer/set_omni_bridged_metadata_for_tokens.ex
+++ b/apps/indexer/lib/indexer/set_omni_bridged_metadata_for_tokens.ex
@@ -9,7 +9,7 @@ defmodule Indexer.SetOmniBridgedMetadataForTokens do
 
   alias Explorer.Chain
 
-  @interval :timer.minutes(1)
+  @interval :timer.minutes(10)
 
   def start_link([init_opts, gen_server_opts]) do
     start_link(init_opts, gen_server_opts)


### PR DESCRIPTION
## Motivation

Increase lp tokens calc process re-check interval from 1 minute to 10 minutes
Increase omni bridge metadata imported process re-check interval from 10 minutes to 20 minutes


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
