### PR TITLE
Allow double quotes for (u)int arrays inputs during contract interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#3722](https://github.com/poanetwork/blockscout/pull/3722) - Allow double quotes for (u)int arrays inputs during contract interaction
 - [#3694](https://github.com/poanetwork/blockscout/pull/3694) - LP tokens total liquidity
 - [#3676](https://github.com/poanetwork/blockscout/pull/3676) - Bridged tokens TLV in USD
 - [#3674](https://github.com/poanetwork/blockscout/pull/3674) - Display Sushiswap pools data

--- a/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
@@ -197,27 +197,26 @@ function getMethodInputs (contractAbi, functionName) {
 
 function prepareMethodArgs ($functionInputs, inputs) {
   return $.map($functionInputs, (element, ind) => {
-    const val = $(element).val()
+    const inputValue = $(element).val()
     const inputType = inputs[ind] && inputs[ind].type
-    let preparedVal
-    if (isNonSpaceInputType(inputType)) { preparedVal = val.replace(/\s/g, '') } else { preparedVal = val }
-    if (isAddressInputType(inputType)) {
-      if (typeof preparedVal.replaceAll === 'function') {
-        preparedVal = preparedVal.replaceAll('"', '')
-      } else {
-        preparedVal = preparedVal.replace(/"/g, '')
-      }
-    }
+    let sanitizedInputValue
+    sanitizedInputValue = replaceSpaces(inputValue, inputType)
+    sanitizedInputValue = replaceDoubleQuotes(sanitizedInputValue, inputType)
     if (isArrayInputType(inputType)) {
-      if (preparedVal === '') {
+      if (sanitizedInputValue === '') {
         return [[]]
       } else {
-        if (preparedVal.startsWith('[') && preparedVal.endsWith(']')) {
-          preparedVal = preparedVal.substring(1, preparedVal.length - 1)
+        if (sanitizedInputValue.startsWith('[') && sanitizedInputValue.endsWith(']')) {
+          sanitizedInputValue = sanitizedInputValue.substring(1, sanitizedInputValue.length - 1)
         }
-        return [preparedVal.split(',')]
+        const inputValueElements = sanitizedInputValue.split(',')
+        const sanitizedInputValueElements = inputValueElements.map(elementValue => {
+          const elementInputType = inputType.split('[')[0]
+          return replaceDoubleQuotes(elementValue, elementInputType)
+        })
+        return [sanitizedInputValueElements]
       }
-    } else { return preparedVal }
+    } else { return sanitizedInputValue }
   })
 }
 
@@ -227,6 +226,14 @@ function isArrayInputType (inputType) {
 
 function isAddressInputType (inputType) {
   return inputType.includes('address')
+}
+
+function isUintInputType (inputType) {
+  return inputType.includes('int') && !inputType.includes('[')
+}
+
+function isStringInputType (inputType) {
+  return inputType.includes('string') && !inputType.includes('[')
 }
 
 function isNonSpaceInputType (inputType) {
@@ -277,6 +284,26 @@ function onTransactionHash (txHash, $element, functionName) {
       })
   }
   const txReceiptPollingIntervalId = setInterval(() => { getTxReceipt(txHash) }, 5 * 1000)
+}
+
+function replaceSpaces (value, type) {
+  if (isNonSpaceInputType(type)) {
+    return value.replace(/\s/g, '')
+  } else {
+    return value
+  }
+}
+
+function replaceDoubleQuotes (value, type) {
+  if (isAddressInputType(type) || isUintInputType(type) || isStringInputType(type)) {
+    if (typeof value.replaceAll === 'function') {
+      return value.replaceAll('"', '')
+    } else {
+      return value.replace(/"/g, '')
+    }
+  } else {
+    return value
+  }
 }
 
 const formatError = (error) => {

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -94,8 +94,13 @@ defmodule BlockScoutWeb.SmartContractView do
   end
 
   def values_with_type(value, type, _components) when type in [:address, "address", "address payable"] do
-    {:ok, address} = Address.cast(value)
-    render_type_value("address", to_string(address))
+    case Address.cast(value) do
+      {:ok, address} ->
+        render_type_value("address", to_string(address))
+
+      _ ->
+        ""
+    end
   end
 
   def values_with_type(value, "string", _components), do: render_type_value("string", value)


### PR DESCRIPTION
## Motivation

Accept quoted numbers as an input for (u)int arrays inputs.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
