### PR TITLE
Rename ethprice API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [#3577](https://github.com/poanetwork/blockscout/pull/3577) - Eliminate GraphiQL page XSS attack
 
 ### Chore
+- [#3719](https://github.com/poanetwork/blockscout/pull/3719) - Rename ethprice API endpoint
 - [#3717](https://github.com/poanetwork/blockscout/pull/3717) - Update alpine-elixir-phoenix 1.11.3
 - [#3714](https://github.com/poanetwork/blockscout/pull/3714) - Application announcements management: whole explorer, staking dapp
 - [#3709](https://github.com/poanetwork/blockscout/pull/3709) - Fix 413 Request Entity Too Large returned from single request batch

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -59,11 +59,11 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
     render(conn, "coinsupply.json", total_supply: cached_coin_total_supply)
   end
 
-  def ethprice(conn, _params) do
+  def coinprice(conn, _params) do
     symbol = Application.get_env(:explorer, :coin)
     rates = ExchangeRates.lookup(symbol)
 
-    render(conn, "ethprice.json", rates: rates)
+    render(conn, "coinprice.json", rates: rates)
   end
 
   defp fetch_contractaddress(params) do

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -313,14 +313,14 @@ defmodule BlockScoutWeb.Etherscan do
 
   @stats_coinsupply_example_value 101_959_776.3115
 
-  @stats_ethprice_example_value %{
+  @stats_coinprice_example_value %{
     "status" => "1",
     "message" => "OK",
     "result" => %{
-      "ethbtc" => "0.03246",
-      "ethbtc_timestamp" => "1537212510",
-      "ethusd" => "204",
-      "ethusd_timestamp" => "1537212513"
+      "coin_btc" => "0.03246",
+      "coin_btc_timestamp" => "1537212510",
+      "coin_usd" => "204",
+      "coin_usd_timestamp" => "1537212513"
     }
   }
 
@@ -1087,25 +1087,25 @@ defmodule BlockScoutWeb.Etherscan do
     }
   }
 
-  @eth_price_model %{
-    name: "EthPrice",
+  @coin_price_model %{
+    name: "CoinPrice",
     fields: %{
-      ethbtc: %{
-        type: "ethbtc",
-        definition: &__MODULE__.ethbtc_type_definition/1,
+      coin_btc: %{
+        type: "coin_btc",
+        definition: &__MODULE__.coin_btc_type_definition/1,
         example: ~s("0.03161")
       },
-      ethbtc_timestamp: %{
+      coin_btc_timestamp: %{
         type: "timestamp",
         definition: "Last updated timestamp.",
         example: ~s("1537234460")
       },
-      ethusd: %{
-        type: "ethusd",
-        definition: &__MODULE__.ethusd_type_definition/1,
+      coin_usd: %{
+        type: "coin_usd",
+        definition: &__MODULE__.coin_usd_type_definition/1,
         example: ~s("197.57")
       },
-      ethusd_timestamp: %{
+      coin_usd_timestamp: %{
         type: "timestamp",
         definition: "Last updated timestamp.",
         example: ~s("1537234460")
@@ -2021,16 +2021,16 @@ defmodule BlockScoutWeb.Etherscan do
     ]
   }
 
-  @stats_ethprice_action %{
-    name: "ethprice",
-    description: "Get latest price in USD and BTC.",
+  @stats_coinprice_action %{
+    name: "coinprice",
+    description: "Get latest price of native coin in USD and BTC.",
     required_params: [],
     optional_params: [],
     responses: [
       %{
         code: "200",
         description: "successful operation",
-        example_value: Jason.encode!(@stats_ethprice_example_value),
+        example_value: Jason.encode!(@stats_coinprice_example_value),
         model: %{
           name: "Result",
           fields: %{
@@ -2038,7 +2038,7 @@ defmodule BlockScoutWeb.Etherscan do
             message: @message_type,
             result: %{
               type: "model",
-              model: @eth_price_model
+              model: @coin_price_model
             }
           }
         }
@@ -2538,7 +2538,7 @@ defmodule BlockScoutWeb.Etherscan do
       @stats_ethsupplyexchange_action,
       @stats_ethsupply_action,
       @stats_coinsupply_action,
-      @stats_ethprice_action
+      @stats_coinprice_action
     ]
   }
 
@@ -2586,11 +2586,11 @@ defmodule BlockScoutWeb.Etherscan do
       "One #{coin} is defined as being 10<sup>18</sup> Wei."
   end
 
-  def ethbtc_type_definition(coin) do
+  def coin_btc_type_definition(coin) do
     "#{coin} price in Bitcoin."
   end
 
-  def ethusd_type_definition(coin) do
+  def coin_usd_type_definition(coin) do
     "#{coin} price in US dollars."
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
@@ -19,7 +19,7 @@ defmodule BlockScoutWeb.API.RPC.StatsView do
     RPCView.render("show_value.json", data: total_supply)
   end
 
-  def render("ethprice.json", %{rates: rates}) do
+  def render("coinprice.json", %{rates: rates}) do
     RPCView.render("show.json", data: prepare_rates(rates))
   end
 
@@ -31,10 +31,10 @@ defmodule BlockScoutWeb.API.RPC.StatsView do
     timestamp = rates.last_updated |> DateTime.to_unix() |> to_string()
 
     %{
-      "ethbtc" => to_string(rates.btc_value),
-      "ethbtc_timestamp" => timestamp,
-      "ethusd" => to_string(rates.usd_value),
-      "ethusd_timestamp" => timestamp
+      "coin_btc" => to_string(rates.btc_value),
+      "coin_btc_timestamp" => timestamp,
+      "coin_usd" => to_string(rates.usd_value),
+      "coin_usd_timestamp" => timestamp
     }
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -187,8 +187,8 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
       expected_result = %{
         "coin_btc" => to_string(eth.btc_value),
         "coin_btc_timestamp" => expected_timestamp,
-        "coin_btc" => to_string(eth.usd_value),
-        "coin_btc_timestamp" => expected_timestamp
+        "coin_usd" => to_string(eth.usd_value),
+        "coin_usd_timestamp" => expected_timestamp
       }
 
       assert response =

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -140,7 +140,7 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
   #   end
   # end
 
-  describe "ethprice" do
+  describe "coinprice" do
     setup :set_mox_global
 
     setup do
@@ -179,16 +179,16 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
 
       params = %{
         "module" => "stats",
-        "action" => "ethprice"
+        "action" => "coinprice"
       }
 
       expected_timestamp = eth.last_updated |> DateTime.to_unix() |> to_string()
 
       expected_result = %{
-        "ethbtc" => to_string(eth.btc_value),
-        "ethbtc_timestamp" => expected_timestamp,
-        "ethusd" => to_string(eth.usd_value),
-        "ethusd_timestamp" => expected_timestamp
+        "coin_btc" => to_string(eth.btc_value),
+        "coin_btc_timestamp" => expected_timestamp,
+        "coin_btc" => to_string(eth.usd_value),
+        "coin_btc_timestamp" => expected_timestamp
       }
 
       assert response =
@@ -199,7 +199,7 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
       assert response["result"] == expected_result
       assert response["status"] == "1"
       assert response["message"] == "OK"
-      assert :ok = ExJsonSchema.Validator.validate(ethprice_schema(), response)
+      assert :ok = ExJsonSchema.Validator.validate(coinprice_schema(), response)
     end
   end
 
@@ -221,14 +221,14 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
     })
   end
 
-  defp ethprice_schema do
+  defp coinprice_schema do
     resolve_schema(%{
       "type" => "object",
       "properties" => %{
-        "ethbtc" => %{"type" => "string"},
-        "ethbtc_timestamp" => %{"type" => "string"},
-        "ethusd" => %{"type" => "string"},
-        "ethusd_timestamp" => %{"type" => "string"}
+        "coin_btc" => %{"type" => "string"},
+        "coin_btc_timestamp" => %{"type" => "string"},
+        "coin_usd" => %{"type" => "string"},
+        "coin_usd_timestamp" => %{"type" => "string"}
       }
     })
   end


### PR DESCRIPTION
## Motivation

From Discord:
> Hey frens, anyone know what this is showing?
https://blockscout.com/poa/xdai/api?module=stats&action=ethprice

## Changelog

Rename `ethprice` API endpoint to `coinprice` in order to eliminate confusion

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
