### PR TITLE
Coinprice api endpoint: handle nil rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3728](https://github.com/poanetwork/blockscout/pull/3728) - Coinprice api endpoint: handle nil rates
 - [#3723](https://github.com/poanetwork/blockscout/pull/3723) - Fix losing digits at value conversion back from WEI
 - [#3715](https://github.com/poanetwork/blockscout/pull/3715) - Pending transactions sanitizer process
 - [#3710](https://github.com/poanetwork/blockscout/pull/3710) - Missing @destination in bridged-tokens template

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
@@ -28,13 +28,22 @@ defmodule BlockScoutWeb.API.RPC.StatsView do
   end
 
   defp prepare_rates(rates) do
-    timestamp = rates.last_updated |> DateTime.to_unix() |> to_string()
+    if rates do
+      timestamp = rates.last_updated |> DateTime.to_unix() |> to_string()
 
-    %{
-      "coin_btc" => to_string(rates.btc_value),
-      "coin_btc_timestamp" => timestamp,
-      "coin_usd" => to_string(rates.usd_value),
-      "coin_usd_timestamp" => timestamp
-    }
+      %{
+        "coin_btc" => to_string(rates.btc_value),
+        "coin_btc_timestamp" => timestamp,
+        "coin_usd" => to_string(rates.usd_value),
+        "coin_usd_timestamp" => timestamp
+      }
+    else
+      %{
+        "coin_btc" => nil,
+        "coin_btc_timestamp" => nil,
+        "coin_usd" => nil,
+        "coin_usd_timestamp" => nil
+      }
+    end
   end
 end


### PR DESCRIPTION
## Motivation

>2021-03-21T15:36:54.476 application=block_scout_web request_id=Fm5llsNt_47yDO4AAEYE [error] Error while calling RPC action"** (Plug.Conn.WrapperError) ** (UndefinedFunctionError) function nil.last_updated/0 is undefined\n    nil.last_updated()\n    (block_scout_web 0.0.1) lib/block_scout_web/views/api/rpc/stats_view.ex:31: BlockScoutWeb.API.RPC.StatsView.prepare_rates/1\n    (block_scout_web 0.0.1) lib/block_scout_web/views/api/rpc/stats_view.ex:23: BlockScoutWeb.API.RPC.StatsView.render/2\n    (phoenix 1.5.6) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3\n    (phoenix 1.5.6) lib/phoenix/controller.ex:776: Phoenix.Controller.render_and_send/4\n    (block_scout_web 0.0.1) lib/block_scout_web/controllers/api/rpc/stats_controller.ex:1: BlockScoutWeb.API.RPC.StatsController.action/2\n    (block_scout_web 0.0.1) lib/block_scout_web/controllers/api/rpc/stats_controller.ex:1: BlockScoutWeb.API.RPC.StatsController.phoenix_controller_pipeline/2\n    (block_scout_web 0.0.1) lib/block_scout_web/controllers/api/rpc/rpc_translator.ex:101: BlockScoutWeb.API.RPC.RPCTranslator.call_controller/3\n"

## Changelog

Check rates are not null object before return its data in `coinprice` API endpoint

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
