### PR TITLE
Fix 413 Request Entity Too Large returned from single request batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [#3577](https://github.com/poanetwork/blockscout/pull/3577) - Eliminate GraphiQL page XSS attack
 
 ### Chore
+- [#3709](https://github.com/poanetwork/blockscout/pull/3709) - Fix 413 Request Entity Too Large returned from single request batch
 - [#3701](https://github.com/poanetwork/blockscout/pull/3701) - Increase LP tokens calc process re-check interval
 - [#3700](https://github.com/poanetwork/blockscout/pull/3700) - Update tool versions
 - [#3697](https://github.com/poanetwork/blockscout/pull/3697) - Update hackney dependency

--- a/apps/block_scout_web/lib/block_scout_web/endpoint.ex
+++ b/apps/block_scout_web/lib/block_scout_web/endpoint.ex
@@ -47,6 +47,8 @@ defmodule BlockScoutWeb.Endpoint do
   plug(
     Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
+    length: 20_000_000,
+    query_string_length: 1_000_000,
     pass: ["*/*"],
     json_decoder: Poison
   )


### PR DESCRIPTION
## Motivation

>2021-03-16T08:44:03.648 application=ethereum_jsonrpc fetcher=coin_balance count=7 [error] 413 Request Entity Too Large returned from single request batch.  Cannot shrink batch further.

>2021-03-15T18:06:00.692 application=ethereum_jsonrpc fetcher=block_realtime block_number=15027643 [error] 413 Request Entity Too Large returned from single request batch.  Cannot shrink batch further.

## Changelog

Increase acceptable max length of the request up to 20Mb. The default is 8Mb (https://hexdocs.pm/plug/Plug.Parsers.html#module-options) 


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
