### PR TITLE
Handle bad gateway at pending transactions fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3731](https://github.com/poanetwork/blockscout/pull/3731) - Handle bad gateway at pending transactions fetcher
 - [#3730](https://github.com/poanetwork/blockscout/pull/3730) - Set default period for average block time counter refresh interval
 - [#3729](https://github.com/poanetwork/blockscout/pull/3729) - Token on-demand balance fetcher: handle nil balance
 - [#3728](https://github.com/poanetwork/blockscout/pull/3728) - Coinprice api endpoint: handle nil rates

--- a/apps/indexer/lib/indexer/fetcher/pending_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/pending_transaction.ex
@@ -135,6 +135,11 @@ defmodule Indexer.Fetcher.PendingTransaction do
         Logger.error("timeout")
 
         :ok
+
+      {:error, {:bad_gateway, _}} ->
+        Logger.error("bad_gateway")
+
+        :ok
     end
   end
 


### PR DESCRIPTION
## Motivation

> 2021-03-21T20:59:55.941 fetcher=pending_transaction [error] Task #PID<0.13429.13> started from Indexer.Fetcher.PendingTransaction terminating
** (CaseClauseError) no case clause matching: {:error, {:bad_gateway, "https://xdai-archive-df.xdaichain.com"}}
    (indexer 0.1.0) lib/indexer/fetcher/pending_transaction.ex:120: Indexer.Fetcher.PendingTransaction.task/1
    (elixir 1.11.3) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (elixir 1.11.3) lib/task/supervised.ex:35: Task.Supervised.reply/5
    (stdlib 3.14) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Function: #Function<2.24088951/0 in Indexer.Fetcher.PendingTransaction.handle_info/2>
    Args: []

## Changelog

Handle `{:error, {:bad_gateway, _}}` response in pending transactions fetcher

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
