### PR TITLE
Application alerts management: whole explorer, staking dapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#3577](https://github.com/poanetwork/blockscout/pull/3577) - Eliminate GraphiQL page XSS attack
 
 ### Chore
+- [#3714](https://github.com/poanetwork/blockscout/pull/3714) - Application announcements management: whole explorer, staking dapp
 - [#3709](https://github.com/poanetwork/blockscout/pull/3709) - Fix 413 Request Entity Too Large returned from single request batch
 - [#3701](https://github.com/poanetwork/blockscout/pull/3701) - Increase LP tokens calc process re-check interval
 - [#3700](https://github.com/poanetwork/blockscout/pull/3700) - Update tool versions

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -24,6 +24,9 @@ config :block_scout_web, BlockScoutWeb.Chain,
   logo_text: System.get_env("LOGO_TEXT"),
   has_emission_funds: false,
   staking_enabled: not is_nil(System.get_env("POS_STAKING_CONTRACT")),
+  staking_enabled_in_menu: System.get_env("ENABLE_POS_STAKING_IN_MENU", "false") == "true",
+  show_staking_warning: System.get_env("SHOW_STAKING_WARNING", "false") == "true",
+  show_maintenance_alert: System.get_env("SHOW_MAINTENANCE_ALERT", "false") == "true",
   # how often (in blocks) the list of pools should autorefresh in UI (zero turns off autorefreshing)
   staking_pool_list_refresh_interval: 5
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -2,6 +2,8 @@
 <link rel="stylesheet" href="<%= static_path(@conn, "/css/awesomplete.css") %>">
 <script src="<%= static_path(@conn, "/js/awesomplete.min.js") %>"></script>
 <script src="<%= static_path(@conn, "/js/awesomplete-util.min.js") %>"></script>
+<% staking_enabled_in_menu = Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:staking_enabled_in_menu] %>
+<% apps_menu = Application.get_env(:block_scout_web, :apps_menu) %>
 <nav class="navbar navbar-dark navbar-expand-lg navbar-primary" data-selector="navbar" id="top-navbar">
   <script>
     if (localStorage.getItem("current-color-mode") === "dark") {
@@ -142,26 +144,26 @@
             </div>
           </li>
         <% end %>
-        <%= if Application.get_env(:block_scout_web, :apps_menu) == true || Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:staking_enabled] do %>
+        <%= if apps_menu == true || staking_enabled_in_menu do %>
           <li class="nav-item dropdown">
             <a href="#" role="button" id="navbarAppsDropdown" class="nav-link topnav-nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <span class="nav-link-icon">
                 <%= render BlockScoutWeb.IconsView, "_apps_icon.html" %>
               </span>
-              <%= if Application.get_env(:block_scout_web, :apps_menu) == true do %>
+              <%= if apps_menu == true do %>
                 <%= gettext("Apps") %>
               <% else %>
                 <%= gettext("Stakes") %>
               <% end %>
             </a>
             <div class="dropdown-menu" aria-labeledby="navbarAppsDropdown">
-              <%= if Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:staking_enabled] do %>
+              <%= if staking_enabled_in_menu do %>
                 <a class="dropdown-item <%= #{tab_status("validators", @conn.request_path)} %>" href="<%= validators_path(@conn, :index) %>">
                   <%= gettext("Staking") %>
                   <span class="bs-label secondary right from-dropdown">New</span>
                 </a>
               <% end %>
-              <%= if Application.get_env(:block_scout_web, :apps_menu) == true do %>
+              <%= if apps_menu == true do %>
                 <%= for %{url: url, title: title} <- external_apps_list() do %> 
                     <a href="<%= url %>" class="dropdown-item" target="_blank"><%= title %>
                       <span class="external-link-icon">

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -163,6 +163,12 @@
       window.onload = applyDarkMode()
     </script>
     <div class="layout-container">
+      <% show_maintenance_alert = Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:show_maintenance_alert] %>
+      <%= if show_maintenance_alert do %>
+        <div class="alert alert-warning text-center mb-0 p-3" data-selector="indexed-status">
+          <%= System.get_env("MAINTENANCE_ALERT_MESSAGE") %>
+        </div>
+      <% end %>
       <%= if not Explorer.Chain.finished_indexing?() do %>
         <div class="alert alert-warning text-center mb-0 p-3" data-selector="indexed-status">
           <span class="loading-spinner-small mr-2">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_warning.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_warning.html.eex
@@ -8,7 +8,11 @@
     </button>
     <span style="font-size: 1.3em;">
         <i style="color: #f7b32b;" class="fa fa-info-circle ml-1"></i>
-        Due to high load volumes, current staking data display may lag behind actual transactions. Transactions are being processed correctly on-chain. We are currently working to address this UI display issue.
+        <%= if @message do %>
+          <%= "#{@message}" %>
+        <% else %>
+          Due to high load volumes, current staking data display may lag behind actual transactions. Transactions are being processed correctly on-chain. We are currently working to address this UI display issue.
+        <% end %>
     </span>
   </div>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/index.html.eex
@@ -2,7 +2,9 @@
   <%= raw(@top) %>
 </div>
 <%= render BlockScoutWeb.StakesView, "_learn-more.html", conn: @conn %>
-<%= # render BlockScoutWeb.StakesView, "_warning.html", conn: @conn %>
+<%= if Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:show_staking_warning] do %>
+  <%= render BlockScoutWeb.StakesView, "_warning.html", conn: @conn, message: System.get_env("STAKING_WARNING_MESSAGE", nil) %>
+<% end %>
 <section data-page="stakes" class="container" data-refresh-interval="<%= @refresh_interval %>">
   <div class="card" data-async-load data-async-listing="<%= @current_path %>" data-no-first-loading>
     <%= render BlockScoutWeb.StakesView, "_stakes_tabs.html", conn: @conn %>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -72,7 +72,7 @@ msgid "(query)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:173
