### PR TITLE
Fix trace internal transactions for create contract without code

### DIFF
--- a/apps/ethereum_jsonrpc/priv/js/ethereum_jsonrpc/geth/debug_traceTransaction/tracer.js
+++ b/apps/ethereum_jsonrpc/priv/js/ethereum_jsonrpc/geth/debug_traceTransaction/tracer.js
@@ -232,7 +232,7 @@
                 call.valueBigInt = bigInt.zero;
                 break;
             default:
-                throw "Unknown custom call op " + op;
+                throw 'Unknown custom call op ' + op;
         }
 
         this.callStack.push(call);
@@ -345,7 +345,11 @@
             result.error = error
         } else {
             result.createdContractAddressHash = toHex(ctx.to);
-            result.createdContractCode = toHex(db.getCode(ctx.to));
+            if (toHex(ctx.input) != '0x') {
+              result.createdContractCode = toHex(db.getCode(ctx.to));
+            } else {
+              result.createdContractCode = '0x';
+            }
         }
     },
 


### PR DESCRIPTION
We faced method handler crashed error in Kotti
```
[%{code: -32000, data: %{block_number: 1743966, transaction_hash: "0x0e439d91608cfcd2ff89ca9345bb8a93a4f1522fe82a0666e21f02afa7011848", transaction_index: 0}, message: "method handler crashed"}]
```

I found similar issues but there is no solution yet
https://github.com/poanetwork/blockscout/issues/3234
https://github.com/poanetwork/blockscout/issues/2445

But I found that in our case in Kotti this transactions is contact creation tx. But tx doesn't has input (so no contract code). 

```
{
    "jsonrpc": "2.0",
    "method": "eth_getTransactionByHash",
    "params": ["0x0e439d91608cfcd2ff89ca9345bb8a93a4f1522fe82a0666e21f02afa7011848"],
    "id": 83
}

{
    "jsonrpc": "2.0",
    "id": 83,
    "result": {
        "blockHash": "0x9e37819c590ace5a4451b4cb6374674bc1270f069d0fb95ad7898bef92844901",
        "blockNumber": "0x1a9c5e",
        "from": "0x0343bd58f238839da7b3b5179a44ab310ad5aa2b",
        "gas": "0x1368c",
        "gasPrice": "0x3b9aca00",
        "hash": "0x0e439d91608cfcd2ff89ca9345bb8a93a4f1522fe82a0666e21f02afa7011848",
        "input": "0x",
        "nonce": "0x3",
        "to": null,
        "transactionIndex": "0x0",
        "value": "0x0",
        "v": "0x30",
        "r": "0x36f1ddd3870a6fde0e94074d068e6208e2260a6fd692e7173a2e45ea024b9b7b",
        "s": "0x597439bd880257437f9656edc3a6120d16e3ccc8c6bd807bd2757bae50a5a6b6"
    }
}
```

I don't know how it could happen (maybe somebody could explain this). But I add handle to not take contact code if input was empty