### PR TITLE
POSDAO refactoring: use pool ID instead of staking address

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -25,4 +25,4 @@ lib/explorer/exchange_rates/source.ex:113
 lib/explorer/smart_contract/verifier.ex:89
 lib/block_scout_web/templates/address_contract/index.html.eex:118
 lib/explorer/staking/stake_snapshotting.ex:15: Function do_snapshotting/7 has no local return
-lib/explorer/staking/stake_snapshotting.ex:214
+lib/explorer/staking/stake_snapshotting.ex:216

--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -24,5 +24,5 @@ lib/explorer/exchange_rates/source.ex:110
 lib/explorer/exchange_rates/source.ex:113
 lib/explorer/smart_contract/verifier.ex:89
 lib/block_scout_web/templates/address_contract/index.html.eex:118
-lib/explorer/staking/stake_snapshotting.ex:15: Function do_snapshotting/6 has no local return
+lib/explorer/staking/stake_snapshotting.ex:15: Function do_snapshotting/7 has no local return
 lib/explorer/staking/stake_snapshotting.ex:214

--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -25,4 +25,4 @@ lib/explorer/exchange_rates/source.ex:113
 lib/explorer/smart_contract/verifier.ex:89
 lib/block_scout_web/templates/address_contract/index.html.eex:118
 lib/explorer/staking/stake_snapshotting.ex:15: Function do_snapshotting/6 has no local return
-lib/explorer/staking/stake_snapshotting.ex:202
+lib/explorer/staking/stake_snapshotting.ex:214

--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -25,4 +25,4 @@ lib/explorer/exchange_rates/source.ex:113
 lib/explorer/smart_contract/verifier.ex:89
 lib/block_scout_web/templates/address_contract/index.html.eex:118
 lib/explorer/staking/stake_snapshotting.ex:15: Function do_snapshotting/6 has no local return