+#: lib/block_scout_web/templates/layout/app.html.eex:179
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
 
@@ -107,12 +107,12 @@ msgid "API for the %{subnetwork} - BlockScout"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:124
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:126
 msgid "APIs"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:78
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:80
 msgid "Accounts"
 msgstr ""
 
@@ -138,7 +138,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:26
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:24
 #: lib/block_scout_web/templates/layout/_network_selector.html.eex:21
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:91
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:93
 #: lib/block_scout_web/views/address_internal_transaction_view.ex:10
 #: lib/block_scout_web/views/address_token_transfer_view.ex:10
 #: lib/block_scout_web/views/address_transaction_view.ex:10
@@ -237,8 +237,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:180
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:34
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:38
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:36
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:40
 msgid "Blocks"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgid "Error: Could not determine contract creator."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:138
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:140
 msgid "Eth RPC"
 msgstr ""
 
@@ -690,7 +690,7 @@ msgid "For any existing contracts in the database, insert all ABI entries into t
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:44
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:46
 msgid "Forked Blocks (Reorgs)"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgid "Github"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:128
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:130
 msgid "GraphQL"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid "To"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:23
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:25
 msgid "Toggle navigation"
 msgstr ""
 
@@ -1153,7 +1153,7 @@ msgid "Parent Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:65
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:67
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:181
 #: lib/block_scout_web/views/transaction_view.ex:261
 #: lib/block_scout_web/views/transaction_view.ex:295
@@ -1192,7 +1192,7 @@ msgid "Query"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:133
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:135
 msgid "RPC"
 msgstr ""
 
@@ -1250,13 +1250,13 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/index.html.eex:14
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:215
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:259
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:217
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:261
 msgid "Search"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:209
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:211
 msgid "Search by address, token symbol name, transaction hash, or block number"
 msgstr ""
 
@@ -1522,7 +1522,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/overview.html.eex:80
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:41
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:43
 msgid "Uncles"
 msgstr ""
 
@@ -1542,7 +1542,7 @@ msgid "Used"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:57
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:59
 msgid "Validated"
 msgstr ""
 
@@ -1860,8 +1860,8 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:21
 #: lib/block_scout_web/templates/address_token/index.html.eex:8
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:11
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:87
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:113
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:89
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:115
 #: lib/block_scout_web/templates/tokens/index.html.eex:4
 #: lib/block_scout_web/views/address_view.ex:343
 msgid "Tokens"
@@ -1873,7 +1873,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:10
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:18
 #: lib/block_scout_web/templates/chain/show.html.eex:238
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:53
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:55
 #: lib/block_scout_web/views/address_view.ex:345
 msgid "Transactions"
 msgstr ""
@@ -1942,7 +1942,7 @@ msgid "Write Proxy"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:152
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:154
 msgid "Apps"
 msgstr ""
 
@@ -1952,7 +1952,7 @@ msgid "Copy Raw Trace"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:213
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:215
 msgid "Search by address, token symbol, name, transaction hash, or block number"
 msgstr ""
 
@@ -2599,7 +2599,7 @@ msgid "validator"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:154
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:156
 msgid "Stakes"
 msgstr ""
 
@@ -2610,12 +2610,12 @@ msgid "Contract is not verified. However, we found a verified contract with the 
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:160
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:162
 msgid "Staking"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:252
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:254
 msgid "Press / and focus will be moved to the search field"
 msgstr ""
 
@@ -2683,12 +2683,12 @@ msgid "Bridged Tokens from "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:96
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:98
 msgid "Bridged from Ethereum"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:101
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:103
 msgid "Bridged from BSC"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -72,7 +72,7 @@ msgid "(query)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/app.html.eex:173
