### PR TITLE
Missing @destination in bridged-tokens template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3710](https://github.com/poanetwork/blockscout/pull/3710) - Missing @destination in bridged-tokens template
 - [#3707](https://github.com/poanetwork/blockscout/pull/3707) - Fetch bridged token price by address of foreign token, not by symbol
 - [#3686](https://github.com/poanetwork/blockscout/pull/3686) - BSC bridged tokens detection fix
 - [#3683](https://github.com/poanetwork/blockscout/pull/3683) - Token instance image IPFS link display fix

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/bridged_tokens_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/bridged_tokens_controller.ex
@@ -45,7 +45,8 @@ defmodule BlockScoutWeb.BridgedTokensController do
     render(conn, "index.html",
       current_path: current_path(conn),
       chain: "Ethereum",
-      chain_id: 1
+      chain_id: 1,
+      destination: :eth
     )
   end
 


### PR DESCRIPTION
## Motivation

>Request: GET /bridged-tokens
** (exit) an exception was raised:
    ** (ArgumentError) assign @destination not available in eex template.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
