### PR TITLE
Fix losing digits at value conversion back from WEI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3723](https://github.com/poanetwork/blockscout/pull/3723) - Fix losing digits at value conversion back from WEI
 - [#3715](https://github.com/poanetwork/blockscout/pull/3715) - Pending transactions sanitizer process
 - [#3710](https://github.com/poanetwork/blockscout/pull/3710) - Missing @destination in bridged-tokens template
 - [#3707](https://github.com/poanetwork/blockscout/pull/3707) - Fetch bridged token price by address of foreign token, not by symbol

--- a/apps/block_scout_web/assets/js/lib/smart_contract/wei_ether_converter.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/wei_ether_converter.js
@@ -8,18 +8,18 @@ const weiToEtherConverter = (element, event) => {
   const $conversionTextWei = $element.find('[data-conversion-text-wei]')
   const $conversionTextEth = $element.find('[data-conversion-text-eth]')
   const $conversionUnit = $element.find('[data-conversion-unit]')
-  let unitVal = new BigNumber(numeral($conversionUnit.html()).value())
+  const originalValueStr = $conversionUnit.data('original-value')
+  const unitVal = new BigNumber(numeral(originalValueStr).value())
+  const weiVal = unitVal.dividedBy(weiUnit)
 
   if (event.target.checked) {
     $conversionTextWei.removeClass('d-inline-block').addClass('d-none')
     $conversionTextEth.removeClass('d-none').addClass('d-inline-block')
-    unitVal = unitVal.dividedBy(weiUnit)
-    $conversionUnit.html(unitVal.toFixed() > 0 ? String(unitVal.toFixed()) : numeral(unitVal).format('0[.000000000000000000]'))
+    $conversionUnit.html(weiVal.toFixed() > 0 ? String(weiVal.toFixed()) : numeral(weiVal).format('0[.000000000000000000]'))
   } else {
     $conversionTextWei.removeClass('d-none').addClass('d-inline-block')
     $conversionTextEth.removeClass('d-inline-block').addClass('d-none')
-    unitVal = unitVal.multipliedBy(weiUnit)
-    $conversionUnit.html(String(unitVal.toFixed()))
+    $conversionUnit.html(originalValueStr)
   }
 }
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -113,7 +113,7 @@ to: address_contract_path(@conn, :index, metadata_for_verification.address_hash)
             <% else %>
                 <%= if output["type"] == "uint256" do %>
                   <div data-wei-ether-converter>
-                    <span data-conversion-unit><%= output["value"] %></span>
+                    <span data-conversion-unit data-original-value="<%= output["value"] %>"><%= output["value"] %></span>
                     <span class="py-2 px-2">
                       <input class="wei-ether" type="checkbox" autocomplete="off">
                       <span class="d-inline-block" data-conversion-text-wei><%= gettext("WEI")%></span>


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/3654

## Motivation

Fix losing of value digits between wei conversions


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