+#: lib/block_scout_web/templates/layout/app.html.eex:179
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
 
@@ -107,12 +107,12 @@ msgid "API for the %{subnetwork} - BlockScout"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:124
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:126
 msgid "APIs"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:78
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:80
 msgid "Accounts"
 msgstr ""
 
@@ -138,7 +138,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:26
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:24
 #: lib/block_scout_web/templates/layout/_network_selector.html.eex:21
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:91
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:93
 #: lib/block_scout_web/views/address_internal_transaction_view.ex:10
 #: lib/block_scout_web/views/address_token_transfer_view.ex:10
 #: lib/block_scout_web/views/address_transaction_view.ex:10
@@ -237,8 +237,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:180
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:34
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:38
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:36
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:40
 msgid "Blocks"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgid "Error: Could not determine contract creator."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:138
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:140
 msgid "Eth RPC"
 msgstr ""
 
@@ -690,7 +690,7 @@ msgid "For any existing contracts in the database, insert all ABI entries into t
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:44
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:46
 msgid "Forked Blocks (Reorgs)"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgid "Github"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:128
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:130
 msgid "GraphQL"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid "To"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:23
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:25
 msgid "Toggle navigation"
 msgstr ""
 
@@ -1153,7 +1153,7 @@ msgid "Parent Hash"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:65
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:67
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:181
 #: lib/block_scout_web/views/transaction_view.ex:261
 #: lib/block_scout_web/views/transaction_view.ex:295
@@ -1192,7 +1192,7 @@ msgid "Query"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:133
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:135
 msgid "RPC"
 msgstr ""
 
@@ -1250,13 +1250,13 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/index.html.eex:14
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:215
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:259
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:217
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:261
 msgid "Search"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:209
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:211
 msgid "Search by address, token symbol name, transaction hash, or block number"
 msgstr ""
 
@@ -1522,7 +1522,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/overview.html.eex:80
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:41
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:43
 msgid "Uncles"
 msgstr ""
 
@@ -1542,7 +1542,7 @@ msgid "Used"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:57
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:59
 msgid "Validated"
 msgstr ""
 
@@ -1860,8 +1860,8 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:21
 #: lib/block_scout_web/templates/address_token/index.html.eex:8
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:11
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:87
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:113
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:89
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:115
 #: lib/block_scout_web/templates/tokens/index.html.eex:4
 #: lib/block_scout_web/views/address_view.ex:343
 msgid "Tokens"
@@ -1873,7 +1873,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:10
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:18
 #: lib/block_scout_web/templates/chain/show.html.eex:238
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:53
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:55
 #: lib/block_scout_web/views/address_view.ex:345
 msgid "Transactions"
 msgstr ""
@@ -1942,7 +1942,7 @@ msgid "Write Proxy"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:152
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:154
 msgid "Apps"
 msgstr ""
 
@@ -1952,7 +1952,7 @@ msgid "Copy Raw Trace"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:213
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:215
 msgid "Search by address, token symbol, name, transaction hash, or block number"
 msgstr ""
 
@@ -2599,7 +2599,7 @@ msgid "validator"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:154
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:156
 msgid "Stakes"
 msgstr ""
 
@@ -2610,12 +2610,12 @@ msgid "Contract is not verified. However, we found a verified contract with the 
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:160
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:162
 msgid "Staking"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:252
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:254
 msgid "Press / and focus will be moved to the search field"
 msgstr ""
 
@@ -2683,12 +2683,12 @@ msgid "Bridged Tokens from "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:96
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:98
 msgid "Bridged from Ethereum"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:101
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:103
 msgid "Bridged from BSC"
 msgstr ""
 


### PR DESCRIPTION
Closes https://github.com/poanetwork/blockscout/issues/1609

## Motivation

Manage Blockskout alerts

## Changelog

Enables explorer alert managing through ENV variables:

<img width="1440" alt="Screenshot 2021-03-17 at 11 28 59" src="https://user-images.githubusercontent.com/4341812/111437333-03561180-8714-11eb-8f42-ceecfdf119d2.png">

`SHOW_MAINTENANCE_ALERT` - true/false enables announcement at the top of explorer
`MAINTENANCE_ALERT_MESSAGE` - Message text of the alert

Enables staking dapp alert managing through ENV variables:

<img width="1321" alt="Screenshot 2021-03-17 at 11 31 30" src="https://user-images.githubusercontent.com/4341812/111437618-5b8d1380-8714-11eb-96c3-64d2185363c4.png">


`SHOW_STAKING_WARNING` - true/false enables announcement inside Staking Dapp
`STAKING_WARNING_MESSAGE` - Message text of the alert


Chore:

Add env var `DISABLE_POS_STAKING_IN_MENU` for management of enabling/disabling of Staking Dapp in the menu


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