-lib/explorer/staking/stake_snapshotting.ex:184
+lib/explorer/staking/stake_snapshotting.ex:202

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Chore
 - [#3717](https://github.com/poanetwork/blockscout/pull/3717) - Update alpine-elixir-phoenix 1.11.3
 - [#3714](https://github.com/poanetwork/blockscout/pull/3714) - Application announcements management: whole explorer, staking dapp
+- [#3712](https://github.com/poanetwork/blockscout/pull/3712) - POSDAO refactoring: use pool ID instead of staking address
 - [#3709](https://github.com/poanetwork/blockscout/pull/3709) - Fix 413 Request Entity Too Large returned from single request batch
 - [#3708](https://github.com/poanetwork/blockscout/pull/3708) - NPM 6 -> 7
 - [#3701](https://github.com/poanetwork/blockscout/pull/3701) - Increase LP tokens calc process re-check interval

--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -86,10 +86,10 @@ async function becomeCandidate ($modal, store, msg) {
     if (!isStakingAllowed(state)) return false
 
     const validatorSetContract = state.validatorSetContract
-    const stakingAddress = await validatorSetContract.methods.stakingByMiningAddress(miningAddress).call()
+    const hasEverBeenMiningAddress = await validatorSetContract.methods.hasEverBeenMiningAddress(miningAddress).call()
 
-    if (stakingAddress !== '0x0000000000000000000000000000000000000000') {
-      displayInputError($miningAddressInput, `This mining address is already bound to another staking address (<span title="${stakingAddress}">${shortenAddress(stakingAddress)}</span>). Please use another mining address.`)
+    if (hasEverBeenMiningAddress) {
+      displayInputError($miningAddressInput, 'This mining address has already been used for another pool. Please use another mining address.')
       $modal.find('form button').blur()
       return false
     }
@@ -100,10 +100,6 @@ async function becomeCandidate ($modal, store, msg) {
   } catch (err) {
     openErrorModal('Error', err.message)
   }
-}
-
-function shortenAddress (address) {
-  return address.substring(0, 6) + '–' + address.substring(address.length - 6)
 }
 
 function isCandidateStakeValid (value, store, msg) {

--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -88,7 +88,7 @@ async function becomeCandidate ($modal, store, msg) {
     const validatorSetContract = state.validatorSetContract
     const hasEverBeenMiningAddress = await validatorSetContract.methods.hasEverBeenMiningAddress(miningAddress).call()
 
-    if (hasEverBeenMiningAddress) {
+    if (hasEverBeenMiningAddress !== '0') {
       displayInputError($miningAddressInput, 'This mining address has already been used for another pool. Please use another mining address.')
       $modal.find('form button').blur()
       return false

--- a/apps/block_scout_web/assets/js/pages/stakes/utils.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/utils.js
@@ -24,7 +24,7 @@ export async function makeContractCall (call, store, gasLimit, callbackFunc) {
     return callbackFunc('Web3 is undefined. Please, contact support.')
   }
 
-  const gasPrice = web3.utils.toWei('1', 'gwei')
+  const gasPrice = web3.utils.toWei('20', 'gwei')
 
   if (!gasLimit) {
     try {

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -39,7 +39,7 @@ defmodule BlockScoutWeb.StakesChannel do
     # fetch pool id by staking address to show `Make stake` modal
     # instead of `Become a candidate` for the staking address which
     # has ever been a pool
-    pool_id =
+    pool_id_raw =
       try do
         validator_set_contract = ContractState.get(:validator_set_contract)
 
@@ -54,8 +54,8 @@ defmodule BlockScoutWeb.StakesChannel do
 
     # convert 0 to nil
     pool_id =
-      if pool_id != 0 do
-        pool_id
+      if pool_id_raw != 0 do
+        pool_id_raw
       end
 
     socket =

--- a/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/stakes_channel.ex
@@ -36,32 +36,32 @@ defmodule BlockScoutWeb.StakesChannel do
   end
 
   def handle_in("set_account", account, socket) do
-    # fetch mining address by staking address to show `Make stake` modal
+    # fetch pool id by staking address to show `Make stake` modal
     # instead of `Become a candidate` for the staking address which
     # has ever been a pool
-    pool_mining_address =
+    pool_id =
       try do
         validator_set_contract = ContractState.get(:validator_set_contract)
 
         ContractReader.perform_requests(
-          ContractReader.mining_by_staking_request(account),
+          ContractReader.id_by_staking_request(account),
           %{validator_set: validator_set_contract.address},
           validator_set_contract.abi
-        ).mining_address
+        ).pool_id
       rescue
         _ -> nil
       end
 
-    # convert zero address to nil
-    mining_address =
-      if pool_mining_address != "0x0000000000000000000000000000000000000000" do
-        pool_mining_address
+    # convert 0 to nil
+    pool_id =
+      if pool_id != 0 do
+        pool_id
       end
 
     socket =
       socket
       |> assign(:account, account)
-      |> assign(:mining_address, mining_address)
+      |> assign(:pool_id, pool_id)
       |> push_contracts()
 
     data =
@@ -520,7 +520,7 @@ defmodule BlockScoutWeb.StakesChannel do
 
       # if `staker` is a pool, prepend its address to the `pools` array
       pools =
-        if socket.assigns[:mining_address] != nil do
+        if socket.assigns[:pool_id] !== nil do
           [staker | pools]
         else
           pools

--- a/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
@@ -70,10 +70,15 @@ defmodule BlockScoutWeb.StakesController do
       if Map.has_key?(params, "filterMy") do
         [paging_options: options] = paging_options(params)
 
-        last_index =
-          params
-          |> Map.get("position", "0")
-          |> String.to_integer()
+        # turn off paging for Validators page as we sort by APY below
+        # and max number of validators is no more than 19
+        # (for the current POSDAO implementation)
+        options =
+          if is_page_unlimited?(filter) do
+            Map.put(options, :page_size, 1_000_000)
+          else
+            options
+          end
 
         pools_plus_one =
           Chain.staking_pools(
@@ -86,21 +91,7 @@ defmodule BlockScoutWeb.StakesController do
             params["filterMy"] == "true"
           )
 
-        {pools, next_page} = split_list_by_page(pools_plus_one)
-
-        next_page_path =
-          case next_page_params(next_page, pools, params) do
-            nil ->
-              nil
-
-            next_page_params ->
-              updated_page_params =
-                next_page_params
-                |> Map.delete("type")
-                |> Map.put("position", last_index + 1)
-
-              next_page_path(filter, conn, updated_page_params)
-          end
+        {pools, next_page_path, last_index} = get_one_page(filter, conn, params, pools_plus_one)
 
         average_block_time = AverageBlockTime.average_block_time()
 
@@ -119,14 +110,13 @@ defmodule BlockScoutWeb.StakesController do
         calc_apy_enabled = ContractState.calc_apy_enabled?()
         snapshotted_delegator_data = snapshotted_delegator_data(filter, calc_apy_enabled)
 
-        items =
+        pools =
           pools
-          |> Enum.with_index(last_index + 1)
-          |> Enum.map(fn {%{pool: pool, delegator: delegator}, index} ->
+          |> Enum.map(fn %{pool: pool} = item ->
             apy =
-              if calc_apy_enabled and snapshotted_delegator_data != nil do
+              if calc_apy_enabled and snapshotted_delegator_data !== nil do
                 calc_apy(
-                  pool,
+                  item.pool,
                   pool_rewards,
                   snapshotted_delegator_data,
                   average_block_time_seconds,
@@ -134,11 +124,22 @@ defmodule BlockScoutWeb.StakesController do
                 )
               end
 
+            pool = Map.put(pool, :apy, apy)
+            Map.put(item, :pool, pool)
+          end)
+
+        # sort pools on Validators page by descending APY if all APYs known
+        pools = sort_pools_by_apy(pools)
+
+        items =
+          pools
+          |> Enum.with_index(last_index + 1)
+          |> Enum.map(fn {%{pool: pool, delegator: delegator}, index} ->
             View.render_to_string(
               StakesView,
               "_rows.html",
               token: token,
-              pool: Map.put(pool, :apy, apy),
+              pool: pool,
               delegator: delegator,
               index: index,
               average_block_time: average_block_time,
@@ -227,7 +228,49 @@ defmodule BlockScoutWeb.StakesController do
     end
   end
 
+  defp sort_pools_by_apy(pools) do
+    if Enum.all?(pools, fn item -> item.pool.apy !== nil end) do
+      Enum.sort(pools, fn item1, item2 -> item1.pool.apy.apy_raw >= item2.pool.apy.apy_raw end)
+    else
+      pools
+    end
+  end
+
   defp address_bytes_to_string(hash), do: "0x" <> Base.encode16(hash, case: :lower)
+
+  defp get_one_page(filter, conn, params, pools_plus_one) do
+    last_index =
+      params
+      |> Map.get("position", "0")
+      |> String.to_integer()
+
+    {pools, next_page} =
+      if is_page_unlimited?(filter) do
+        {pools_plus_one, []}
+      else
+        split_list_by_page(pools_plus_one)
+      end
+
+    next_page_path =
+      case next_page_params(next_page, pools, params) do
+        nil ->
+          nil
+
+        next_page_params ->
+          updated_page_params =
+            next_page_params
+            |> Map.delete("type")
+            |> Map.put("position", last_index + 1)
+
+          next_page_path(filter, conn, updated_page_params)
+      end
+
+    {pools, next_page_path, last_index}
+  end
+
+  defp is_page_unlimited?(filter) do
+    filter == :validator
+  end
 
   defp next_page_path(:validator, conn, params) do
     validators_path(conn, :index, params)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
@@ -44,7 +44,7 @@ defmodule BlockScoutWeb.StakesController do
           address: account_address,
           balance: Chain.fetch_last_token_balance(account_address, token.contract_address_hash),
           pool: Chain.staking_pool(account_address),
-          pool_mining_address: conn.assigns[:mining_address]
+          pool_id: conn.assigns[:pool_id]
         })
       end
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_top.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_top.html.eex
@@ -14,7 +14,7 @@
         <% else %>
           <%=
             button_class = "full-width " <>
-              if !is_nil(@account[:pool]) or !is_nil(@account[:pool_mining_address]) do
+              if !is_nil(@account[:pool]) or !is_nil(@account[:pool_id]) do
                 "js-make-stake"
               else
                 "js-become-candidate"

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -2183,7 +2183,7 @@ msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:762
+#: lib/block_scout_web/channels/stakes_channel.ex:769
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2258,7 +2258,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:818
+#: lib/block_scout_web/channels/stakes_channel.ex:825
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:859
+#: lib/block_scout_web/channels/stakes_channel.ex:866
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2358,7 +2358,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:862
+#: lib/block_scout_web/channels/stakes_channel.ex:869
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2453,19 +2453,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:825
-#: lib/block_scout_web/channels/stakes_channel.ex:872
+#: lib/block_scout_web/channels/stakes_channel.ex:832
+#: lib/block_scout_web/channels/stakes_channel.ex:879
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:865
+#: lib/block_scout_web/channels/stakes_channel.ex:872
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:821
-#: lib/block_scout_web/channels/stakes_channel.ex:868
+#: lib/block_scout_web/channels/stakes_channel.ex:828
+#: lib/block_scout_web/channels/stakes_channel.ex:875
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -2183,7 +2183,7 @@ msgid "It's me!"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:762
+#: lib/block_scout_web/channels/stakes_channel.ex:769
 msgid "JSON RPC error"
 msgstr ""
 
@@ -2258,7 +2258,7 @@ msgid "Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:818
+#: lib/block_scout_web/channels/stakes_channel.ex:825
 msgid "Pools searching is already in progress for this address"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgid "Remove My Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:859
+#: lib/block_scout_web/channels/stakes_channel.ex:866
 msgid "Reward calculating is already in progress for this address"
 msgstr ""
 
@@ -2358,7 +2358,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:862
+#: lib/block_scout_web/channels/stakes_channel.ex:869
 msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
@@ -2453,19 +2453,19 @@ msgid "Unable to find any pools you could claim a reward from."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:825
-#: lib/block_scout_web/channels/stakes_channel.ex:872
+#: lib/block_scout_web/channels/stakes_channel.ex:832
+#: lib/block_scout_web/channels/stakes_channel.ex:879
 msgid "Unknown address of Staking contract. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:865
+#: lib/block_scout_web/channels/stakes_channel.ex:872
 msgid "Unknown pool staking address. Please, contact support"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/channels/stakes_channel.ex:821
-#: lib/block_scout_web/channels/stakes_channel.ex:868
+#: lib/block_scout_web/channels/stakes_channel.ex:828
+#: lib/block_scout_web/channels/stakes_channel.ex:875
 msgid "Unknown staker address. Please, choose your account in MetaMask"
 msgstr ""
 
@@ -2700,6 +2700,11 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_top.html.eex:38
 msgid "Swap STAKE on Honeyswap"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_stakes_top.html.eex:34
+msgid "Bridge to Ethereum"
 msgstr ""
 
 #, elixir-format

--- a/apps/explorer/lib/explorer/staking/contract_reader.ex
+++ b/apps/explorer/lib/explorer/staking/contract_reader.ex
@@ -457,6 +457,13 @@ defmodule Explorer.Staking.ContractReader do
     ]
   end
 
+  def id_by_staking_request(staking_address) do
+    [
+      # a26301f9 = keccak256(idByStakingAddress(address))
+      pool_id: {:validator_set, "a26301f9", [staking_address]}
+    ]
+  end
+
   def staking_by_mining_request(mining_address, block_number) do
     [
       # 1ee4d0bc = keccak256(stakingByMiningAddress(address))

--- a/apps/explorer/lib/explorer/staking/contract_reader.ex
+++ b/apps/explorer/lib/explorer/staking/contract_reader.ex
@@ -46,10 +46,10 @@ defmodule Explorer.Staking.ContractReader do
     ]
   end
 
-  def active_delegators_request(staking_address, block_number) do
+  def active_delegators_request(pool_id, block_number) do
     [
-      # 9ea8082b = keccak256(poolDelegators(address))
-      active_delegators: {:staking, "9ea8082b", [staking_address], block_number}
+      # 561c4c81 = keccak256(poolDelegators(uint256))
+      active_delegators: {:staking, "561c4c81", [pool_id], block_number}
     ]
   end
 
@@ -119,7 +119,7 @@ defmodule Explorer.Staking.ContractReader do
   #     uint256 _stakingEpoch,
   #     uint256 _totalRewardShareNum,
   #     uint256 _totalRewardShareDenom,
-  #     address[] memory _validators
+  #     uint256[] memory _validators
   # ) public view returns(uint256 rewardToDistribute, uint256 totalReward);
   def call_current_token_reward_to_distribute(
         block_reward_address,
@@ -136,7 +136,7 @@ defmodule Explorer.Staking.ContractReader do
       |> Integer.to_string(16)
       |> String.pad_leading(64, ["0"])
 
-    function_signature = "0x46955281"
+    function_signature = "0x43544960"
     mandatory_params = staking_contract_address <> staking_epoch
 
     optional_params =
@@ -356,6 +356,13 @@ defmodule Explorer.Staking.ContractReader do
     ]
   end
 
+  def mining_by_id_request(pool_id, block_number) do
+    [
+      # e2847895 = keccak256(miningAddressById(uint256))
+      mining_address: {:validator_set, "e2847895", [pool_id], block_number}
+    ]
+  end
+
   def mining_by_staking_request(staking_address) do
     [
       # 00535175 = keccak256(miningByStakingAddress(address))
@@ -370,22 +377,21 @@ defmodule Explorer.Staking.ContractReader do
     ]
   end
 
-  def pool_staking_requests(staking_address, block_number, net_version) do
-    staking_address_or_zero = refine_staker_address(staking_address, staking_address, block_number, net_version)
-
+  def pool_staking_requests(pool_id, block_number) do
     [
-      active_delegators: active_delegators_request(staking_address, block_number)[:active_delegators],
-      # 73c21803 = keccak256(poolDelegatorsInactive(address))
-      inactive_delegators: {:staking, "73c21803", [staking_address], block_number},
-      # a711e6a1 = keccak256(isPoolActive(address))
-      is_active: {:staking, "a711e6a1", [staking_address], block_number},
-      mining_address_hash: mining_by_staking_request(staking_address, block_number)[:mining_address],
-      # a697ecff = keccak256(stakeAmount(address,address))
-      self_staked_amount: {:staking, "a697ecff", [staking_address, staking_address_or_zero], block_number},
-      # 5267e1d6 = keccak256(stakeAmountTotal(address))
-      total_staked_amount: {:staking, "5267e1d6", [staking_address], block_number},
-      # 527d8bc4 = keccak256(validatorRewardPercent(address))
-      validator_reward_percent: {:block_reward, "527d8bc4", [staking_address], block_number}
+      active_delegators: active_delegators_request(pool_id, block_number)[:active_delegators],
+      # a1fc2753 = keccak256(poolDelegatorsInactive(uint256))
+      inactive_delegators: {:staking, "a1fc2753", [pool_id], block_number},
+      # bbbaf8c8 = keccak256(isPoolActive(uint256))
+      is_active: {:staking, "bbbaf8c8", [pool_id], block_number},
+      mining_address_hash: mining_by_id_request(pool_id, block_number)[:mining_address],
+      staking_address_hash: staking_by_id_request(pool_id, block_number)[:staking_address],
+      # 3fb1a1e4 = keccak256(stakeAmount(uint256,address))
+      self_staked_amount: {:staking, "3fb1a1e4", [pool_id, "0x0000000000000000000000000000000000000000"], block_number},
+      # 2a8f6ecd = keccak256(stakeAmountTotal(uint256))
+      total_staked_amount: {:staking, "2a8f6ecd", [pool_id], block_number},
+      # 3bf47e96 = keccak256(validatorRewardPercent(uint256))
+      validator_reward_percent: {:block_reward, "3bf47e96", [pool_id], block_number}
     ]
   end
 
@@ -408,32 +414,46 @@ defmodule Explorer.Staking.ContractReader do
     ]
   end
 
-  def refine_staker_address(pool_staking_address, staker_address, block_number, net_version) do
-    # this is a block number from which POSDAO on xDai chain started to use a zero address
-    # instead of staking address for the cases when the staker is a pool staking address
-    zero_allowed = (net_version == 100 and block_number >= 14_474_689) or net_version != 100
-
-    if staker_address == pool_staking_address and zero_allowed do
-      "0x0000000000000000000000000000000000000000"
-    else
-      staker_address
-    end
-  end
-
-  def staker_requests(pool_staking_address, staker_address, block_number, net_version) do
-    delegator_or_zero = refine_staker_address(pool_staking_address, staker_address, block_number, net_version)
+  def staker_requests(pool_id, pool_staking_address, staker_address, block_number) do
+    delegator_or_zero =
+      if staker_address == pool_staking_address do
+        "0x0000000000000000000000000000000000000000"
+      else
+        staker_address
+      end
 
     [
       # 950a6513 = keccak256(maxWithdrawOrderAllowed(address,address))
       max_ordered_withdraw_allowed: {:staking, "950a6513", [pool_staking_address, staker_address], block_number},
       # 6bda1577 = keccak256(maxWithdrawAllowed(address,address))
       max_withdraw_allowed: {:staking, "6bda1577", [pool_staking_address, staker_address], block_number},
-      # e9ab0300 = keccak256(orderedWithdrawAmount(address,address))
-      ordered_withdraw: {:staking, "e9ab0300", [pool_staking_address, delegator_or_zero], block_number},
-      # a4205967 = keccak256(orderWithdrawEpoch(address,address))
-      ordered_withdraw_epoch: {:staking, "a4205967", [pool_staking_address, delegator_or_zero], block_number},
-      # a697ecff = keccak256(stakeAmount(address,address))
-      stake_amount: {:staking, "a697ecff", [pool_staking_address, delegator_or_zero], block_number}
+      # e3f0ff66 = keccak256(orderedWithdrawAmount(uint256,address))
+      ordered_withdraw: {:staking, "e3f0ff66", [pool_id, delegator_or_zero], block_number},
+      # d2f2a136 = keccak256(orderWithdrawEpoch(uint256,address))
+      ordered_withdraw_epoch: {:staking, "d2f2a136", [pool_id, delegator_or_zero], block_number},
+      # 3fb1a1e4 = keccak256(stakeAmount(uint256,address))
+      stake_amount: {:staking, "3fb1a1e4", [pool_id, delegator_or_zero], block_number}
+    ]
+  end
+
+  def staking_by_id_request(pool_id) do
+    [
+      # 16cf66ab = keccak256(stakingAddressById(uint256))
+      staking_address: {:validator_set, "16cf66ab", [pool_id]}
+    ]
+  end
+
+  def staking_by_id_request(pool_id, block_number) do
+    [
+      # 16cf66ab = keccak256(stakingAddressById(uint256))
+      staking_address: {:validator_set, "16cf66ab", [pool_id], block_number}
+    ]
+  end
+
+  def id_by_mining_request(mining_address, block_number) do
+    [
+      # 2bbb7b72 = keccak256(idByMiningAddress(address))
+      pool_id: {:validator_set, "2bbb7b72", [mining_address], block_number}
     ]
   end
 

--- a/apps/explorer/lib/explorer/staking/contract_reader.ex
+++ b/apps/explorer/lib/explorer/staking/contract_reader.ex
@@ -46,10 +46,18 @@ defmodule Explorer.Staking.ContractReader do
     ]
   end
 
-  def active_delegators_request(pool_id, block_number) do
+  def active_delegators_request(pool_id, block_number, new_signatures) do
+    pool_delegators_signature =
+      if new_signatures do
+        # 561c4c81 = keccak256(poolDelegators(uint256))
+        "561c4c81"
+      else
+        # 9ea8082b = keccak256(poolDelegators(address))
+        "9ea8082b"
+      end
+
     [
-      # 561c4c81 = keccak256(poolDelegators(uint256))
-      active_delegators: {:staking, "561c4c81", [pool_id], block_number}
+      active_delegators: {:staking, pool_delegators_signature, [pool_id], block_number}
     ]
   end
 
@@ -379,7 +387,7 @@ defmodule Explorer.Staking.ContractReader do
 
   def pool_staking_requests(pool_id, block_number) do
     [
-      active_delegators: active_delegators_request(pool_id, block_number)[:active_delegators],
+      active_delegators: active_delegators_request(pool_id, block_number, true)[:active_delegators],
       # a1fc2753 = keccak256(poolDelegatorsInactive(uint256))
       inactive_delegators: {:staking, "a1fc2753", [pool_id], block_number},
       # bbbaf8c8 = keccak256(isPoolActive(uint256))

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -296,7 +296,8 @@ defmodule Explorer.Staking.ContractState do
       epochs_per_year = floor(31_536_000 / average_block_time / staking_epoch_duration)
       predicted_reward = decimal_to_float(reward_ratio) * pool_reward / 100
       apy = predicted_reward / decimal_to_integer(stake_amount) * epochs_per_year * 100
-      %{apy: "#{floor(apy * 100) / 100}%", predicted_reward: floor(predicted_reward)}
+      apy_raw = floor(apy * 100) / 100
+      %{apy: "#{apy_raw}%", predicted_reward: floor(predicted_reward), apy_raw: apy_raw}
     end
   end
 
@@ -349,7 +350,7 @@ defmodule Explorer.Staking.ContractState do
 
   defp start_snapshotting?(global_responses) do
     global_responses.epoch_number > get(:snapshotted_epoch_number) && global_responses.epoch_number > 0 &&
-      not get(:is_snapshotting) && (global_responses.epoch_number >= 49 || global_responses.epoch_number < 47)
+      not get(:is_snapshotting)
   end
 
   defp update_database(

--- a/apps/explorer/lib/explorer/staking/stake_snapshotting.ex
+++ b/apps/explorer/lib/explorer/staking/stake_snapshotting.ex
@@ -46,6 +46,8 @@ defmodule Explorer.Staking.StakeSnapshotting do
       |> Enum.zip(pool_staking_addresses)
       |> Map.new()
 
+    abi = abi_clarify_signatures(abi, new_signatures)
+
     # get snapshotted amounts and active delegator list for the pool for each
     # pending validator by their pool id.
     # use `cached_pool_staking_responses` when possible
@@ -227,6 +229,16 @@ defmodule Explorer.Staking.StakeSnapshotting do
     :ets.insert(ets_table_name, is_snapshotting: false)
 
     Publisher.broadcast(:stake_snapshotting_finished)
+  end
+
+  defp abi_clarify_signatures(abi, new_signatures) do
+    if new_signatures do
+      abi
+    else
+      Jason.decode!(
+        ~s([{"constant":true,"inputs":[{"name":"","type":"address"}],"name":"stakeAmountTotal","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"},{"name":"","type":"address"}],"name":"stakeAmount","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"}],"name":"poolDelegators","outputs":[{"name":"","type":"address[]"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"","type":"uint256"},{"name":"","type":"uint256"},{"name":"","type":"uint256"},{"name":"","type":"uint256"}],"name":"validatorShare","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"","type":"uint256"},{"name":"","type":"uint256"},{"name":"","type":"uint256"},{"name":"","type":"uint256"},{"name":"","type":"uint256"}],"name":"delegatorShare","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"}])
+      )
+    end
   end
 
   defp address_bytes_to_string(hash), do: "0x" <> Base.encode16(hash, case: :lower)

--- a/apps/explorer/lib/explorer/staking/stake_snapshotting.ex
+++ b/apps/explorer/lib/explorer/staking/stake_snapshotting.ex
@@ -71,7 +71,7 @@ defmodule Explorer.Staking.StakeSnapshotting do
                 staking_address_hash: pool_staking_address
               },
               ContractReader.perform_requests(
-                ContractReader.active_delegators_request(pool_id, block_number) ++
+                ContractReader.active_delegators_request(pool_id, block_number, new_signatures) ++
                   snapshotted_pool_amounts_requests(pool_id, pool_staking_address, block_number, new_signatures),
                 contracts,
                 abi

--- a/apps/explorer/lib/explorer/staking/stake_snapshotting.ex
+++ b/apps/explorer/lib/explorer/staking/stake_snapshotting.ex
@@ -13,66 +13,83 @@ defmodule Explorer.Staking.StakeSnapshotting do
   alias Explorer.Staking.ContractReader
 
   def do_snapshotting(
-        %{contracts: contracts, abi: abi, ets_table_name: ets_table_name, net_version: net_version},
+        %{contracts: contracts, abi: abi, ets_table_name: ets_table_name},
         epoch_number,
         cached_pool_staking_responses,
         pools_mining_addresses,
         mining_to_staking_address,
+        mining_address_to_id,
         block_number
       ) do
-    # get staking addresses for the pending validators
+    # get pool ids and staking addresses for the pending validators
+    pool_ids =
+      pools_mining_addresses
+      |> Enum.map(&mining_address_to_id[&1])
+
     pool_staking_addresses =
       pools_mining_addresses
       |> Enum.map(&mining_to_staking_address[&1])
 
-    staking_to_mining_address =
-      pool_staking_addresses
+    id_to_mining_address =
+      pool_ids
       |> Enum.zip(pools_mining_addresses)
       |> Map.new()
 
+    id_to_staking_address =
+      pool_ids
+      |> Enum.zip(pool_staking_addresses)
+      |> Map.new()
+
     # get snapshotted amounts and active delegator list for the pool for each
-    # pending validator by their staking address.
+    # pending validator by their pool id.
     # use `cached_pool_staking_responses` when possible
     pool_staking_responses =
-      pool_staking_addresses
-      |> Enum.map(fn staking_address_hash ->
-        case Map.fetch(cached_pool_staking_responses, staking_address_hash) do
+      pool_ids
+      |> Enum.map(fn pool_id ->
+        case Map.fetch(cached_pool_staking_responses, pool_id) do
           {:ok, resp} ->
             Map.merge(
               resp,
               ContractReader.perform_requests(
-                snapshotted_pool_amounts_requests(staking_address_hash, block_number, net_version),
+                snapshotted_pool_amounts_requests(pool_id, resp.staking_address_hash, block_number),
                 contracts,
                 abi
               )
             )
 
           :error ->
-            ContractReader.perform_requests(
-              ContractReader.active_delegators_request(staking_address_hash, block_number) ++
-                snapshotted_pool_amounts_requests(staking_address_hash, block_number, net_version),
-              contracts,
-              abi
+            pool_staking_address = id_to_staking_address[pool_id]
+
+            Map.merge(
+              %{
+                staking_address_hash: pool_staking_address
+              },
+              ContractReader.perform_requests(
+                ContractReader.active_delegators_request(pool_id, block_number) ++
+                  snapshotted_pool_amounts_requests(pool_id, pool_staking_address, block_number),
+                contracts,
+                abi
+              )
             )
         end
       end)
-      |> Enum.zip(pool_staking_addresses)
+      |> Enum.zip(pool_ids)
       |> Map.new(fn {key, val} -> {val, key} end)
 
     # get a flat list of all stakers of each validator
-    # in the form of {pool_staking_address, staker_address}
+    # in the form of {pool_id, pool_staking_address, staker_address}
     stakers =
-      Enum.flat_map(pool_staking_responses, fn {pool_staking_address, resp} ->
-        [{pool_staking_address, pool_staking_address}] ++
-          Enum.map(resp.active_delegators, &{pool_staking_address, &1})
+      Enum.flat_map(pool_staking_responses, fn {pool_id, resp} ->
+        [{pool_id, resp.staking_address_hash, resp.staking_address_hash}] ++
+          Enum.map(resp.active_delegators, &{pool_id, resp.staking_address_hash, &1})
       end)
 
     # read info about each staker from the contracts
     staker_responses =
       stakers
-      |> Enum.map(fn {pool_staking_address, staker_address} ->
+      |> Enum.map(fn {pool_id, pool_staking_address, staker_address} ->
         ContractReader.perform_requests(
-          snapshotted_staker_amount_request(pool_staking_address, staker_address, block_number, net_version),
+          snapshotted_staker_amount_request(pool_id, pool_staking_address, staker_address, block_number),
           contracts,
           abi
         )
@@ -87,7 +104,7 @@ defmodule Explorer.Staking.StakeSnapshotting do
     # to get validator's reward share of the pool (needed for the `Delegators` list in UI)
     validator_reward_responses =
       pool_staking_responses
-      |> Enum.map(fn {_pool_staking_address, resp} ->
+      |> Enum.map(fn {_pool_id, resp} ->
         ContractReader.validator_reward_request(
           [
             epoch_number,
@@ -103,7 +120,7 @@ defmodule Explorer.Staking.StakeSnapshotting do
     # call `BlockReward.delegatorShare` function for each delegator
     # to get their reward share of the pool (needed for the `Delegators` list in UI)
     delegator_responses =
-      Enum.reduce(staker_responses, %{}, fn {{pool_staking_address, staker_address} = key, value}, acc ->
+      Enum.reduce(staker_responses, %{}, fn {{_pool_id, pool_staking_address, staker_address} = key, value}, acc ->
         if pool_staking_address != staker_address do
           Map.put(acc, key, value)
         else
@@ -115,8 +132,8 @@ defmodule Explorer.Staking.StakeSnapshotting do
 
     delegator_reward_responses =
       delegator_responses
-      |> Enum.map(fn {{pool_staking_address, _staker_address}, resp} ->
-        staking_resp = pool_staking_responses[pool_staking_address]
+      |> Enum.map(fn {{pool_id, _pool_staking_address, _staker_address}, resp} ->
+        staking_resp = pool_staking_responses[pool_id]
 
         ContractReader.delegator_reward_request(
           [
@@ -133,9 +150,10 @@ defmodule Explorer.Staking.StakeSnapshotting do
 
     # form entries for updating the `staking_pools` table in DB
     pool_entries =
-      Enum.map(pool_staking_addresses, fn pool_staking_address ->
-        staking_resp = pool_staking_responses[pool_staking_address]
-        validator_reward_resp = validator_reward_responses[pool_staking_address]
+      Enum.map(pool_ids, fn pool_id ->
+        staking_resp = pool_staking_responses[pool_id]
+        validator_reward_resp = validator_reward_responses[pool_id]
+        pool_staking_address = id_to_staking_address[pool_id]
 
         %{
           banned_until: 0,
@@ -145,7 +163,7 @@ defmodule Explorer.Staking.StakeSnapshotting do
           is_validator: false,
           staking_address_hash: pool_staking_address,
           delegators_count: 0,
-          mining_address_hash: address_bytes_to_string(staking_to_mining_address[pool_staking_address]),
+          mining_address_hash: address_bytes_to_string(id_to_mining_address[pool_id]),
           self_staked_amount: 0,
           snapshotted_self_staked_amount: staking_resp.snapshotted_self_staked_amount,
           snapshotted_total_staked_amount: staking_resp.snapshotted_total_staked_amount,
@@ -158,7 +176,7 @@ defmodule Explorer.Staking.StakeSnapshotting do
 
     # form entries for updating the `staking_pools_delegators` table in DB
     delegator_entries =
-      Enum.map(staker_responses, fn {{pool_staking_address, staker_address} = key, resp} ->
+      Enum.map(staker_responses, fn {{_pool_id, pool_staking_address, staker_address} = key, resp} ->
         delegator_share =
           if Map.has_key?(delegator_reward_responses, key) do
             delegator_reward_responses[key].delegator_share
@@ -201,24 +219,28 @@ defmodule Explorer.Staking.StakeSnapshotting do
 
   defp address_bytes_to_string(hash), do: "0x" <> Base.encode16(hash, case: :lower)
 
-  defp snapshotted_pool_amounts_requests(pool_staking_address, block_number, net_version) do
+  defp snapshotted_pool_amounts_requests(pool_id, pool_staking_address, block_number) do
     [
-      # 5267e1d6 = keccak256(stakeAmountTotal(address))
-      snapshotted_total_staked_amount: {:staking, "5267e1d6", [pool_staking_address], block_number},
+      # 2a8f6ecd = keccak256(stakeAmountTotal(uint256))
+      snapshotted_total_staked_amount: {:staking, "2a8f6ecd", [pool_id], block_number},
       snapshotted_self_staked_amount:
-        snapshotted_staker_amount_request(pool_staking_address, pool_staking_address, block_number, net_version)[
+        snapshotted_staker_amount_request(pool_id, pool_staking_address, pool_staking_address, block_number)[
           :snapshotted_stake_amount
         ]
     ]
   end
 
-  defp snapshotted_staker_amount_request(pool_staking_address, staker_address, block_number, net_version) do
+  defp snapshotted_staker_amount_request(pool_id, pool_staking_address, staker_address, block_number) do
     delegator_or_zero =
-      ContractReader.refine_staker_address(pool_staking_address, staker_address, block_number, net_version)
+      if staker_address == pool_staking_address do
+        "0x0000000000000000000000000000000000000000"
+      else
+        staker_address
+      end
 
     [
-      # a697ecff = keccak256(stakeAmount(address,address))
-      snapshotted_stake_amount: {:staking, "a697ecff", [pool_staking_address, delegator_or_zero], block_number}
+      # 3fb1a1e4 = keccak256(stakeAmount(uint256,address))
+      snapshotted_stake_amount: {:staking, "3fb1a1e4", [pool_id, delegator_or_zero], block_number}
     ]
   end
 

--- a/apps/explorer/priv/contracts_abi/posdao/BlockRewardAuRa.json
+++ b/apps/explorer/priv/contracts_abi/posdao/BlockRewardAuRa.json
@@ -68,7 +68,7 @@
       },
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       }
     ],
     "name": "epochPoolNativeReward",
@@ -190,7 +190,7 @@
       },
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       }
     ],
     "name": "epochPoolTokenReward",
@@ -260,7 +260,7 @@
       },
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       }
     ],
     "name": "blocksCreated",
@@ -364,6 +364,10 @@
     "inputs": [
       {
         "name": "_validatorSet",
+        "type": "address"
+      },
+      {
+        "name": "_prevBlockReward",
         "type": "address"
       }
     ],
@@ -548,8 +552,8 @@
     "constant": true,
     "inputs": [
       {
-        "name": "_stakingAddress",
-        "type": "address"
+        "name": "_poolId",
+        "type": "uint256"
       }
     ],
     "name": "validatorRewardPercent",

--- a/apps/explorer/priv/contracts_abi/posdao/README.md
+++ b/apps/explorer/priv/contracts_abi/posdao/README.md
@@ -1,2 +1,1 @@
 ABIs are taken from compiled contract JSONs in the `build/` directory of https://github.com/poanetwork/posdao-contracts.
-Docs: https://poanetwork.github.io/posdao-contracts/docs/

--- a/apps/explorer/priv/contracts_abi/posdao/StakingAuRa.json
+++ b/apps/explorer/priv/contracts_abi/posdao/StakingAuRa.json
@@ -4,7 +4,7 @@
     "inputs": [
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       },
       {
         "name": "",
@@ -56,7 +56,7 @@
     "outputs": [
       {
         "name": "result",
-        "type": "address[]"
+        "type": "uint256[]"
       }
     ],
     "payable": false,
@@ -87,7 +87,7 @@
     "inputs": [
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       }
     ],
     "name": "poolInactiveIndex",
@@ -148,7 +148,7 @@
     "inputs": [
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       },
       {
         "name": "",
@@ -185,7 +185,7 @@
     "inputs": [
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       },
       {
         "name": "",
@@ -208,7 +208,7 @@
     "inputs": [
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       }
     ],
     "name": "poolIndex",
@@ -255,7 +255,7 @@
     "inputs": [
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       }
     ],
     "name": "orderedWithdrawAmountTotal",
@@ -288,7 +288,7 @@
     "inputs": [
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       },
       {
         "name": "",
@@ -311,7 +311,7 @@
     "inputs": [
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       }
     ],
     "name": "poolToBeRemovedIndex",
@@ -344,7 +344,7 @@
     "inputs": [
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       }
     ],
     "name": "poolToBeElectedIndex",
@@ -380,6 +380,11 @@
         "indexed": false,
         "name": "amount",
         "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "fromPoolId",
+        "type": "uint256"
       }
     ],
     "name": "ClaimedOrderedWithdrawal",
@@ -406,6 +411,11 @@
       {
         "indexed": false,
         "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "toPoolId",
         "type": "uint256"
       }
     ],
@@ -439,6 +449,16 @@
         "indexed": false,
         "name": "amount",
         "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "fromPoolId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "toPoolId",
+        "type": "uint256"
       }
     ],
     "name": "MovedStake",
@@ -466,6 +486,11 @@
         "indexed": false,
         "name": "amount",
         "type": "int256"
+      },
+      {
+        "indexed": false,
+        "name": "fromPoolId",
+        "type": "uint256"
       }
     ],
     "name": "OrderedWithdrawal",
@@ -493,6 +518,11 @@
         "indexed": false,
         "name": "amount",
         "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "fromPoolId",
+        "type": "uint256"
       }
     ],
     "name": "WithdrewStake",
@@ -511,7 +541,12 @@
       }
     ],
     "name": "addPool",
-    "outputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"
@@ -538,8 +573,8 @@
     "constant": false,
     "inputs": [
       {
-        "name": "_unremovableStakingAddress",
-        "type": "address"
+        "name": "_unremovablePoolId",
+        "type": "uint256"
       }
     ],
     "name": "clearUnremovableValidator",
@@ -565,8 +600,8 @@
         "type": "address"
       },
       {
-        "name": "_initialStakingAddresses",
-        "type": "address[]"
+        "name": "_initialIds",
+        "type": "uint256[]"
       },
       {
         "name": "_delegatorMinStake",
@@ -599,8 +634,8 @@
     "constant": false,
     "inputs": [
       {
-        "name": "_stakingAddress",
-        "type": "address"
+        "name": "_poolId",
+        "type": "uint256"
       }
     ],
     "name": "removePool",
@@ -771,7 +806,7 @@
     "outputs": [
       {
         "name": "",
-        "type": "address[]"
+        "type": "uint256[]"
       }
     ],
     "payable": false,
@@ -785,7 +820,7 @@
     "outputs": [
       {
         "name": "",
-        "type": "address[]"
+        "type": "uint256[]"
       }
     ],
     "payable": false,
@@ -817,7 +852,7 @@
     "outputs": [
       {
         "name": "",
-        "type": "address[]"
+        "type": "uint256[]"
       }
     ],
     "payable": false,
@@ -831,7 +866,7 @@
     "outputs": [
       {
         "name": "",
-        "type": "address[]"
+        "type": "uint256[]"
       }
     ],
     "payable": false,
@@ -870,8 +905,8 @@
     "constant": true,
     "inputs": [
       {
-        "name": "_stakingAddress",
-        "type": "address"
+        "name": "_poolId",
+        "type": "uint256"
       }
     ],
     "name": "isPoolActive",
@@ -932,7 +967,7 @@
     "type": "function"
   },
   {
-    "constant": true,
+    "constant": false,
     "inputs": [
       {
         "name": "",
@@ -955,15 +990,15 @@
       }
     ],
     "payable": false,
-    "stateMutability": "pure",
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "constant": true,
     "inputs": [
       {
-        "name": "_poolStakingAddress",
-        "type": "address"
+        "name": "_poolId",
+        "type": "uint256"
       }
     ],
     "name": "poolDelegators",
@@ -981,8 +1016,8 @@
     "constant": true,
     "inputs": [
       {
-        "name": "_poolStakingAddress",
-        "type": "address"
+        "name": "_poolId",
+        "type": "uint256"
       }
     ],
     "name": "poolDelegatorsInactive",
@@ -1000,11 +1035,11 @@
     "constant": true,
     "inputs": [
       {
-        "name": "_poolStakingAddress",
-        "type": "address"
+        "name": "_poolId",
+        "type": "uint256"
       },
       {
-        "name": "_staker",
+        "name": "_delegatorOrZero",
         "type": "address"
       }
     ],
@@ -1023,11 +1058,11 @@
     "constant": true,
     "inputs": [
       {
-        "name": "_poolStakingAddress",
-        "type": "address"
+        "name": "_poolId",
+        "type": "uint256"
       },
       {
-        "name": "_staker",
+        "name": "_delegatorOrZero",
         "type": "address"
       }
     ],
@@ -1046,8 +1081,8 @@
     "constant": true,
     "inputs": [
       {
-        "name": "_poolStakingAddress",
-        "type": "address"
+        "name": "_poolId",
+        "type": "uint256"
       }
     ],
     "name": "stakeAmountTotal",

--- a/apps/explorer/priv/contracts_abi/posdao/ValidatorSetAuRa.json
+++ b/apps/explorer/priv/contracts_abi/posdao/ValidatorSetAuRa.json
@@ -72,48 +72,6 @@
   },
   {
     "constant": true,
-    "inputs": [
-      {
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "isValidatorPrevious",
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [
-      {
-        "name": "",
-        "type": "address"
-      },
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "reportingCounter",
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
     "inputs": [],
     "name": "blockRewardContract",
     "outputs": [
@@ -190,7 +148,7 @@
     "outputs": [
       {
         "name": "",
-        "type": "address"
+        "type": "uint256"
       }
     ],
     "payable": false,
@@ -266,52 +224,6 @@
       {
         "name": "",
         "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "reportingCounterTotal",
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [
-      {
-        "name": "",
-        "type": "address"
-      },
-      {
-        "name": "",
-        "type": "uint256"
-      },
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "maliceReportedForBlock",
-    "outputs": [
-      {
-        "name": "",
-        "type": "address"
       }
     ],
     "payable": false,
@@ -455,16 +367,7 @@
     "constant": false,
     "inputs": [],
     "name": "newValidatorSet",
-    "outputs": [
-      {
-        "name": "called",
-        "type": "bool"
-      },
-      {
-        "name": "poolsToBeElectedLength",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"
@@ -506,24 +409,6 @@
     "type": "function"
   },
   {
-    "constant": false,
-    "inputs": [
-      {
-        "name": "_miningAddress",
-        "type": "address"
-      },
-      {
-        "name": "_stakingAddress",
-        "type": "address"
-      }
-    ],
-    "name": "setStakingAddress",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "constant": true,
     "inputs": [],
     "name": "emitInitiateChangeCallable",
@@ -531,20 +416,6 @@
       {
         "name": "",
         "type": "bool"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "getPreviousValidators",
-    "outputs": [
-      {
-        "name": "",
-        "type": "address[]"
       }
     ],
     "payable": false,
@@ -703,6 +574,82 @@
       {
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "hasEverBeenMiningAddress",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "idByMiningAddress",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "miningAddressById",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "stakingAddressById",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
       }
     ],
     "payable": false,

--- a/apps/explorer/priv/contracts_abi/posdao/ValidatorSetAuRa.json
+++ b/apps/explorer/priv/contracts_abi/posdao/ValidatorSetAuRa.json
@@ -592,7 +592,7 @@
     "outputs": [
       {
         "name": "",
-        "type": "bool"
+        "type": "uint256"
       }
     ],
     "payable": false,

--- a/apps/explorer/priv/contracts_abi/posdao/ValidatorSetAuRa.json
+++ b/apps/explorer/priv/contracts_abi/posdao/ValidatorSetAuRa.json
@@ -655,5 +655,24 @@
     "payable": false,
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "idByStakingAddress",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/apps/explorer/test/explorer/staking/contract_state_test.exs
+++ b/apps/explorer/test/explorer/staking/contract_state_test.exs
@@ -73,15 +73,6 @@ defmodule Explorer.Staking.ContractStateTest do
       end
     )
 
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn _request, _opts ->
-        # net_version
-        {:ok, "101"}
-      end
-    )
-
     # get_token, fetch_token, MetadataRetriever.get_functions_of
     expect(
       EthereumJSONRPC.Mox,
@@ -244,7 +235,7 @@ defmodule Explorer.Staking.ContractStateTest do
       end
     )
 
-    # get_mining_to_staking_address
+    # get_mining_address_to_id
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,
@@ -253,17 +244,17 @@ defmodule Explorer.Staking.ContractStateTest do
 
         {:ok,
          format_responses([
-           # 1 ValidatorSetAuRa.stakingByMiningAddress
+           # 1 ValidatorSetAuRa.idByMiningAddress
            "0x0000000000000000000000000b2f5e2f3cbd864eaa2c642e3769c1582361caf6",
-           # 2 ValidatorSetAuRa.stakingByMiningAddress
+           # 2 ValidatorSetAuRa.idByMiningAddress
            "0x000000000000000000000000aa94b687d3f9552a453b81b2834ca53778980dc0",
-           # 3 ValidatorSetAuRa.stakingByMiningAddress
+           # 3 ValidatorSetAuRa.idByMiningAddress
            "0x000000000000000000000000312c230e7d6db05224f60208a656e3541c5c42ba",
-           # 4 ValidatorSetAuRa.stakingByMiningAddress
+           # 4 ValidatorSetAuRa.idByMiningAddress
            "0x000000000000000000000000b916e7e1f4bcb13549602ed042d36746fd0d96c9",
-           # 5 ValidatorSetAuRa.stakingByMiningAddress
+           # 5 ValidatorSetAuRa.idByMiningAddress
            "0x000000000000000000000000db9cb2478d917719c53862008672166808258577",
-           # 6 ValidatorSetAuRa.stakingByMiningAddress
+           # 6 ValidatorSetAuRa.idByMiningAddress
            "0x000000000000000000000000b6695f5c2e3f5eff8036b5f5f3a9d83a5310e51e"
          ])}
       end
@@ -274,7 +265,7 @@ defmodule Explorer.Staking.ContractStateTest do
       EthereumJSONRPC.Mox,
       :json_rpc,
       fn requests, _opts ->
-        assert length(requests) == 6 * 7
+        assert length(requests) == 6 * 8
 
         {:ok,
          format_responses([
@@ -284,13 +275,15 @@ defmodule Explorer.Staking.ContractStateTest do
            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
            # 1.3 StakingAuRa.isPoolActive
            "0x0000000000000000000000000000000000000000000000000000000000000000",
-           # 1.4 ValidatorSetAuRa.miningByStakingAddress
+           # 1.4 ValidatorSetAuRa.miningAddressById
            "0x000000000000000000000000522df396ae70a058bd69778408630fdb023389b2",
-           # 1.5 StakingAuRa.stakeAmount
+           # 1.5 ValidatorSetAuRa.stakingAddressById
+           "0x0000000000000000000000000b2f5e2f3cbd864eaa2c642e3769c1582361caf6",
+           # 1.6 StakingAuRa.stakeAmount
            "0x0000000000000000000000000000000000000000000000000000000000000000",
-           # 1.6 StakingAuRa.stakeAmountTotal
+           # 1.7 StakingAuRa.stakeAmountTotal
            "0x0000000000000000000000000000000000000000000000000000000000000000",
-           # 1.7 BlockRewardAuRa.validatorRewardPercent
+           # 1.8 BlockRewardAuRa.validatorRewardPercent
            "0x0000000000000000000000000000000000000000000000000000000000000000",
 
            # 2.1 StakingAuRa.poolDelegators
@@ -299,13 +292,15 @@ defmodule Explorer.Staking.ContractStateTest do
            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
            # 2.3 StakingAuRa.isPoolActive
            "0x0000000000000000000000000000000000000000000000000000000000000001",
-           # 2.4 ValidatorSetAuRa.miningByStakingAddress
+           # 2.4 ValidatorSetAuRa.miningAddressById
            "0x000000000000000000000000720e118ab1006cc97ed2ef6b4b49ac04bb3aa6d9",
-           # 2.5 StakingAuRa.stakeAmount
+           # 2.5 ValidatorSetAuRa.stakingAddressById
+           "0x000000000000000000000000aa94b687d3f9552a453b81b2834ca53778980dc0",
+           # 2.6 StakingAuRa.stakeAmount
            "0x0000000000000000000000000000000000000000000000001bc16d674ec80000",
-           # 2.6 StakingAuRa.stakeAmountTotal
+           # 2.7 StakingAuRa.stakeAmountTotal
            "0x00000000000000000000000000000000000000000000000029a2241af62c0000",
-           # 2.7 BlockRewardAuRa.validatorRewardPercent
+           # 2.8 BlockRewardAuRa.validatorRewardPercent
            "0x00000000000000000000000000000000000000000000000000000000000a2c2a",
 
            # 3.1 StakingAuRa.poolDelegators
@@ -314,13 +309,15 @@ defmodule Explorer.Staking.ContractStateTest do
            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
            # 3.3 StakingAuRa.isPoolActive
            "0x0000000000000000000000000000000000000000000000000000000000000000",
-           # 3.4 ValidatorSetAuRa.miningByStakingAddress
+           # 3.4 ValidatorSetAuRa.miningAddressById
            "0x00000000000000000000000075df42383afe6bf5194aa8fa0e9b3d5f9e869441",
-           # 3.5 StakingAuRa.stakeAmount
+           # 3.5 ValidatorSetAuRa.stakingAddressById
+           "0x000000000000000000000000312c230e7d6db05224f60208a656e3541c5c42ba",
+           # 3.6 StakingAuRa.stakeAmount
            "0x0000000000000000000000000000000000000000000000000000000000000000",
-           # 3.6 StakingAuRa.stakeAmountTotal
+           # 3.7 StakingAuRa.stakeAmountTotal
            "0x0000000000000000000000000000000000000000000000000000000000000000",
-           # 3.7 BlockRewardAuRa.validatorRewardPercent
+           # 3.8 BlockRewardAuRa.validatorRewardPercent
            "0x0000000000000000000000000000000000000000000000000000000000000000",
 
            # 4.1 StakingAuRa.poolDelegators
@@ -329,13 +326,15 @@ defmodule Explorer.Staking.ContractStateTest do
            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
            # 4.3 StakingAuRa.isPoolActive
            "0x0000000000000000000000000000000000000000000000000000000000000001",
-           # 4.4 ValidatorSetAuRa.miningByStakingAddress
+           # 4.4 ValidatorSetAuRa.miningAddressById
            "0x000000000000000000000000bbcaa8d48289bb1ffcf9808d9aa4b1d215054c78",
-           # 4.5 StakingAuRa.stakeAmount
+           # 4.5 ValidatorSetAuRa.stakingAddressById
+           "0x000000000000000000000000b916e7e1f4bcb13549602ed042d36746fd0d96c9",
+           # 4.6 StakingAuRa.stakeAmount
            "0x0000000000000000000000000000000000000000000000000000000000000000",
-           # 4.6 StakingAuRa.stakeAmountTotal
+           # 4.7 StakingAuRa.stakeAmountTotal
            "0x0000000000000000000000000000000000000000000000000000000000000000",
-           # 4.7 BlockRewardAuRa.validatorRewardPercent
+           # 4.8 BlockRewardAuRa.validatorRewardPercent
            "0x0000000000000000000000000000000000000000000000000000000000000000",
 
            # 5.1 StakingAuRa.poolDelegators
@@ -344,13 +343,15 @@ defmodule Explorer.Staking.ContractStateTest do
            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
            # 5.3 StakingAuRa.isPoolActive
            "0x0000000000000000000000000000000000000000000000000000000000000001",
-           # 5.4 ValidatorSetAuRa.miningByStakingAddress
+           # 5.4 ValidatorSetAuRa.miningAddressById
            "0x000000000000000000000000be69eb0968226a1808975e1a1f2127667f2bffb3",
-           # 5.5 StakingAuRa.stakeAmount
+           # 5.5 ValidatorSetAuRa.stakingAddressById
+           "0x000000000000000000000000db9cb2478d917719c53862008672166808258577",
+           # 5.6 StakingAuRa.stakeAmount
            "0x0000000000000000000000000000000000000000000000001bc16d674ec80000",
-           # 5.6 StakingAuRa.stakeAmountTotal
+           # 5.7 StakingAuRa.stakeAmountTotal
            "0x00000000000000000000000000000000000000000000000098a7d9b8314c0000",
-           # 5.7 BlockRewardAuRa.validatorRewardPercent
+           # 5.8 BlockRewardAuRa.validatorRewardPercent
            "0x00000000000000000000000000000000000000000000000000000000000493e0",
 
            # 6.1 StakingAuRa.poolDelegators
@@ -359,13 +360,15 @@ defmodule Explorer.Staking.ContractStateTest do
            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
            # 6.3 StakingAuRa.isPoolActive
            "0x0000000000000000000000000000000000000000000000000000000000000001",
-           # 6.4 ValidatorSetAuRa.miningByStakingAddress
+           # 6.4 ValidatorSetAuRa.miningAddressById
            "0x000000000000000000000000f67cc5231c5858ad6cc87b105217426e17b824bb",
-           # 6.5 StakingAuRa.stakeAmount
+           # 6.5 ValidatorSetAuRa.stakingAddressById
+           "0x000000000000000000000000b6695f5c2e3f5eff8036b5f5f3a9d83a5310e51e",
+           # 6.6 StakingAuRa.stakeAmount
            "0x0000000000000000000000000000000000000000000000001bc16d674ec80000",
-           # 6.6 StakingAuRa.stakeAmountTotal
+           # 6.7 StakingAuRa.stakeAmountTotal
            "0x0000000000000000000000000000000000000000000000001bc16d674ec80000",
-           # 6.7 BlockRewardAuRa.validatorRewardPercent
+           # 6.8 BlockRewardAuRa.validatorRewardPercent
            "0x00000000000000000000000000000000000000000000000000000000000f4240"
          ])}
       end
@@ -719,7 +722,28 @@ defmodule Explorer.Staking.ContractStateTest do
       end
     )
 
-    # invoke do_snapshotting()
+    # invoke do_start_snapshotting()
+
+    ## get_mining_to_staking_address
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn requests, _opts ->
+        assert length(requests) == 4
+
+        {:ok,
+         format_responses([
+           # 1 ValidatorSetAuRa.stakingByMiningAddress
+           "0x000000000000000000000000b916e7e1f4bcb13549602ed042d36746fd0d96c9",
+           # 2 ValidatorSetAuRa.stakingByMiningAddress
+           "0x000000000000000000000000b6695f5c2e3f5eff8036b5f5f3a9d83a5310e51e",
+           # 3 ValidatorSetAuRa.stakingByMiningAddress
+           "0x000000000000000000000000db9cb2478d917719c53862008672166808258577",
+           # 4 ValidatorSetAuRa.stakingByMiningAddress
+           "0x000000000000000000000000aa94b687d3f9552a453b81b2834ca53778980dc0"
+         ])}
+      end
+    )
 
     ## 1 snapshotted_pool_amounts_requests
     expect(


### PR DESCRIPTION
## Motivation

`1.` This is a refactoring PR that continues https://github.com/poanetwork/blockscout/pull/3612 and https://github.com/poanetwork/blockscout/pull/3616 and reflects the changes made in https://github.com/poanetwork/posdao-contracts/compare/0f8bf7f61782abfadcebe0a5cc26e99305050894...79803fdb40c5e106f60ab4b200d0cdf9a1714859.

It is a final part of big refactoring in POSDAO contracts to add there an ability for changing pool's staking address and/or mining address.

The `changeStakingAddress` and `changeMiningAddress` features weren't added to Staking UI, so this is refactoring only.

This PR doesn't change the DB structure.

Please, don't merge and publish Blockscout release with these changes until we upgrade POSDAO contracts to apply the changes. I'll let you know once that happens.

`2.` Also, it adds pools sorting by APY descending on the `Validators` tab. The sorting only activates if the APY of each validator is known and can be calculated, otherwise, the default sorting from the database is applied.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
