### PR TITLE
Token on-demand balance fetcher: handle nil balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3729](https://github.com/poanetwork/blockscout/pull/3729) - Token on-demand balance fetcher: handle nil balance
 - [#3728](https://github.com/poanetwork/blockscout/pull/3728) - Coinprice api endpoint: handle nil rates
 - [#3723](https://github.com/poanetwork/blockscout/pull/3723) - Fix losing digits at value conversion back from WEI
 - [#3715](https://github.com/poanetwork/blockscout/pull/3715) - Pending transactions sanitizer process

--- a/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
@@ -87,12 +87,19 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
 
         updated_balance = BalanceReader.get_balances_of(stale_current_token_balances_to_fetch)[:ok]
 
-        %{}
-        |> Map.put(:address_hash, stale_current_token_balance.address_hash)
-        |> Map.put(:token_contract_address_hash, stale_current_token_balance.token_contract_address_hash)
-        |> Map.put(:block_number, block_number)
-        |> Map.put(:value, Decimal.new(updated_balance))
-        |> Map.put(:value_fetched_at, DateTime.utc_now())
+        token_balance =
+          %{}
+          |> Map.put(:address_hash, stale_current_token_balance.address_hash)
+          |> Map.put(:token_contract_address_hash, stale_current_token_balance.token_contract_address_hash)
+          |> Map.put(:block_number, block_number)
+
+        if updated_balance do
+          token_balance
+          |> Map.put(:value, Decimal.new(updated_balance))
+          |> Map.put(:value_fetched_at, DateTime.utc_now())
+        else
+          token_balance
+        end
       end)
 
     Chain.import(%{


### PR DESCRIPTION
## Motivation

> 2021-03-21T20:59:51.783 [error] GenServer Indexer.Fetcher.TokenBalanceOnDemand terminating
** (FunctionClauseError) no function clause matching in Decimal.new/1
    (decimal 1.9.0) lib/decimal.ex:1181: Decimal.new(nil)
    (indexer 0.1.0) lib/indexer/fetcher/token_balance_on_demand.ex:94: anonymous fn/3 in Indexer.Fetcher.TokenBalanceOnDemand.fetch_and_update/4
    (elixir 1.11.3) lib/enum.ex:1411: Enum."-map/2-lists^map/1-0-"/2
    (elixir 1.11.3) lib/enum.ex:1411: Enum."-map/2-lists^map/1-0-"/2
    (indexer 0.1.0) lib/indexer/fetcher/token_balance_on_demand.ex:78: Indexer.Fetcher.TokenBalanceOnDemand.fetch_and_update/4
    (indexer 0.1.0) lib/indexer/fetcher/token_balance_on_demand.ex:53: Indexer.Fetcher.TokenBalanceOnDemand.handle_cast/2
    (stdlib 3.14) gen_server.erl:689: :gen_server.try_dispatch/4
    (stdlib 3.14) gen_server.erl:765: :gen_server.handle_msg/6



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
