### PR TITLE
Set default period for average block time counter refresh interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3730](https://github.com/poanetwork/blockscout/pull/3730) - Set default period for average block time counter refresh interval
 - [#3729](https://github.com/poanetwork/blockscout/pull/3729) - Token on-demand balance fetcher: handle nil balance
 - [#3728](https://github.com/poanetwork/blockscout/pull/3728) - Coinprice api endpoint: handle nil rates
 - [#3723](https://github.com/poanetwork/blockscout/pull/3723) - Fix losing digits at value conversion back from WEI

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -23,7 +23,9 @@ config :explorer,
       else: Explorer.Chain.Events.DBSender
     )
 
-config :explorer, Explorer.Counters.AverageBlockTime, enabled: true
+config :explorer, Explorer.Counters.AverageBlockTime,
+  enabled: true,
+  period: :timer.minutes(10)
 
 config :explorer, Explorer.Chain.Events.Listener,
   enabled:


### PR DESCRIPTION
## Motivation

> 2021-03-21T19:39:34.473 [error] GenServer Explorer.Counters.AverageBlockTime terminating
** (ArgumentError) argument error
    :erlang.send_after(nil, #PID<0.1135.0>, :refresh_timestamps)
    (explorer 0.0.1) lib/explorer/counters/average_block_time.ex:59: Explorer.Counters.AverageBlockTime.handle_info/2
    (stdlib 3.14) gen_server.erl:689: :gen_server.try_dispatch/4
    (stdlib 3.14) gen_server.erl:765: :gen_server.handle_msg/6
    (stdlib 3.14) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: :refresh_timestamps


## Changelog

Set 10 mins default period for average block time counter refresh interval

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
